### PR TITLE
Ensure font atlas is correctly released even if it does not exist in the atlas cache.

### DIFF
--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -239,9 +239,9 @@ bool FontAtlasCache::releaseFontAtlas(FontAtlas *atlas)
     {
         if (atlas->getReferenceCount() == 1)
         {
-            for( auto &item: _atlasMap )
+            for (auto& item: _atlasMap)
             {
-                if ( item.second == atlas )
+                if (item.second == atlas)
                 {
                     _atlasMap.erase(item.first);
                     break;


### PR DESCRIPTION
This is to fix the dangling reference to a `FontAtlas` if the atlas cache is purged before all Labels referencing those atlases are released.  Refer to #530 