### PR TITLE
Clipper_1.05

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -37,8 +37,7 @@
 
 ## Clipper2
 - [![Upstream](https://img.shields.io/github/v/tag/AngusJohnson/Clipper2?label=Upstream)](https://github.com/AngusJohnson/Clipper2)
-- Upstream: 
-- Version: 1.0.4
+- Version: 1.0.5
 - License: BSL-1.0
 
 ## ConvertUTF

--- a/thirdparty/clipper2/clipper.core.h
+++ b/thirdparty/clipper2/clipper.core.h
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <algorithm>
 
-namespace Clipper2Lib 
+namespace Clipper2Lib
 {
 
 	static double const PI = 3.141592653589793238;

--- a/thirdparty/clipper2/clipper.engine.cpp
+++ b/thirdparty/clipper2/clipper.engine.cpp
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include "clipper.engine.h"
 
-namespace Clipper2Lib {
+namespace Clipper2Lib { 
 
 	static const double FloatingPointTolerance = 1.0e-12;
 	static const Rect64 invalid_rect = Rect64(

--- a/thirdparty/clipper2/clipper.engine.h
+++ b/thirdparty/clipper2/clipper.engine.h
@@ -20,7 +20,7 @@
 #include <functional>
 #include "clipper.core.h"
 
-namespace Clipper2Lib {
+namespace Clipper2Lib { 
 
 	struct Scanline;
 	struct IntersectNode;

--- a/thirdparty/clipper2/clipper.h
+++ b/thirdparty/clipper2/clipper.h
@@ -19,7 +19,7 @@
 #include "clipper.offset.h"
 #include "clipper.minkowski.h"
 
-namespace Clipper2Lib 
+namespace Clipper2Lib
 {
 
   static const Rect64 MaxInvalidRect64 = Rect64(

--- a/thirdparty/clipper2/clipper.minkowski.h
+++ b/thirdparty/clipper2/clipper.minkowski.h
@@ -16,7 +16,7 @@
 #include <string>
 #include "clipper.core.h"
 
-namespace Clipper2Lib 
+namespace Clipper2Lib
 {
 
   namespace detail

--- a/thirdparty/clipper2/clipper.offset.cpp
+++ b/thirdparty/clipper2/clipper.offset.cpp
@@ -12,7 +12,7 @@
 #include "clipper.h"
 #include "clipper.offset.h"
 
-namespace Clipper2Lib {
+namespace Clipper2Lib { 
 
 const double default_arc_tolerance = 0.25;
 const double floating_point_tolerance = 1e-12;

--- a/thirdparty/clipper2/clipper.offset.h
+++ b/thirdparty/clipper2/clipper.offset.h
@@ -24,7 +24,7 @@ enum class EndType {Polygon, Joined, Butt, Square, Round};
 //Joined : offsets both sides of a path, with joined ends
 //Polygon: offsets only one side of a closed path
 
-class ClipperOffset {
+class ClipperOffset { 
 private:
 
 	class Group {


### PR DESCRIPTION
Version 1.0.5 - 2 October 2022

- Numerous improvements to C++ makefile and revised C++ folder structure (#243, #247)
- Fixed bug in C++ Point constructor when USINGZ defined (#246)
- Improved performance by removing time costly round() function calls (#236)
- Changed Library's C# target framework back to netstandard2.0 (#225)
- Updated several sample apps.

THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
see above

## Issue ticket number and link
-

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
