### PR TITLE
Replace use of deprecated sprintf with snprintf

### DIFF
--- a/core/2d/CCFontAtlasCache.cpp
+++ b/core/2d/CCFontAtlasCache.cpp
@@ -183,7 +183,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(std::string_view plistFile)
 FontAtlas* FontAtlasCache::getFontAtlasCharMap(Texture2D* texture, int itemWidth, int itemHeight, int startCharMap)
 {
     char key[ATLAS_MAP_KEY_PREFIX_BUFFER_SIZE];
-    sprintf(key, "name:%p_%d_%d_%d", texture->getBackendTexture(), itemWidth, itemHeight, startCharMap);
+    snprintf(key, sizeof(key), "name:%p_%d_%d_%d", texture->getBackendTexture(), itemWidth, itemHeight, startCharMap);
     std::string atlasName = key;
 
     auto it = _atlasMap.find(atlasName);

--- a/core/2d/CCLabel.cpp
+++ b/core/2d/CCLabel.cpp
@@ -2396,7 +2396,7 @@ void Label::updateColor()
 std::string Label::getDescription() const
 {
     char tmp[50];
-    sprintf(tmp, "<Label | Tag = %d, Label = >", _tag);
+    snprintf(tmp, sizeof(tmp), "<Label | Tag = %d, Label = >", _tag);
     std::string ret = tmp;
     ret += _utf8Text;
 

--- a/core/2d/CCSprite.cpp
+++ b/core/2d/CCSprite.cpp
@@ -132,7 +132,7 @@ Sprite* Sprite::createWithSpriteFrameName(std::string_view spriteFrameName)
 
 #if _AX_DEBUG > 0
     char msg[256] = {0};
-    sprintf(msg, "Invalid spriteFrameName: %s", spriteFrameName.data());
+    snprintf(msg, sizeof(msg), "Invalid spriteFrameName: %s", spriteFrameName.data());
     AXASSERT(frame != nullptr, msg);
 #endif
 
@@ -1685,10 +1685,10 @@ std::string Sprite::getDescription() const
 {
     char textureDescriptor[100];
     if (_renderMode == RenderMode::QUAD_BATCHNODE)
-        sprintf(textureDescriptor, "<Sprite | Tag = %d, TextureID = %p>", _tag,
+        snprintf(textureDescriptor, sizeof(textureDescriptor), "<Sprite | Tag = %d, TextureID = %p>", _tag,
                 _batchNode->getTextureAtlas()->getTexture()->getBackendTexture());
     else
-        sprintf(textureDescriptor, "<Sprite | Tag = %d, TextureID = %p>", _tag, _texture->getBackendTexture());
+        snprintf(textureDescriptor, sizeof(textureDescriptor), "<Sprite | Tag = %d, TextureID = %p>", _tag, _texture->getBackendTexture());
 
     return textureDescriptor;
 }

--- a/core/3d/CCBundle3D.cpp
+++ b/core/3d/CCBundle3D.cpp
@@ -240,7 +240,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas,
             tex.wrapS    = backend::SamplerAddressMode::CLAMP_TO_EDGE;
             tex.wrapT    = backend::SamplerAddressMode::CLAMP_TO_EDGE;
 
-            sprintf(str, "%d", ++i);
+            snprintf(str, sizeof(str), "%d", ++i);
             materialdata.textures.emplace_back(tex);
             materialdata.id = str;
             material.name   = str;
@@ -315,7 +315,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas,
                 auto& storedIndices = meshdata->subMeshIndices.emplace_back(std::move(submesh.second));
                 meshdata->subMeshAABB.emplace_back(
                     calculateAABB(meshdata->vertex, meshdata->getPerVertexSize(), storedIndices));
-                sprintf(str, "%d", ++i);
+                snprintf(str, sizeof(str), "%d", ++i);
                 meshdata->subMeshIds.emplace_back(str);
 
                 auto modelnode        = new ModelData();
@@ -1119,7 +1119,7 @@ bool Bundle3D::loadBinary(std::string_view path)
     }
 
     char version[20] = {0};
-    sprintf(version, "%d.%d", ver[0], ver[1]);
+    snprintf(version, sizeof(version), "%d.%d", ver[0], ver[1]);
     _version = version;
 
     // Read ref table size

--- a/core/3d/CCTerrain.cpp
+++ b/core/3d/CCTerrain.cpp
@@ -816,7 +816,7 @@ void Terrain::cacheUniformAttribLocation()
         for (int i = 0; i < _maxDetailMapValue; ++i)
         {
             char str[20];
-            sprintf(str, "u_tex%d", i);
+            snprintf(str, sizeof(str), "u_tex%d", i);
             _detailMapLocation[i] = _programState->getUniformLocation(str);
         }
 

--- a/core/base/CCConsole.cpp
+++ b/core/base/CCConsole.cpp
@@ -1273,17 +1273,17 @@ void Console::commandProjection(socket_native_type fd, std::string_view /*args*/
     switch (proj)
     {
     case ax::Director::Projection::_2D:
-        sprintf(buf, "2d");
+        snprintf(buf, sizeof(buf), "2d");
         break;
     case ax::Director::Projection::_3D:
-        sprintf(buf, "3d");
+        snprintf(buf, sizeof(buf), "3d");
         break;
     case ax::Director::Projection::CUSTOM:
-        sprintf(buf, "custom");
+        snprintf(buf, sizeof(buf), "custom");
         break;
 
     default:
-        sprintf(buf, "unknown");
+        snprintf(buf, sizeof(buf), "unknown");
         break;
     }
     Console::Utility::mydprintf(fd, "Current projection: %s\n", buf);

--- a/core/base/CCDirector.cpp
+++ b/core/base/CCDirector.cpp
@@ -1195,7 +1195,7 @@ void Director::showStats()
         // to make the FPS stable
         if (_accumDt > AX_DIRECTOR_STATS_INTERVAL)
         {
-            sprintf(buffer, "%.1f / %.3f", _frames / _accumDt, _secondsPerFrame);
+            snprintf(buffer, sizeof(buffer), "%.1f / %.3f", _frames / _accumDt, _secondsPerFrame);
             _FPSLabel->setString(buffer);
             _accumDt = 0;
             _frames  = 0;
@@ -1205,14 +1205,14 @@ void Director::showStats()
         auto currentVerts = (uint32_t)_renderer->getDrawnVertices();
         if (currentCalls != prevCalls)
         {
-            sprintf(buffer, "GL calls:%6u", currentCalls);
+            snprintf(buffer, sizeof(buffer), "GL calls:%6u", currentCalls);
             _drawnBatchesLabel->setString(buffer);
             prevCalls = currentCalls;
         }
 
         if (currentVerts != prevVerts)
         {
-            sprintf(buffer, "GL verts:%6u", currentVerts);
+            snprintf(buffer, sizeof(buffer), "GL verts:%6u", currentVerts);
             _drawnVerticesLabel->setString(buffer);
             prevVerts = currentVerts;
         }

--- a/core/base/CCProfiling.cpp
+++ b/core/base/CCProfiling.cpp
@@ -103,7 +103,7 @@ std::string ProfilingTimer::getDescription() const
 {
     static char s_description[512] = {0};
 
-    sprintf(s_description, "%s ::\tavg1: %u,\tavg2: %u,\tmin: %u,\tmax: %u,\ttotal: %.2fs,\tnr calls: %d",
+    snprintf(s_description, sizeof(s_description), "%s ::\tavg1: %u,\tavg2: %u,\tmin: %u,\tmax: %u,\ttotal: %.2fs,\tnr calls: %d",
             _nameStr.c_str(), _averageTime1, _averageTime2, minTime, maxTime, totalTime / 1000000., numberOfCalls);
     return s_description;
 }

--- a/core/base/CCUserDefault.cpp
+++ b/core/base/CCUserDefault.cpp
@@ -253,7 +253,7 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
     // format the value
     char tmp[50];
     memset(tmp, 0, sizeof(tmp));
-    sprintf(tmp, "%d", value);
+    snprintf(tmp, sizeof(tmp), "%d", value);
 
     setStringForKey(pKey, tmp);
 }
@@ -268,7 +268,7 @@ void UserDefault::setLargeIntForKey(const char* pKey, int64_t value)
     // format the value
     char tmp[96];
     memset(tmp, 0, sizeof(tmp));
-    sprintf(tmp, "%" PRId64, value);
+    snprintf(tmp, sizeof(tmp), "%" PRId64, value);
 
     setStringForKey(pKey, tmp);
 }
@@ -289,7 +289,7 @@ void UserDefault::setDoubleForKey(const char* pKey, double value)
     // format the value
     char tmp[50];
     memset(tmp, 0, 50);
-    sprintf(tmp, "%f", value);
+    snprintf(tmp, sizeof(tmp), "%f", value);
 
     setStringForKey(pKey, tmp);
 }

--- a/core/network/CCDownloader-curl.cpp
+++ b/core/network/CCDownloader-curl.cpp
@@ -540,7 +540,7 @@ private:
             if (coTask->_acceptRanges && coTask->_totalBytesReceived > 0)
             {
                 char buf[128];
-                sprintf(buf, "%" PRId64 "-", coTask->_totalBytesReceived);
+                snprintf(buf, sizeof(buf), "%" PRId64 "-", coTask->_totalBytesReceived);
                 curl_easy_setopt(handle, CURLOPT_RANGE, buf);
                 curl_easy_setopt(handle, CURLOPT_RESUME_FROM_LARGE, (curl_off_t)coTask->_totalBytesReceived);
             }
@@ -970,7 +970,7 @@ void DownloaderCURL::_lazyScheduleUpdate()
         _scheduler->retain();
 
         char key[128];
-        sprintf(key, "DownloaderCURL(%p)", this);
+        snprintf(key, sizeof(key), "DownloaderCURL(%p)", this);
         _schedulerKey = key;
 
         _scheduler->schedule(std::bind(&DownloaderCURL::_onUpdate, this, std::placeholders::_1), this, 0.1f, true,

--- a/core/network/HttpClient.cpp
+++ b/core/network/HttpClient.cpp
@@ -350,7 +350,7 @@ void HttpClient::handleNetworkEvent(yasio::io_event* event)
                 char strContentLength[128] = {0};
                 auto requestData           = request->getRequestData();
                 auto requestDataSize       = request->getRequestDataSize();
-                sprintf(strContentLength, "Content-Length: %d\r\n\r\n", static_cast<int>(requestDataSize));
+                snprintf(strContentLength, sizeof(strContentLength), "Content-Length: %d\r\n\r\n", static_cast<int>(requestDataSize));
                 obs.write_bytes(strContentLength);
 
                 if (requestData && requestDataSize > 0)

--- a/core/network/HttpCookie.cpp
+++ b/core/network/HttpCookie.cpp
@@ -275,7 +275,7 @@ void HttpCookie::writeFile()
         line.append(1, '\t');
         cookie.secure ? line.append("TRUE") : line.append("FALSE");
         line.append(1, '\t');
-        sprintf(expires, "%lld", static_cast<long long>(cookie.expires));
+        snprintf(expires, sizeof(expires), "%lld", static_cast<long long>(cookie.expires));
         line.append(expires);
         line.append(1, '\t');
         line.append(cookie.name);


### PR DESCRIPTION
THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes

This removes Clang warnings about use of deprecated sprintf:

```
'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.
```

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] An improved cpp-test/lua-test is not needed (explain why not, thanks).
