### PR TITLE
feat: experimental linux prebuilt support

### DIFF
--- a/cmake/Modules/AXLinkHelpers.cmake
+++ b/cmake/Modules/AXLinkHelpers.cmake
@@ -84,7 +84,7 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
     if (WINDOWS)
         target_link_libraries(${APP_NAME} winmm Version)
     else()
-        target_link_libraries(${APP_NAME} X11 fontconfig)
+        target_link_libraries(${APP_NAME} X11 fontconfig glib-2.0 gtk-3 gobject-2.0)
     endif()
 
     # Linking engine and thirdparty libs
@@ -131,9 +131,9 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
             ${LIBS}
             z
             jpeg
-            crypto
-            ssl
             curl
+            ssl
+            crypto
             openal
         )
     endif()
@@ -183,14 +183,15 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
 endfunction(ax_link_cxx_prebuilt)
 
 function(ax_link_lua_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
-    ax_link_cxx_prebuilt(${APP_NAME} ${AX_ROOT_DIR} ${AX_PREBUILT_DIR})
-
     if (NOT AX_USE_SHARED_PREBUILT)
         target_compile_definitions(${APP_NAME}
 	        PRIVATE _USRLUASTATIC=1
         )
     endif()
     target_link_libraries(${APP_NAME} axlua lua-cjson tolua plainlua)
+
+    ax_link_cxx_prebuilt(${APP_NAME} ${AX_ROOT_DIR} ${AX_PREBUILT_DIR})
+
     if (WINDOWS)
         add_custom_command(TARGET ${APP_NAME} POST_BUILD
            COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/templates/cpp-template-default/CMakeLists.txt
+++ b/templates/cpp-template-default/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT DEFINED BUILD_ENGINE_DONE) # to test HelloCpp into root project
 
     include(AXBuildSet)
     set(_AX_USE_PREBUILT FALSE)
-    if (WIN32 AND DEFINED AX_PREBUILT_DIR AND IS_DIRECTORY ${_AX_ROOT_PATH}/${AX_PREBUILT_DIR})
+    if ((WIN32 OR LINUX) AND DEFINED AX_PREBUILT_DIR AND IS_DIRECTORY ${_AX_ROOT_PATH}/${AX_PREBUILT_DIR})
         set(_AX_USE_PREBUILT TRUE)
     endif()
 
@@ -210,7 +210,7 @@ if (AX_WITH_YAML_CPP)
     target_link_libraries(${APP_NAME} yaml-cpp)
 endif()
 
-if (_AX_USE_PREBUILT) # support windows only
+if (_AX_USE_PREBUILT) # support windows and linux
     include(${_AX_ROOT_PATH}/cmake/Modules/AXConfigDefine.cmake)
     use_ax_compile_define(${APP_NAME})
 

--- a/templates/lua-template-default/CMakeLists.txt
+++ b/templates/lua-template-default/CMakeLists.txt
@@ -58,7 +58,7 @@ if(NOT DEFINED BUILD_ENGINE_DONE) # to test HelloLua into root project
     set(AX_ENABLE_EXT_LUA ON)
 
     set(_AX_USE_PREBUILT FALSE)
-    if (WIN32 AND DEFINED AX_PREBUILT_DIR AND IS_DIRECTORY ${_AX_ROOT_PATH}/${AX_PREBUILT_DIR})
+    if ((WIN32 OR LINUX) AND DEFINED AX_PREBUILT_DIR AND IS_DIRECTORY ${_AX_ROOT_PATH}/${AX_PREBUILT_DIR})
         set(_AX_USE_PREBUILT TRUE)
     endif()
 
@@ -226,7 +226,7 @@ if (AX_WITH_YAML_CPP)
     target_link_libraries(${APP_NAME} yaml-cpp)
 endif()
 
-if (_AX_USE_PREBUILT) # support windows only
+if (_AX_USE_PREBUILT) # support windows and linux
     include(${_AX_ROOT_PATH}/cmake/Modules/AXConfigDefine.cmake)
     use_ax_compile_define(${APP_NAME})
 


### PR DESCRIPTION
Add experimental engine prebuilt support on linux. Usage is almost the same as on windows.

Since I mainly work on linux, this feature is truly a lifesaver. But it is not fully tested yet; I've just made sure that cpp/lua templates run on my machine (Arch Linux). More tests may be needed on different distros.

Note that `ld` on linux is very strict about the linking order of libraries.