### PR TITLE
Fix warnings (implicit conversion loses and use of deprecated function)

### DIFF
--- a/core/2d/CCFontFNT.cpp
+++ b/core/2d/CCFontFNT.cpp
@@ -151,7 +151,7 @@ std::set<unsigned int>* BMFontConfiguration::parseConfigFile(std::string_view co
     if (data.size() >= (sizeof("BMP") - 1) && memcmp("BMF", data.c_str(), sizeof("BMP") - 1) == 0)
     {
         // Handle fnt file of binary format
-        std::set<unsigned int>* ret = parseBinaryConfigFile((unsigned char*)&data.front(), data.size(), controlFile);
+        std::set<unsigned int>* ret = parseBinaryConfigFile((unsigned char*)&data.front(), static_cast<uint32_t>(data.size()), controlFile);
         return ret;
     }
     if (data[0] == 0)

--- a/core/2d/CCFontFreeType.cpp
+++ b/core/2d/CCFontFreeType.cpp
@@ -82,7 +82,7 @@ static unsigned long ft_stream_read_callback(FT_Stream stream,
         fd->seek(offset, SEEK_SET);
 
     if (buf)
-        return fd->read(buf, size);
+        return fd->read(buf, static_cast<unsigned int>(size));
 
     return 0;
 }
@@ -278,13 +278,13 @@ bool FontFreeType::loadFontFace(std::string_view fontPath, float fontSize)
 #    define FT_PIX_FLOOR(x) ((x) & ~FT_TYPEOF(x) 63)
 #    define FT_PIX_ROUND(x) FT_PIX_FLOOR((x) + 32)
 #endif
-            _ascender  = FT_PIX_ROUND(FT_MulFix(face->ascender, size_metrics.y_scale));
-            _descender = FT_PIX_ROUND(FT_MulFix(face->descender, size_metrics.y_scale));
+            _ascender  = static_cast<int>(FT_PIX_ROUND(FT_MulFix(face->ascender, size_metrics.y_scale)));
+            _descender = static_cast<int>(FT_PIX_ROUND(FT_MulFix(face->descender, size_metrics.y_scale)));
         }
         else
         {
-            _ascender  = size_metrics.ascender;
-            _descender = size_metrics.descender;
+            _ascender  = static_cast<int>(size_metrics.ascender);
+            _descender = static_cast<int>(size_metrics.descender);
         }
 
         _lineHeight = (_ascender - _descender) >> 6;
@@ -501,8 +501,8 @@ unsigned char* FontFreeType::getGlyphBitmap(char32_t charCode,
 
             outRect.size.width  = (float)blendWidth;
             outRect.size.height = (float)blendHeight;
-            outWidth            = blendWidth;
-            outHeight           = blendHeight;
+            outWidth            = static_cast<int>(blendWidth);
+            outHeight           = static_cast<int>(blendHeight);
 
             delete[] outlineBitmap;
             delete[] copyBitmap;
@@ -534,8 +534,8 @@ unsigned char* FontFreeType::getGlyphBitmapWithOutline(unsigned int glyphIndex, 
                 {
                     FT_Outline* outline = &reinterpret_cast<FT_OutlineGlyph>(glyph)->outline;
                     FT_Glyph_Get_CBox(glyph, FT_GLYPH_BBOX_GRIDFIT, &bbox);
-                    int32_t width = (bbox.xMax - bbox.xMin) >> 6;
-                    int32_t rows  = (bbox.yMax - bbox.yMin) >> 6;
+                    int32_t width = static_cast<int32_t>((bbox.xMax - bbox.xMin) >> 6);
+                    int32_t rows  = static_cast<int32_t>((bbox.yMax - bbox.yMin) >> 6);
 
                     FT_Bitmap bmp;
                     bmp.buffer = new unsigned char[width * rows];

--- a/core/2d/CCLabel.cpp
+++ b/core/2d/CCLabel.cpp
@@ -1099,7 +1099,7 @@ bool Label::alignText()
         auto size      = textures.size();
         if (size > static_cast<size_t>(_batchNodes.size()))
         {
-            for (auto index = static_cast<size_t>(_batchNodes.size()); index < size; ++index)
+            for (auto index = static_cast<unsigned int>(_batchNodes.size()); index < size; ++index)
             {
                 auto batchNode = SpriteBatchNode::createWithTexture(textures.at(index));
                 if (batchNode)

--- a/core/2d/CCParticleSystem.cpp
+++ b/core/2d/CCParticleSystem.cpp
@@ -831,7 +831,7 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
                 Vec2 point = {0, 0};
 
                 int rand0 = _rng.float01() * mask.points.size();
-                int index = MIN(rand0, mask.points.size() - 1);
+                auto index = MIN(rand0, mask.points.size() - 1);
                 point = mask.points[index];
 
                 point -= size / 2;
@@ -904,7 +904,7 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
             for (int i = start; i < _particleCount; ++i)
             {
                 int rand0                  = _rng.float01() * _randomAnimations.size();
-                int index                  = MIN(rand0, _randomAnimations.size() - 1);
+                auto index                  = MIN(rand0, _randomAnimations.size() - 1);
                 _particleData.animIndex[i] = _randomAnimations[index];
                 auto& descriptor           = _animations.at(_particleData.animIndex[i]);
                 _particleData.animTimeLength[i] =

--- a/core/2d/CCSpriteBatchNode.cpp
+++ b/core/2d/CCSpriteBatchNode.cpp
@@ -334,7 +334,7 @@ void SpriteBatchNode::updateAtlasIndex(Sprite* sprite, ssize_t* curIndex)
     if (count == 0)
     {
         oldIndex = sprite->getAtlasIndex();
-        sprite->setAtlasIndex(*curIndex);
+        sprite->setAtlasIndex(static_cast<unsigned int>(*curIndex));
         if (oldIndex != *curIndex)
         {
             swap(oldIndex, *curIndex);
@@ -349,7 +349,7 @@ void SpriteBatchNode::updateAtlasIndex(Sprite* sprite, ssize_t* curIndex)
         {
             // all children are in front of the parent
             oldIndex = sprite->getAtlasIndex();
-            sprite->setAtlasIndex(*curIndex);
+            sprite->setAtlasIndex(static_cast<unsigned int>(*curIndex));
             if (oldIndex != *curIndex)
             {
                 swap(oldIndex, *curIndex);
@@ -365,7 +365,7 @@ void SpriteBatchNode::updateAtlasIndex(Sprite* sprite, ssize_t* curIndex)
             if (needNewIndex && sp->getLocalZOrder() >= 0)
             {
                 oldIndex = sprite->getAtlasIndex();
-                sprite->setAtlasIndex(*curIndex);
+                sprite->setAtlasIndex(static_cast<unsigned int>(*curIndex));
                 if (oldIndex != *curIndex)
                 {
                     this->swap(oldIndex, *curIndex);
@@ -380,7 +380,7 @@ void SpriteBatchNode::updateAtlasIndex(Sprite* sprite, ssize_t* curIndex)
         if (needNewIndex)
         {  // all children have a zOrder < 0)
             oldIndex = sprite->getAtlasIndex();
-            sprite->setAtlasIndex(*curIndex);
+            sprite->setAtlasIndex(static_cast<unsigned int>(*curIndex));
             if (oldIndex != *curIndex)
             {
                 swap(oldIndex, *curIndex);
@@ -404,7 +404,7 @@ void SpriteBatchNode::swap(ssize_t oldIndex, ssize_t newIndex)
     auto oldIt = std::next(_descendants.begin(), oldIndex);
     auto newIt = std::next(_descendants.begin(), newIndex);
 
-    (*newIt)->setAtlasIndex(oldIndex);
+    (*newIt)->setAtlasIndex(static_cast<unsigned int>(oldIndex));
     //    (*oldIt)->setAtlasIndex(newIndex);
 
     std::swap(*oldIt, *newIt);
@@ -484,7 +484,7 @@ ssize_t SpriteBatchNode::rebuildIndexInOrder(Sprite* parent, ssize_t index)
     // ignore self (batch node)
     if (parent != static_cast<Ref*>(this))
     {
-        parent->setAtlasIndex(index);
+        parent->setAtlasIndex(static_cast<unsigned int>(index));
         index++;
     }
 
@@ -721,7 +721,7 @@ void SpriteBatchNode::insertQuadFromSprite(Sprite* sprite, ssize_t index)
     // update the quad directly. Don't add the sprite to the scene graph
     //
     sprite->setBatchNode(this);
-    sprite->setAtlasIndex(index);
+    sprite->setAtlasIndex(static_cast<unsigned int>(index));
 
     V3F_C4B_T2F_Quad quad = sprite->getQuad();
     _textureAtlas->insertQuad(&quad, index);
@@ -747,7 +747,7 @@ void SpriteBatchNode::updateQuadFromSprite(Sprite* sprite, ssize_t index)
     // update the quad directly. Don't add the sprite to the scene graph
     //
     sprite->setBatchNode(this);
-    sprite->setAtlasIndex(index);
+    sprite->setAtlasIndex(static_cast<unsigned int>(index));
 
     sprite->setDirty(true);
 

--- a/core/3d/CCMesh.cpp
+++ b/core/3d/CCMesh.cpp
@@ -151,7 +151,7 @@ const MeshVertexAttrib& Mesh::getMeshVertexAttribute(int idx)
 
 int Mesh::getVertexSizeInBytes() const
 {
-    return _meshIndexData->getMeshVertexData()->getSizePerVertex();
+    return static_cast<int>(_meshIndexData->getMeshVertexData()->getSizePerVertex());
 }
 
 Mesh* Mesh::create(const std::vector<float>& positions,
@@ -450,7 +450,7 @@ void Mesh::draw(Renderer* renderer,
 
     _meshIndexData->setPrimitiveType(_material->_drawPrimitive);
     _material->draw(commands.data(), globalZ, getVertexBuffer(), getIndexBuffer(), getPrimitiveType(), getIndexFormat(),
-                    getIndexCount(), transform);
+                    static_cast<unsigned int>(getIndexCount()), transform);
 }
 
 void Mesh::setSkin(MeshSkin* skin)

--- a/core/audio/AudioDecoderOgg.cpp
+++ b/core/audio/AudioDecoderOgg.cpp
@@ -107,7 +107,7 @@ uint32_t AudioDecoderOgg::read(uint32_t framesToRead, char* pcmBuf)
 {
     int currentSection = 0;
     int bytesToRead    = framesToBytes(framesToRead);
-    int32_t bytesRead  = ov_read(&_vf, pcmBuf, bytesToRead, 0, 2, 1, &currentSection);
+    int32_t bytesRead  = static_cast<int32_t>(ov_read(&_vf, pcmBuf, bytesToRead, 0, 2, 1, &currentSection));
     return bytesToFrames(bytesRead);
 }
 

--- a/core/base/TGAlib.cpp
+++ b/core/base/TGAlib.cpp
@@ -280,7 +280,7 @@ tImageTGA* tgaLoad(const char* filename)
 
     if (!data.isNull())
     {
-        return tgaLoadBuffer(data.getBytes(), data.getSize());
+        return tgaLoadBuffer(data.getBytes(), static_cast<int32_t>(data.getSize()));
     }
 
     return nullptr;

--- a/core/base/ccUtils.cpp
+++ b/core/base/ccUtils.cpp
@@ -666,7 +666,7 @@ std::vector<int> parseIntegerList(std::string_view intsString)
         const char* cStr = intsString.data();
         char* endptr;
 
-        for (int32_t i = strtol(cStr, &endptr, 10); endptr != cStr; i = strtol(cStr, &endptr, 10))
+        for (auto i = strtol(cStr, &endptr, 10); endptr != cStr; i = strtol(cStr, &endptr, 10))
         {
             if (errno == ERANGE)
             {

--- a/core/network/CCDownloader-curl.cpp
+++ b/core/network/CCDownloader-curl.cpp
@@ -268,7 +268,7 @@ public:
 
         if (_fs)
         {
-            ret = _fs->write(buffer, bytes_transferred);  // fwrite(buffer, size, count, _fp);
+            ret = _fs->write(buffer, static_cast<unsigned int>(bytes_transferred));  // fwrite(buffer, size, count, _fp);
         }
         else
         {

--- a/core/platform/CCImage.cpp
+++ b/core/platform/CCImage.cpp
@@ -433,7 +433,7 @@ void pngWriteCallback(png_structp png_ptr, png_bytep data, size_t length)
 
     FileStream* fileStream = (FileStream*)png_get_io_ptr(png_ptr);
 
-    const auto check = fileStream->write(data, length);
+    const auto check = fileStream->write(data, static_cast<unsigned int>(length));
 
     if (check != length)
         png_error(png_ptr, "Write Error");
@@ -691,7 +691,7 @@ bool Image::initWithImageData(uint8_t* data, ssize_t dataLen, bool ownData)
         default:
         {
             // load and detect image format
-            tImageTGA* tgaData = tgaLoadBuffer(unpackedData, unpackedLen);
+            tImageTGA* tgaData = tgaLoadBuffer(unpackedData, static_cast<int32_t>(unpackedLen));
 
             if (tgaData != nullptr && tgaData->status == TGA_OK)
             {
@@ -1218,7 +1218,7 @@ bool Image::initWithPngData(uint8_t* data, ssize_t dataLen)
 bool Image::initWithBmpData(uint8_t* data, ssize_t dataLen)
 {
     const int nrChannels = 4;
-    _data                = stbi_load_from_memory(data, dataLen, &_width, &_height, nullptr, nrChannels);
+    _data                = stbi_load_from_memory(data, static_cast<int>(dataLen), &_width, &_height, nullptr, nrChannels);
     if (_data)
     {
         _dataLen     = _width * _height * nrChannels;
@@ -1584,7 +1584,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
 
     const int pixelOffset = (sizeof(PVRv3TexHeader) + header->metadataLength);
     uint8_t* pixelData    = data + pixelOffset;
-    int pixelLen          = dataLen - pixelOffset;
+    int pixelLen          = static_cast<int>(dataLen) - pixelOffset;
 
     int dataOffset = 0, dataSize = 0;
     int blockSize = 0, widthBlocks = 0, heightBlocks = 0;
@@ -1898,7 +1898,7 @@ bool Image::initWithASTCData(uint8_t* data, ssize_t dataLen, bool ownData)
             _dataLen = _width * _height * 4;
             _data    = static_cast<uint8_t*>(malloc(_dataLen));
             if (UTILS_UNLIKELY(astc_decompress_image(static_cast<const uint8_t*>(data) + ASTC_HEAD_SIZE,
-                                                     dataLen - ASTC_HEAD_SIZE, _data, _width, _height, block_x,
+                                                     static_cast<uint32_t>(dataLen) - ASTC_HEAD_SIZE, _data, _width, _height, block_x,
                                                      block_y) != 0))
             {
                 AX_SAFE_FREE(_data);
@@ -2461,7 +2461,7 @@ bool Image::saveImageToJPG(std::string_view filePath)
 
         jpeg_finish_compress(&cinfo);
 
-        outfile->write(outputBuffer, outputSize);
+        outfile->write(outputBuffer, static_cast<unsigned int>(outputSize));
         outfile.reset();
 
         if (outputBuffer)

--- a/core/platform/CCPosixFileStream.cpp
+++ b/core/platform/CCPosixFileStream.cpp
@@ -229,7 +229,7 @@ int PosixFileStream::read(void* buf, unsigned int size)
 
 int PosixFileStream::write(const void* buf, unsigned int size)
 {
-    return posix_write(_handle._fd, buf, size);
+    return static_cast<int>(posix_write(_handle._fd, buf, size));
 }
 
 int64_t PosixFileStream::tell()

--- a/core/renderer/backend/metal/CommandBufferMTL.mm
+++ b/core/renderer/backend/metal/CommandBufferMTL.mm
@@ -591,8 +591,8 @@ void CommandBufferMTL::readPixels(id<MTLTexture> texture,
       {
           [readPixelsTexture getBytes:texelData bytesPerRow:bytePerRow fromRegion:imageRegion mipmapLevel:0];
           UtilsMTL::swizzleImage(texelData, rectWidth, rectHeight, readPixelsTexture.pixelFormat);
-          pbd._width  = rectWidth;
-          pbd._height = rectHeight;
+          pbd._width  = static_cast<int>(rectWidth);
+          pbd._height = static_cast<int>(rectHeight);
       }
       [readPixelsTexture release];
     }];

--- a/core/renderer/backend/metal/RenderTargetMTL.mm
+++ b/core/renderer/backend/metal/RenderTargetMTL.mm
@@ -39,7 +39,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassDescriptor& par
 
     for (size_t i = 0; i < MAX_COLOR_ATTCHMENT; i++)
     {
-        auto attachment = getColorAttachment(i);
+        auto attachment = getColorAttachment(static_cast<int>(i));
         if (!attachment)
         {
             continue;

--- a/core/renderer/backend/metal/TextureMTL.mm
+++ b/core/renderer/backend/metal/TextureMTL.mm
@@ -233,7 +233,7 @@ void TextureMTL::updateSubData(std::size_t xoffset,
         {width, height, 1}      // MTLSize
     };
 
-    auto bytesPerRow = PixelFormatUtils::computeRowPitch(_textureFormat, width);
+    auto bytesPerRow = PixelFormatUtils::computeRowPitch(_textureFormat, static_cast<uint32_t>(width));
 
     [mtlTexture replaceRegion:region mipmapLevel:level withBytes:data bytesPerRow:bytesPerRow];
 

--- a/core/ui/UIEditBox/Mac/CCUIPasswordTextField.m
+++ b/core/ui/UIEditBox/Mac/CCUIPasswordTextField.m
@@ -66,8 +66,8 @@
                  inView:(NSView *)controlView
                  editor:(NSText *)textObj
                delegate:(id)anObject
-                  start:(int32_t)selStart
-                 length:(int32_t)selLength
+                  start:(NSInteger)selStart
+                 length:(NSInteger)selLength
 {
     aRect = [self drawingRectForBounds:aRect];
     mIsEditingOrSelecting = YES;

--- a/core/ui/UIEditBox/Mac/CCUISingleLineTextField.m
+++ b/core/ui/UIEditBox/Mac/CCUISingleLineTextField.m
@@ -66,8 +66,8 @@
                  inView:(NSView *)controlView
                  editor:(NSText *)textObj
                delegate:(id)anObject
-                  start:(int32_t)selStart
-                 length:(int32_t)selLength
+                  start:(NSInteger)selStart
+                 length:(NSInteger)selLength
 {
     aRect = [self drawingRectForBounds:aRect];
     mIsEditingOrSelecting = YES;

--- a/core/ui/UITextFieldEx.cpp
+++ b/core/ui/UITextFieldEx.cpp
@@ -558,7 +558,7 @@ void TextFieldEx::insertText(const char* text, size_t len)
     }
 
     int nb;
-    auto n = _truncateUTF8String(text, this->charLimit - this->charCount, nb);
+    auto n = _truncateUTF8String(text, static_cast<int>(this->charLimit - this->charCount), nb);
 
     std::string insert(text, nb);
 
@@ -823,9 +823,9 @@ void TextFieldEx::setString(std::string_view text)
 
     if (bInsertAtEnd)
     {
-        insertPosUtf8 = charCount;
-        insertPos     = inputText.length();
-        cursorPos     = displayText->length();
+        insertPosUtf8 = static_cast<int>(charCount);
+        insertPos     = static_cast<int>(inputText.length());
+        cursorPos     = static_cast<int>(displayText->length());
     }
 }
 
@@ -975,22 +975,22 @@ void TextFieldEx::__moveCursor(int direction)
 
         if (direction < 0)
         {
-            this->insertPos = internalUTF8MoveLeft(this->inputText, this->insertPos).size();
+            this->insertPos = static_cast<int>(internalUTF8MoveLeft(this->inputText, this->insertPos).size());
 
             auto s = internalUTF8MoveLeft(displayText, this->cursorPos);
 
             auto width = internalCalcStringWidth(s, this->fontName, this->fontSize);
             this->cursor->setPosition(Point(width, this->getContentSize().height / 2));
-            this->cursorPos = s.length();
+            this->cursorPos = static_cast<int>(s.length());
         }
         else
         {
-            this->insertPos = internalUTF8MoveRight(this->inputText, this->insertPos).size();
+            this->insertPos = static_cast<int>(internalUTF8MoveRight(this->inputText, this->insertPos).size());
 
             auto s     = internalUTF8MoveRight(displayText, this->cursorPos);
             auto width = internalCalcStringWidth(s, this->fontName, this->fontSize);
             this->cursor->setPosition(Point(width, this->getContentSize().height / 2));
-            this->cursorPos = s.length();
+            this->cursorPos = static_cast<int>(s.length());
         }
 
         this->insertPosUtf8 = newOffset;
@@ -1026,8 +1026,8 @@ void TextFieldEx::__moveCursorTo(float x)
         }
     }
 
-    int length = displayText.length();
-    int n      = this->charCount;  // UTF8 char counter
+    int length = static_cast<int>(displayText.length());
+    int n      = static_cast<int>(this->charCount);  // UTF8 char counter
 
     int insertWhere     = 0;
     int insertWhereUtf8 = 0;

--- a/core/ui/UITextFieldEx.h
+++ b/core/ui/UITextFieldEx.h
@@ -46,7 +46,7 @@ public:
 
     Label* getRenderLabel();
 
-    inline int getCharCount() const { return charCount; };
+    inline int getCharCount() const { return static_cast<int>(charCount); };
 
     virtual void setPlaceholderColor(const Color4B& color);
     virtual const Color4B& getPlaceholderColor() const;

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -281,7 +281,7 @@ void AssetsManager::checkStoragePath()
 static std::string keyWithHash(const char* prefix, std::string_view url)
 {
     char buf[256];
-    sprintf(buf, "%s%zd", prefix, std::hash<std::string_view>()(url));
+    snprintf(buf, sizeof(buf), "%s%zd", prefix, std::hash<std::string_view>()(url));
     return buf;
 }
 


### PR DESCRIPTION
THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes

* Linux and Apple platforms use the LP64 model[1]; 32-bit `int`, 64-bit `long`. This fixes a lot of warnings about integer precision lose on the platforms.
* Replace use of deprecated sprintf with safer snprintf.
* This patch doesn't touch third party code.

[1] [64-bit data models](https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models)

## Issue ticket number and link

Related issue: #842

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] An improved cpp-test/lua-test is not needed (explain why not, thanks).
