### PR TITLE
[BUG] Fix camera `applyZoom()` when window size changes and remove unnecessary projection code 

### DIFF
--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -188,7 +188,6 @@ void Camera::initDefault()
     {
         case Director::Projection::_2D:
         {
-            _zoomFactor  = 1.0F;
             _fieldOfView = 60.0F;
             _nearPlane   = -1024.0F;
             _farPlane    = 1024.0F;
@@ -201,7 +200,6 @@ void Camera::initDefault()
         case Director::Projection::_3D:
         {
             float zeye   = _director->getZEye();
-            _zoomFactor  = 1.0F;
             _fieldOfView = 60.0F;
             _nearPlane   = 0.5F;
             _farPlane    = zeye + size.height / 2.0f;
@@ -216,21 +214,24 @@ void Camera::initDefault()
     }
 
     setDepth(0);
+
+    if (_zoomFactor != 1.0F)
+        applyZoom();
 }
 
 void Camera::updateTransform()
 {
     auto& size = _director->getWinSize();
     // create default camera
-    switch (_type)
+    switch (_director->getProjection())
     {
-        case Type::ORTHOGRAPHIC:
+    case Director::Projection::_2D:
         {
             initOrthographic(size.width, size.height, _nearPlane, _farPlane);
             break;
         }
 
-        case Type::PERSPECTIVE:
+    case Director::Projection::_3D:
         {
             float zeye = _director->getZEye();
             initPerspective(_fieldOfView, (float)size.width / size.height, _nearPlane, _farPlane);
@@ -256,7 +257,6 @@ bool Camera::initPerspective(float fieldOfView, float aspectRatio, float nearPla
     Mat4::createPerspective(_fieldOfView, aspectRatio, _nearPlane, _farPlane, &_projection);
     _viewProjectionDirty = true;
     _frustumDirty        = true;
-    _type                = Type::PERSPECTIVE;
 
     return true;
 }
@@ -270,7 +270,6 @@ bool Camera::initOrthographic(float zoomX, float zoomY, float nearPlane, float f
     Mat4::createOrthographic(_zoom[0] * _zoomFactor, _zoom[1] * _zoomFactor, _nearPlane, _farPlane, &_projection);
     _viewProjectionDirty = true;
     _frustumDirty        = true;
-    _type                = Type::ORTHOGRAPHIC;
 
     return true;
 }

--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -188,6 +188,7 @@ void Camera::initDefault()
     {
         case Director::Projection::_2D:
         {
+            _zoomFactor  = 1.0F;
             _fieldOfView = 60.0F;
             _nearPlane   = -1024.0F;
             _farPlane    = 1024.0F;
@@ -200,6 +201,7 @@ void Camera::initDefault()
         case Director::Projection::_3D:
         {
             float zeye   = _director->getZEye();
+            _zoomFactor  = 1.0F;
             _fieldOfView = 60.0F;
             _nearPlane   = 0.5F;
             _farPlane    = zeye + size.height / 2.0f;
@@ -214,24 +216,21 @@ void Camera::initDefault()
     }
 
     setDepth(0);
-
-    if (_zoomFactor != 1.0F)
-        applyZoom();
 }
 
 void Camera::updateTransform()
 {
     auto& size = _director->getWinSize();
     // create default camera
-    switch (_director->getProjection())
+    switch (_type)
     {
-    case Director::Projection::_2D:
+        case Type::ORTHOGRAPHIC:
         {
             initOrthographic(size.width, size.height, _nearPlane, _farPlane);
             break;
         }
 
-    case Director::Projection::_3D:
+        case Type::PERSPECTIVE:
         {
             float zeye = _director->getZEye();
             initPerspective(_fieldOfView, (float)size.width / size.height, _nearPlane, _farPlane);
@@ -257,6 +256,7 @@ bool Camera::initPerspective(float fieldOfView, float aspectRatio, float nearPla
     Mat4::createPerspective(_fieldOfView, aspectRatio, _nearPlane, _farPlane, &_projection);
     _viewProjectionDirty = true;
     _frustumDirty        = true;
+    _type                = Type::PERSPECTIVE;
 
     return true;
 }
@@ -270,6 +270,7 @@ bool Camera::initOrthographic(float zoomX, float zoomY, float nearPlane, float f
     Mat4::createOrthographic(_zoom[0] * _zoomFactor, _zoom[1] * _zoomFactor, _nearPlane, _farPlane, &_projection);
     _viewProjectionDirty = true;
     _frustumDirty        = true;
+    _type                = Type::ORTHOGRAPHIC;
 
     return true;
 }

--- a/core/2d/CCCamera.cpp
+++ b/core/2d/CCCamera.cpp
@@ -188,7 +188,6 @@ void Camera::initDefault()
     {
         case Director::Projection::_2D:
         {
-            _zoomFactor  = 1.0F;
             _fieldOfView = 60.0F;
             _nearPlane   = -1024.0F;
             _farPlane    = 1024.0F;
@@ -201,7 +200,6 @@ void Camera::initDefault()
         case Director::Projection::_3D:
         {
             float zeye   = _director->getZEye();
-            _zoomFactor  = 1.0F;
             _fieldOfView = 60.0F;
             _nearPlane   = 0.5F;
             _farPlane    = zeye + size.height / 2.0f;
@@ -216,6 +214,9 @@ void Camera::initDefault()
     }
 
     setDepth(0);
+	
+    if (_zoomFactor != 1.0F)
+        applyZoom();
 }
 
 void Camera::updateTransform()

--- a/core/2d/CCCamera.h
+++ b/core/2d/CCCamera.h
@@ -381,7 +381,7 @@ protected:
                          // with larger depth is drawn on top of camera with smaller depth
 
     float _eyeZdistance; // Z eye projection distance for 2D in 3D projection.
-    float _zoomFactor; // The zoom factor of the camera. 3D = (cameraZDistance * _zoomFactor), 2D = (cameraScale * _zoomFactor)
+    float _zoomFactor = 1.0F; // The zoom factor of the camera. 3D = (cameraZDistance * _zoomFactor), 2D = (cameraScale * _zoomFactor)
     float _zoomFactorFarPlane;
     float _zoomFactorNearPlane;
 

--- a/core/2d/CCCamera.h
+++ b/core/2d/CCCamera.h
@@ -71,6 +71,16 @@ class AX_DLL Camera : public Node
 
 public:
     /**
+     * The type of camera.
+     */
+    enum class Type
+    {
+        PERSPECTIVE  = 1,
+        ORTHOGRAPHIC = 2
+    };
+
+public:
+    /**
      * Creates a perspective camera.
      *
      * @param fieldOfView The field of view for the perspective camera (normally in the range of 40-60 degrees).
@@ -107,6 +117,13 @@ public:
      * Get the default camera of the current running scene.
      */
     static Camera* getDefaultCamera();
+
+    /**
+     * Gets the type of camera.
+     *
+     * @return The camera type.
+     */
+    Camera::Type getType() const { return _type; }
 
     /**get & set Camera flag*/
     CameraFlag getCameraFlag() const { return _cameraFlag; }
@@ -350,6 +367,7 @@ protected:
     mutable Mat4 _viewProjection;
 
     Vec3 _up;
+    Camera::Type _type;
     float _fieldOfView                = 0.f;
     float _zoom[2]                    = {0.f};
     float _nearPlane                  = 0.f;
@@ -363,7 +381,7 @@ protected:
                          // with larger depth is drawn on top of camera with smaller depth
 
     float _eyeZdistance; // Z eye projection distance for 2D in 3D projection.
-    float _zoomFactor = 1.0F; // The zoom factor of the camera. 3D = (cameraZDistance * _zoomFactor), 2D = (cameraScale * _zoomFactor)
+    float _zoomFactor; // The zoom factor of the camera. 3D = (cameraZDistance * _zoomFactor), 2D = (cameraScale * _zoomFactor)
     float _zoomFactorFarPlane;
     float _zoomFactorNearPlane;
 

--- a/core/2d/CCCamera.h
+++ b/core/2d/CCCamera.h
@@ -71,16 +71,6 @@ class AX_DLL Camera : public Node
 
 public:
     /**
-     * The type of camera.
-     */
-    enum class Type
-    {
-        PERSPECTIVE  = 1,
-        ORTHOGRAPHIC = 2
-    };
-
-public:
-    /**
      * Creates a perspective camera.
      *
      * @param fieldOfView The field of view for the perspective camera (normally in the range of 40-60 degrees).
@@ -117,13 +107,6 @@ public:
      * Get the default camera of the current running scene.
      */
     static Camera* getDefaultCamera();
-
-    /**
-     * Gets the type of camera.
-     *
-     * @return The camera type.
-     */
-    Camera::Type getType() const { return _type; }
 
     /**get & set Camera flag*/
     CameraFlag getCameraFlag() const { return _cameraFlag; }
@@ -367,7 +350,6 @@ protected:
     mutable Mat4 _viewProjection;
 
     Vec3 _up;
-    Camera::Type _type;
     float _fieldOfView                = 0.f;
     float _zoom[2]                    = {0.f};
     float _nearPlane                  = 0.f;
@@ -381,7 +363,7 @@ protected:
                          // with larger depth is drawn on top of camera with smaller depth
 
     float _eyeZdistance; // Z eye projection distance for 2D in 3D projection.
-    float _zoomFactor; // The zoom factor of the camera. 3D = (cameraZDistance * _zoomFactor), 2D = (cameraScale * _zoomFactor)
+    float _zoomFactor = 1.0F; // The zoom factor of the camera. 3D = (cameraZDistance * _zoomFactor), 2D = (cameraScale * _zoomFactor)
     float _zoomFactorFarPlane;
     float _zoomFactorNearPlane;
 


### PR DESCRIPTION
## Describe your changes
when changing the size of the game windows the camera's zoom resets to 1, the game code that sets the size of the camera has to be set again to mitigate this, this pr fixes this issue.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [x] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [x] An improved cpp-test/lua-test is not needed (explain why not, thanks).
    it's a core feature that presumably doesn't need to have a test
