### PR TITLE
Fix for UIEditBox password on Mac/iOS (Montery+/15+).

### DIFF
--- a/core/ui/UIEditBox/Mac/CCUIPasswordTextField.h
+++ b/core/ui/UIEditBox/Mac/CCUIPasswordTextField.h
@@ -27,7 +27,7 @@
 #import <AppKit/AppKit.h>
 #include "ui/UIEditBox/Mac/CCUITextInput.h"
 
-@interface CCUIPasswordTextField : NSTextField <CCUITextInput> {
+@interface CCUIPasswordTextField : NSSecureTextField <CCUITextInput> {
 }
 
 @end

--- a/core/ui/UIEditBox/Mac/CCUIPasswordTextField.m
+++ b/core/ui/UIEditBox/Mac/CCUIPasswordTextField.m
@@ -123,7 +123,9 @@
 
 +(void)load
 {
-    [self setCellClass:[RSVerticallyCenteredSecureTextFieldCell class]];
+//    [self setCellClass:[RSVerticallyCenteredSecureTextFieldCell class]];
+    //Verwijderd na upgrade Xcode 13.1 (ios 15/monterey)
+
 }
 
 


### PR DESCRIPTION
Fix for UIEditBox password on Mac/iOS (Montery+/15+).

THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
Changed the delegate for CCUIPasswordTextField to NSSecureTextField (from NSTextField) to prevent crash on Mac/iOS

## Issue ticket number and link
994 
https://github.com/axmolengine/axmol/issues/994

## Checklist before requesting a review
-  [x ] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] An improved cpp-test/lua-test is not needed (explain why not, thanks).
