### PR TITLE
Update CCFileUtils-win32.cpp

### DIFF
--- a/core/platform/win32/CCFileUtils-win32.cpp
+++ b/core/platform/win32/CCFileUtils-win32.cpp
@@ -111,13 +111,14 @@ bool FileUtilsWin32::init()
     _checkWorkingPath();
     _checkExePath();
 
-    bool startedFromSelfLocation = s_workingDir == s_exeDir;
-    if (!startedFromSelfLocation || !isDirectoryExistInternal(AX_PC_RESOURCES_DIR))
-        _defaultResRootPath = s_workingDir;
-    else
+    // By default check "{s_exeDir}/Resources" if not exist fallback to s_workingDir
+    _defaultResRootPath.reserve(s_exeDir.size() + AX_PC_RESOURCES_DIR_LEN);
+    _defaultResRootPath.append(s_exeDir).append(AX_PC_RESOURCES_DIR, AX_PC_RESOURCES_DIR_LEN);
+    bool startedFromSelfLocation = true;
+    if (!isDirectoryExistInternal(_defaultResRootPath))
     {
-        _defaultResRootPath.reserve(s_exeDir.size() + AX_PC_RESOURCES_DIR_LEN);
-        _defaultResRootPath.append(s_exeDir).append(AX_PC_RESOURCES_DIR, AX_PC_RESOURCES_DIR_LEN);
+        startedFromSelfLocation = false;
+        _defaultResRootPath     = s_workingDir;
     }
 
     bool bRet = FileUtils::init();


### PR DESCRIPTION
THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes

By default check "{s_exeDir}/Resources" if not exist fallback to s_workingDir

Before that change "{s_exeDir}/Resources" was used only when application was started from exe dir (s_workingDir == s_exeDir)

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] An improved cpp-test/lua-test is not needed (explain why not, thanks).
