### PR TITLE
[BUG] fix _AX_HAVE_WEBVIEW2 compilation error when not defined.

### DIFF
--- a/core/ui/UIWebView/UIWebView-inl.h
+++ b/core/ui/UIWebView/UIWebView-inl.h
@@ -26,7 +26,7 @@
 
 /// @cond DO_NOT_SHOW
 
-#if defined(_AX_HAVE_WEBVIEW2)
+#if defined(_WIN32) && defined(_AX_HAVE_WEBVIEW2)
 
 #include "ui/UIWebView/UIWebView.h"
 #include "platform/CCGLView.h"

--- a/core/ui/UIWebView/UIWebView-inl.h
+++ b/core/ui/UIWebView/UIWebView-inl.h
@@ -26,6 +26,8 @@
 
 /// @cond DO_NOT_SHOW
 
+#if defined(_AX_HAVE_WEBVIEW2)
+
 #include "ui/UIWebView/UIWebView.h"
 #include "platform/CCGLView.h"
 #include "base/CCDirector.h"
@@ -236,5 +238,7 @@ WebView::ccWebViewCallback WebView::getOnJSCallback() const
 
 }  // namespace ui
 NS_AX_END  // namespace ax
+
+#endif
 
 /// @endcond

--- a/core/ui/UIWebView/UIWebView-inl.h
+++ b/core/ui/UIWebView/UIWebView-inl.h
@@ -26,7 +26,7 @@
 
 /// @cond DO_NOT_SHOW
 
-#if defined(_WIN32) && defined(_AX_HAVE_WEBVIEW2)
+#if (defined(_WIN32) && defined(_AX_HAVE_WEBVIEW2)) || (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID || AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
 
 #include "ui/UIWebView/UIWebView.h"
 #include "platform/CCGLView.h"

--- a/core/ui/UIWebView/UIWebView.h
+++ b/core/ui/UIWebView/UIWebView.h
@@ -29,7 +29,7 @@
 #include "ui/GUIExport.h"
 #include "base/CCData.h"
 
-#if defined(_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID || AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
+#if (defined(_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID || AX_TARGET_PLATFORM == AX_PLATFORM_IOS)) && defined(_AX_HAVE_WEBVIEW2)
 /**
  * @addtogroup ui
  * @{

--- a/core/ui/UIWebView/UIWebView.h
+++ b/core/ui/UIWebView/UIWebView.h
@@ -29,7 +29,7 @@
 #include "ui/GUIExport.h"
 #include "base/CCData.h"
 
-#if (defined(_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID || AX_TARGET_PLATFORM == AX_PLATFORM_IOS)) && defined(_AX_HAVE_WEBVIEW2)
+#if (defined(_WIN32) && defined(_AX_HAVE_WEBVIEW2)) || (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID || AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
 /**
  * @addtogroup ui
  * @{


### PR DESCRIPTION
## Describe your changes
when `_AX_HAVE_WEBVIEW2` is not defined the files `UIWebView-inl.h` and `UIWebView.h` get included no matter what and prevent the project from compiling because of the missing header file `WebView2.h`, this PR fixes the issue.

affected platforms: `WIN32`

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
