### PR TITLE
[BUG] Fix `positionColorLengthTexture.vert` shader compilation

### DIFF
--- a/core/renderer/shaders/positionColorLengthTexture.vert
+++ b/core/renderer/shaders/positionColorLengthTexture.vert
@@ -31,7 +31,7 @@ attribute mediump vec2 a_texCoord;
 attribute mediump vec4 a_color;
 
 varying mediump vec4 v_color;
-varying mediump vec2 v_texcoord;
+varying mediump vec2 v_texCoord;
 
 #else
 
@@ -40,7 +40,7 @@ attribute vec2 a_texCoord;
 attribute vec4 a_color;
 
 varying vec4 v_color;
-varying vec2 v_texcoord;
+varying vec2 v_texCoord;
 
 #endif
 


### PR DESCRIPTION
## Describe your changes
fix shader `positionColorLengthTexture.vert` compilation error.

This PR fixes:
`cocos2d: ERROR: Failed to compile shader, detail: ERROR: 0:35: 'v_texCoord' : undeclared identifier`

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
