### PR TITLE
Resize on Windows

### DIFF
--- a/core/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/core/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -1056,8 +1056,11 @@ void GLViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
 {
     if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
     {
+         /* Invoke `GLView::setFrameSize` to sync screen size immediately,
+            this->setFrameSize will invoke `glfwSetWindowSize` which is unnecessary.
+         */
+         GLView::setFrameSize(w, h);
 
-        setFrameSize(w, h);
         /*
          x-studio spec, fix view size incorrect when window size changed.
          The original code behavior:
@@ -1066,7 +1069,8 @@ void GLViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
            1). w,h=976,679
            2). w,h=1024,768
 
-         @remark: we should use glfwSetWindowMonitor to control the window size in full screen mode
+         @remark:
+         1. we should use glfwSetWindowMonitor to control the window size in full screen mode
          @see also: updateWindowSize (call after enter/exit full screen mode)
         */
         updateDesignResolutionSize();

--- a/core/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/core/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -1056,6 +1056,8 @@ void GLViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
 {
     if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
     {
+
+        setFrameSize(w, h);
         /*
          x-studio spec, fix view size incorrect when window size changed.
          The original code behavior:


### PR DESCRIPTION
Fixed resize on Windows

THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes

Added setFrameSize in onGLFWWindowSizeCallback. This fixes the issue with the Windows not being properly resizeable.

## Issue ticket number and link
1025
https://github.com/axmolengine/axmol/issues/1025

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
