### PR TITLE
Improved error handling in shader initialization

### DIFF
--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -49,7 +49,9 @@ ShaderModuleMTL::ShaderModuleMTL(id<MTLDevice> mtlDevice, ShaderStage stage, std
     {
         NSLog(@"Can not get metal shader:");
         NSLog(@"%s", source.data());
+        NSLog(@"%s", glslopt_get_log(glslShader));
         glslopt_cleanup(ctx);
+        assert(false);
         return;
     }
 
@@ -68,8 +70,10 @@ ShaderModuleMTL::ShaderModuleMTL(id<MTLDevice> mtlDevice, ShaderStage stage, std
     {
         NSLog(@"Can not compile metal shader: %@", error);
         NSLog(@"%s", metalShader);
+        NSLog(@"%s", glslopt_get_log(glslShader));
         glslopt_shader_delete(glslShader);
         glslopt_cleanup(ctx);
+        assert(false);
         return;
     }
 
@@ -81,6 +85,7 @@ ShaderModuleMTL::ShaderModuleMTL(id<MTLDevice> mtlDevice, ShaderStage stage, std
     {
         NSLog(@"metal shader is ---------------");
         NSLog(@"%s", metalShader);
+        NSLog(@"%s", glslopt_get_log(glslShader));
         assert(false);
     }
 


### PR DESCRIPTION
## Describe your changes

Incorrect shader code isn't reported with helpful error message, the application is not terminated and might crash later with a heap corruption. With this change an error message is printed and execution is stopped. Example:

```
(24,26): error: `CC_Texture0' undeclared
(24,16): error: no matching function for call to `texture2D(error, vec2)'; candidates are:
(24,16): error:    vec4 texture2D(sampler2D, vec2)
(24,16): error:    vec4 texture2D(sampler2D, vec2, float)
Assertion failed: (false), function ShaderModuleMTL, file ShaderModuleMTL.mm, line 54.
````

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
