### PR TITLE
[BUG] TileMap OpenGL pixel-tolerance fix

### DIFF
--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -594,7 +594,7 @@ void FastTMXLayer::updateTotalQuads()
                 bottom           = (tileTexture.origin.y / texSize.height);
                 top              = bottom + (tileTexture.size.height / texSize.height);
 
-                // issue# OpenGL sub-pixel horizontal-vertical lines pixel-talorance fix.
+                // issue#1085 OpenGL sub-pixel horizontal-vertical lines pixel-tolerance fix.
                 float pt = FLT_EPSILON;
 
                 quad.bl.texCoords.u = left + pt;

--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -594,14 +594,17 @@ void FastTMXLayer::updateTotalQuads()
                 bottom           = (tileTexture.origin.y / texSize.height);
                 top              = bottom + (tileTexture.size.height / texSize.height);
 
-                quad.bl.texCoords.u = left;
-                quad.bl.texCoords.v = bottom;
-                quad.br.texCoords.u = right;
-                quad.br.texCoords.v = bottom;
-                quad.tl.texCoords.u = left;
-                quad.tl.texCoords.v = top;
-                quad.tr.texCoords.u = right;
-                quad.tr.texCoords.v = top;
+                // issue# OpenGL sub-pixel horizontal-vertical lines pixel-talorance fix.
+                float pt = FLT_EPSILON;
+
+                quad.bl.texCoords.u = left + pt;
+                quad.bl.texCoords.v = bottom + pt;
+                quad.br.texCoords.u = right - pt;
+                quad.br.texCoords.v = bottom + pt;
+                quad.tl.texCoords.u = left + pt;
+                quad.tl.texCoords.v = top - pt;
+                quad.tr.texCoords.u = right - pt;
+                quad.tr.texCoords.v = top - pt;
 
                 quad.bl.colors = color;
                 quad.br.colors = color;

--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -596,7 +596,7 @@ void FastTMXLayer::updateTotalQuads()
 
                 // issue#1085 OpenGL sub-pixel horizontal-vertical lines pixel-tolerance fix.
                 float ptx = 1.0 / (_layerSize.x * tileSize.x);
-                float pty = 1.0 / (_layerSize.y * tileSize.x);
+                float pty = 1.0 / (_layerSize.y * tileSize.y);
 
                 quad.bl.texCoords.u = left + ptx;
                 quad.bl.texCoords.v = bottom + pty;

--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -595,8 +595,8 @@ void FastTMXLayer::updateTotalQuads()
                 top              = bottom + (tileTexture.size.height / texSize.height);
 
                 // issue#1085 OpenGL sub-pixel horizontal-vertical lines pixel-tolerance fix.
-                float ptx = 1.0 / (_layerSize.x * tileSize.x);
-                float pty = 1.0 / (_layerSize.y * tileSize.y);
+                float ptx = 1.0 / (_tileSet->_imageSize.x * tileSize.x);
+                float pty = 1.0 / (_tileSet->_imageSize.y * tileSize.y);
 
                 quad.bl.texCoords.u = left + ptx;
                 quad.bl.texCoords.v = bottom + pty;

--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -595,16 +595,17 @@ void FastTMXLayer::updateTotalQuads()
                 top              = bottom + (tileTexture.size.height / texSize.height);
 
                 // issue#1085 OpenGL sub-pixel horizontal-vertical lines pixel-tolerance fix.
-                float pt = FLT_EPSILON;
+                float ptx = 1.0 / (_layerSize.x * tileSize.x);
+                float pty = 1.0 / (_layerSize.y * tileSize.x);
 
-                quad.bl.texCoords.u = left + pt;
-                quad.bl.texCoords.v = bottom + pt;
-                quad.br.texCoords.u = right - pt;
-                quad.br.texCoords.v = bottom + pt;
-                quad.tl.texCoords.u = left + pt;
-                quad.tl.texCoords.v = top - pt;
-                quad.tr.texCoords.u = right - pt;
-                quad.tr.texCoords.v = top - pt;
+                quad.bl.texCoords.u = left + ptx;
+                quad.bl.texCoords.v = bottom + pty;
+                quad.br.texCoords.u = right - ptx;
+                quad.br.texCoords.v = bottom + pty;
+                quad.tl.texCoords.u = left + ptx;
+                quad.tl.texCoords.v = top - pty;
+                quad.tr.texCoords.u = right - ptx;
+                quad.tr.texCoords.v = top - pty;
 
                 quad.bl.colors = color;
                 quad.br.colors = color;


### PR DESCRIPTION
THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
This PR fixes a problem with TileMap rendering that causes irritating red lines to appear. i.e:

![image](https://user-images.githubusercontent.com/45469625/221569513-ed5fca74-663b-4eba-a9a5-a18ad159a9c2.png)

Notice how there are lines between the tiles in the image above? Sometimes these horizontal and vertical lines appear.

**Why does it happen?** This happens because we're performing sub-pixel rendering without using texture borders. This causes OpenGL to read/take a pixel from the texture that doesn't fall into the boundaries of the tex-coords for a given tile. In other words, when a sub-pixel is rendered on the boundary of the tile, OpenGL assumes that you'll want to retrieve a pixel on the boundary of your tex-coords. In texture atlases this can be a problem, since that one pixel can mess up your tile map -as seen above.

In this case with the vertical lines we're getting the color red because there are red pixels leaking from the atlas of the TileMap
![image](https://user-images.githubusercontent.com/45469625/221571223-2a3e3aaa-174a-433f-9526-8e16a3601f68.png)

`float pt = FLT_EPSILON;` shifts the tex-coords by `FLT_EPSILON` so that margin of error can be mitigated.

![image](https://user-images.githubusercontent.com/45469625/221570333-21d7dfe8-27de-47c5-a271-70fc22e9c7b9.png)

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
