### PR TITLE
Impore Metal Renderer Dirty Detection.

### DIFF
--- a/core/renderer/backend/RenderTarget.h
+++ b/core/renderer/backend/RenderTarget.h
@@ -38,7 +38,6 @@ public:
     TargetBufferFlags getTargetFlags() const { return _flags; }
     void setTargetFlags(TargetBufferFlags flags) { 
         _flags = flags; 
-        _dirty = true;
     }
 
     void setColorAttachment(ColorAttachment attachment)


### PR DESCRIPTION
THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
Remove setTargetFlags _dirty
CommandBufferMTL already checks whether the TargetFlags are the same, so there is no need to set dirty. This is done to increase performance.

## Issue ticket number and link
Fix issue #1094 

## Checklist before requesting a review
-  [ ] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
