### PR TITLE
[IMPROVEMENT] Fix tilemap camera move and zoom culling 

### DIFF
--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -146,8 +146,8 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
 
         rect.origin.x -= _tileSet->_tileSize.x;
         rect.origin.y -= _tileSet->_tileSize.y;
-        rect.size.x += s.x * zoom / 2;
-        rect.size.y += s.y * zoom / 2;
+        rect.size.x += s.x * (zoom / 2) / 2 + _tileSet->_tileSize.x * zoom;
+        rect.size.y += s.y * (zoom / 2) / 2 + _tileSet->_tileSize.y * zoom;
 
         Mat4 inv = transform;
         inv.inverse();

--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -132,13 +132,22 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
 {
     updateTotalQuads();
 
-    if (flags != 0 || _dirty || _quadsDirty)
+    auto cam = Camera::getVisitingCamera();
+    if (flags != 0 || _dirty || _quadsDirty || !_cameraPositionDirty.fuzzyEquals(cam->getPosition(), _tileSet->_tileSize.x) ||
+        _cameraZoomDirty != cam->getZoom())
     {
-        Vec2 s             = _director->getVisibleSize();
-        const Vec2& anchor = getAnchorPoint();
-        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * (anchor.x == 0.0f ? 0.5f : anchor.x),
-                         Camera::getVisitingCamera()->getPositionY() - s.height * (anchor.y == 0.0f ? 0.5f : anchor.y),
-                         s.width, s.height);
+        _cameraPositionDirty = cam->getPosition();
+        auto zoom            = _cameraZoomDirty = cam->getZoom();
+        Vec2 s               = _director->getVisibleSize();
+        const Vec2& anchor   = getAnchorPoint();
+        auto rect            = Rect(cam->getPositionX() - s.width * zoom * (anchor.x == 0.0f ? 0.5f : anchor.x),
+                                    cam->getPositionY() - s.height * zoom * (anchor.y == 0.0f ? 0.5f : anchor.y),
+                                    s.width * zoom, s.height * zoom);
+
+        rect.origin.x -= _tileSet->_tileSize.x;
+        rect.origin.y -= _tileSet->_tileSize.y;
+        rect.size.x += s.x * zoom / 2;
+        rect.size.y += s.y * zoom / 2;
 
         Mat4 inv = transform;
         inv.inverse();

--- a/core/2d/CCFastTMXLayer.h
+++ b/core/2d/CCFastTMXLayer.h
@@ -361,6 +361,9 @@ protected:
     Mat4 _tileToNodeTransform;
     /** data for rendering */
     bool _quadsDirty = true;
+    Vec2 _cameraPositionDirty = {INFINITY, INFINITE};
+    float _cameraZoomDirty;
+
     std::vector<int> _tileToQuadIndex;
     std::vector<V3F_C4B_T2F_Quad> _totalQuads;
 #ifdef AX_FAST_TILEMAP_32_BIT_INDICES

--- a/core/2d/CCFastTMXLayer.h
+++ b/core/2d/CCFastTMXLayer.h
@@ -361,7 +361,7 @@ protected:
     Mat4 _tileToNodeTransform;
     /** data for rendering */
     bool _quadsDirty = true;
-    Vec2 _cameraPositionDirty = {INFINITY, INFINITE};
+    Vec2 _cameraPositionDirty = {INFINITY, INFINITY};
     float _cameraZoomDirty;
 
     std::vector<int> _tileToQuadIndex;


### PR DESCRIPTION
## Describe your changes
Fix TileMap incorrect culling when camera is moved/zoomed, Before/After video:

https://user-images.githubusercontent.com/45469625/227595442-6181a214-7d90-44ea-a417-95e168a2e538.mp4

You'll notice that the culling is still working by looking at GL Verts count and seeing that when part of the TMX map is outside the camera it's actually being culled correctly.

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
