### PR TITLE
Fix: error C2360: initialization of 't' is skipped by 'case' label

### DIFF
--- a/templates/cpp-template-default/Source/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Source/HelloWorldScene.cpp
@@ -211,6 +211,7 @@ void HelloWorld::update(float delta)
         _gameState = ExampleGameState::update;
         break;
     }
+
     case ExampleGameState::update:
     {
         /////////////////////////////
@@ -222,6 +223,7 @@ void HelloWorld::update(float delta)
         // ...
         break;
     }
+
     case ExampleGameState::pause:
     {
         /////////////////////////////
@@ -232,7 +234,6 @@ void HelloWorld::update(float delta)
         break;
     }
 
-
     case ExampleGameState::menu1:
     {    /////////////////////////////
         // Add your codes below...like....
@@ -240,6 +241,7 @@ void HelloWorld::update(float delta)
         // UpdateMenu1();
         break;
     }
+
     case ExampleGameState::menu2:
     {    /////////////////////////////
         // Add your codes below...like....
@@ -247,6 +249,7 @@ void HelloWorld::update(float delta)
         // UpdateMenu2();
         break;
     }
+
     case ExampleGameState::end:
     {    /////////////////////////////
         // Add your codes below...like....
@@ -255,6 +258,7 @@ void HelloWorld::update(float delta)
         menuCloseCallback(this);
         break;
     }
+
     }
 }
 

--- a/templates/cpp-template-default/Source/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Source/HelloWorldScene.cpp
@@ -47,9 +47,9 @@ bool HelloWorld::init()
     }
 
     auto visibleSize = _director->getVisibleSize();
-    auto origin      = _director->getVisibleOrigin();
-    auto safeArea    = _director->getSafeAreaRect();
-    auto safeOrigin  = safeArea.origin;
+    auto origin = _director->getVisibleOrigin();
+    auto safeArea = _director->getSafeAreaRect();
+    auto safeOrigin = safeArea.origin;
 
     /////////////////////////////
     // 2. add a menu item with "X" image, which is clicked to quit the program
@@ -57,7 +57,7 @@ bool HelloWorld::init()
 
     // add a "close" icon to exit the progress. it's an autorelease object
     auto closeItem = MenuItemImage::create("CloseNormal.png", "CloseSelected.png",
-                                           AX_CALLBACK_1(HelloWorld::menuCloseCallback, this));
+        AX_CALLBACK_1(HelloWorld::menuCloseCallback, this));
 
     if (closeItem == nullptr || closeItem->getContentSize().width <= 0 || closeItem->getContentSize().height <= 0)
     {
@@ -79,7 +79,7 @@ bool HelloWorld::init()
     // 3. add your codes below...
 
     // Some templates (uncomment what you  need)
-    auto touchListener            = EventListenerTouchAllAtOnce::create();
+    auto touchListener = EventListenerTouchAllAtOnce::create();
     touchListener->onTouchesBegan = AX_CALLBACK_2(HelloWorld::onTouchesBegan, this);
     touchListener->onTouchesMoved = AX_CALLBACK_2(HelloWorld::onTouchesMoved, this);
     touchListener->onTouchesEnded = AX_CALLBACK_2(HelloWorld::onTouchesEnded, this);
@@ -134,13 +134,13 @@ bool HelloWorld::init()
         drawNode->setPosition(Vec2(0, 0));
         addChild(drawNode);
 
-        drawNode->drawRect(safeArea.origin + Vec2(1,1), safeArea.origin + safeArea.size, Color4F::BLUE);
+        drawNode->drawRect(safeArea.origin + Vec2(1, 1), safeArea.origin + safeArea.size, Color4F::BLUE);
     }
 
     // scheduleUpdate() is required to ensure update(float) is called on every loop
     scheduleUpdate();
 
-    return true; 
+    return true;
 }
 
 
@@ -259,7 +259,7 @@ void HelloWorld::update(float delta)
         break;
     }
 
-    }
+    } //switch
 }
 
 void HelloWorld::menuCloseCallback(Ref* sender)
@@ -271,6 +271,6 @@ void HelloWorld::menuCloseCallback(Ref* sender)
      * _director->end() as given above,instead trigger a custom event created in RootViewController.mm
      * as below*/
 
-    // EventCustom customEndEvent("game_scene_close_event");
-    //_eventDispatcher->dispatchEvent(&customEndEvent);
+     // EventCustom customEndEvent("game_scene_close_event");
+     //_eventDispatcher->dispatchEvent(&customEndEvent);
 }

--- a/templates/cpp-template-default/Source/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Source/HelloWorldScene.cpp
@@ -207,10 +207,12 @@ void HelloWorld::update(float delta)
     switch (_gameState)
     {
     case ExampleGameState::init:
+    {
         _gameState = ExampleGameState::update;
         break;
-
+    }
     case ExampleGameState::update:
+    {
         /////////////////////////////
         // Add your codes below...like....
         // 
@@ -219,35 +221,40 @@ void HelloWorld::update(float delta)
         // UpdatePhysics();
         // ...
         break;
-
+    }
     case ExampleGameState::pause:
+    {
         /////////////////////////////
         // Add your codes below...like....
         //
         // anyPauseStuff()
+
         break;
+    }
+
 
     case ExampleGameState::menu1:
-        /////////////////////////////
+    {    /////////////////////////////
         // Add your codes below...like....
         // 
         // UpdateMenu1();
         break;
-
+    }
     case ExampleGameState::menu2:
-        /////////////////////////////
+    {    /////////////////////////////
         // Add your codes below...like....
         // 
         // UpdateMenu2();
         break;
-
+    }
     case ExampleGameState::end:
-        /////////////////////////////
+    {    /////////////////////////////
         // Add your codes below...like....
         // 
         // CleanUpMyCrap();
         menuCloseCallback(this);
         break;
+    }
     }
 }
 


### PR DESCRIPTION
Situation:
```
case ExampleGameState::update:
        /////////////////////////////
        // Add your codes below...like....
        //
        // UpdateJoyStick();
        // UpdatePlayer();
        // UpdatePhysics();
        // ...
        int t = 10;
        break;
```

THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
add brakets on each `case <nn>:`
## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
