### PR TITLE
[BUG] Fix HSV/HSL reverse hue degrees

### DIFF
--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -440,7 +440,7 @@ void HSV::set(float r, float g, float b, float a)
 
 void HSV::get(float& r, float& g, float& b) const
 {
-    float hue = -(remainder(std::fabs(h), 360));
+    float hue = remainder(std::fabs(h), 360);
     hue += 360;
 
     float fC      = v * s;
@@ -686,13 +686,13 @@ float HSL::hue2rgb(float p, float q, float t)
 
 void HSL::get(float& r, float& g, float& b) const
 {
-    float hue = -(remainder(std::fabs(h), 360));
+    float hue = remainder(std::fabs(h), 360);
     hue += 360;
     hue /= 360.0F;
 
     if (0 == s)
     {
-        r = g = b = l;  // achromatic
+        r = g = b = l;
     }
     else
     {


### PR DESCRIPTION
## Describe your changes
HSV & HSL hue is reversed in degrees, A value of 90 degrees hue will be treated as 270 degrees hue which results in an incorrect color.

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
