### PR TITLE
[IMPROVMENT] Remove unnecessary float pass reference in HSV/HSL

### DIFF
--- a/core/base/ccTypes.cpp
+++ b/core/base/ccTypes.cpp
@@ -438,7 +438,7 @@ void HSV::set(float r, float g, float b, float a)
     this->a = a;
 }
 
-void HSV::get(float& r, float& g, float& b) const
+void HSV::get(float r, float g, float b) const
 {
     float hue = remainder(std::fabs(h), 360);
     hue += 360;
@@ -684,7 +684,7 @@ float HSL::hue2rgb(float p, float q, float t)
     return p;
 }
 
-void HSL::get(float& r, float& g, float& b) const
+void HSL::get(float r, float g, float b) const
 {
     float hue = remainder(std::fabs(h), 360);
     hue += 360;

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -197,7 +197,7 @@ struct AX_DLL HSV
     bool equals(const HSV& other) const { return (*this == other); }
 
     void set(float r, float g, float b, float a = 1.0F);
-    void get(float& r, float& g, float& b) const;
+    void get(float r, float g, float b) const;
 
     Color3B toColor3B();
     Color4B toColor4B();
@@ -246,7 +246,7 @@ struct AX_DLL HSL
     bool equals(const HSL& other) const { return (*this == other); }
 
     void set(float r, float g, float b, float a = 1.0F);
-    void get(float& r, float& g, float& b) const;
+    void get(float r, float g, float b) const;
 
     static float hue2rgb(float p, float q, float t);
 


### PR DESCRIPTION
## Describe your changes
It's not optimal to pass floats by reference since they're 32bits and doing so copies 64bits for the pointer instead of 32bits on 64bit systems.

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.