### PR TITLE
Update UnitTest.cpp

### DIFF
--- a/tests/cpp-tests/Source/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Source/UnitTest/UnitTest.cpp
@@ -1387,20 +1387,20 @@ void ParseUriTest::onEnter()
         EXPECT_EQ(u4.getHost(), "localhost");
         EXPECT_EQ(u4.getPort(), 8080);
         EXPECT_EQ(u4.getPath(), "/");
-        EXPECT_EQ(u4.getPathEtc(), "");
+        EXPECT_EQ(u4.getPathEtc(), "/");
 
         EXPECT_EQ(u5.getScheme(), "bb");
         EXPECT_EQ(u5.getHost(), "localhost");
         EXPECT_EQ(u5.getPort(), 0);
         EXPECT_EQ(u5.getPath(), "/");
-        EXPECT_EQ(u5.getPathEtc(), "?&foo=12:4&ccc=13");
+        EXPECT_EQ(u5.getPathEtc(), "/?&foo=12:4&ccc=13");
         EXPECT_EQ(u5.getQuery(), "&foo=12:4&ccc=13");
 
         EXPECT_EQ(u6.getScheme(), "cc");
         EXPECT_EQ(u6.getHost(), "localhost");
         EXPECT_EQ(u6.getPort(), 91);
         EXPECT_EQ(u6.getPath(), "/");
-        EXPECT_EQ(u6.getPathEtc(), "?&foo=321&bbb=1");
+        EXPECT_EQ(u6.getPathEtc(), "/?&foo=321&bbb=1");
         EXPECT_EQ(u6.getQuery(), "&foo=321&bbb=1");
     }
 }


### PR DESCRIPTION
For getPathEth() of u4, u5, u6, adding "/" is needed to pass the unit_test(uri::parse)

Viusal Studio 2022 Debug x64