### PR TITLE
Update ChipmunkTestBed.cpp

### DIFF
--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
@@ -309,7 +309,7 @@ ChipmunkTestBed::ChipmunkTestBed()
     // construct is ok see also: https://github.com/axmolengine/axmol/commit/581a7921554c09746616759d5a5ca6ce9d3eaa22
     auto director = Director::getInstance();
     auto glView   = director->getOpenGLView();
-    Size designSize(g_designSize.width * 0.85, g_designSize.height * 0.85);
+    Size designSize(960, 640);   // Shows all drawable objects (g_resourceSize(960, 640))
     glView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::SHOW_ALL);
 
     // creating a keyboard event listener


### PR DESCRIPTION
 ChipmunkTestBed design size fix:
 // Shows all drawable objects (g_resourceSize(960, 640))

THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
Shows all drawable objects 

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [x] I have added/adapted some tests too.
