### PR TITLE
Add 1 overload AudioEngine::play2d for time offset support

### DIFF
--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -174,6 +174,11 @@ bool AudioEngine::lazyInit()
 
 AUDIO_ID AudioEngine::play2d(std::string_view filePath, bool loop, float volume, const AudioProfile* profile)
 {
+    return play2d(filePath, ax::AudioPlayerSettings{loop, volume, 0.0f});
+}
+
+AUDIO_ID AudioEngine::play2d(std::string_view filePath, const AudioPlayerSettings& settings, const AudioProfile* profile)
+{
     AUDIO_ID ret = AudioEngine::INVALID_AUDIO_ID;
 
     do
@@ -226,6 +231,7 @@ AUDIO_ID AudioEngine::play2d(std::string_view filePath, bool loop, float volume,
             }
         }
 
+        float volume = settings.volume;
         if (volume < 0.0f)
         {
             volume = 0.0f;
@@ -235,7 +241,7 @@ AUDIO_ID AudioEngine::play2d(std::string_view filePath, bool loop, float volume,
             volume = 1.0f;
         }
 
-        ret = _audioEngineImpl->play2d(filePath, loop, volume);
+        ret = _audioEngineImpl->play2d(filePath, settings.loop, volume, settings.time);
         if (ret != INVALID_AUDIO_ID)
         {
             _audioPathIDMap[filePath.data()].emplace_back(ret);
@@ -243,7 +249,7 @@ AUDIO_ID AudioEngine::play2d(std::string_view filePath, bool loop, float volume,
 
             auto& audioRef    = _audioIDInfoMap[ret];
             audioRef.volume   = volume;
-            audioRef.loop     = loop;
+            audioRef.loop     = settings.loop;
             audioRef.filePath = it->first;
 
             if (profileHelper)

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2018 HALX99.
- Copyright (c) 2021 Bytedance Inc.
+ Copyright (c) 2021-2023 Bytedance Inc.
 
  https://axmolengine.github.io/
 
@@ -46,11 +46,17 @@
 
 NS_AX_BEGIN
 
+/**
+ * @struct AudioPlayerSettings
+ *
+ * @brief
+ * @js NA
+ */
 struct AX_DLL AudioPlayerSettings
 {
-    bool loop = false;
-    float volume = 1.0f;
-    float time = 0.0f;
+    bool loop = false; // Whether audio instance loop or not.
+    float volume = 1.0f; // Volume value (range from 0.0 to 1.0).
+    float time = 0.0f; // The initial time offset when play audio
 };
 
 /**
@@ -138,6 +144,16 @@ public:
                            float volume                = 1.0f,
                            const AudioProfile* profile = nullptr);
 
+     /**
+     * Play 2d sound.
+     *
+     * @param filePath The path of an audio file.
+     * @param settings The player settings for audio.
+     * @param profile A profile for audio instance. When profile is not specified, default profile will be used.
+     * @return An audio ID. It allows you to dynamically change the behavior of an audio instance on the fly.
+     *
+     * @see `AudioProfile`, `AudioPlayerSettings`
+     */
     static AUDIO_ID play2d(std::string_view filePath,
                            const AudioPlayerSettings& settings,
                            const AudioProfile* profile = nullptr);

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -46,6 +46,13 @@
 
 NS_AX_BEGIN
 
+struct AX_DLL AudioPlayerSettings
+{
+    bool loop = false;
+    float volume = 1.0f;
+    float time = 0.0f;
+};
+
 /**
  * @class AudioProfile
  *
@@ -131,6 +138,9 @@ public:
                            float volume                = 1.0f,
                            const AudioProfile* profile = nullptr);
 
+    static AUDIO_ID play2d(std::string_view filePath,
+                           const AudioPlayerSettings& settings,
+                           const AudioProfile* profile = nullptr);
     /**
      * Sets whether an audio instance loop or not.
      *

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -447,7 +447,7 @@ AudioCache* AudioEngineImpl::preload(std::string_view filePath, std::function<vo
     return audioCache;
 }
 
-AUDIO_ID AudioEngineImpl::play2d(std::string_view filePath, bool loop, float volume)
+AUDIO_ID AudioEngineImpl::play2d(std::string_view filePath, bool loop, float volume, float time)
 {
     if (s_ALDevice == nullptr)
     {
@@ -469,6 +469,11 @@ AUDIO_ID AudioEngineImpl::play2d(std::string_view filePath, bool loop, float vol
     player->_alSource = alSource;
     player->_loop     = loop;
     player->_volume   = volume;
+    if (time > 0.0f)
+    {
+        player->_currTime  = time;
+        player->_timeDirty = true;
+    }
 
     auto audioCache = preload(filePath, nullptr);
     if (audioCache == nullptr)

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -49,7 +49,7 @@ public:
     ~AudioEngineImpl();
 
     bool init();
-    AUDIO_ID play2d(std::string_view fileFullPath, bool loop, float volume);
+    AUDIO_ID play2d(std::string_view fileFullPath, bool loop, float volume, float time);
     void setVolume(AUDIO_ID audioID, float volume);
     void setLoop(AUDIO_ID audioID, bool loop);
     bool pause(AUDIO_ID audioID);

--- a/core/audio/AudioPlayer.cpp
+++ b/core/audio/AudioPlayer.cpp
@@ -263,6 +263,13 @@ bool AudioPlayer::play2d()
         // OpenAL framework: sometime when switch audio too fast, the result state will error, but there is no any
         // alError, so just skip for workaround.
         assert(state == AL_PLAYING);
+
+        if (!_streamingSource && _currTime >= 0.0f)
+        {
+            alSourcef(_alSource, AL_SEC_OFFSET, _currTime);
+            CHECK_AL_ERROR_DEBUG();
+        }
+
         _ready = true;
         ret    = true;
     } while (false);


### PR DESCRIPTION
Usage:

`AudioEngine::play2d("xxx/xxx.mp3", AudioPlayerSettings{false/*looping*/, 1.0f/*volume*/, 2.0f /*time offset in seconds*/})`;

THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
-  [ ] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
