### PR TITLE
Add support for haptic feedback on iOS and Android devices

### DIFF
--- a/core/platform/CCDevice.h
+++ b/core/platform/CCDevice.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2021-2023 Bytedance Inc.
 
 https://axmolengine.github.io/
 
@@ -61,6 +62,22 @@ public:
         TOP_LEFT     = 0x11, /** Horizontal left and vertical top. */
     };
 
+    /** Defines the impact haptic feedback style. */
+    enum ImpactFeedbackStyle
+    {
+        ImpactFeedbackStyleLight = 0,
+        ImpactFeedbackStyleMedium,
+        ImpactFeedbackStyleHeavy
+    };
+
+    /** Defines the notification haptic feedback style. */
+    enum NotificationFeedbackType
+    {
+        NotificationFeedbackTypeSuccess = 0,
+        NotificationFeedbackTypeWarning,
+        NotificationFeedbackTypeError
+    };
+
     /**
      *  Gets the DPI of device
      *  @return The DPI of device.
@@ -92,6 +109,45 @@ public:
      * @param duration The duration in seconds.
      */
     static void vibrate(float duration);
+
+    /**
+     * Prepare haptic feedback impact with selected style
+     * If haptic feedback is not supported, then invoking this method has no effect.
+     * @param style The style of the feedback.
+     */
+    static void prepareImpactFeedbackGenerator(ImpactFeedbackStyle style);
+
+    /**
+     * Generate haptic feedback impact with selected style
+     * If haptic feedback is not supported, then invoking this method has no effect.
+     */
+    static void impactOccurred(ImpactFeedbackStyle style);
+
+    /**
+     * Prepare haptic feedback notification
+     * If haptic feedback is not supported, then invoking this method has no effect.
+     * @param style The style of the feedback.
+     */
+    static void prepareNotificationFeedbackGenerator();
+
+    /**
+     * Generate haptic feedback notification with selected type
+     * If haptic feedback is not supported, then invoking this method has no effect.
+     */
+    static void notificationOccurred(NotificationFeedbackType type);
+
+    /**
+     * Prepare haptic feedback selection
+     * If haptic feedback is not supported, then invoking this method has no effect.
+     * @param style The style of the feedback.
+     */
+    static void prepareSelectionFeedbackGenerator();
+
+    /**
+     * Generate haptic feedback selection changed
+     * If haptic feedback is not supported, then invoking this method has no effect.
+     */
+    static void selectionChanged();
 
     /**
      * Gets texture data for text.

--- a/core/platform/android/CCDevice-android.cpp
+++ b/core/platform/android/CCDevice-android.cpp
@@ -2,7 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
-Copyright (c) 2021 Bytedance Inc.
+Copyright (c) 2021-2023 Bytedance Inc.
 
 https://axmolengine.github.io/
 
@@ -182,6 +182,27 @@ void Device::setKeepScreenOn(bool value)
 void Device::vibrate(float duration)
 {
     JniHelper::callStaticVoidMethod(helperClassName, "vibrate", duration);
+}
+
+void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style) {}
+
+void Device::impactOccurred(ImpactFeedbackStyle style)
+{
+    JniHelper::callStaticVoidMethod(helperClassName, "impactOccurred", (int)style);
+}
+
+void Device::prepareNotificationFeedbackGenerator() {}
+
+void Device::notificationOccurred(NotificationFeedbackType type)
+{
+    JniHelper::callStaticVoidMethod(helperClassName, "notificationOccurred", (int)type);
+}
+
+void Device::prepareSelectionFeedbackGenerator() {}
+
+void Device::selectionChanged()
+{
+    JniHelper::callStaticVoidMethod(helperClassName, "selectionChanged");
 }
 
 NS_AX_END

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -39,6 +39,7 @@ import android.os.Message;
 import android.os.PowerManager;
 import android.preference.PreferenceManager.OnActivityResultListener;
 import android.util.Log;
+import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -61,10 +62,10 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     // ===========================================================
     // Fields
     // ===========================================================
-    
+
     private AxmolGLSurfaceView mGLSurfaceView = null;
     private int[] mGLContextAttrs = null;
-    private AxmolHandler mHandler = null;   
+    private AxmolHandler mHandler = null;
     private static AxmolActivity sContext = null;
     private VideoHelper mVideoHelper = null;
     private WebViewHelper mWebViewHelper = null;
@@ -80,7 +81,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     public static Context getContext() {
         return sContext;
     }
-    
+
     public void setKeepScreenOn(boolean value) {
         final boolean newValue = value;
         runOnUiThread(new Runnable() {
@@ -89,6 +90,43 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
                 mGLSurfaceView.setKeepScreenOn(newValue);
             }
         });
+    }
+
+    public void impactOccurred(int style) {
+        int feedback = HapticFeedbackConstants.VIRTUAL_KEY;
+        performHapticFeedback(feedback);
+    }
+
+    public void notificationOccurred(int type) {
+        int feedback;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            switch (type) {
+                case 1:
+                case 2:
+                    feedback = HapticFeedbackConstants.REJECT;
+                    break;
+                default:
+                    feedback = HapticFeedbackConstants.CONFIRM;
+                    break;
+            }
+        } else {
+            feedback = HapticFeedbackConstants.VIRTUAL_KEY;
+        }
+        performHapticFeedback(feedback);
+    }
+
+    public void selectionChanged() {
+        int feedback;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            feedback = HapticFeedbackConstants.CLOCK_TICK;
+        } else {
+            feedback = HapticFeedbackConstants.VIRTUAL_KEY;
+        }
+        performHapticFeedback(feedback);
+    }
+
+    protected void performHapticFeedback(int feedback) {
+        getWindow().getDecorView().performHapticFeedback(feedback);
     }
 
     public void setEnableVirtualButton(boolean value) {
@@ -105,7 +143,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
             e.printStackTrace();
         }
     }
-    
+
     // ===========================================================
     // Constructors
     // ===========================================================
@@ -130,16 +168,16 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
         sContext = this;
         this.mHandler = new AxmolHandler(this);
-        
+
         AxmolEngine.init(this);
-        
+
         this.mGLContextAttrs = getGLContextAttrs();
         this.init();
 
         if (mVideoHelper == null) {
             mVideoHelper = new VideoHelper(this, mFrameLayout);
         }
-        
+
         if(mWebViewHelper == null){
             mWebViewHelper = new WebViewHelper(mFrameLayout);
         }
@@ -175,12 +213,12 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
             resume();
         }
     }
-    
+
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
     	Log.d(TAG, "onWindowFocusChanged() hasFocus=" + hasFocus);
         super.onWindowFocusChanged(hasFocus);
-        
+
         this.hasFocus = hasFocus;
         if (this.hasFocus && !paused) {
             resume();
@@ -192,7 +230,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
         AxmolEngine.onResume();
         mGLSurfaceView.onResume();
     }
-    
+
     private void resumeIfHasFocus() {
         //It is possible for the app to receive the onWindowsFocusChanged(true) event
         //even though it is locked or asleep
@@ -211,7 +249,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
         AxmolEngine.onPause();
         mGLSurfaceView.onPause();
     }
-    
+
     @Override
     protected void onDestroy() {
         super.onDestroy();
@@ -229,7 +267,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     public void runOnGLThread(final Runnable runnable) {
         AxmolEngine.runOnGLThread(runnable);
     }
-    
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data)
     {
@@ -246,7 +284,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     // Methods
     // ===========================================================
     public void init() {
-        
+
         // FrameLayout
         ViewGroup.LayoutParams framelayout_params =
             new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
@@ -285,7 +323,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
         setContentView(mFrameLayout);
     }
 
-    
+
     public AxmolGLSurfaceView onCreateView() {
         AxmolGLSurfaceView glSurfaceView = new AxmolGLSurfaceView(this);
         //this line is need on some device if we specify an alpha bits
@@ -364,7 +402,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
             return !powerManager.isScreenOn();
         }
     }
-    
+
     // ===========================================================
     // Inner and Anonymous Classes
     // ===========================================================

--- a/core/platform/android/java/src/org/axmol/lib/AxmolEngine.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolEngine.java
@@ -50,7 +50,6 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
 import android.view.DisplayCutout;
-import android.view.HapticFeedbackConstants;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.ViewConfiguration;

--- a/core/platform/android/java/src/org/axmol/lib/AxmolEngine.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolEngine.java
@@ -50,6 +50,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
 import android.view.DisplayCutout;
+import android.view.HapticFeedbackConstants;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.ViewConfiguration;
@@ -286,6 +287,18 @@ public class AxmolEngine {
 
     public static void vibrate(float duration) {
         sVibrateService.vibrate((long)(duration * 1000));
+    }
+
+    public static void impactOccurred(int style) {
+        ((AxmolActivity)sActivity).impactOccurred(style);
+    }
+
+    public static void notificationOccurred(int type) {
+        ((AxmolActivity)sActivity).notificationOccurred(type);
+    }
+
+    public static void selectionChanged() {
+        ((AxmolActivity)sActivity).selectionChanged();
     }
 
  	public static String getVersion() {

--- a/core/platform/ios/CCDevice-ios.mm
+++ b/core/platform/ios/CCDevice-ios.mm
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2021-2023 Bytedance Inc.
 
  https://axmolengine.github.io/
 
@@ -42,6 +43,10 @@
 #import <AudioToolbox/AudioToolbox.h>
 
 const float MAX_MEASURE_HEIGHT = 10000;
+
+static UIImpactFeedbackGenerator *impactFeedbackGenerator[3];
+static UINotificationFeedbackGenerator *notificationFeedbackGenerator;
+static UISelectionFeedbackGenerator *selectionFeedbackGenerator;
 
 static NSAttributedString* __attributedStringWithFontSize(NSMutableAttributedString* attributedString, CGFloat fontSize)
 {
@@ -657,6 +662,82 @@ void Device::vibrate(float duration)
         // play the less annoying tick noise or one of your own
         AudioServicesPlayAlertSound(kSystemSoundID_Vibrate);
     }
+}
+
+void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style)
+{
+    if (impactFeedbackGenerator[style] == nullptr) {
+        UIImpactFeedbackStyle impactStyle;
+        switch (style) {
+            case ImpactFeedbackStyleLight:
+                impactStyle = UIImpactFeedbackStyleLight;
+                break;
+            case ImpactFeedbackStyleMedium:
+                impactStyle = UIImpactFeedbackStyleMedium;
+                break;
+            case ImpactFeedbackStyleHeavy:
+                impactStyle = UIImpactFeedbackStyleHeavy;
+                break;
+        }
+
+        impactFeedbackGenerator[style] = [[UIImpactFeedbackGenerator alloc] initWithStyle:impactStyle];
+    }
+    [impactFeedbackGenerator[style] prepare];
+}
+
+void Device::impactOccurred(ImpactFeedbackStyle style)
+{
+    if (impactFeedbackGenerator[style] == nullptr) {
+        prepareImpactFeedbackGenerator(style);
+    }
+    [impactFeedbackGenerator[style] impactOccurred];
+}
+
+void Device::prepareNotificationFeedbackGenerator()
+{
+    if (notificationFeedbackGenerator == nullptr) {
+        notificationFeedbackGenerator = [[UINotificationFeedbackGenerator alloc] init];
+    }
+    [notificationFeedbackGenerator prepare];
+}
+
+void Device::notificationOccurred(NotificationFeedbackType type)
+{
+    if (notificationFeedbackGenerator == nullptr) {
+        prepareNotificationFeedbackGenerator();
+    }
+
+    UINotificationFeedbackType notificationType;
+    switch (type) {
+        case NotificationFeedbackTypeError:
+            notificationType = UINotificationFeedbackTypeError;
+            break;
+        case NotificationFeedbackTypeSuccess:
+            notificationType = UINotificationFeedbackTypeSuccess;
+            break;
+        case NotificationFeedbackTypeWarning:
+            notificationType = UINotificationFeedbackTypeWarning;
+            break;
+    }
+
+    [notificationFeedbackGenerator notificationOccurred:notificationType];
+}
+
+void Device::prepareSelectionFeedbackGenerator()
+{
+    if (selectionFeedbackGenerator == nullptr) {
+        selectionFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
+    }
+    [selectionFeedbackGenerator prepare];
+}
+
+void Device::selectionChanged()
+{
+    if (selectionFeedbackGenerator == nullptr) {
+        prepareSelectionFeedbackGenerator();
+    }
+    [selectionFeedbackGenerator selectionChanged];
+    [selectionFeedbackGenerator prepare];
 }
 
 NS_AX_END

--- a/core/platform/ios/CCDevice-ios.mm
+++ b/core/platform/ios/CCDevice-ios.mm
@@ -44,9 +44,11 @@
 
 const float MAX_MEASURE_HEIGHT = 10000;
 
+#if !defined(AX_TARGET_OS_TVOS)
 static UIImpactFeedbackGenerator *impactFeedbackGenerator[3];
 static UINotificationFeedbackGenerator *notificationFeedbackGenerator;
 static UISelectionFeedbackGenerator *selectionFeedbackGenerator;
+#endif
 
 static NSAttributedString* __attributedStringWithFontSize(NSMutableAttributedString* attributedString, CGFloat fontSize)
 {
@@ -666,6 +668,7 @@ void Device::vibrate(float duration)
 
 void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style)
 {
+#if !defined(AX_TARGET_OS_TVOS)
     if (impactFeedbackGenerator[style] == nullptr) {
         UIImpactFeedbackStyle impactStyle;
         switch (style) {
@@ -683,26 +686,32 @@ void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style)
         impactFeedbackGenerator[style] = [[UIImpactFeedbackGenerator alloc] initWithStyle:impactStyle];
     }
     [impactFeedbackGenerator[style] prepare];
+#endif
 }
 
 void Device::impactOccurred(ImpactFeedbackStyle style)
 {
+#if !defined(AX_TARGET_OS_TVOS)
     if (impactFeedbackGenerator[style] == nullptr) {
         prepareImpactFeedbackGenerator(style);
     }
     [impactFeedbackGenerator[style] impactOccurred];
+#endif
 }
 
 void Device::prepareNotificationFeedbackGenerator()
 {
+#if !defined(AX_TARGET_OS_TVOS)
     if (notificationFeedbackGenerator == nullptr) {
         notificationFeedbackGenerator = [[UINotificationFeedbackGenerator alloc] init];
     }
     [notificationFeedbackGenerator prepare];
+#endif
 }
 
 void Device::notificationOccurred(NotificationFeedbackType type)
 {
+#if !defined(AX_TARGET_OS_TVOS)
     if (notificationFeedbackGenerator == nullptr) {
         prepareNotificationFeedbackGenerator();
     }
@@ -721,23 +730,28 @@ void Device::notificationOccurred(NotificationFeedbackType type)
     }
 
     [notificationFeedbackGenerator notificationOccurred:notificationType];
+#endif
 }
 
 void Device::prepareSelectionFeedbackGenerator()
 {
+#if !defined(AX_TARGET_OS_TVOS)
     if (selectionFeedbackGenerator == nullptr) {
         selectionFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
     }
     [selectionFeedbackGenerator prepare];
+#endif
 }
 
 void Device::selectionChanged()
 {
+#if !defined(AX_TARGET_OS_TVOS)
     if (selectionFeedbackGenerator == nullptr) {
         prepareSelectionFeedbackGenerator();
     }
     [selectionFeedbackGenerator selectionChanged];
     [selectionFeedbackGenerator prepare];
+#endif
 }
 
 NS_AX_END

--- a/core/platform/linux/CCDevice-linux.cpp
+++ b/core/platform/linux/CCDevice-linux.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Laschweinski
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2021-2023 Bytedance Inc.
 
 https://axmolengine.github.io/
 
@@ -573,5 +574,17 @@ Data Device::getTextureDataForText(std::string_view text,
 void Device::setKeepScreenOn(bool /*value*/) {}
 
 void Device::vibrate(float /*duration*/) {}
+
+void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle /*style*/) {}
+
+void Device::impactOccurred(ImpactFeedbackStyle /*style*/) {}
+
+void Device::prepareNotificationFeedbackGenerator() {}
+
+void Device::notificationOccurred(NotificationFeedbackType /*type*/) {}
+
+void Device::prepareSelectionFeedbackGenerator() {}
+
+void Device::selectionChanged() {}
 
 NS_AX_END

--- a/core/platform/mac/CCDevice-mac.mm
+++ b/core/platform/mac/CCDevice-mac.mm
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2021-2023 Bytedance Inc.
 
 https://axmolengine.github.io/
 
@@ -431,5 +432,17 @@ Data Device::getTextureDataForText(std::string_view text,
 void Device::setKeepScreenOn(bool value) {}
 
 void Device::vibrate(float duration) {}
+
+void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style) {}
+
+void Device::impactOccurred(ImpactFeedbackStyle style) {}
+
+void Device::prepareNotificationFeedbackGenerator() {}
+
+void Device::notificationOccurred(NotificationFeedbackType type) {}
+
+void Device::prepareSelectionFeedbackGenerator() {}
+
+void Device::selectionChanged() {}
 
 NS_AX_END

--- a/core/platform/win32/CCDevice-win32.cpp
+++ b/core/platform/win32/CCDevice-win32.cpp
@@ -2,7 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
-Copyright (c) 2021 Bytedance Inc.
+Copyright (c) 2021-2023 Bytedance Inc.
 
 https://axmolengine.github.io/
 
@@ -480,5 +480,26 @@ void Device::vibrate(float duration)
 {
     AX_UNUSED_PARAM(duration);
 }
+
+void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style)
+{
+    AX_UNUSED_PARAM(style);
+}
+
+void Device::impactOccurred(ImpactFeedbackStyle style)
+{
+    AX_UNUSED_PARAM(style);
+}
+
+void Device::prepareNotificationFeedbackGenerator() {}
+
+void Device::notificationOccurred(NotificationFeedbackType type)
+{
+    AX_UNUSED_PARAM(type);
+}
+
+void Device::prepareSelectionFeedbackGenerator() {}
+
+void Device::selectionChanged() {}
 
 NS_AX_END

--- a/core/platform/winrt/CCDevice-winrt.cpp
+++ b/core/platform/winrt/CCDevice-winrt.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2021-2023 Bytedance Inc.
 
 https://axmolengine.github.io/
 
@@ -568,6 +569,18 @@ void Device::vibrate(float duration)
     testVibrationDevice->Vibrate(timespan);
 #    endif  // (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
 }
+
+void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle /*style*/) {}
+
+void Device::impactOccurred(ImpactFeedbackStyle /*style*/) {}
+
+void Device::prepareNotificationFeedbackGenerator() {}
+
+void Device::notificationOccurred(NotificationFeedbackType /*type*/) {}
+
+void Device::prepareSelectionFeedbackGenerator() {}
+
+void Device::selectionChanged() {}
 
 NS_AX_END
 


### PR DESCRIPTION
These changes add the ability for games to use haptic feedback engines on iOS and Android.

They can be used as shown below:
```
Device::notificationOccurred(Device::NotificationFeedbackTypeError);
Device::impactOccurred(Device::ImpactFeedbackStyleLight);
Device::selectionChanged();
```