### PR TITLE
Add missing include guard in NinePatchImageParser.h

### DIFF
--- a/core/base/NinePatchImageParser.h
+++ b/core/base/NinePatchImageParser.h
@@ -22,6 +22,8 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 ****************************************************************************/
+#pragma once
+
 #include "platform/PlatformMacros.h"
 #include "math/Math.h"
 


### PR DESCRIPTION
Hello, NinePatchImageParser.h was missing an include guard. This PR adds one :)