### PR TITLE
Fix missing return value in EditBoxImplLinux::getNativeDefaultFontNam…

### DIFF
--- a/core/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -69,7 +69,7 @@ public:
     virtual void setNativePlaceHolder(const char* pText) override{};
     virtual void setNativeVisible(bool visible) override{};
     virtual void updateNativeFrame(const Rect& rect) override{};
-    virtual const char* getNativeDefaultFontName() override{};
+    virtual const char* getNativeDefaultFontName() override{ return ""; };
     virtual void nativeOpenKeyboard() override;
     virtual void nativeCloseKeyboard() override{};
     virtual void setNativeMaxLength(int maxLength) override{};


### PR DESCRIPTION
 `const char* EditBoxImplLinux::getNativeDefaultFontName()` should return a value but did not. This PR modifies its implementation to return an empty string.