### PR TITLE
Allow unity builds on a subset of the sources.

### DIFF
--- a/core/2d/AutoPolygon.cpp
+++ b/core/2d/AutoPolygon.cpp
@@ -37,8 +37,6 @@ THE SOFTWARE.
 #include <algorithm>
 #include <math.h>
 
-USING_NS_AX;
-
 static unsigned short quadIndices9[] = {
     0 + 4 * 0, 1 + 4 * 0, 2 + 4 * 0, 3 + 4 * 0, 2 + 4 * 0, 1 + 4 * 0, 0 + 4 * 1, 1 + 4 * 1, 2 + 4 * 1,
     3 + 4 * 1, 2 + 4 * 1, 1 + 4 * 1, 0 + 4 * 2, 1 + 4 * 2, 2 + 4 * 2, 3 + 4 * 2, 2 + 4 * 2, 1 + 4 * 2,
@@ -49,6 +47,8 @@ static unsigned short quadIndices9[] = {
 };
 
 const static float PRECISION = 10.0f;
+
+NS_AX_BEGIN
 
 PolygonInfo::PolygonInfo() : _isVertsOwner(true), _rect(Rect::ZERO), _filename("")
 {
@@ -609,7 +609,7 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
     cdt.Triangulate();
     std::vector<p2t::Triangle*> tris = cdt.GetTriangles();
 
-    axstd::pod_vector<unsigned short> indices(tris.size() * 3); 
+    axstd::pod_vector<unsigned short> indices(tris.size() * 3);
     axstd::pod_vector<V3F_C4B_T2F> verts;
     verts.reserve(indices.size() / 2);  // we won't know the size of verts until we process all of the triangles!
 
@@ -728,3 +728,5 @@ PolygonInfo AutoPolygon::generatePolygon(std::string_view filename, const Rect& 
     AutoPolygon ap(filename);
     return ap.generateTriangles(rect, epsilon, threshold);
 }
+
+NS_AX_END

--- a/core/audio/AudioCache.cpp
+++ b/core/audio/AudioCache.cpp
@@ -56,7 +56,7 @@ unsigned int __idIndex = 0;
 #define INVALID_AL_BUFFER_ID 0xFFFFFFFF
 #define PCMDATA_CACHEMAXSIZE 1048576
 
-USING_NS_AX;
+NS_AX_BEGIN
 
 AudioCache::AudioCache()
     : _totalFrames(0)
@@ -424,3 +424,5 @@ void AudioCache::invokingLoadCallbacks()
         _loadCallbacks.clear();
     });
 }
+NS_AX_END
+#undef LOG_TAG

--- a/core/audio/AudioDecoder.cpp
+++ b/core/audio/AudioDecoder.cpp
@@ -102,3 +102,5 @@ AUDIO_SOURCE_FORMAT AudioDecoder::getSourceFormat() const
     return _sourceFormat;
 }
 NS_AX_END  // namespace ax
+
+#undef LOG_TAG

--- a/core/audio/AudioDecoderManager.cpp
+++ b/core/audio/AudioDecoderManager.cpp
@@ -92,3 +92,5 @@ void AudioDecoderManager::destroyDecoder(AudioDecoder* decoder)
 }
 
 NS_AX_END  // namespace ax
+
+#undef LOG_TAG

--- a/core/audio/AudioDecoderMp3.cpp
+++ b/core/audio/AudioDecoderMp3.cpp
@@ -299,3 +299,5 @@ bool AudioDecoderMp3::seek(uint32_t frameOffset)
 #endif
 }
 NS_AX_END  // namespace ax
+
+#undef LOG_TAG

--- a/core/audio/AudioDecoderOgg.cpp
+++ b/core/audio/AudioDecoderOgg.cpp
@@ -116,3 +116,5 @@ bool AudioDecoderOgg::seek(uint32_t frameOffset)
     return 0 == ov_pcm_seek(&_vf, frameOffset);
 }
 NS_AX_END  // namespace ax
+
+#undef LOG_TAG

--- a/core/audio/AudioDecoderWav.cpp
+++ b/core/audio/AudioDecoderWav.cpp
@@ -259,3 +259,6 @@ bool AudioDecoderWav::seek(uint32_t frameOffset)
     return wav_seek(&_wavf, offset) == offset;
 }
 NS_AX_END  // namespace ax
+
+#undef LOG_TAG
+

--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -41,7 +41,7 @@
 #    undef ERROR
 #endif  // ERROR
 
-USING_NS_AX;
+NS_AX_BEGIN
 
 const int AudioEngine::INVALID_AUDIO_ID = -1;
 const float AudioEngine::TIME_UNKNOWN   = -1.0f;
@@ -615,3 +615,5 @@ bool AudioEngine::isEnabled()
 {
     return _isEnabled;
 }
+NS_AX_END
+#undef LOG_TAG

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -49,11 +49,9 @@
 #    import <UIKit/UIKit.h>
 #endif
 
-USING_NS_AX;
-
 static ALCdevice* s_ALDevice       = nullptr;
 static ALCcontext* s_ALContext     = nullptr;
-static AudioEngineImpl* s_instance = nullptr;
+static ax::AudioEngineImpl* s_instance = nullptr;
 
 static void ccALPauseDevice()
 {
@@ -169,10 +167,10 @@ static void ccALResumeDevice()
                 NSError* error = nil;
                 [[AVAudioSession sharedInstance] setActive:YES error:&error];
                 ccALResumeDevice();
-                if (Director::getInstance()->isPaused())
+                if (ax::Director::getInstance()->isPaused())
                 {
                     ALOGD("AVAudioSessionInterruptionTypeEnded, director was paused, try to resume it.");
-                    Director::getInstance()->resume();
+                    ax::Director::getInstance()->resume();
                 }
             }
             else
@@ -246,7 +244,7 @@ static id s_AudioEngineSessionHandler = nullptr;
 #    endif
 static void alcReopenDeviceOnAxmolThread()
 {
-    Director::getInstance()->queueOperation([](void*) {
+  ax::Director::getInstance()->queueOperation([](void*) {
         auto alcReopenDeviceSOFTProc =
             (decltype(alcReopenDeviceSOFT)*)alcGetProcAddress(s_ALDevice, "alcReopenDeviceSOFT");
         if (alcReopenDeviceSOFTProc)
@@ -305,7 +303,7 @@ static ALenum alSourceAddNotificationExt(ALuint sid,
     return AL_INVALID_VALUE;
 }
 
-ALvoid AudioEngineImpl::myAlSourceNotificationCallback(ALuint sid, ALuint notificationID, ALvoid* userData)
+ALvoid ax::AudioEngineImpl::myAlSourceNotificationCallback(ALuint sid, ALuint notificationID, ALvoid* userData)
 {
     // Currently, we only care about AL_BUFFERS_PROCESSED event
     if (notificationID != AL_BUFFERS_PROCESSED)
@@ -324,6 +322,8 @@ ALvoid AudioEngineImpl::myAlSourceNotificationCallback(ALuint sid, ALuint notifi
     s_instance->_threadMutex.unlock();
 }
 #endif
+
+NS_AX_BEGIN
 
 AudioEngineImpl::AudioEngineImpl() : _scheduled(false), _currentAudioID(0), _scheduler(nullptr)
 {
@@ -969,3 +969,5 @@ void AudioEngineImpl::uncacheAll()
 
     _audioCaches.clear();
 }
+NS_AX_END
+#undef LOG_TAG

--- a/core/audio/AudioMacros.h
+++ b/core/audio/AudioMacros.h
@@ -41,7 +41,7 @@
 // is needed. Define the following macros (ALOGV, ALOGD, ALOGI, ALOGW, ALOGE) for threadsafe log output.
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
 #    include "base/UTF8.h"  // for StringUtils::format
-#    define AUDIO_LOG(fmt, ...) OutputDebugStringA(StringUtils::format((fmt "\r\n"), ##__VA_ARGS__).c_str())
+#    define AUDIO_LOG(fmt, ...) OutputDebugStringA(ax::StringUtils::format((fmt "\r\n"), ##__VA_ARGS__).c_str())
 #elif AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
 #    include <android/log.h>
 #    define AUDIO_LOG(fmt, ...) __android_log_print(ANDROID_LOG_DEBUG, "AudioEngine", fmt, ##__VA_ARGS__)

--- a/core/audio/AudioPlayer.cpp
+++ b/core/audio/AudioPlayer.cpp
@@ -43,11 +43,11 @@
         } while (false)
 #endif
 
-USING_NS_AX;
+NS_AX_BEGIN
 
 namespace
 {
-unsigned int __idIndex = 0;
+unsigned int __playerIdIndex = 0;
 }
 
 AudioPlayer::AudioPlayer()
@@ -64,7 +64,7 @@ AudioPlayer::AudioPlayer()
 #if defined(__APPLE__)
     , _needWakeupRotateThread(false)
 #endif
-    , _id(++__idIndex)
+    , _id(++__playerIdIndex)
 {
     memset(_bufferIds, 0, sizeof(_bufferIds));
 }
@@ -468,3 +468,5 @@ bool AudioPlayer::setTime(float time)
     }
     return false;
 }
+NS_AX_END
+#undef LOG_TAG

--- a/core/base/EventDispatcher.cpp
+++ b/core/base/EventDispatcher.cpp
@@ -41,6 +41,7 @@
 #include "base/Director.h"
 #include "base/EventType.h"
 #include "2d/Camera.h"
+#include "2d/ProtectedNode.h"
 
 #define DUMP_LISTENER_ITEM_PRIORITY_INFO 0
 
@@ -276,7 +277,7 @@ void EventDispatcher::visitTarget(Node* node, bool isRootNode)
             {
                 _globalZOrderNodeMap[node->getGlobalZOrder()].emplace_back(node);
             }
-        }    
+        }
     }
     else
     {
@@ -319,7 +320,7 @@ void EventDispatcher::visitTarget(Node* node, bool isRootNode)
             {
                 _globalZOrderNodeMap[node->getGlobalZOrder()].emplace_back(node);
             }
-        }        
+        }
     }
 
     if (isRootNode)

--- a/core/base/etc1.cpp
+++ b/core/base/etc1.cpp
@@ -16,7 +16,7 @@
 
 #include <string.h>
 
-static const char kMagic[] = {'P', 'K', 'M', ' ', '1', '0'};
+static const char ketc1Magic[] = {'P', 'K', 'M', ' ', '1', '0'};
 
 static const etc1_uint32 ETC1_PKM_FORMAT_OFFSET         = 6;
 static const etc1_uint32 ETC1_PKM_ENCODED_WIDTH_OFFSET  = 8;
@@ -31,7 +31,7 @@ static const etc1_uint32 ETC1_RGB_NO_MIPMAPS = 0;
 //     pOut[1] = (etc1_byte) data;
 // }
 
-static etc1_uint32 readBEUint16(const etc1_byte* pIn)
+static etc1_uint32 etc1ReadBEUint16(const etc1_byte* pIn)
 {
     return (pIn[0] << 8) | pIn[1];
 }
@@ -39,7 +39,7 @@ static etc1_uint32 readBEUint16(const etc1_byte* pIn)
 // Format a PKM header
 
 // void etc1_pkm_format_header(etc1_byte* pHeader, etc1_uint32 width, etc1_uint32 height) {
-//     memcpy(pHeader, kMagic, sizeof(kMagic));
+//     memcpy(pHeader, ketc1Magic, sizeof(ketc1Magic));
 //     etc1_uint32 encodedWidth = (width + 3) & ~3;
 //     etc1_uint32 encodedHeight = (height + 3) & ~3;
 //     writeBEUint16(pHeader + ETC1_PKM_FORMAT_OFFSET, ETC1_RGB_NO_MIPMAPS);
@@ -53,15 +53,15 @@ static etc1_uint32 readBEUint16(const etc1_byte* pIn)
 
 etc1_bool etc1_pkm_is_valid(const etc1_byte* pHeader)
 {
-    if (memcmp(pHeader, kMagic, sizeof(kMagic)))
+    if (memcmp(pHeader, ketc1Magic, sizeof(ketc1Magic)))
     {
         return false;
     }
-    etc1_uint32 format        = readBEUint16(pHeader + ETC1_PKM_FORMAT_OFFSET);
-    etc1_uint32 encodedWidth  = readBEUint16(pHeader + ETC1_PKM_ENCODED_WIDTH_OFFSET);
-    etc1_uint32 encodedHeight = readBEUint16(pHeader + ETC1_PKM_ENCODED_HEIGHT_OFFSET);
-    etc1_uint32 width         = readBEUint16(pHeader + ETC1_PKM_WIDTH_OFFSET);
-    etc1_uint32 height        = readBEUint16(pHeader + ETC1_PKM_HEIGHT_OFFSET);
+    etc1_uint32 format        = etc1ReadBEUint16(pHeader + ETC1_PKM_FORMAT_OFFSET);
+    etc1_uint32 encodedWidth  = etc1ReadBEUint16(pHeader + ETC1_PKM_ENCODED_WIDTH_OFFSET);
+    etc1_uint32 encodedHeight = etc1ReadBEUint16(pHeader + ETC1_PKM_ENCODED_HEIGHT_OFFSET);
+    etc1_uint32 width         = etc1ReadBEUint16(pHeader + ETC1_PKM_WIDTH_OFFSET);
+    etc1_uint32 height        = etc1ReadBEUint16(pHeader + ETC1_PKM_HEIGHT_OFFSET);
     return format == ETC1_RGB_NO_MIPMAPS && encodedWidth >= width && encodedWidth - width < 4 &&
            encodedHeight >= height && encodedHeight - height < 4;
 }
@@ -70,12 +70,12 @@ etc1_bool etc1_pkm_is_valid(const etc1_byte* pHeader)
 
 etc1_uint32 etc1_pkm_get_width(const etc1_byte* pHeader)
 {
-    return readBEUint16(pHeader + ETC1_PKM_WIDTH_OFFSET);
+    return etc1ReadBEUint16(pHeader + ETC1_PKM_WIDTH_OFFSET);
 }
 
 // Read the image height from a PKM header
 
 etc1_uint32 etc1_pkm_get_height(const etc1_byte* pHeader)
 {
-    return readBEUint16(pHeader + ETC1_PKM_HEIGHT_OFFSET);
+    return etc1ReadBEUint16(pHeader + ETC1_PKM_HEIGHT_OFFSET);
 }

--- a/core/base/etc2.cpp
+++ b/core/base/etc2.cpp
@@ -40,7 +40,7 @@
 #include <algorithm>
 #include <limits>
 
-static const char kMagic[] = {'P', 'K', 'M', ' ', '2', '0'};
+static const char ketc2Magic[] = {'P', 'K', 'M', ' ', '2', '0'};
 
 static const etc2_uint32 ETC2_PKM_FORMAT_OFFSET         = 6;
 static const etc2_uint32 ETC2_PKM_ENCODED_WIDTH_OFFSET  = 8;
@@ -54,7 +54,7 @@ static void writeBEUint16(etc2_byte* pOut, etc2_uint32 data)
     pOut[1] = (etc2_byte)data;
 }
 
-static etc2_uint32 readBEUint16(const etc2_byte* pIn)
+static etc2_uint32 etc2ReadBEUint16(const etc2_byte* pIn)
 {
     return (pIn[0] << 8) | pIn[1];
 }
@@ -63,15 +63,15 @@ static etc2_uint32 readBEUint16(const etc2_byte* pIn)
 
 etc2_bool etc2_pkm_is_valid(const etc2_byte* pHeader)
 {
-    if (memcmp(pHeader, kMagic, sizeof(kMagic)))
+    if (memcmp(pHeader, ketc2Magic, sizeof(ketc2Magic)))
     {
         return false;
     }
-    etc2_uint32 format        = readBEUint16(pHeader + ETC2_PKM_FORMAT_OFFSET);
-    etc2_uint32 encodedWidth  = readBEUint16(pHeader + ETC2_PKM_ENCODED_WIDTH_OFFSET);
-    etc2_uint32 encodedHeight = readBEUint16(pHeader + ETC2_PKM_ENCODED_HEIGHT_OFFSET);
-    etc2_uint32 width         = readBEUint16(pHeader + ETC2_PKM_WIDTH_OFFSET);
-    etc2_uint32 height        = readBEUint16(pHeader + ETC2_PKM_HEIGHT_OFFSET);
+    etc2_uint32 format        = etc2ReadBEUint16(pHeader + ETC2_PKM_FORMAT_OFFSET);
+    etc2_uint32 encodedWidth  = etc2ReadBEUint16(pHeader + ETC2_PKM_ENCODED_WIDTH_OFFSET);
+    etc2_uint32 encodedHeight = etc2ReadBEUint16(pHeader + ETC2_PKM_ENCODED_HEIGHT_OFFSET);
+    etc2_uint32 width         = etc2ReadBEUint16(pHeader + ETC2_PKM_WIDTH_OFFSET);
+    etc2_uint32 height        = etc2ReadBEUint16(pHeader + ETC2_PKM_HEIGHT_OFFSET);
     return (format == ETC2_RGB_NO_MIPMAPS || format == ETC2_RGBA_NO_MIPMAPS) && encodedWidth >= width &&
            encodedWidth - width < 4 && encodedHeight >= height && encodedHeight - height < 4;
 }
@@ -80,19 +80,19 @@ etc2_bool etc2_pkm_is_valid(const etc2_byte* pHeader)
 
 etc2_uint32 etc2_pkm_get_width(const etc2_byte* pHeader)
 {
-    return readBEUint16(pHeader + ETC2_PKM_WIDTH_OFFSET);
+    return etc2ReadBEUint16(pHeader + ETC2_PKM_WIDTH_OFFSET);
 }
 
 // Read the image height from a PKM header
 
 etc2_uint32 etc2_pkm_get_height(const etc2_byte* pHeader)
 {
-    return readBEUint16(pHeader + ETC2_PKM_HEIGHT_OFFSET);
+    return etc2ReadBEUint16(pHeader + ETC2_PKM_HEIGHT_OFFSET);
 }
 
 etc2_uint32 etc2_pkm_get_format(const etc2_byte* pHeader)
 {
-    return readBEUint16(pHeader + ETC2_PKM_FORMAT_OFFSET);
+    return etc2ReadBEUint16(pHeader + ETC2_PKM_FORMAT_OFFSET);
 }
 
 // The etc2 software decode implementation is modified from angleproject, and only support ETC2_RGB and ETC2_RGBA
@@ -955,7 +955,7 @@ private:
     size_t ComputeETC2RowPitch(size_t width, size_t blockWidth, size_t bytesPerPixel) {
         return ((width + blockWidth - 1) / blockWidth) * bytesPerPixel;
     }
-    
+
     size_t ComputeETC2DepthPitch(size_t height, size_t blockHeight, size_t rowPitch)
     {
         return ((height + blockHeight - 1) / blockHeight) * rowPitch;

--- a/core/media/WmfMediaEngine.cpp
+++ b/core/media/WmfMediaEngine.cpp
@@ -405,6 +405,7 @@ bool WmfMediaEngine::open(std::string_view sourceUri)
         catch (const std::exception& ex)
         {
             AXME_TRACE("Exception occurred when Open Media: %s", ex.what());
+            (void)ex;
             m_state = MEMediaState::Error;
         }
 

--- a/core/network/HttpCookie.cpp
+++ b/core/network/HttpCookie.cpp
@@ -28,6 +28,7 @@
 #include "network/Uri.h"
 #include "platform/FileUtils.h"
 #include "yasio/utils.hpp"
+#include "yasio/string_view.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,6 +54,8 @@ void HttpCookie::readFile()
         NAME_INDEX,
         VALUE_INDEX,
     };
+
+    using namespace std::literals::string_view_literals;
 
     std::string inString = FileUtils::getInstance()->getStringFromFile(_cookieFileName);
     if (!inString.empty())
@@ -153,6 +156,8 @@ std::string HttpCookie::checkAndGetFormatedMatchCookies(const Uri& uri)
 
 bool HttpCookie::updateOrAddCookie(std::string_view cookie, const Uri& uri)
 {
+    using namespace std::literals::string_view_literals;
+
     unsigned int count = 0;
     CookieInfo info;
     axstd::split_cb(cookie.data(), cookie.length(), ';', [&](const char* start, const char* end) {

--- a/core/platform/Image.cpp
+++ b/core/platform/Image.cpp
@@ -52,7 +52,7 @@ THE SOFTWARE.
 extern "C" {
 // To resolve link error when building 32bits with Xcode 6.
 // More information please refer to the discussion in https://github.com/cocos2d/cocos2d-x/pull/6986
-#if defined(__unix) || (AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
+#if defined(__unix) && (AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
 #    ifndef __ENABLE_COMPATIBILITY_WITH_UNIX_2003__
 #        define __ENABLE_COMPATIBILITY_WITH_UNIX_2003__
 #        include <stdio.h>

--- a/core/renderer/backend/DeviceInfo.h
+++ b/core/renderer/backend/DeviceInfo.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <string>
+#include <stdint.h>
 
 #include "Macros.h"
 

--- a/core/ui/UIScale9Sprite.cpp
+++ b/core/ui/UIScale9Sprite.cpp
@@ -38,7 +38,6 @@
 #include "renderer/Renderer.h"
 #include "renderer/backend/ProgramStateRegistry.h"
 
-USING_NS_AX;
 using namespace ax::ui;
 
 Scale9Sprite* Scale9Sprite::create()
@@ -362,12 +361,12 @@ void Scale9Sprite::updateCapInset()
     }
 }
 
-Vec2 Scale9Sprite::getOriginalSize() const
+ax::Vec2 Scale9Sprite::getOriginalSize() const
 {
     return _originalContentSize;
 }
 
-Vec2 Scale9Sprite::getPreferredSize() const
+ax::Vec2 Scale9Sprite::getPreferredSize() const
 {
     return getContentSize();
 }
@@ -413,7 +412,7 @@ bool Scale9Sprite::isScale9Enabled() const
     return (_renderingType == RenderingType::SLICE);
 }
 
-Sprite* Scale9Sprite::getSprite()
+ax::Sprite* Scale9Sprite::getSprite()
 {
     return this;
 }
@@ -585,7 +584,7 @@ void Scale9Sprite::setCapInsets(const ax::Rect& insetsCopy)
     }
 }
 
-Rect Scale9Sprite::getCapInsets() const
+ax::Rect Scale9Sprite::getCapInsets() const
 {
     return Rect(_insetLeft, _insetTop, _originalContentSize.width - _insetLeft - _insetRight,
                 _originalContentSize.height - _insetTop - _insetBottom);


### PR DESCRIPTION
Hello, this PR contains many small changes to allow unity builds (a.k.a jumbo builds) on a subset of the sources:

  - avoid "using namespace" at file scope (e.g. `USING_NAMESPACE_AX`),
  - #undef our file-specific #defines (e.g `#define LOG_TAG …` in audio-related files),
  - and avoid having static functions with identical name and signature (e.g. `readBEUint16` in both etc1.cpp and etc2.cpp).

For context, for my project I compile a subset of axmol of 180 files. Using the default build it takes 3m50s on my laptop (13m30s user time), but if I use unity builds it's only 1m50s (5m10s user time).