### PR TITLE
Optimize `OpenGL` State Management

### DIFF
--- a/core/base/Types.h
+++ b/core/base/Types.h
@@ -662,10 +662,23 @@ extern const ssize_t AX_DLL AX_INVALID_INDEX;
 
 struct AX_DLL Viewport
 {
-    int x          = 0;
-    int y          = 0;
+    int x = 0;
+    int y = 0;
     unsigned int w = 0;
     unsigned int h = 0;
+
+    void set(int _x, int _y, unsigned int _w, unsigned int _h)
+    {
+        x = _x;
+        y = _y;
+        w = _w;
+        h = _h;
+    }
+
+    bool operator==(const Viewport& v) const
+    {
+        return this->x == v.x && this->y == v.y && this->w == v.w && this->h == v.h;
+    };
 };
 
 struct AX_DLL ScissorRect

--- a/core/renderer/Renderer.h
+++ b/core/renderer/Renderer.h
@@ -580,6 +580,120 @@ protected:
     std::deque<StateBlock> _stateBlockStack;
 };
 
+struct BlendEquationSeparateState
+{
+    unsigned int rgbBlendOperation;
+    unsigned int alphaBlendOperation;
+
+    bool operator==(const BlendEquationSeparateState& other) const
+    {
+        return this->rgbBlendOperation == other.rgbBlendOperation &&
+               this->alphaBlendOperation == other.alphaBlendOperation;
+    }
+};
+
+struct BlendFuncSeparateState
+{
+    unsigned int sourceRGBBlendFactor;
+    unsigned int destinationRGBBlendFactor;
+    unsigned int sourceAlphaBlendFactor;
+    unsigned int destinationAlphaBlendFactor;
+
+    bool operator==(const BlendFuncSeparateState& other) const
+    {
+        return this->sourceRGBBlendFactor == other.sourceRGBBlendFactor &&
+               this->destinationRGBBlendFactor == other.destinationRGBBlendFactor &&
+               this->sourceAlphaBlendFactor == other.sourceAlphaBlendFactor &&
+               this->destinationAlphaBlendFactor == other.destinationAlphaBlendFactor;
+    }
+};
+
+struct ColorMaskState
+{
+    unsigned char writeMaskRed;
+    unsigned char writeMaskGreen;
+    unsigned char writeMaskBlue;
+    unsigned char writeMaskAlpha;
+
+    bool operator==(const ColorMaskState& other) const
+    {
+        return this->writeMaskRed == other.writeMaskRed && this->writeMaskGreen == other.writeMaskGreen &&
+               this->writeMaskBlue == other.writeMaskBlue && this->writeMaskAlpha == other.writeMaskAlpha;
+    }
+};
+
+struct StencilFuncState
+{
+    unsigned int stencilCompareFunction;
+    int stencilReferenceValueFront;
+    unsigned int readMask;
+
+    bool operator==(const StencilFuncState& other) const
+    {
+        return this->stencilCompareFunction == other.stencilCompareFunction &&
+               this->stencilReferenceValueFront == other.stencilReferenceValueFront && this->readMask == other.readMask;
+    }
+};
+
+struct StencilOperationState
+{
+    unsigned int stencilFailureOperation;
+    unsigned int depthFailureOperation;
+    unsigned int depthStencilPassOperation;
+
+    bool operator==(const StencilOperationState& other) const
+    {
+        return this->stencilFailureOperation == other.stencilFailureOperation &&
+               this->depthFailureOperation == other.depthFailureOperation &&
+               this->depthStencilPassOperation == other.depthStencilPassOperation;
+    }
+};
+
+struct TextureBindState
+{
+    unsigned int target;
+    unsigned int texture;
+
+    bool operator==(const TextureBindState& other) const
+    {
+        return this->target == other.target && this->texture == other.texture;
+    }
+};
+
+struct OpenGLStateHandeler
+{
+    std::optional<Viewport> _viewPort;
+    std::optional<Winding> _winding;
+    std::optional<bool> _depthTest;
+    std::optional<bool> _blend;
+    std::optional<bool> _scissor;
+    std::optional<float> _lineWidth;
+    std::optional<int> _frameBufferBind;
+    std::optional<BlendEquationSeparateState> _blendEquationSeparate;
+    std::optional<BlendFuncSeparateState> _blendFuncSeparate;
+    std::optional<ColorMaskState> _colorMask;
+    std::optional<int> _depthMask;
+    std::optional<int> _depthFunc;
+    std::optional<bool> _stencilTest;
+    std::optional<bool> _cullFace;
+    std::optional<unsigned int> _programBind;
+    std::optional<StencilFuncState> _stencilFunc;
+    std::optional<StencilFuncState> _stencilFuncFront;
+    std::optional<StencilFuncState> _stencilFuncBack;
+    std::optional<StencilOperationState> _stencilOp;
+    std::optional<StencilOperationState> _stencilOpFront;
+    std::optional<StencilOperationState> _stencilOpBack;
+    std::optional<unsigned int> _stencilMask;
+    std::optional<unsigned int> _stencilMaskFront;
+    std::optional<unsigned int> _stencilMaskBack;
+    std::optional<unsigned int> _activeTexture;
+    std::optional<TextureBindState> _textureBind;
+    std::optional<unsigned int> _arrayBuffer;
+    std::optional<unsigned int> _elementArrayBuffer;
+};
+
+inline OpenGLStateHandeler _glState;
+
 NS_AX_END
 
 /**

--- a/core/renderer/backend/opengl/CommandBufferGL.h
+++ b/core/renderer/backend/opengl/CommandBufferGL.h
@@ -196,13 +196,6 @@ protected:
                     PixelBufferDescriptor& pbd);
 
 private:
-    struct Viewport
-    {
-        int x          = 0;
-        int y          = 0;
-        unsigned int w = 0;
-        unsigned int h = 0;
-    };
 
     void prepareDrawing() const;
     void bindVertexBuffer(ProgramGL* program) const;

--- a/core/renderer/backend/opengl/DepthStencilStateGL.cpp
+++ b/core/renderer/backend/opengl/DepthStencilStateGL.cpp
@@ -42,58 +42,56 @@ void DepthStencilStateGL::apply(unsigned int stencilReferenceValueFront, unsigne
     // depth test
     if (bitmask::any(dsFlags, DepthStencilFlags::DEPTH_TEST))
     {
-        glEnable(GL_DEPTH_TEST);
+        GL_ENABLE_DEPTH_TEST;
     }
     else
     {
-        glDisable(GL_DEPTH_TEST);
+        GL_DISABLE_DEPTH_TEST;
     }
 
     if (bitmask::any(dsFlags, DepthStencilFlags::DEPTH_WRITE))
-        glDepthMask(GL_TRUE);
+        GL_SET_DEPTH_MASK(GL_TRUE);
     else
-        glDepthMask(GL_FALSE);
+        GL_SET_DEPTH_MASK(GL_FALSE);
 
-    glDepthFunc(UtilsGL::toGLComareFunction(_depthStencilInfo.depthCompareFunction));
+    GL_SET_DEPTH_FUNC(UtilsGL::toGLComareFunction(_depthStencilInfo.depthCompareFunction));
 
     // stencil test
     if (bitmask::any(dsFlags, DepthStencilFlags::STENCIL_TEST))
     {
-        glEnable(GL_STENCIL_TEST);
+        GL_ENABLE_STENCIL_TEST;
 
         if (_isBackFrontStencilEqual)
         {
-            glStencilFunc(UtilsGL::toGLComareFunction(_depthStencilInfo.frontFaceStencil.stencilCompareFunction),
-                          stencilReferenceValueFront, _depthStencilInfo.frontFaceStencil.readMask);
-            glStencilOp(UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.stencilFailureOperation),
-                        UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.depthFailureOperation),
-                        UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.depthStencilPassOperation));
-            glStencilMask(_depthStencilInfo.frontFaceStencil.writeMask);
+            GL_STENCIL_FUNC(UtilsGL::toGLComareFunction(_depthStencilInfo.frontFaceStencil.stencilCompareFunction),
+                            (GLint)stencilReferenceValueFront, _depthStencilInfo.frontFaceStencil.readMask);
+
+            GL_STENCIL_OP(UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.stencilFailureOperation),
+                          UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.depthFailureOperation),
+                          UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.depthStencilPassOperation));
+
+            GL_STENCIL_MASK(_depthStencilInfo.frontFaceStencil.writeMask);
         }
         else
         {
-            glStencilFuncSeparate(GL_BACK,
-                                  UtilsGL::toGLComareFunction(_depthStencilInfo.backFaceStencil.stencilCompareFunction),
-                                  stencilReferenceValueBack, _depthStencilInfo.backFaceStencil.readMask);
-            glStencilFuncSeparate(
-                GL_FRONT, UtilsGL::toGLComareFunction(_depthStencilInfo.frontFaceStencil.stencilCompareFunction),
-                stencilReferenceValueFront, _depthStencilInfo.frontFaceStencil.readMask);
+            GL_STENCIL_FUNC_FRONT(UtilsGL::toGLComareFunction(_depthStencilInfo.backFaceStencil.stencilCompareFunction),
+                                  (GLint)stencilReferenceValueBack, _depthStencilInfo.backFaceStencil.readMask);
+            GL_STENCIL_FUNC_BACK(UtilsGL::toGLComareFunction(_depthStencilInfo.frontFaceStencil.stencilCompareFunction),
+                                 (GLint)stencilReferenceValueFront, _depthStencilInfo.frontFaceStencil.readMask);
 
-            glStencilOpSeparate(
-                GL_BACK, UtilsGL::toGLStencilOperation(_depthStencilInfo.backFaceStencil.stencilFailureOperation),
+            GL_STENCIL_OP_FRONT(UtilsGL::toGLStencilOperation(_depthStencilInfo.backFaceStencil.stencilFailureOperation),
                 UtilsGL::toGLStencilOperation(_depthStencilInfo.backFaceStencil.depthFailureOperation),
                 UtilsGL::toGLStencilOperation(_depthStencilInfo.backFaceStencil.depthStencilPassOperation));
-            glStencilOpSeparate(
-                GL_FRONT, UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.stencilFailureOperation),
+            GL_STENCIL_OP_BACK(UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.stencilFailureOperation),
                 UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.depthFailureOperation),
                 UtilsGL::toGLStencilOperation(_depthStencilInfo.frontFaceStencil.depthStencilPassOperation));
 
-            glStencilMaskSeparate(GL_BACK, _depthStencilInfo.backFaceStencil.writeMask);
-            glStencilMaskSeparate(GL_FRONT, _depthStencilInfo.frontFaceStencil.writeMask);
+            GL_STENCIL_MASK_BACK(_depthStencilInfo.backFaceStencil.writeMask);
+            GL_STENCIL_MASK_FRONT(_depthStencilInfo.frontFaceStencil.writeMask);
         }
     }
     else
-        glDisable(GL_STENCIL_TEST);
+        GL_DISABLE_STENCIL_TEST;
 
     CHECK_GL_ERROR_DEBUG();
 }

--- a/core/renderer/backend/opengl/MacrosGL.h
+++ b/core/renderer/backend/opengl/MacrosGL.h
@@ -29,24 +29,24 @@
 #if !defined(_AX_DEBUG) || _AX_DEBUG == 0
 #    define CHECK_GL_ERROR_DEBUG()
 #else
-#    define CHECK_GL_ERROR_DEBUG()                                                                            \
-        do                                                                                                    \
-        {                                                                                                     \
-            GLenum __error = glGetError();                                                                    \
-            if (__error)                                                                                      \
-            {                                                                                                 \
+#    define CHECK_GL_ERROR_DEBUG()                                                                       \
+        do                                                                                               \
+        {                                                                                                \
+            GLenum __error = glGetError();                                                               \
+            if (__error)                                                                                 \
+            {                                                                                            \
                 ax::log("OpenGL error 0x%04X in %s %s %d\n", __error, __FILE__, __FUNCTION__, __LINE__); \
-            }                                                                                                 \
+            }                                                                                            \
         } while (false)
-#    define CHECK_GL_ERROR_ABORT()                                                                            \
-        do                                                                                                    \
-        {                                                                                                     \
-            GLenum __error = glGetError();                                                                    \
-            if (__error)                                                                                      \
-            {                                                                                                 \
+#    define CHECK_GL_ERROR_ABORT()                                                                       \
+        do                                                                                               \
+        {                                                                                                \
+            GLenum __error = glGetError();                                                               \
+            if (__error)                                                                                 \
+            {                                                                                            \
                 ax::log("OpenGL error 0x%04X in %s %s %d\n", __error, __FILE__, __FUNCTION__, __LINE__); \
-                assert(false);                                                                                \
-            }                                                                                                 \
+                assert(false);                                                                           \
+            }                                                                                            \
         } while (false)
 #endif
 
@@ -69,3 +69,333 @@
             AX_ASSERT(__gl_error_code == GL_NO_ERROR, "Error"); \
         } while (0)
 #endif
+
+#define GL_ENABLE_DEPTH_TEST                                                  \
+    do                                                                        \
+    {                                                                         \
+        if (!_glState._depthTest.has_value() || !_glState._depthTest.value()) \
+        {                                                                     \
+            glEnable(GL_DEPTH_TEST);                                          \
+            _glState._depthTest = true;                                       \
+        }                                                                     \
+    } while (0)
+
+#define GL_DISABLE_DEPTH_TEST                                                \
+    do                                                                       \
+    {                                                                        \
+        if (!_glState._depthTest.has_value() || _glState._depthTest.value()) \
+        {                                                                    \
+            glDisable(GL_DEPTH_TEST);                                        \
+            _glState._depthTest = false;                                     \
+        }                                                                    \
+    } while (0)
+
+#define GL_ENABLE_BLENDING                                            \
+    do                                                                \
+    {                                                                 \
+        if (!_glState._blend.has_value() || !_glState._blend.value()) \
+        {                                                             \
+            glEnable(GL_BLEND);                                       \
+            _glState._blend = true;                                   \
+        }                                                             \
+    } while (0)
+
+#define GL_DISABLE_BLENDING                                          \
+    do                                                               \
+    {                                                                \
+        if (!_glState._blend.has_value() || _glState._blend.value()) \
+        {                                                            \
+            glDisable(GL_BLEND);                                     \
+            _glState._blend = false;                                 \
+        }                                                            \
+    } while (0)
+
+#define GL_ENABLE_SCISSOR_TEST                                            \
+    do                                                                    \
+    {                                                                     \
+        if (!_glState._scissor.has_value() || !_glState._scissor.value()) \
+        {                                                                 \
+            glEnable(GL_SCISSOR_TEST);                                    \
+            _glState._scissor = true;                                     \
+        }                                                                 \
+    } while (0)
+
+#define GL_DISABLE_SCISSOR_TEST                                          \
+    do                                                                   \
+    {                                                                    \
+        if (!_glState._scissor.has_value() || _glState._scissor.value()) \
+        {                                                                \
+            glDisable(GL_SCISSOR_TEST);                                  \
+            _glState._scissor = false;                                   \
+        }                                                                \
+    } while (0)
+
+#define GL_LINE_WIDTH(V)                                                          \
+    do                                                                            \
+    {                                                                             \
+        if (!_glState._lineWidth.has_value() || _glState._lineWidth.value() != V) \
+        {                                                                         \
+            glLineWidth(V);                                                       \
+            _glState._lineWidth = V;                                              \
+        }                                                                         \
+    } while (0)
+
+#define GL_BIND_FRAMEBUFFER(I)                                                                \
+    do                                                                                        \
+    {                                                                                         \
+        if (!_glState._frameBufferBind.has_value() || _glState._frameBufferBind.value() != I) \
+        {                                                                                     \
+            glBindFramebuffer(GL_FRAMEBUFFER, I);                                             \
+            _glState._frameBufferBind = I;                                                    \
+        }                                                                                     \
+    } while (0)
+
+#define GL_BIND_FRAMEBUFFER(I)                                                                \
+    do                                                                                        \
+    {                                                                                         \
+        if (!_glState._frameBufferBind.has_value() || _glState._frameBufferBind.value() != I) \
+        {                                                                                     \
+            glBindFramebuffer(GL_FRAMEBUFFER, I);                                             \
+            _glState._frameBufferBind = I;                                                    \
+        }                                                                                     \
+    } while (0)
+
+#define GL_BLEND_EQUATION_SEPARATE(BLEND_RBG_OPER, BLEND_ALPHA_OPER)                                                 \
+    do                                                                                                               \
+    {                                                                                                                \
+        if (!_glState._blendEquationSeparate.has_value() ||                                                          \
+            _glState._blendEquationSeparate.value() != BlendEquationSeparateState{BLEND_RBG_OPER, BLEND_ALPHA_OPER}) \
+        {                                                                                                            \
+            glBlendEquationSeparate(BLEND_RBG_OPER, BLEND_ALPHA_OPER);                                               \
+            _glState._blendEquationSeparate = BlendEquationSeparateState{BLEND_RBG_OPER, BLEND_ALPHA_OPER};          \
+        }                                                                                                            \
+    } while (0)
+
+#define GL_BLEND_FUNC_SEPARATE(SRC_RBG_FACTOR, DST_RGB_FACTOR, SRC_ALPHA_FACTOR, DST_ALPHA_FACTOR)          \
+    do                                                                                                      \
+    {                                                                                                       \
+        if (!_glState._blendFuncSeparate.has_value() ||                                                     \
+            _glState._blendFuncSeparate.value() !=                                                          \
+                BlendFuncSeparateState{SRC_RBG_FACTOR, DST_RGB_FACTOR, SRC_ALPHA_FACTOR, DST_ALPHA_FACTOR}) \
+        {                                                                                                   \
+            glBlendFuncSeparate(SRC_RBG_FACTOR, DST_RGB_FACTOR, SRC_ALPHA_FACTOR, DST_ALPHA_FACTOR);        \
+            _glState._blendFuncSeparate =                                                                   \
+                BlendFuncSeparateState{SRC_RBG_FACTOR, DST_RGB_FACTOR, SRC_ALPHA_FACTOR, DST_ALPHA_FACTOR}; \
+        }                                                                                                   \
+    } while (0)
+
+#define GL_COLOR_MASK(RED_MASK, GREEN_MASK, BLUE_MASK, ALPHA_MASK)                                      \
+    do                                                                                                  \
+    {                                                                                                   \
+        if (!_glState._colorMask.has_value() ||                                                         \
+            _glState._colorMask.value() != ColorMaskState{RED_MASK, GREEN_MASK, BLUE_MASK, ALPHA_MASK}) \
+        {                                                                                               \
+            glColorMask(RED_MASK, GREEN_MASK, BLUE_MASK, ALPHA_MASK);                                   \
+            _glState._colorMask = ColorMaskState{RED_MASK, GREEN_MASK, BLUE_MASK, ALPHA_MASK};          \
+        }                                                                                               \
+    } while (0)
+
+#define GL_SET_DEPTH_MASK(V)                                                      \
+    do                                                                            \
+    {                                                                             \
+        if (!_glState._depthMask.has_value() || _glState._depthMask.value() != V) \
+        {                                                                         \
+            glDepthMask(V);                                                       \
+            _glState._depthMask = V;                                              \
+        }                                                                         \
+    } while (0)
+
+#define GL_SET_DEPTH_FUNC(V)                                                      \
+    do                                                                            \
+    {                                                                             \
+        if (!_glState._depthFunc.has_value() || _glState._depthFunc.value() != V) \
+        {                                                                         \
+            glDepthFunc(V);                                                       \
+            _glState._depthFunc = V;                                              \
+        }                                                                         \
+    } while (0)
+
+#define GL_ENABLE_STENCIL_TEST                                                    \
+    do                                                                            \
+    {                                                                             \
+        if (!_glState._stencilTest.has_value() || !_glState._stencilTest.value()) \
+        {                                                                         \
+            glEnable(GL_STENCIL_TEST);                                            \
+            _glState._stencilTest = true;                                         \
+        }                                                                         \
+    } while (0)
+
+#define GL_DISABLE_STENCIL_TEST                                                  \
+    do                                                                           \
+    {                                                                            \
+        if (!_glState._stencilTest.has_value() || _glState._stencilTest.value()) \
+        {                                                                        \
+            glDisable(GL_STENCIL_TEST);                                          \
+            _glState._stencilTest = false;                                       \
+        }                                                                        \
+    } while (0)
+
+#define GL_ENABLE_CULL_FACE                                                 \
+    do                                                                      \
+    {                                                                       \
+        if (!_glState._cullFace.has_value() || !_glState._cullFace.value()) \
+        {                                                                   \
+            glEnable(GL_CULL_FACE);                                         \
+            _glState._cullFace = true;                                      \
+        }                                                                   \
+    } while (0)
+
+#define GL_DISABLE_CULL_FACE                                               \
+    do                                                                     \
+    {                                                                      \
+        if (!_glState._cullFace.has_value() || _glState._cullFace.value()) \
+        {                                                                  \
+            glDisable(GL_CULL_FACE);                                       \
+            _glState._cullFace = false;                                    \
+        }                                                                  \
+    } while (0)
+
+#define GL_USE_PROGRAM(I)                                                             \
+    do                                                                                \
+    {                                                                                 \
+        if (!_glState._programBind.has_value() || _glState._programBind.value() != I) \
+        {                                                                             \
+            glUseProgram(I);                                                          \
+            _glState._programBind = I;                                                \
+        }                                                                             \
+    } while (0)
+
+#define GL_STENCIL_FUNC(FUNC, REF, MASK)                                                                              \
+    do                                                                                                                \
+    {                                                                                                                 \
+        if (!_glState._stencilFunc.has_value() || _glState._stencilFunc.value() != StencilFuncState{FUNC, REF, MASK}) \
+        {                                                                                                             \
+            glStencilFunc(FUNC, REF, MASK);                                                                           \
+            _glState._stencilFunc = StencilFuncState{FUNC, REF, MASK};                                                \
+        }                                                                                                             \
+    } while (0)
+
+#define GL_STENCIL_OP(FAIL, ZFAIL, ZPASS)                                             \
+    do                                                                                \
+    {                                                                                 \
+        if (!_glState._stencilOp.has_value() ||                                       \
+            _glState._stencilOp.value() != StencilOperationState{FAIL, ZFAIL, ZPASS}) \
+        {                                                                             \
+            glStencilOp(FAIL, ZFAIL, ZPASS);                                          \
+            _glState._stencilOp = StencilOperationState{FAIL, ZFAIL, ZPASS};          \
+        }                                                                             \
+    } while (0)
+
+#define GL_STENCIL_MASK(MASK)                                                            \
+    do                                                                                   \
+    {                                                                                    \
+        if (!_glState._stencilMask.has_value() || _glState._stencilMask.value() != MASK) \
+        {                                                                                \
+            glStencilMask(MASK);                                                         \
+            _glState._stencilMask = MASK;                                                \
+        }                                                                                \
+    } while (0)
+
+#define GL_STENCIL_FUNC_FRONT(FUNC, REF, MASK)                                       \
+    do                                                                               \
+    {                                                                                \
+        if (!_glState._stencilFuncFront.has_value() ||                               \
+            _glState._stencilFuncFront.value() != StencilFuncState{FUNC, REF, MASK}) \
+        {                                                                            \
+            glStencilFuncSeparate(GL_FRONT, FUNC, REF, MASK);                        \
+            _glState._stencilFuncFront = StencilFuncState{FUNC, REF, MASK};          \
+        }                                                                            \
+    } while (0)
+
+#define GL_STENCIL_FUNC_BACK(FUNC, REF, MASK)                                       \
+    do                                                                              \
+    {                                                                               \
+        if (!_glState._stencilFuncBack.has_value() ||                               \
+            _glState._stencilFuncBack.value() != StencilFuncState{FUNC, REF, MASK}) \
+        {                                                                           \
+            glStencilFuncSeparate(GL_BACK, FUNC, REF, MASK);                        \
+            _glState._stencilFuncBack = StencilFuncState{FUNC, REF, MASK};          \
+        }                                                                           \
+    } while (0)
+
+#define GL_STENCIL_OP_FRONT(FAIL, ZFAIL, ZPASS)                                            \
+    do                                                                                     \
+    {                                                                                      \
+        if (!_glState._stencilOpFront.has_value() ||                                       \
+            _glState._stencilOpFront.value() != StencilOperationState{FAIL, ZFAIL, ZPASS}) \
+        {                                                                                  \
+            glStencilOpSeparate(GL_FRONT, FAIL, ZFAIL, ZPASS);                             \
+            _glState._stencilOpFront = StencilOperationState{FAIL, ZFAIL, ZPASS};          \
+        }                                                                                  \
+    } while (0)
+
+#define GL_STENCIL_OP_BACK(FAIL, ZFAIL, ZPASS)                                            \
+    do                                                                                    \
+    {                                                                                     \
+        if (!_glState._stencilOpBack.has_value() ||                                       \
+            _glState._stencilOpBack.value() != StencilOperationState{FAIL, ZFAIL, ZPASS}) \
+        {                                                                                 \
+            glStencilOpSeparate(GL_BACK, FAIL, ZFAIL, ZPASS);                             \
+            _glState._stencilOpBack = StencilOperationState{FAIL, ZFAIL, ZPASS};          \
+        }                                                                                 \
+    } while (0)
+
+#define GL_STENCIL_MASK_FRONT(MASK)                                                                \
+    do                                                                                             \
+    {                                                                                              \
+        if (!_glState._stencilMaskFront.has_value() || _glState._stencilMaskFront.value() != MASK) \
+        {                                                                                          \
+            glStencilMaskSeparate(GL_FRONT, MASK);                                                 \
+            _glState._stencilMaskFront = MASK;                                                     \
+        }                                                                                          \
+    } while (0)
+
+#define GL_STENCIL_MASK_BACK(MASK)                                                               \
+    do                                                                                           \
+    {                                                                                            \
+        if (!_glState._stencilMaskBack.has_value() || _glState._stencilMaskBack.value() != MASK) \
+        {                                                                                        \
+            glStencilMaskSeparate(GL_BACK, MASK);                                                \
+            _glState._stencilMaskBack = MASK;                                                    \
+        }                                                                                        \
+    } while (0)
+
+#define GL_SET_ACTIVE_TEXTURE(T)                                                          \
+    do                                                                                    \
+    {                                                                                     \
+        if (!_glState._activeTexture.has_value() || _glState._activeTexture.value() != T) \
+        {                                                                                 \
+            glActiveTexture(T);                                                           \
+            _glState._activeTexture = T;                                                  \
+        }                                                                                 \
+    } while (0)
+
+#define GL_BIND_TEXTURE(TARGET, TEXTURE)                                                                              \
+    do                                                                                                                \
+    {                                                                                                                 \
+        if (!_glState._textureBind.has_value() || _glState._textureBind.value() != TextureBindState{TARGET, TEXTURE}) \
+        {                                                                                                             \
+            glBindTexture(TARGET, TEXTURE);                                                                           \
+            _glState._textureBind = TextureBindState{TARGET, TEXTURE};                                                \
+        }                                                                                                             \
+    } while (0)
+
+#define GL_BIND_ARRAY_BUFFER(B)                                                       \
+    do                                                                                \
+    {                                                                                 \
+        if (!_glState._arrayBuffer.has_value() || _glState._arrayBuffer.value() != B) \
+        {                                                                             \
+            glBindBuffer(GL_ARRAY_BUFFER, B);                                         \
+            _glState._arrayBuffer = B;                                                \
+        }                                                                             \
+    } while (0)
+
+#define GL_BIND_ELEMENT_ARRAY_BUFFER(B)                                                             \
+    do                                                                                              \
+    {                                                                                               \
+        if (!_glState._elementArrayBuffer.has_value() || _glState._elementArrayBuffer.value() != B) \
+        {                                                                                           \
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, B);                                               \
+            _glState._elementArrayBuffer = B;                                                       \
+        }                                                                                           \
+    } while (0)

--- a/core/renderer/backend/opengl/RenderPipelineGL.cpp
+++ b/core/renderer/backend/opengl/RenderPipelineGL.cpp
@@ -28,6 +28,7 @@ Copyright (c) 2020 C4games Ltd.
 #include "DepthStencilStateGL.h"
 #include "ProgramGL.h"
 #include "UtilsGL.h"
+#include "MacrosGL.h"
 
 #include <assert.h>
 
@@ -61,15 +62,15 @@ void RenderPipelineGL::updateBlendState(const BlendDescriptor& descriptor)
 
     if (blendEnabled)
     {
-        glEnable(GL_BLEND);
-        glBlendEquationSeparate(rgbBlendOperation, alphaBlendOperation);
-        glBlendFuncSeparate(sourceRGBBlendFactor, destinationRGBBlendFactor, sourceAlphaBlendFactor,
-                            destinationAlphaBlendFactor);
+        GL_ENABLE_BLENDING;
+        GL_BLEND_EQUATION_SEPARATE(rgbBlendOperation, alphaBlendOperation);
+        GL_BLEND_FUNC_SEPARATE(sourceRGBBlendFactor, destinationRGBBlendFactor, sourceAlphaBlendFactor,
+                               destinationAlphaBlendFactor);
     }
     else
-        glDisable(GL_BLEND);
+        GL_DISABLE_BLENDING;
 
-    glColorMask(writeMaskRed, writeMaskGreen, writeMaskBlue, writeMaskAlpha);
+    GL_COLOR_MASK(writeMaskRed, writeMaskGreen, writeMaskBlue, writeMaskAlpha);
 }
 
 RenderPipelineGL::~RenderPipelineGL()

--- a/core/renderer/backend/opengl/RenderTargetGL.cpp
+++ b/core/renderer/backend/opengl/RenderTargetGL.cpp
@@ -35,12 +35,12 @@ RenderTargetGL::~RenderTargetGL()
 
 void RenderTargetGL::bindFrameBuffer() const
 {
-    glBindFramebuffer(GL_FRAMEBUFFER, _FBO);
+    GL_BIND_FRAMEBUFFER(_FBO);
 }
 
 void RenderTargetGL::unbindFrameBuffer() const
 {
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    GL_BIND_FRAMEBUFFER(0);
 }
 
 void RenderTargetGL::update() const {

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -96,8 +96,8 @@ void TextureInfoGL::setCurrentTexParameters(GLenum target)
 
 void TextureInfoGL::apply(int slot, int index, GLenum target) const
 {
-    glActiveTexture(GL_TEXTURE0 + slot);
-    glBindTexture(target, index < AX_META_TEXTURES ? textures[index] : textures[0]);
+    GL_SET_ACTIVE_TEXTURE(GL_TEXTURE0 + slot);
+    GL_BIND_TEXTURE(target, index < AX_META_TEXTURES ? textures[index] : textures[0]);
 }
 
 GLuint TextureInfoGL::ensure(int index, GLenum target)
@@ -108,7 +108,7 @@ GLuint TextureInfoGL::ensure(int index, GLenum target)
     auto& texID = this->textures[index];
     if (!texID)
         glGenTextures(1, &texID);
-    glBindTexture(target, texID);
+    GL_BIND_TEXTURE(target, texID);
 
     setCurrentTexParameters(target);  // set once
 
@@ -305,7 +305,7 @@ void Texture2DGL::generateMipmaps()
     if (!_hasMipmaps)
     {
         _hasMipmaps = true;
-        glBindTexture(GL_TEXTURE_2D, this->getHandler());
+        GL_BIND_TEXTURE(GL_TEXTURE_2D, (GLuint)this->getHandler());
         glGenerateMipmap(GL_TEXTURE_2D);
     }
 }
@@ -362,7 +362,7 @@ void TextureCubeGL::updateFaceData(TextureCubeFace side, void* data, int index)
                  _textureInfo.format, _textureInfo.type, data);
 
     CHECK_GL_ERROR_DEBUG();
-    glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+    GL_BIND_TEXTURE(GL_TEXTURE_CUBE_MAP, 0);
 }
 
 void TextureCubeGL::generateMipmaps()
@@ -373,7 +373,7 @@ void TextureCubeGL::generateMipmaps()
     if (!_hasMipmaps)
     {
         _hasMipmaps = true;
-        glBindTexture(GL_TEXTURE_CUBE_MAP, this->getHandler());
+        GL_BIND_TEXTURE(GL_TEXTURE_CUBE_MAP, (GLuint)this->getHandler());
         glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
     }
 }


### PR DESCRIPTION
## Describe your changes
This PR fixes a problem I've been noticing in rendering, state changes are changed way too much in OpenGL, calls to bind the same buffer, shader, and texture causes the GPU to reset it's texel units which leads to poor performance, this was fixed by keeping track of states and detect if a change is necessary, this reduced the total state and draw events from ~1700 to ~650 state calls which will be a significant boost especially with low-end hardware.

In the pictures provided you can see that a bunch of useless states are called like `glDisable`, `glEnable` and other things that can be tracked, there is also the most expensive ones like `glUseProgram`, `glBindBuffer`, `glBindTexture` which are the real deal breakers here, if a draw call chooses to use texture `21` and the next draw call also chooses texture `21`, then why rebind the same texture again and reset GPU texel units?

you can kinda call it batching, but for OpenGL Calls.

Before proper state optimization (1700 state changes which is quite a lot):
![image](https://github.com/axmolengine/axmol/assets/45469625/aee3e6ff-9dc4-4ef7-9ef2-cce41b2a75f4)

After proper state optimization (a mere 650 state changes which is an improvment of about 61%):
![image](https://github.com/axmolengine/axmol/assets/45469625/a88d15eb-7c69-4930-94d2-7fcaca58a0ff)

Tested and Works on a Windows 10 Environment.

Framerate Before:
![image](https://github.com/axmolengine/axmol/assets/45469625/48c42cba-8d2d-4e3c-a8e7-5d2fcdfd8f12)

Framerate After:
![image](https://github.com/axmolengine/axmol/assets/45469625/b3795eff-1580-4294-ac19-e4a76413c525)

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
