### PR TITLE
Fix for adding axmol bin path to user path environment variable

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -21,8 +21,8 @@ if ($IsWin) {
     }
 
     $pathList = [System.Collections.ArrayList]$env:PATH.Split(';')
-    if (!$pathList.IndexOf($AX_CONSOLE_BIN) -eq -1) {
-        $pathList = [Environment]::GetEnvironmentVariable('PATH', 'User').Split(';')
+    if ($pathList.IndexOf($AX_CONSOLE_BIN) -eq -1) {
+        $pathList = [System.Collections.ArrayList][Environment]::GetEnvironmentVariable('PATH', 'User').Split(';')
         $pathList.Insert(0, $AX_CONSOLE_BIN)
         $PATH = $pathList -join ';'
         [Environment]::SetEnvironmentVariable('PATH', $PATH, 'User')


### PR DESCRIPTION
## Describe your changes
Invert if condition checking for existence of the axmol bin path in the user path env variable
Make list mutable to allow for inserting new path

## Issue ticket number and link
Discussion at #1274 

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
