### PR TITLE
Fix AX_SIZE_* macros

### DIFF
--- a/core/base/Macros.h
+++ b/core/base/Macros.h
@@ -163,14 +163,14 @@ On iPhone it returns 2 if RetinaDisplay is On. Otherwise it returns 1
  Converts a rect in pixels to points
  */
 #define AX_SIZE_PIXELS_TO_POINTS(__size_in_pixels__)             \
-    Vec2((__size_in_pixels__).width / AX_CONTENT_SCALE_FACTOR(), \
+    ax::Vec2((__size_in_pixels__).width / AX_CONTENT_SCALE_FACTOR(), \
          (__size_in_pixels__).height / AX_CONTENT_SCALE_FACTOR())
 
 /** @def AX_POINT_POINTS_TO_PIXELS
  Converts a rect in points to pixels
  */
 #define AX_SIZE_POINTS_TO_PIXELS(__size_in_points__) \
-    Vec2((__size_in_points__).width* AX_CONTENT_SCALE_FACTOR(), (__size_in_points__).height* AX_CONTENT_SCALE_FACTOR())
+    ax::Vec2((__size_in_points__).width* AX_CONTENT_SCALE_FACTOR(), (__size_in_points__).height* AX_CONTENT_SCALE_FACTOR())
 
 #ifndef FLT_EPSILON
 #    define FLT_EPSILON 1.192092896e-07F


### PR DESCRIPTION
Which branch your pull-request should merge into?
* I based it off of `dev`, but happy to change to `main` if deemed necessary 🤷

## Describe your changes
* Using `AX_SIZE_PIXELS_TO_POINTS` or `AX_SIZE_POINTS_TO_PIXELS` results in the following kind of error, because they expand to `Vec2` without the `ax` namespace:
```
/Users/dummy-user/src/dummy-project/dummy_file_path.cpp:119:9: error: use of undeclared identifier 'Vec2'
        AX_SIZE_PIXELS_TO_POINTS(
        ^
/Users/dummy-user/src/dummy-project/lib/axmol-1.0.0b13/core/base/ccMacros.h:166:5: note: expanded from macro 'AX_SIZE_PIXELS_TO_POINTS'
    Vec2((__size_in_pixels__).width / AX_CONTENT_SCALE_FACTOR(), \
    ^
```
* This PR fixes it by changing to `ax::Vec2` instead, just like other macros in this file.

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
