### PR TITLE
Fix issue where RichText URL touch listener does not activate on touch

### DIFF
--- a/core/ui/UIRichText.cpp
+++ b/core/ui/UIRichText.cpp
@@ -87,7 +87,7 @@ public:
     ~UrlTouchListenerComponent() override
     {
         Director::getInstance()->getEventDispatcher()->removeEventListener(_touchListener);
-        _touchListener->release();
+        _touchListener = nullptr;
     }
 
     bool onTouchBegan(Touch* touch, Event* /*event*/)

--- a/core/ui/UIRichText.cpp
+++ b/core/ui/UIRichText.cpp
@@ -102,7 +102,7 @@ public:
         return false;
     }
 
-    void onTouchEnded(Touch* touch, Event* /*event*/)
+    void onTouchEnded(Touch* /*touch*/, Event* /*event*/)
     {
         if (_handleOpenUrl)
         {


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.0 BugFixs or Features

## Describe your changes
Due to the way that touch input is dispatched to touch event listeners, instances of `EventListenerTouchAllAtOnce` will not receive touch inputs until after all instances of `EventListenerTouchOneByOne` are processed.  If any `EventListenerTouchOneByOne` listeners return `true` for the `onTouchBegin` handler, and also are set to swallow touches, then that touch is no longer available for when listeners of type `EventListenerTouchAllAtOnce` are processed. 

The RichText URL touch handler was of type `EventListenerTouchAllAtOnce`, so in a scene where other handlers exist of type `EventListenerTouchOneByOne`, the URL handler may not receive touch inputs.

The fix to this problem is to use `EventListenerTouchOneByOne` for the URL touch handling, and the implementation should behave in exactly the same way as before.

## Issue ticket number and link
#1327 

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
