### PR TITLE
Add enable global TTF SDF rendering support 

### DIFF
--- a/core/2d/FontAtlasCache.cpp
+++ b/core/2d/FontAtlasCache.cpp
@@ -59,15 +59,17 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
     bool useDistanceField  = config->distanceFieldEnabled;
     int outlineSize        = useDistanceField ? 0 : config->outlineSize;
 
+    auto baseFontSize = config->distanceFieldEnabled ? config->baseFontSize : config->fontSize;
+
     std::string atlasName =
         config->distanceFieldEnabled
-            ? fmt::format("df {:.2f} {} {}", config->fontSize, outlineSize, realFontFilename)
-            : fmt::format("{:.2f} {} {}", config->fontSize, outlineSize, realFontFilename);
+                                ? fmt::format("df {:.2f} {} {}", baseFontSize, outlineSize, realFontFilename)
+                                : fmt::format("{:.2f} {} {}", baseFontSize, outlineSize, realFontFilename);
     auto it = _atlasMap.find(atlasName);
 
     if (it == _atlasMap.end())
     {
-        auto font = FontFreeType::create(realFontFilename, config->fontSize, config->glyphs, config->customGlyphs,
+        auto font = FontFreeType::create(realFontFilename, baseFontSize, config->glyphs, config->customGlyphs,
                                          useDistanceField, static_cast<float>(outlineSize));
         if (font)
         {

--- a/core/2d/FontFreeType.cpp
+++ b/core/2d/FontFreeType.cpp
@@ -253,9 +253,9 @@ bool FontFreeType::loadFontFace(std::string_view fontPath, float fontSize)
             break;
 
         // set the requested font size
-        int dpi            = 72;
-        int fontSizePoints = (int)(64.f * fontSize * AX_CONTENT_SCALE_FACTOR());
-        if (FT_Set_Char_Size(face, fontSizePoints, fontSizePoints, dpi, dpi))
+         int dpi            = 72;
+         int fontSizePoints = (int)(64.f * fontSize * AX_CONTENT_SCALE_FACTOR());
+         if (FT_Set_Char_Size(face, fontSizePoints, fontSizePoints, dpi, dpi))
             break;
 
         // store the face globally

--- a/core/2d/FontFreeType.cpp
+++ b/core/2d/FontFreeType.cpp
@@ -253,9 +253,9 @@ bool FontFreeType::loadFontFace(std::string_view fontPath, float fontSize)
             break;
 
         // set the requested font size
-         int dpi            = 72;
-         int fontSizePoints = (int)(64.f * fontSize * AX_CONTENT_SCALE_FACTOR());
-         if (FT_Set_Char_Size(face, fontSizePoints, fontSizePoints, dpi, dpi))
+        int dpi            = 72;
+        int fontSizePoints = (int)(64.f * fontSize * AX_CONTENT_SCALE_FACTOR());
+        if (FT_Set_Char_Size(face, fontSizePoints, fontSizePoints, dpi, dpi))
             break;
 
         // store the face globally

--- a/core/2d/FontFreeType.h
+++ b/core/2d/FontFreeType.h
@@ -28,12 +28,15 @@
 #ifndef _FontFreetype_h_
 #define _FontFreetype_h_
 
-/// @cond DO_NOT_SHOW
-
 #include "2d/Font.h"
 #include <string>
 
+/**
+ * @addtogroup _2d
+ * @{
+ */
 /* freetype fwd decls */
+
 typedef struct FT_LibraryRec_* FT_Library;
 typedef struct FT_StreamRec_* FT_Stream;
 typedef struct FT_FaceRec_* FT_Face;
@@ -46,6 +49,46 @@ class AX_DLL FontFreeType : public Font
 {
 public:
     static const int DistanceMapSpread;
+    static constexpr int DEFAULT_BASE_FONT_SIZE = 32;
+
+     /**
+     * @remark: if you want enable stream parsing, you need do one of follow steps
+     *          a. disable .ttf compress on .apk, see:
+     *             https://simdsoft.com/notes/#build-apk-config-nocompress-file-type-at-appbuildgradle
+     *          b. uncomporess .ttf to disk by yourself.
+     */
+    static void setStreamParsingEnabled(bool bEnabled) { _streamParsingEnabled = bEnabled; }
+    static bool isStreamParsingEnabled() { return _streamParsingEnabled; }
+
+    /**
+     * @brief Set the Missing Glyph Character
+     *
+     * @param charCode
+     */
+    static void setMissingGlyphCharacter(char32_t charCode) { _mssingGlyphCharacter = charCode; };
+
+    /**
+     * @brief Set the Share Distance Field Enabled
+     *
+     * @param enabled
+     */
+    static void setShareDistanceFieldEnabled(bool enabled) { _shareDistanceFieldEnabled = enabled; }
+    static bool isShareDistanceFieldEnabled() { return _shareDistanceFieldEnabled; }
+
+    /**
+     * @brief TrueType fonts with native bytecode hinting * *
+     *
+     *   All applications that handle TrueType fonts with native hinting must
+     *   be aware that TTFs expect different rounding of vertical font
+     *   dimensions.  The application has to cater for this, especially if it
+     *   wants to rely on a TTF's vertical data (for example, to properly align
+     *   box characters vertically).
+     *   - Since freetype-2.8.1 TureType matrics isn't sync to size_matrics
+     *   - By default it's enabled for compatible with cocos2d-x-4.0 or older with freetype-2.5.5
+     *   - Please see freetype.h
+     */
+    static void setNativeBytecodeHintingEnabled(bool bEnabled) { _doNativeBytecodeHinting = bEnabled; }
+    static bool isNativeBytecodeHintingEnabled() { return _doNativeBytecodeHinting; }
 
     static FontFreeType* create(std::string_view fontPath,
                                 float fontSize,
@@ -55,32 +98,6 @@ public:
                                 float outline             = 0);
 
     static void shutdownFreeType();
-
-    /*
-     * @remark: if you want enable stream parsing, you need do one of follow steps
-     *          a. disable .ttf compress on .apk, see:
-     *             https://simdsoft.com/notes/#build-apk-config-nocompress-file-type-at-appbuildgradle
-     *          b. uncomporess .ttf to disk by yourself.
-     */
-    static void setStreamParsingEnabled(bool bEnabled) { _streamParsingEnabled = bEnabled; }
-    static bool isStreamParsingEnabled() { return _streamParsingEnabled; }
-
-    static void setMissingGlyphCharacter(char32_t charCode) { _mssingGlyphCharacter = charCode; };
-
-    /*
-    **TrueType fonts with native bytecode hinting**
-    *
-    *   All applications that handle TrueType fonts with native hinting must
-    *   be aware that TTFs expect different rounding of vertical font
-    *   dimensions.  The application has to cater for this, especially if it
-    *   wants to rely on a TTF's vertical data (for example, to properly align
-    *   box characters vertically).
-    *   - Since freetype-2.8.1 TureType matrics isn't sync to size_matrics
-    *   - By default it's enabled for compatible with cocos2d-x-4.0 or older with freetype-2.5.5
-    *   - Please see freetype.h
-    * */
-    static void setNativeBytecodeHintingEnabled(bool bEnabled) { _doNativeBytecodeHinting = bEnabled; }
-    static bool isNativeBytecodeHintingEnabled() { return _doNativeBytecodeHinting; }
 
     bool isDistanceFieldEnabled() const { return _distanceFieldEnabled; }
 
@@ -113,14 +130,15 @@ private:
     static bool _FTInitialized;
     static bool _streamParsingEnabled;
     static bool _doNativeBytecodeHinting;
+    static bool _shareDistanceFieldEnabled;
     static char32_t _mssingGlyphCharacter;
+
+    static bool initFreeType();
 
     FontFreeType(bool distanceFieldEnabled = false, float outline = 0);
     virtual ~FontFreeType();
 
     bool loadFontFace(std::string_view fontPath, float fontSize);
-
-    static bool initFreeType();
 
     int getHorizontalKerningForChars(uint64_t firstChar, uint64_t secondChar) const;
     unsigned char* getGlyphBitmapWithOutline(unsigned int glyphIndex, FT_BBox& bbox);
@@ -144,7 +162,8 @@ private:
     std::string _customGlyphs;
 };
 
-/// @endcond
+// end group
+/// @}
 
 NS_AX_END
 

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -74,18 +74,6 @@ void updateBlend(backend::BlendDescriptor& blendDescriptor, BlendFunc blendFunc)
 }
 }  // namespace
 
-static bool _distanceFieldEnabled = false;
-
-AX_DLL bool isDistanceFieldEnabled()
-{
-    return _distanceFieldEnabled;
-}
-
-AX_DLL void setDistanceFieldEnabled(bool enabled)
-{
-    _distanceFieldEnabled = enabled;
-}
-
 /**
  * LabelLetter used to update the quad in texture atlas without SpriteBatchNode.
  */

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -32,6 +32,7 @@
 #include "renderer/CustomCommand.h"
 #include "renderer/QuadCommand.h"
 #include "2d/FontAtlas.h"
+#include "2d/FontFreeType.h"
 #include "base/Types.h"
 
 NS_AX_BEGIN
@@ -42,10 +43,6 @@ NS_AX_BEGIN
  */
 
 #define AX_DEFAULT_FONT_LABEL_SIZE 12
-#define AX_DEFAULT_BASE_FONT_SIZE  32
-
-AX_DLL bool isDistanceFieldEnabled();
-AX_DLL void setDistanceFieldEnabled(bool enabled);
 
 /**
  * @struct TTFConfig
@@ -71,7 +68,7 @@ typedef struct _ttfConfig
                float size                             = AX_DEFAULT_FONT_LABEL_SIZE,
                const GlyphCollection& glyphCollection = GlyphCollection::DYNAMIC,
                const char* customGlyphCollection      = nullptr, /* nullable */
-               bool useDistanceField                  = isDistanceFieldEnabled(),
+               bool useDistanceField                  = FontFreeType::isShareDistanceFieldEnabled(),
                int outline                            = 0,
                bool useItalics                        = false,
                bool useBold                           = false,
@@ -79,7 +76,7 @@ typedef struct _ttfConfig
                bool useStrikethrough                  = false)
         : fontFilePath(filePath)
         , fontSize(size)
-        , baseFontSize(AX_DEFAULT_BASE_FONT_SIZE)
+        , baseFontSize(FontFreeType::DEFAULT_BASE_FONT_SIZE)
         , glyphs(glyphCollection)
         , customGlyphs(customGlyphCollection ? customGlyphCollection : "")
         , distanceFieldEnabled(useDistanceField)

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -785,7 +785,9 @@ protected:
     void createShadowSpriteForSystemFont(const FontDefinition& fontDef);
 
     virtual void updateShaderProgram();
-    virtual void updateBMFontScale();
+    virtual void updateFontScale();
+    /* DEPRECATED: use updateFontScale instead */
+    AX_DEPRECATED_ATTRIBUTE virtual void updateBMFontScale() { updateFontScale(); }
     void scaleFontSize(float fontSize);
     bool setTTFConfigInternal(const TTFConfig& ttfConfig);
     void setBMFontSizeInternal(float fontSize);
@@ -811,9 +813,6 @@ protected:
     void updateBuffer(TextureAtlas* textureAtlas, CustomCommand& customCommand);
 
     void updateBatchCommand(BatchCommand& batch);
-
-    const Mat4& getNodeToParentTransform() const override;
-
     
     bool _contentDirty;
     bool _useDistanceField;
@@ -867,11 +866,10 @@ protected:
     LabelEffect _currLabelEffect;
     float _shadowBlurRadius;
     float _bmFontSize;
-    float _bmfontScale;
+    float _fontScale; // The bmFontScale or ttfFontScale(SDF rendering mode)
 
     Overflow _overflow;
     float _originalFontSize;
-    float _ttfFontScale;
     Color4B _textColor;
 
     BlendFunc _blendFunc;

--- a/core/2d/LabelTextFormatter.cpp
+++ b/core/2d/LabelTextFormatter.cpp
@@ -145,7 +145,7 @@ void Label::updateFontScale()
     }
     else if (_currentLabelType == LabelType::TTF && _fontConfig.distanceFieldEnabled)
     {
-        _fontScale = _fontConfig.fontSize / _fontConfig.baseFontSize;
+        _fontScale = _fontConfig.fontSize * AX_CONTENT_SCALE_FACTOR() / _fontConfig.baseFontSize;
     }
     else
     {

--- a/core/2d/LabelTextFormatter.cpp
+++ b/core/2d/LabelTextFormatter.cpp
@@ -84,8 +84,6 @@ int Label::getFirstWordLen(const std::u32string& utf32Text, int startIndex, int 
     auto nextLetterX = 0;
     FontLetterDefinition letterDef;
     auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
-    
-    const auto fontScale = _currentLabelType == LabelType::TTF ? _ttfFontScale : _bmfontScale;
 
     for (int index = startIndex; index < textLen; ++index)
     {
@@ -105,13 +103,13 @@ int Label::getFirstWordLen(const std::u32string& utf32Text, int startIndex, int 
 
         if (_maxLineWidth > 0.f)
         {
-            auto letterX = (nextLetterX + letterDef.offsetX * fontScale) / contentScaleFactor;
+            auto letterX = (nextLetterX + letterDef.offsetX * _fontScale) / contentScaleFactor;
 
-            if (letterX + letterDef.width * fontScale > _maxLineWidth)
+            if (letterX + letterDef.width * _fontScale > _maxLineWidth)
                 break;
         }
 
-        nextLetterX += static_cast<int>(letterDef.xAdvance * fontScale + _additionalKerning);
+        nextLetterX += static_cast<int>(letterDef.xAdvance * _fontScale + _additionalKerning);
 
         len++;
     }
@@ -136,18 +134,22 @@ bool Label::getFontLetterDef(char32_t character, FontLetterDefinition& letterDef
     return _fontAtlas->getLetterDefinitionForChar(character, letterDef);
 }
 
-void Label::updateBMFontScale()
+void Label::updateFontScale()
 {
     auto font = _fontAtlas->getFont();
     if (_currentLabelType == LabelType::BMFONT)
     {
         FontFNT* bmFont       = (FontFNT*)font;
         auto originalFontSize = bmFont->getOriginalFontSize();
-        _bmfontScale          = _bmFontSize * AX_CONTENT_SCALE_FACTOR() / originalFontSize;
+        _fontScale          = _bmFontSize * AX_CONTENT_SCALE_FACTOR() / originalFontSize;
+    }
+    else if (_currentLabelType == LabelType::TTF && _fontConfig.distanceFieldEnabled)
+    {
+        _fontScale = _fontConfig.fontSize / _fontConfig.baseFontSize;
     }
     else
     {
-        _bmfontScale = 1.0f;
+        _fontScale = 1.0f;
     }
 }
 
@@ -170,9 +172,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
     Vec2 letterPosition;
     bool nextChangeSize = true;
 
-    this->updateBMFontScale();
-
-    const auto fontScale = _currentLabelType == LabelType::TTF ? _ttfFontScale : _bmfontScale;
+    this->updateFontScale();
 
     for (int index = 0; index < textLen;)
     {
@@ -183,7 +183,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             letterRight = 0.f;
             lineIndex++;
             nextTokenX = 0.f;
-            nextTokenY -= _lineHeight * fontScale + lineSpacing;
+            nextTokenY -= _lineHeight * _fontScale + lineSpacing;
             recordPlaceholderInfo(index, character);
             index++;
             continue;
@@ -222,9 +222,9 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                 continue;
             }
 
-            auto letterX = (nextLetterX + letterDef.offsetX * fontScale) / contentScaleFactor;
+            auto letterX = (nextLetterX + letterDef.offsetX * _fontScale) / contentScaleFactor;
             if (_enableWrap && _maxLineWidth > 0.f && nextTokenX > 0.f &&
-                letterX + letterDef.width * fontScale > _maxLineWidth && !StringUtils::isUnicodeSpace(character) &&
+                letterX + letterDef.width * _fontScale > _maxLineWidth && !StringUtils::isUnicodeSpace(character) &&
                 nextChangeSize)
             {
                 _linesWidth.emplace_back(letterRight - whitespaceWidth);
@@ -232,7 +232,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                 letterRight         = 0.f;
                 lineIndex++;
                 nextTokenX = 0.f;
-                nextTokenY -= (_lineHeight * fontScale + lineSpacing);
+                nextTokenY -= (_lineHeight * _fontScale + lineSpacing);
                 newLine = true;
                 break;
             }
@@ -240,7 +240,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             {
                 letterPosition.x = letterX;
             }
-            letterPosition.y = (nextTokenY - letterDef.offsetY * fontScale) / contentScaleFactor;
+            letterPosition.y = (nextTokenY - letterDef.offsetY * _fontScale) / contentScaleFactor;
             recordLetterInfo(letterPosition, character, letterIndex, lineIndex);
 
             if (nextChangeSize)
@@ -248,7 +248,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                 float newLetterWidth = 0.f;
                 if (_horizontalKernings && letterIndex < textLen - 1)
                     newLetterWidth = static_cast<float>(_horizontalKernings[letterIndex + 1]);
-                newLetterWidth += letterDef.xAdvance * fontScale + _additionalKerning;
+                newLetterWidth += letterDef.xAdvance * _fontScale + _additionalKerning;
 
                 nextLetterX += newLetterWidth;
                 tokenRight = nextLetterX / contentScaleFactor;
@@ -266,8 +266,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
 
             if (tokenHighestY < letterPosition.y)
                 tokenHighestY = letterPosition.y;
-            if (tokenLowestY > letterPosition.y - letterDef.height * fontScale)
-                tokenLowestY = letterPosition.y - letterDef.height * fontScale;
+            if (tokenLowestY > letterPosition.y - letterDef.height * _fontScale)
+                tokenLowestY = letterPosition.y - letterDef.height * _fontScale;
         }
 
         if (newLine)
@@ -301,7 +301,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
     }
 
     _numberOfLines     = lineIndex + 1;
-    _textDesiredHeight = (_numberOfLines * _lineHeight * fontScale) / contentScaleFactor;
+    _textDesiredHeight = (_numberOfLines * _lineHeight * _fontScale) / contentScaleFactor;
     if (_numberOfLines > 1)
         _textDesiredHeight += (_numberOfLines - 1) * _lineSpacing; // ?? use scaled lineSpacing
     Vec2 contentSize(_labelWidth, _labelHeight);
@@ -347,15 +347,13 @@ bool Label::isHorizontalClamp()
 {
     bool letterClamp = false;
     
-    const auto fontScale = _currentLabelType == LabelType::TTF ? _ttfFontScale : _bmfontScale;
-    
     for (int ctr = 0; ctr < _lengthOfString; ++ctr)
     {
         if (_lettersInfo[ctr].valid)
         {
             auto& letterDef = _fontAtlas->_letterDefinitions[_lettersInfo[ctr].utf32Char];
 
-            auto px        = _lettersInfo[ctr].positionX + letterDef.width / 2 * fontScale;
+            auto px        = _lettersInfo[ctr].positionX + letterDef.width / 2 * _fontScale;
             auto lineIndex = _lettersInfo[ctr].lineIndex;
 
             if (_labelWidth > 0.f)

--- a/core/2d/LabelTextFormatter.cpp
+++ b/core/2d/LabelTextFormatter.cpp
@@ -84,6 +84,8 @@ int Label::getFirstWordLen(const std::u32string& utf32Text, int startIndex, int 
     auto nextLetterX = 0;
     FontLetterDefinition letterDef;
     auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
+    
+    const auto fontScale = _currentLabelType == LabelType::TTF ? _ttfFontScale : _bmfontScale;
 
     for (int index = startIndex; index < textLen; ++index)
     {
@@ -103,13 +105,13 @@ int Label::getFirstWordLen(const std::u32string& utf32Text, int startIndex, int 
 
         if (_maxLineWidth > 0.f)
         {
-            auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
+            auto letterX = (nextLetterX + letterDef.offsetX * fontScale) / contentScaleFactor;
 
-            if (letterX + letterDef.width * _bmfontScale > _maxLineWidth)
+            if (letterX + letterDef.width * fontScale > _maxLineWidth)
                 break;
         }
 
-        nextLetterX += static_cast<int>(letterDef.xAdvance * _bmfontScale + _additionalKerning);
+        nextLetterX += static_cast<int>(letterDef.xAdvance * fontScale + _additionalKerning);
 
         len++;
     }
@@ -160,6 +162,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
     float nextWhitespaceWidth = 0.f;
 
     auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
+
     float lineSpacing       = _lineSpacing * contentScaleFactor;
     float highestY          = 0.f;
     float lowestY           = 0.f;
@@ -168,6 +171,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
     bool nextChangeSize = true;
 
     this->updateBMFontScale();
+
+    const auto fontScale = _currentLabelType == LabelType::TTF ? _ttfFontScale : _bmfontScale;
 
     for (int index = 0; index < textLen;)
     {
@@ -178,7 +183,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             letterRight = 0.f;
             lineIndex++;
             nextTokenX = 0.f;
-            nextTokenY -= _lineHeight * _bmfontScale + lineSpacing;
+            nextTokenY -= _lineHeight * fontScale + lineSpacing;
             recordPlaceholderInfo(index, character);
             index++;
             continue;
@@ -217,9 +222,9 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                 continue;
             }
 
-            auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
+            auto letterX = (nextLetterX + letterDef.offsetX * fontScale) / contentScaleFactor;
             if (_enableWrap && _maxLineWidth > 0.f && nextTokenX > 0.f &&
-                letterX + letterDef.width * _bmfontScale > _maxLineWidth && !StringUtils::isUnicodeSpace(character) &&
+                letterX + letterDef.width * fontScale > _maxLineWidth && !StringUtils::isUnicodeSpace(character) &&
                 nextChangeSize)
             {
                 _linesWidth.emplace_back(letterRight - whitespaceWidth);
@@ -227,7 +232,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                 letterRight         = 0.f;
                 lineIndex++;
                 nextTokenX = 0.f;
-                nextTokenY -= (_lineHeight * _bmfontScale + lineSpacing);
+                nextTokenY -= (_lineHeight * fontScale + lineSpacing);
                 newLine = true;
                 break;
             }
@@ -235,7 +240,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             {
                 letterPosition.x = letterX;
             }
-            letterPosition.y = (nextTokenY - letterDef.offsetY * _bmfontScale) / contentScaleFactor;
+            letterPosition.y = (nextTokenY - letterDef.offsetY * fontScale) / contentScaleFactor;
             recordLetterInfo(letterPosition, character, letterIndex, lineIndex);
 
             if (nextChangeSize)
@@ -243,7 +248,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                 float newLetterWidth = 0.f;
                 if (_horizontalKernings && letterIndex < textLen - 1)
                     newLetterWidth = static_cast<float>(_horizontalKernings[letterIndex + 1]);
-                newLetterWidth += letterDef.xAdvance * _bmfontScale + _additionalKerning;
+                newLetterWidth += letterDef.xAdvance * fontScale + _additionalKerning;
 
                 nextLetterX += newLetterWidth;
                 tokenRight = nextLetterX / contentScaleFactor;
@@ -261,8 +266,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
 
             if (tokenHighestY < letterPosition.y)
                 tokenHighestY = letterPosition.y;
-            if (tokenLowestY > letterPosition.y - letterDef.height * _bmfontScale)
-                tokenLowestY = letterPosition.y - letterDef.height * _bmfontScale;
+            if (tokenLowestY > letterPosition.y - letterDef.height * fontScale)
+                tokenLowestY = letterPosition.y - letterDef.height * fontScale;
         }
 
         if (newLine)
@@ -296,9 +301,9 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
     }
 
     _numberOfLines     = lineIndex + 1;
-    _textDesiredHeight = (_numberOfLines * _lineHeight * _bmfontScale) / contentScaleFactor;
+    _textDesiredHeight = (_numberOfLines * _lineHeight * fontScale) / contentScaleFactor;
     if (_numberOfLines > 1)
-        _textDesiredHeight += (_numberOfLines - 1) * _lineSpacing;
+        _textDesiredHeight += (_numberOfLines - 1) * _lineSpacing; // ?? use scaled lineSpacing
     Vec2 contentSize(_labelWidth, _labelHeight);
     if (_labelWidth <= 0.f)
         contentSize.width = longestLine;
@@ -341,13 +346,16 @@ bool Label::isVerticalClamp()
 bool Label::isHorizontalClamp()
 {
     bool letterClamp = false;
+    
+    const auto fontScale = _currentLabelType == LabelType::TTF ? _ttfFontScale : _bmfontScale;
+    
     for (int ctr = 0; ctr < _lengthOfString; ++ctr)
     {
         if (_lettersInfo[ctr].valid)
         {
             auto& letterDef = _fontAtlas->_letterDefinitions[_lettersInfo[ctr].utf32Char];
 
-            auto px        = _lettersInfo[ctr].positionX + letterDef.width / 2 * _bmfontScale;
+            auto px        = _lettersInfo[ctr].positionX + letterDef.width / 2 * fontScale;
             auto lineIndex = _lettersInfo[ctr].lineIndex;
 
             if (_labelWidth > 0.f)

--- a/extensions/fairygui/display/FUILabel.cpp
+++ b/extensions/fairygui/display/FUILabel.cpp
@@ -176,18 +176,18 @@ void FUILabel::setGrayed(bool value)
     }
 }
 
-void FUILabel::updateBMFontScale()
+void FUILabel::updateFontScale()
 {
     auto font = _fontAtlas->getFont();
     if (_currentLabelType == LabelType::BMFONT)
     {
         BitmapFont* bmFont = (BitmapFont*)font;
         float originalFontSize = bmFont->getOriginalFontSize();
-        _bmfontScale = _bmFontSize * AX_CONTENT_SCALE_FACTOR() / originalFontSize;
+        _fontScale             = _bmFontSize * AX_CONTENT_SCALE_FACTOR() / originalFontSize;
     }
     else
     {
-        _bmfontScale = 1.0f;
+        ax::Label::updateFontScale();
     }
 }
 

--- a/extensions/fairygui/display/FUILabel.h
+++ b/extensions/fairygui/display/FUILabel.h
@@ -41,7 +41,7 @@ protected:
     因为这个方法里有强制字体对象指针为FontFnt类型的代码，但我们不使用FontFnt（FontFnt只支持从外部文件中载入配置，更糟糕的是BMFontConfiguration是定义在cpp里的。）
     所以需要重写这个方法。
     */
-    virtual void updateBMFontScale() override;
+    virtual void updateFontScale() override;
 
 private:
     TextFormat* _textFormat;

--- a/templates/cpp-template-default/Source/AppDelegate.cpp
+++ b/templates/cpp-template-default/Source/AppDelegate.cpp
@@ -62,11 +62,6 @@ static int register_all_packages()
 
 bool AppDelegate::applicationDidFinishLaunching()
 {
-    // whether enable global SDF font render support, since axmol-2.0.1
-    ax::setDistanceFieldEnabled(true);
-
-    auto md4Val = utils::computeDigest("hello world", "md4");
-
     // initialize director
     auto director = Director::getInstance();
     auto glView   = director->getOpenGLView();

--- a/templates/cpp-template-default/Source/AppDelegate.cpp
+++ b/templates/cpp-template-default/Source/AppDelegate.cpp
@@ -62,6 +62,9 @@ static int register_all_packages()
 
 bool AppDelegate::applicationDidFinishLaunching()
 {
+    // whether enable global SDF font render support, since axmol-2.0.1
+    ax::setDistanceFieldEnabled(true);
+
     auto md4Val = utils::computeDigest("hello world", "md4");
 
     // initialize director

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -56,7 +56,7 @@ void AppDelegate::initGLContextAttrs()
 bool AppDelegate::applicationDidFinishLaunching()
 {
     // whether enable global SDF font render support, since axmol-2.0.1
-    ax::setDistanceFieldEnabled(true);
+    FontFreeType::setShareDistanceFieldEnabled(true);
 
     // As an example, load config file
     // FIXME:: This should be loaded before the Director is initialized,

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -55,6 +55,9 @@ void AppDelegate::initGLContextAttrs()
 
 bool AppDelegate::applicationDidFinishLaunching()
 {
+    // whether enable global SDF font render support, since axmol-2.0.1
+    ax::setDistanceFieldEnabled(true);
+
     // As an example, load config file
     // FIXME:: This should be loaded before the Director is initialized,
     // FIXME:: but at this point, the director is already initialized


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.0 Features

## Improvements

- [x] Auto scale font size with SDF baseFontSize, how to modify `baseFontSize`
```cpp
auto ttfcfg = label->getTTFConfig();
ttfcfg.baseFontSize = 36;
label->setTTFConfig(ttfcfg);
```
- [x] Provide API to control this new feature beahvior: `FontFreeType::setShareDistanceFieldEnabled` and `FontFreeType::isShareDistanceFieldEnabled()`
- [x] Rename `updateBMfontScale` to `updateFontScale`, mark `updateBMFontScale` deprecated
- [x] `sizeof(Label)` reduce from 2088bytes to 2048bytes(-40bytes) on win64

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [x] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [x] I have added/adapted some tests too.
