### PR TITLE
[IMPROVEMENT] Prevent Label Extra Pixels

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -3043,7 +3043,7 @@ void Label::recordLetterInfo(const ax::Vec2& point, char32_t utf32Char, int lett
     }
     _lettersInfo[letterIndex].lineIndex  = lineIndex;
     _lettersInfo[letterIndex].utf32Char  = utf32Char;
-    _lettersInfo[letterIndex].valid      = _fontAtlas->_letterDefinitions[utf32Char].validDefinition;
+    _lettersInfo[letterIndex].valid      = _fontAtlas->_letterDefinitions[utf32Char].validDefinition && utf32Char != ' ';
     _lettersInfo[letterIndex].positionX  = point.x;
     _lettersInfo[letterIndex].positionY  = point.y;
     _lettersInfo[letterIndex].atlasIndex = -1;


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.0 BugFixs or Features

## Describe your changes

When creating a label using `createWithBMFont` I noticed that space characters are being drawn even though they don't have any opaque pixels.

You can see in the image below that the character `' '` is being accounted for and rendered which wastes GPU resources. (in this case GPU pixel fill rate is wasted)
![image](https://github.com/axmolengine/axmol/assets/45469625/e905d440-c1fd-407b-bcbb-01934f72e023)

And this is after making sure that the character `' '` is invalid which will make it not render.
![image](https://github.com/axmolengine/axmol/assets/45469625/12ceacfb-8b3f-452a-a84a-f392b3a0835f)


## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [x] I have checked readme and add important infos to this PR (if it needed).
