### PR TITLE
[Android] Restrict temporary and generated files to build folder

### DIFF
--- a/cmake/Modules/AXBuildSet.cmake
+++ b/cmake/Modules/AXBuildSet.cmake
@@ -28,7 +28,7 @@ set(_AX_EXTENSION_LIBS "" CACHE INTERNAL "extensions for auto link to target app
 
 # configure android GLSLCC compile output, this is the first include cmake module
 if (ANDROID)
-    file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/proj.android/build/runtime/axslc" _GLSLCC_OUT_DIR)
+    file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/proj.android/app/build/runtime/axslc" _GLSLCC_OUT_DIR)
     set(GLSLCC_OUT_DIR "${_GLSLCC_OUT_DIR}" CACHE STRING "" FORCE)
     message(AUTHOR_WARNING "Set GLSLCC_OUT_DIR to ${GLSLCC_OUT_DIR} for android")
 endif()

--- a/templates/cpp-template-default/proj.android/app/build.gradle
+++ b/templates/cpp-template-default/proj.android/app/build.gradle
@@ -110,7 +110,7 @@ android.applicationVariants.all { variant ->
         }
         doLast {
             copy {
-                from "${projectDir}/build/assets/runtime/axslc"
+                from "${projectDir}/build/runtime/axslc"
                 into "${projectDir}/build/assets/axslc"
             }
         }

--- a/templates/cpp-template-default/proj.android/app/build.gradle
+++ b/templates/cpp-template-default/proj.android/app/build.gradle
@@ -39,7 +39,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "assets"
+        assets.srcDir "build/assets"
     }
 
     externalNativeBuild {
@@ -90,14 +90,14 @@ android.applicationVariants.all { variant ->
     def targetName = variant.name.capitalize()
 
     def copyContentToAssets = "copy${targetName}ContentToAssets"
-    tasks.register("copy${targetName}ContentToAssets") {
+    tasks.register(copyContentToAssets) {
         doFirst {
-            delete "${projectDir}/assets"
+            delete "${projectDir}/build/assets"
         }
         doLast {
             copy {
                 from "${projectDir}/../../Content"
-                into "${projectDir}/assets"
+                into "${projectDir}/build/assets"
                 exclude "**/*.gz"
             }
         }
@@ -106,12 +106,12 @@ android.applicationVariants.all { variant ->
 
     tasks.register("copy${targetName}AxslcToAssets") {
         doFirst {
-            delete "${projectDir}/assets/axslc"
+            delete "${projectDir}/build/assets/axslc"
         }
         doLast {
             copy {
-                from "${projectDir}/../build/runtime/axslc"
-                into "${projectDir}/assets/axslc"
+                from "${projectDir}/build/assets/runtime/axslc"
+                into "${projectDir}/build/assets/axslc"
             }
         }
     }

--- a/templates/lua-template-default/proj.android/app/build.gradle
+++ b/templates/lua-template-default/proj.android/app/build.gradle
@@ -110,7 +110,7 @@ android.applicationVariants.all { variant ->
         }
         doLast {
             copy {
-                from "${projectDir}/build/assets/runtime/axslc"
+                from "${projectDir}/build/runtime/axslc"
                 into "${projectDir}/build/assets/axslc"
             }
         }

--- a/templates/lua-template-default/proj.android/app/build.gradle
+++ b/templates/lua-template-default/proj.android/app/build.gradle
@@ -39,7 +39,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "assets"
+        assets.srcDir "build/assets"
     }
 
     externalNativeBuild {
@@ -90,14 +90,14 @@ android.applicationVariants.all { variant ->
     def targetName = variant.name.capitalize()
 
     def copyContentToAssets = "copy${targetName}ContentToAssets"
-    tasks.register("copy${targetName}ContentToAssets") {
+    tasks.register(copyContentToAssets) {
         doFirst {
-            delete "${projectDir}/assets"
+            delete "${projectDir}/build/assets"
         }
         doLast {
             copy {
                 from "${projectDir}/../../Content"
-                into "${projectDir}/assets"
+                into "${projectDir}/build/assets"
                 exclude "**/*.gz"
             }
         }
@@ -106,12 +106,12 @@ android.applicationVariants.all { variant ->
 
     tasks.register("copy${targetName}AxslcToAssets") {
         doFirst {
-            delete "${projectDir}/assets/axslc"
+            delete "${projectDir}/build/assets/axslc"
         }
         doLast {
             copy {
-                from "${projectDir}/../build/runtime/axslc"
-                into "${projectDir}/assets/axslc"
+                from "${projectDir}/build/assets/runtime/axslc"
+                into "${projectDir}/build/assets/axslc"
             }
         }
     }

--- a/tests/cpp-tests/proj.android/app/build.gradle
+++ b/tests/cpp-tests/proj.android/app/build.gradle
@@ -40,7 +40,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "assets"
+        assets.srcDir "build/assets"
     }
 
     externalNativeBuild {
@@ -93,12 +93,12 @@ android.applicationVariants.all { variant ->
     def copyContentToAssets = "copy${targetName}ContentToAssets"
     tasks.register(copyContentToAssets) {
         doFirst {
-            delete "${projectDir}/assets"
+            delete "${projectDir}/build/assets"
         }
         doLast {
             copy {
                 from "${projectDir}/../../Content"
-                into "${projectDir}/assets"
+                into "${projectDir}/build/assets"
                 exclude "**/*.gz"
             }
         }
@@ -107,12 +107,12 @@ android.applicationVariants.all { variant ->
 
     tasks.register("copy${targetName}AxslcToAssets") {
         doFirst {
-            delete "${projectDir}/assets/axslc"
+            delete "${projectDir}/build/assets/axslc"
         }
         doLast {
             copy {
-                from "${projectDir}/../build/runtime/axslc"
-                into "${projectDir}/assets/axslc"
+                from "${projectDir}/build/assets/runtime/axslc"
+                into "${projectDir}/build/assets/axslc"
             }
         }
     }

--- a/tests/cpp-tests/proj.android/app/build.gradle
+++ b/tests/cpp-tests/proj.android/app/build.gradle
@@ -111,7 +111,7 @@ android.applicationVariants.all { variant ->
         }
         doLast {
             copy {
-                from "${projectDir}/build/assets/runtime/axslc"
+                from "${projectDir}/build/runtime/axslc"
                 into "${projectDir}/build/assets/axslc"
             }
         }

--- a/tests/fairygui-tests/proj.android/app/build.gradle
+++ b/tests/fairygui-tests/proj.android/app/build.gradle
@@ -41,7 +41,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "assets"
+        assets.srcDir "build/assets"
     }
 
     externalNativeBuild {
@@ -92,14 +92,14 @@ android.applicationVariants.all { variant ->
     def targetName = variant.name.capitalize()
 
     def copyContentToAssets = "copy${targetName}ContentToAssets"
-    tasks.register("copy${targetName}ContentToAssets") {
+    tasks.register(copyContentToAssets) {
         doFirst {
-            delete "${projectDir}/assets"
+            delete "${projectDir}/build/assets"
         }
         doLast {
             copy {
                 from "${projectDir}/../../Content"
-                into "${projectDir}/assets"
+                into "${projectDir}/build/assets"
                 exclude "**/*.gz"
             }
         }
@@ -108,12 +108,12 @@ android.applicationVariants.all { variant ->
 
     tasks.register("copy${targetName}AxslcToAssets") {
         doFirst {
-            delete "${projectDir}/assets/axslc"
+            delete "${projectDir}/build/assets/axslc"
         }
         doLast {
             copy {
-                from "${projectDir}/../build/runtime/axslc"
-                into "${projectDir}/assets/axslc"
+                from "${projectDir}/build/assets/runtime/axslc"
+                into "${projectDir}/build/assets/axslc"
             }
         }
     }

--- a/tests/fairygui-tests/proj.android/app/build.gradle
+++ b/tests/fairygui-tests/proj.android/app/build.gradle
@@ -112,7 +112,7 @@ android.applicationVariants.all { variant ->
         }
         doLast {
             copy {
-                from "${projectDir}/build/assets/runtime/axslc"
+                from "${projectDir}/build/runtime/axslc"
                 into "${projectDir}/build/assets/axslc"
             }
         }

--- a/tests/live2d-tests/proj.android/app/build.gradle
+++ b/tests/live2d-tests/proj.android/app/build.gradle
@@ -110,7 +110,7 @@ android.applicationVariants.all { variant ->
         }
         doLast {
             copy {
-                from "${projectDir}/build/assets/runtime/axslc"
+                from "${projectDir}/build/runtime/axslc"
                 into "${projectDir}/build/assets/axslc"
             }
         }

--- a/tests/live2d-tests/proj.android/app/build.gradle
+++ b/tests/live2d-tests/proj.android/app/build.gradle
@@ -39,7 +39,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "assets"
+        assets.srcDir "build/assets"
     }
 
     externalNativeBuild {
@@ -90,14 +90,14 @@ android.applicationVariants.all { variant ->
     def targetName = variant.name.capitalize()
 
     def copyContentToAssets = "copy${targetName}ContentToAssets"
-    tasks.register("copy${targetName}ContentToAssets") {
+    tasks.register(copyContentToAssets) {
         doFirst {
-            delete "${projectDir}/assets"
+            delete "${projectDir}/build/assets"
         }
         doLast {
             copy {
                 from "${projectDir}/../../Content"
-                into "${projectDir}/assets"
+                into "${projectDir}/build/assets"
                 exclude "**/*.gz"
             }
         }
@@ -106,12 +106,12 @@ android.applicationVariants.all { variant ->
 
     tasks.register("copy${targetName}AxslcToAssets") {
         doFirst {
-            delete "${projectDir}/assets/axslc"
+            delete "${projectDir}/build/assets/axslc"
         }
         doLast {
             copy {
-                from "${projectDir}/../build/runtime/axslc"
-                into "${projectDir}/assets/axslc"
+                from "${projectDir}/build/assets/runtime/axslc"
+                into "${projectDir}/build/assets/axslc"
             }
         }
     }

--- a/tests/lua-tests/proj.android/app/build.gradle
+++ b/tests/lua-tests/proj.android/app/build.gradle
@@ -111,7 +111,7 @@ android.applicationVariants.all { variant ->
         }
         doLast {
             copy {
-                from "${projectDir}/build/assets/runtime/axslc"
+                from "${projectDir}/build/runtime/axslc"
                 into "${projectDir}/build/assets/axslc"
             }
         }

--- a/tests/lua-tests/proj.android/app/build.gradle
+++ b/tests/lua-tests/proj.android/app/build.gradle
@@ -40,7 +40,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "assets"
+        assets.srcDir "build/assets"
     }
 
     externalNativeBuild {
@@ -91,14 +91,14 @@ android.applicationVariants.all { variant ->
     def targetName = variant.name.capitalize()
 
     def copyContentToAssets = "copy${targetName}ContentToAssets"
-    tasks.register("copy${targetName}ContentToAssets") {
+    tasks.register(copyContentToAssets) {
         doFirst {
-            delete "${projectDir}/assets"
+            delete "${projectDir}/build/assets"
         }
         doLast {
             copy {
                 from "${projectDir}/../../Content"
-                into "${projectDir}/assets"
+                into "${projectDir}/build/assets"
                 exclude "**/*.gz"
             }
         }
@@ -107,12 +107,12 @@ android.applicationVariants.all { variant ->
 
     tasks.register("copy${targetName}AxslcToAssets") {
         doFirst {
-            delete "${projectDir}/assets/axslc"
+            delete "${projectDir}/build/assets/axslc"
         }
         doLast {
             copy {
-                from "${projectDir}/../build/runtime/axslc"
-                into "${projectDir}/assets/axslc"
+                from "${projectDir}/build/assets/runtime/axslc"
+                into "${projectDir}/build/assets/axslc"
             }
         }
     }


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes

At the moment a copy of assets and runtime shaders is created in different parts of the source folders for Android builds.  These files are temporary, and only for builds, so perhaps it is best to put them in the build folder.  

The other benefit to this is that if we clean the project (either through "Clean Project" in Android Studio or otherwise), then those generated assets folders are also removed, since they're all in the "build" folder.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
