### PR TITLE
fix warning messages in gcc 13.2.1 to compliance with C++20

### DIFF
--- a/extensions/Particle3D/Particle3DRender.cpp
+++ b/extensions/Particle3D/Particle3DRender.cpp
@@ -167,8 +167,8 @@ void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, Par
     auto afterCommand = renderer->nextCallbackCommand();
     afterCommand->init(depthZ);
 
-    beforeCommand->func = [=]() { onBeforeDraw(); };  // AX_CALLBACK_0(Particle3DQuadRender::onBeforeDraw, this);
-    afterCommand->func  = [=]() { onAfterDraw(); };   // AX_CALLBACK_0(Particle3DQuadRender::onAfterDraw, this);
+    beforeCommand->func = [this] { onBeforeDraw(); };  // AX_CALLBACK_0(Particle3DQuadRender::onBeforeDraw, this);
+    afterCommand->func  = [this] { onAfterDraw(); };   // AX_CALLBACK_0(Particle3DQuadRender::onAfterDraw, this);
 
     _meshCommand.setVertexBuffer(_vertexBuffer);
     _meshCommand.setIndexBuffer(_indexBuffer, MeshCommand::IndexFormat::U_SHORT);


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`:  fix some warning messages
`
170:27: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
  170 |     beforeCommand->func = [=]() { onBeforeDraw(); };  // AX_CALLBACK_0(Particle3DQuadRender::onBeforeDraw, this);
      |                           ^
/home/joilnen/axmol_devel/axmol-2.0.x1/extensions/Particle3D/Particle3DRender.cpp:170:27: note: add explicit ‘this’ or ‘*this’ capture
/home/joilnen/axmol_devel/axmol-2.0.x1/extensions/Particle3D/Particle3DRender.cpp: In lambda function:
/home/joilnen/axmol_devel/axmol-2.0.x1/extensions/Particle3D/Particle3DRender.cpp:171:27: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
`