### PR TITLE
Support adding custom properties to the inspector for derived types

### DIFF
--- a/extensions/Inspector/Inspector.h
+++ b/extensions/Inspector/Inspector.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <map>
+#include <memory>
+
 #include "ExtensionMacros.h"
 #include "base/Config.h"
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 NS_AX_BEGIN
-
 class Node;
 class Scene;
 
@@ -13,25 +17,62 @@ NS_AX_END
 
 NS_AX_EXT_BEGIN
 
+class InspectPropertyHandler
+{
+public:
+    virtual ~InspectPropertyHandler() = default;
+    virtual bool isSupportedType(Node* node) = 0;
+    virtual void drawProperties(Node* node) = 0;
+};
+
+class InspectorNodePropertyHandler : public InspectPropertyHandler
+{
+public:
+    ~InspectorNodePropertyHandler() override = default;
+    bool isSupportedType(Node* node) override;
+    void drawProperties(Node* node) override;
+};
+
+class InspectorSpritePropertyHandler : public InspectPropertyHandler
+{
+public:
+    ~InspectorSpritePropertyHandler() override = default;
+    bool isSupportedType(Node* node) override;
+    void drawProperties(Node* node) override;
+};
+
+class InspectorLabelProtocolPropertyHandler : public InspectPropertyHandler
+{
+public:
+    ~InspectorLabelProtocolPropertyHandler() override = default;
+    bool isSupportedType(Node* node) override;
+    void drawProperties(Node* node) override;
+};
+
 class Inspector
 {
   public:
     static Inspector* getInstance();
     static void destroyInstance();
-    static std::string getNodeName(Node*);
+    static std::string getNodeTypeName(Node*);
     static std::string demangle(const char* mangled);
     void openForScene(Scene*);
     void close();
+
+    bool addPropertyHandler(std::string_view handlerId, std::unique_ptr<InspectPropertyHandler> handler);
+    void removePropertyHandler(const std::string& handlerId);
 
   private:
     void init();
     void cleanup();
     void mainLoop();
-    void drawTreeRecusrive(Node*, int index = 0);
+    void drawTreeRecursive(Node*, int index = 0);
     void drawProperties();
 
     ax::Node* _selected_node = nullptr;
     ax::Scene* _target = nullptr;
+
+    std::unordered_map<std::string, std::unique_ptr<InspectPropertyHandler>> _propertyHandlers;
 };
 
 NS_AX_EXT_END


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
Minor code clean-up.

Enable support for custom property handlers to display extra properties in the property editor.

Add the display of the node name (via `Node::getName`) in the node tree, only if it exists.
Add property editor for node global Z.

The default handlers exist for Node, Sprite and LabelProtocol, so the default implementation hasn't changed.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
