### PR TITLE
[Inspector] Fix crash and add enhancements

### DIFF
--- a/extensions/Inspector/Inspector.cpp
+++ b/extensions/Inspector/Inspector.cpp
@@ -313,7 +313,7 @@ void Inspector::drawProperties()
         return;
     }
 
-    if (_selected_node && _selected_node->getReferenceCount() <= 1)
+    if (_selected_node->getReferenceCount() <= 1)
     {
         // Node no longer exists in the scene, and we're holding the only reference to it, so release it
         _selected_node = nullptr;

--- a/extensions/Inspector/Inspector.cpp
+++ b/extensions/Inspector/Inspector.cpp
@@ -371,7 +371,7 @@ void Inspector::drawProperties()
     //     ImGui::EndPopup();
     // }
 
-    ImGui::Text("Addr: %p", _selected_node);
+    ImGui::Text("Addr: %p", _selected_node.get());
 
     for (auto&& propertyHandler : _propertyHandlers)
     {

--- a/extensions/Inspector/Inspector.h
+++ b/extensions/Inspector/Inspector.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <map>
 #include <memory>
-
 #include "ExtensionMacros.h"
 #include "base/Config.h"
 #include <string>
 #include <unordered_map>
-#include <vector>
+#include "EventListenerCustom.h"
+#include "RefPtr.h"
+#include "2d/Node.h"
 
 NS_AX_BEGIN
 class Node;
@@ -57,10 +57,16 @@ class Inspector
     static std::string getNodeTypeName(Node*);
     static std::string demangle(const char* mangled);
     void openForScene(Scene*);
+    void openForCurrentScene();
     void close();
 
     bool addPropertyHandler(std::string_view handlerId, std::unique_ptr<InspectPropertyHandler> handler);
     void removePropertyHandler(const std::string& handlerId);
+
+    void setAutoAddToScenes(bool autoAdd);
+
+    std::string_view getFontPath() { return _fontPath; }
+    void setFontPath(std::string_view fontPath);
 
   private:
     void init();
@@ -69,10 +75,15 @@ class Inspector
     void drawTreeRecursive(Node*, int index = 0);
     void drawProperties();
 
-    ax::Node* _selected_node = nullptr;
+    ax::RefPtr<ax::Node> _selected_node = nullptr;
     ax::Scene* _target = nullptr;
 
     std::unordered_map<std::string, std::unique_ptr<InspectPropertyHandler>> _propertyHandlers;
+    RefPtr<EventListenerCustom> _beforeNewSceneEventListener;
+    RefPtr<EventListenerCustom> _afterNewSceneEventListener;
+
+    bool _autoAddToScenes = false;
+    std::string _fontPath;
 };
 
 NS_AX_EXT_END


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes

Fix crash related to invalid selected node if it no longer exists in the scene.  The selected node was never retained in the inspector, so if the currently selected node is deleted from the scene, yet still selected in the inspector, a crash would occur due to invalid memory access.

Support using a custom font for the inspector. The default font is still "arial.ttf", but it may not exists in the application, so allow setting a custom font. This can be set via `Inspector::setFontPath()`.

Support automatic registration of inspector on scene switches.  To avoid adding and removing the inspector explicitly for each scene, the inspector can be set to automatically link to the current scene using the `Director::EVENT_BEFORE_SET_NEXT_SCENE` and `Director::EVENT_AFTER_SET_NEXT_SCENE` broadcasts.  This can be set via `Inspector::setAutoAddToScenes(bool)`.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
