### PR TITLE
[Android] Reset the OpenGL state cache if the context is lost

### DIFF
--- a/core/platform/android/javaactivity-android.cpp
+++ b/core/platform/android/javaactivity-android.cpp
@@ -29,12 +29,14 @@ THE SOFTWARE.
 #include "base/EventCustom.h"
 #include "base/EventType.h"
 #include "base/EventDispatcher.h"
+#include "renderer/backend/Device.h"
 #include "renderer/TextureCache.h"
 #include "platform/android/jni/JniHelper.h"
 
 #include <android/log.h>
 #include <android/api-level.h>
 #include <jni.h>
+
 
 #define LOG_TAG "main"
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
@@ -94,6 +96,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeInit(JNIEnv*, jcla
     }
     else
     {
+        backend::Device::getInstance()->resetState();
         ax::Director::getInstance()->resetMatrixStack();
         ax::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
         director->getEventDispatcher()->dispatchEvent(&recreatedEvent);

--- a/core/renderer/backend/Device.h
+++ b/core/renderer/backend/Device.h
@@ -135,6 +135,8 @@ public:
      */
     inline DeviceInfo* getDeviceInfo() const { return _deviceInfo; }
 
+    virtual void resetState() {};
+
 protected:
     /**
      * New a shaderModule, not auto released.

--- a/core/renderer/backend/opengl/DeviceGL.cpp
+++ b/core/renderer/backend/opengl/DeviceGL.cpp
@@ -147,4 +147,9 @@ Program* DeviceGL::newProgram(std::string_view vertexShader, std::string_view fr
     return new ProgramGL(vertexShader, fragmentShader);
 }
 
+void DeviceGL::resetState()
+{
+    OpenGLState::reset();
+}
+
 NS_AX_BACKEND_END

--- a/core/renderer/backend/opengl/DeviceGL.h
+++ b/core/renderer/backend/opengl/DeviceGL.h
@@ -25,6 +25,7 @@
 
 #include "../Device.h"
 #include "platform/GL.h"
+#include "OpenGLState.h"
 
 NS_AX_BACKEND_BEGIN
 /**
@@ -94,6 +95,8 @@ public:
      * @return A Program instance.
      */
     virtual Program* newProgram(std::string_view vertexShader, std::string_view fragmentShader) override;
+
+    void resetState() override;
 
 protected:
     /**

--- a/core/renderer/backend/opengl/OpenGLState.cpp
+++ b/core/renderer/backend/opengl/OpenGLState.cpp
@@ -2,8 +2,17 @@
 
 NS_AX_BACKEND_BEGIN
 
-static auto defaultOpenGLState = std::make_unique<OpenGLState>();
+namespace
+{
+auto g_defaultOpenGLState = std::make_unique<OpenGLState>();
+}
 
-OpenGLState* __gl = defaultOpenGLState.get();
+OpenGLState* __gl = g_defaultOpenGLState.get();
+
+void OpenGLState::reset()
+{
+    g_defaultOpenGLState = std::make_unique<OpenGLState>();
+    __gl = g_defaultOpenGLState.get();
+}
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/opengl/OpenGLState.h
+++ b/core/renderer/backend/opengl/OpenGLState.h
@@ -194,6 +194,8 @@ struct OpenGLState
     using Winding  = backend::Winding;
     using UtilsGL  = backend::UtilsGL;
 
+    static void reset();
+
     void viewport(const Viewport& v) { try_callf(glViewport, _viewPort, v, v.x, v.y, v.width, v.height); }
     void winding(Winding v) { try_callf(glFrontFace, _winding, v, UtilsGL::toGLFrontFace(v)); }
     void enableDepthTest() { try_enable(GL_DEPTH_TEST, _depthTest); }


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
The OpenGLState caches the state of the OpenGL context.  If that context is no longer valid (or is changed), then the cache would contain values that do not represent the true state of the new context.  On Android, the context is invalidated, so the cache needs to be reset (or in this case, recreated).

This will fix blank screen issue after context lost (due to OpenGL state errors).  Refer to https://github.com/axmolengine/axmol/issues/1211#issuecomment-1776559187

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
