### PR TITLE
[Android] Fix corrupted FPS stats font textures on OpenGL context lost

### DIFF
--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -142,6 +142,16 @@ bool Director::init()
 
     _renderer = new Renderer;
 
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    // listen the event that renderer was recreated on Android/WP8
+    _rendererRecreatedListener = EventListenerCustom::create(
+        EVENT_RENDERER_RECREATED, [this](EventCustom*) {
+            _isStatusLabelUpdated = true; // Force recreation of textures
+        });
+
+    _eventDispatcher->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
+#endif
+
     return true;
 }
 

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -159,6 +159,11 @@ Director::~Director()
 {
     AXLOGINFO("deallocing Director: %p", this);
 
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    _eventDispatcher->removeEventListener(_rendererRecreatedListener);
+    _rendererRecreatedListener = nullptr;
+#endif
+
     AX_SAFE_RELEASE(_FPSLabel);
     AX_SAFE_RELEASE(_drawnVerticesLabel);
     AX_SAFE_RELEASE(_drawnBatchesLabel);
@@ -1089,6 +1094,16 @@ void Director::restartDirector()
 #endif
 
     setGLDefaultValues();
+
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    // listen the event that renderer was recreated on Android/WP8
+    _rendererRecreatedListener = EventListenerCustom::create(
+            EVENT_RENDERER_RECREATED, [this](EventCustom*) {
+                _isStatusLabelUpdated = true; // Force recreation of textures
+            });
+
+    _eventDispatcher->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
+#endif
 }
 
 void Director::setNextScene()

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -497,7 +497,7 @@ public:
      * returns the axmol thread id.
      Useful to know if certain code is already running on the axmol thread
      */
-    const std::thread::id& getCocos2dThreadId() const { return getAxmolThreadId(); } 
+    const std::thread::id& getCocos2dThreadId() const { return getAxmolThreadId(); }
     const std::thread::id& getAxmolThreadId() const { return _axmol_thread_id; }
 
     /** Enable node tree children indexer map, the concept is like database INDEX
@@ -666,6 +666,10 @@ protected:
 #if defined(AX_PLATFORM_PC)
     /* axmol priority operations in render thread for PC platforms */
     moodycamel::ConcurrentQueue<std::function<void()>> _operations;
+#endif
+
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    EventListenerCustom* _rendererRecreatedListener = nullptr;
 #endif
 
     // GLView will recreate stats labels to fit visible rect


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
The FPS stats text display becomes corrupted if the OpenGL context becomes invalid and needs to be recreated.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
