### PR TITLE
Update Live2D to work with Axmol 2.x

### DIFF
--- a/extensions/Live2D/CMakeLists.txt
+++ b/extensions/Live2D/CMakeLists.txt
@@ -42,6 +42,9 @@ else()
     target_link_libraries(${LIB_NAME} Live2DCubismCore)
 endif()
 
+ax_find_shaders("${CMAKE_CURRENT_LIST_DIR}/Framework/src/Rendering/axmol/shaders" LIVE2D_SHADER_SOURCES)
+ax_target_compile_shaders(${LIB_NAME} FILES ${LIVE2D_SHADER_SOURCES} CUSTOM)
+
 setup_ax_extension_config(${LIB_NAME})
 
 unset(LIB_NAME)

--- a/extensions/Live2D/Framework/src/Rendering/axmol/CubismRenderer_Cocos2dx.cpp
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/CubismRenderer_Cocos2dx.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -744,294 +744,64 @@ void CubismShader_Cocos2dx::ReleaseShaderProgram()
 }
 
 // SetupMask
-static const csmChar* VertShaderSrcSetupMask =
-#if !defined(AX_PLATFORM_MOBILE) && !defined(AX_USE_GLES)
-    "#version 120\n"
-#endif
-    "attribute vec2 a_position;"
-    "attribute vec2 a_texCoord;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_myPos;"
-    "uniform mat4 u_clipMatrix;"
-    "void main()"
-    "{"
-    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
-    "gl_Position = u_clipMatrix * pos;"
-    "v_myPos = u_clipMatrix * pos;"
-    "v_texCoord = a_texCoord;"
-    "v_texCoord.y = 1.0 - v_texCoord.y;"
-    "}";
-static const csmChar* FragShaderSrcSetupMask =
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_myPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "float isInside = "
-    "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-    "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-    "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-    "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-    "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-    "}";
+static const csmChar* VertShaderSrcSetupMask = "custom/live2d_setup_mask_vs";
+static const csmChar* FragShaderSrcSetupMask = "custom/live2d_setup_mask_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcSetupMaskTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_myPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "float isInside = "
-    "  step(u_baseColor.x, v_myPos.x/v_myPos.w)"
-    "* step(u_baseColor.y, v_myPos.y/v_myPos.w)"
-    "* step(v_myPos.x/v_myPos.w, u_baseColor.z)"
-    "* step(v_myPos.y/v_myPos.w, u_baseColor.w);"
-
-    "gl_FragColor = u_channelFlag * texture2D(s_texture0 , v_texCoord).a * isInside;"
-    "}";
+static const csmChar* FragShaderSrcSetupMaskTegra = "custom/live2d_setup_mask_fs";
+//"custom/live2d_setup_mask_tegra_fs";
 #endif
+
 
 //----- バーテックスシェーダプログラム -----
 // Normal & Add & Mult 共通
-static const csmChar* VertShaderSrc =
-#if !defined(AX_PLATFORM_MOBILE) && !defined(AX_USE_GLES)
-    "#version 120\n"
-#endif
-    "attribute vec2 a_position;" //v.vertex
-    "attribute vec2 a_texCoord;" //v.texcoord
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform mat4 u_matrix;"
-    "void main()"
-    "{"
-    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
-    "gl_Position = u_matrix * pos;"
-    "v_texCoord = a_texCoord;"
-    "v_texCoord.y = 1.0 - v_texCoord.y;"
-    "}";
+static const csmChar* VertShaderSrc = "custom/live2d_vs";
 
 // Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* VertShaderSrcMasked =
-#if !defined(AX_PLATFORM_MOBILE) && !defined(AX_USE_GLES)
-    "#version 120\n"
-#endif
-    "attribute vec2 a_position;"
-    "attribute vec2 a_texCoord;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform mat4 u_matrix;"
-    "uniform mat4 u_clipMatrix;"
-    "void main()"
-    "{"
-    "vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);"
-    "gl_Position = u_matrix * pos;"
-    "v_clipPos = u_clipMatrix * pos;"
-#if defined(AX_USE_METAL)
-    "v_clipPos = vec4(v_clipPos.x, 1.0 - v_clipPos.y, v_clipPos.zw);"
-#endif
-    "v_texCoord = a_texCoord;"
-    "v_texCoord.y = 1.0 - v_texCoord.y;"
-    "}";
+static const csmChar* VertShaderSrcMasked = "custom/live2d_masked_vs";
 
 //----- フラグメントシェーダプログラム -----
 // Normal & Add & Mult 共通
-static const csmChar* FragShaderSrc =
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "void main()"
-    "{"
-    "vec4 color = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-    "}";
+static const csmChar* FragShaderSrc = "custom/live2d_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "void main()"
-    "{"
-    "vec4 color = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "gl_FragColor = vec4(color.rgb * color.a,  color.a);"
-    "}";
+static const csmChar* FragShaderSrcTegra = "custom/live2d_fs";
+//"custom/live2d_tegra_fs";
 #endif
 
 // Normal & Add & Mult 共通 （PremultipliedAlpha）
-static const csmChar* FragShaderSrcPremultipliedAlpha =
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "void main()"
-    "{"
-    "gl_FragColor = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "}";
+static const csmChar* FragShaderSrcPremultipliedAlpha = "custom/live2d_premultiplied_alpha_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcPremultipliedAlphaTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;" //v2f.texcoord
-    "uniform sampler2D s_texture0;" //_MainTex
-    "uniform vec4 u_baseColor;" //v2f.color
-    "void main()"
-    "{"
-    "gl_FragColor = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "}";
+static const csmChar* FragShaderSrcPremultipliedAlphaTegra = "custom/live2d_premultiplied_alpha_fs";
+//"custom/live2d_premultiplied_alpha_tegra_fs";
 #endif
 
 // Normal & Add & Mult 共通（クリッピングされたものの描画用）
-static const csmChar* FragShaderSrcMask =
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
+static const csmChar* FragShaderSrcMask = "custom/live2d_mask_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
+static const csmChar* FragShaderSrcMaskTegra = "custom/live2d_mask_fs";
+//"custom/live2d_mask_tegra_fs";
 #endif
 
 // Normal & Add & Mult 共通（クリッピングされて反転使用の描画用）
-static const csmChar* FragShaderSrcMaskInverted =
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
+static const csmChar* FragShaderSrcMaskInverted = "custom/live2d_mask_inverted_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskInvertedTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "col_formask.rgb = col_formask.rgb  * col_formask.a ;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
+static const csmChar* FragShaderSrcMaskInvertedTegra = "custom/live2d_mask_inverted_fs";
+//"custom/live2d_mask_inverted_tegra_fs";
 #endif
 
 // Normal & Add & Mult 共通（クリッピングされたものの描画用、PremultipliedAlphaの場合）
-static const csmChar* FragShaderSrcMaskPremultipliedAlpha =
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
+static const csmChar* FragShaderSrcMaskPremultipliedAlpha = "custom/live2d_mask_premultiplied_alpha_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
-static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * maskVal;"
-    "gl_FragColor = col_formask;"
-    "}";
+static const csmChar* FragShaderSrcMaskPremultipliedAlphaTegra = "custom/live2d_mask_premultiplied_alpha_fs";
+    //"custom/live2d_mask_premultiplied_alpha_tegra_fs";
 #endif
 
 // Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
 static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlpha =
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
+    "custom/live2d_mask_inverted_premultiplied_alpha_fs";
 #if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
 static const csmChar* FragShaderSrcMaskInvertedPremultipliedAlphaTegra =
-    "#extension GL_NV_shader_framebuffer_fetch : enable\n"
-    "precision mediump float;"
-    "varying vec2 v_texCoord;"
-    "varying vec4 v_clipPos;"
-    "uniform sampler2D s_texture0;"
-    "uniform sampler2D s_texture1;"
-    "uniform vec4 u_channelFlag;"
-    "uniform vec4 u_baseColor;"
-    "void main()"
-    "{"
-    "vec4 col_formask = texture2D(s_texture0 , v_texCoord) * u_baseColor;"
-    "vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;"
-    "float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;"
-    "col_formask = col_formask * (1.0 - maskVal);"
-    "gl_FragColor = col_formask;"
-    "}";
+    "custom/live2d_mask_inverted_premultiplied_alpha_fs";
+    //"custom/live2d_mask_inverted_premultiplied_alpha_tegra_fs";
 #endif
 
 CubismShader_Cocos2dx::CubismShader_Cocos2dx()
@@ -1150,7 +920,7 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // SetupMask
     _shaderSets[0]->AttributePositionLocation = _shaderSets[0]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[0]->AttributeTexCoordLocation = _shaderSets[0]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[0]->SamplerTexture0Location = _shaderSets[0]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[0]->SamplerTexture0Location = _shaderSets[0]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[0]->UniformClipMatrixLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[0]->UnifromChannelFlagLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_channelFlag");
     _shaderSets[0]->UniformBaseColorLocation = _shaderSets[0]->ShaderProgram->getUniformLocation("u_baseColor");
@@ -1158,15 +928,15 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 通常
     _shaderSets[1]->AttributePositionLocation = _shaderSets[1]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[1]->AttributeTexCoordLocation = _shaderSets[1]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[1]->SamplerTexture0Location = _shaderSets[1]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[1]->SamplerTexture0Location = _shaderSets[1]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[1]->UniformMatrixLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[1]->UniformBaseColorLocation = _shaderSets[1]->ShaderProgram->getUniformLocation("u_baseColor");
 
     // 通常（クリッピング）
     _shaderSets[2]->AttributePositionLocation = _shaderSets[2]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[2]->AttributeTexCoordLocation = _shaderSets[2]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[2]->SamplerTexture0Location = _shaderSets[2]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[2]->SamplerTexture1Location = _shaderSets[2]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[2]->SamplerTexture0Location = _shaderSets[2]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[2]->SamplerTexture1Location = _shaderSets[2]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[2]->UniformMatrixLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[2]->UniformClipMatrixLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[2]->UnifromChannelFlagLocation = _shaderSets[2]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1175,8 +945,8 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 通常（クリッピング・反転）
     _shaderSets[3]->AttributePositionLocation = _shaderSets[3]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[3]->AttributeTexCoordLocation = _shaderSets[3]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[3]->SamplerTexture0Location = _shaderSets[3]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[3]->SamplerTexture1Location = _shaderSets[3]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[3]->SamplerTexture0Location = _shaderSets[3]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[3]->SamplerTexture1Location = _shaderSets[3]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[3]->UniformMatrixLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[3]->UniformClipMatrixLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[3]->UnifromChannelFlagLocation = _shaderSets[3]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1185,15 +955,15 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 通常（PremultipliedAlpha）
     _shaderSets[4]->AttributePositionLocation = _shaderSets[4]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[4]->AttributeTexCoordLocation = _shaderSets[4]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[4]->SamplerTexture0Location = _shaderSets[4]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[4]->SamplerTexture0Location = _shaderSets[4]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[4]->UniformMatrixLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[4]->UniformBaseColorLocation = _shaderSets[4]->ShaderProgram->getUniformLocation("u_baseColor");
 
     // 通常（クリッピング、PremultipliedAlpha）
     _shaderSets[5]->AttributePositionLocation = _shaderSets[5]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[5]->AttributeTexCoordLocation = _shaderSets[5]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[5]->SamplerTexture0Location = _shaderSets[5]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[5]->SamplerTexture1Location = _shaderSets[5]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[5]->SamplerTexture0Location = _shaderSets[5]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[5]->SamplerTexture1Location = _shaderSets[5]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[5]->UniformMatrixLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[5]->UniformClipMatrixLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[5]->UnifromChannelFlagLocation = _shaderSets[5]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1202,8 +972,8 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 通常（クリッピング・反転、PremultipliedAlpha）
     _shaderSets[6]->AttributePositionLocation = _shaderSets[6]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[6]->AttributeTexCoordLocation = _shaderSets[6]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[6]->SamplerTexture0Location = _shaderSets[6]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[6]->SamplerTexture1Location = _shaderSets[6]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[6]->SamplerTexture0Location = _shaderSets[6]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[6]->SamplerTexture1Location = _shaderSets[6]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[6]->UniformMatrixLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[6]->UniformClipMatrixLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[6]->UnifromChannelFlagLocation = _shaderSets[6]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1212,15 +982,15 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 加算
     _shaderSets[7]->AttributePositionLocation = _shaderSets[7]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[7]->AttributeTexCoordLocation = _shaderSets[7]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[7]->SamplerTexture0Location = _shaderSets[7]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[7]->SamplerTexture0Location = _shaderSets[7]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[7]->UniformMatrixLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[7]->UniformBaseColorLocation = _shaderSets[7]->ShaderProgram->getUniformLocation("u_baseColor");
 
     // 加算（クリッピング）
     _shaderSets[8]->AttributePositionLocation = _shaderSets[8]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[8]->AttributeTexCoordLocation = _shaderSets[8]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[8]->SamplerTexture0Location = _shaderSets[8]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[8]->SamplerTexture1Location = _shaderSets[8]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[8]->SamplerTexture0Location = _shaderSets[8]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[8]->SamplerTexture1Location = _shaderSets[8]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[8]->UniformMatrixLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[8]->UniformClipMatrixLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[8]->UnifromChannelFlagLocation = _shaderSets[8]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1229,8 +999,8 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 加算（クリッピング・反転）
     _shaderSets[9]->AttributePositionLocation = _shaderSets[9]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[9]->AttributeTexCoordLocation = _shaderSets[9]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[9]->SamplerTexture0Location = _shaderSets[9]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[9]->SamplerTexture1Location = _shaderSets[9]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[9]->SamplerTexture0Location = _shaderSets[9]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[9]->SamplerTexture1Location = _shaderSets[9]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[9]->UniformMatrixLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[9]->UniformClipMatrixLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[9]->UnifromChannelFlagLocation = _shaderSets[9]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1239,15 +1009,15 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 加算（PremultipliedAlpha）
     _shaderSets[10]->AttributePositionLocation = _shaderSets[10]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[10]->AttributeTexCoordLocation = _shaderSets[10]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[10]->SamplerTexture0Location = _shaderSets[10]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[10]->SamplerTexture0Location = _shaderSets[10]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[10]->UniformMatrixLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[10]->UniformBaseColorLocation = _shaderSets[10]->ShaderProgram->getUniformLocation("u_baseColor");
 
     // 加算（クリッピング、PremultipliedAlpha）
     _shaderSets[11]->AttributePositionLocation = _shaderSets[11]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[11]->AttributeTexCoordLocation = _shaderSets[11]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[11]->SamplerTexture0Location = _shaderSets[11]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[11]->SamplerTexture1Location = _shaderSets[11]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[11]->SamplerTexture0Location = _shaderSets[11]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[11]->SamplerTexture1Location = _shaderSets[11]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[11]->UniformMatrixLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[11]->UniformClipMatrixLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[11]->UnifromChannelFlagLocation = _shaderSets[11]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1256,8 +1026,8 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 加算（クリッピング・反転、PremultipliedAlpha）
     _shaderSets[12]->AttributePositionLocation = _shaderSets[12]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[12]->AttributeTexCoordLocation = _shaderSets[12]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[12]->SamplerTexture0Location = _shaderSets[12]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[12]->SamplerTexture1Location = _shaderSets[12]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[12]->SamplerTexture0Location = _shaderSets[12]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[12]->SamplerTexture1Location = _shaderSets[12]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[12]->UniformMatrixLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[12]->UniformClipMatrixLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[12]->UnifromChannelFlagLocation = _shaderSets[12]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1266,15 +1036,15 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 乗算
     _shaderSets[13]->AttributePositionLocation = _shaderSets[13]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[13]->AttributeTexCoordLocation = _shaderSets[13]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[13]->SamplerTexture0Location = _shaderSets[13]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[13]->SamplerTexture0Location = _shaderSets[13]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[13]->UniformMatrixLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[13]->UniformBaseColorLocation = _shaderSets[13]->ShaderProgram->getUniformLocation("u_baseColor");
 
     // 乗算（クリッピング）
     _shaderSets[14]->AttributePositionLocation = _shaderSets[14]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[14]->AttributeTexCoordLocation = _shaderSets[14]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[14]->SamplerTexture0Location = _shaderSets[14]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[14]->SamplerTexture1Location = _shaderSets[14]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[14]->SamplerTexture0Location = _shaderSets[14]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[14]->SamplerTexture1Location = _shaderSets[14]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[14]->UniformMatrixLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[14]->UniformClipMatrixLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[14]->UnifromChannelFlagLocation = _shaderSets[14]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1283,8 +1053,8 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 乗算（クリッピング・反転）
     _shaderSets[15]->AttributePositionLocation = _shaderSets[15]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[15]->AttributeTexCoordLocation = _shaderSets[15]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[15]->SamplerTexture0Location = _shaderSets[15]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[15]->SamplerTexture1Location = _shaderSets[15]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[15]->SamplerTexture0Location = _shaderSets[15]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[15]->SamplerTexture1Location = _shaderSets[15]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[15]->UniformMatrixLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[15]->UniformClipMatrixLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[15]->UnifromChannelFlagLocation = _shaderSets[15]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1293,15 +1063,15 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 乗算（PremultipliedAlpha）
     _shaderSets[16]->AttributePositionLocation = _shaderSets[16]->ShaderProgram->getAttributeLocation( "a_position");
     _shaderSets[16]->AttributeTexCoordLocation = _shaderSets[16]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[16]->SamplerTexture0Location = _shaderSets[16]->ShaderProgram->getUniformLocation("s_texture0");
+    _shaderSets[16]->SamplerTexture0Location = _shaderSets[16]->ShaderProgram->getUniformLocation("u_tex0");
     _shaderSets[16]->UniformMatrixLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[16]->UniformBaseColorLocation = _shaderSets[16]->ShaderProgram->getUniformLocation("u_baseColor");
 
     // 乗算（クリッピング、PremultipliedAlpha）
     _shaderSets[17]->AttributePositionLocation = _shaderSets[17]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[17]->AttributeTexCoordLocation = _shaderSets[17]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[17]->SamplerTexture0Location = _shaderSets[17]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[17]->SamplerTexture1Location = _shaderSets[17]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[17]->SamplerTexture0Location = _shaderSets[17]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[17]->SamplerTexture1Location = _shaderSets[17]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[17]->UniformMatrixLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[17]->UniformClipMatrixLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[17]->UnifromChannelFlagLocation = _shaderSets[17]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1310,8 +1080,8 @@ void CubismShader_Cocos2dx::GenerateShaders()
     // 乗算（クリッピング・反転、PremultipliedAlpha）
     _shaderSets[18]->AttributePositionLocation = _shaderSets[18]->ShaderProgram->getAttributeLocation("a_position");
     _shaderSets[18]->AttributeTexCoordLocation = _shaderSets[18]->ShaderProgram->getAttributeLocation("a_texCoord");
-    _shaderSets[18]->SamplerTexture0Location = _shaderSets[18]->ShaderProgram->getUniformLocation("s_texture0");
-    _shaderSets[18]->SamplerTexture1Location = _shaderSets[18]->ShaderProgram->getUniformLocation("s_texture1");
+    _shaderSets[18]->SamplerTexture0Location = _shaderSets[18]->ShaderProgram->getUniformLocation("u_tex0");
+    _shaderSets[18]->SamplerTexture1Location = _shaderSets[18]->ShaderProgram->getUniformLocation("u_tex1");
     _shaderSets[18]->UniformMatrixLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_matrix");
     _shaderSets[18]->UniformClipMatrixLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_clipMatrix");
     _shaderSets[18]->UnifromChannelFlagLocation = _shaderSets[18]->ShaderProgram->getUniformLocation("u_channelFlag");
@@ -1335,6 +1105,7 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
     ax::PipelineDescriptor* pipelineDescriptor = drawCommand->GetPipelineDescriptor();
 
     ax::backend::ProgramState* programState = pipelineDescriptor->programState;
+    VertexLayout* layout                    = nullptr;
 
     if (renderer->GetClippingContextBufferForMask() != NULL) // マスク生成時
     {
@@ -1345,14 +1116,16 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
             programState = new ax::backend::ProgramState(shaderSet->ShaderProgram);
         }
 
+        layout = programState->getMutableVertexLayout();
 
         //テクスチャ設定
         programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
 
         // 頂点配列の設定
-        programState->setVertexAttrib("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
+        layout->setAttrib("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
         // テクスチャ頂点の設定
-        programState->setVertexAttrib("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
+        layout->setAttrib("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2,
+                          sizeof(csmFloat32) * 2, false);
 
         // チャンネル
         const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
@@ -1415,11 +1188,14 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         {
             programState = new ax::backend::ProgramState(shaderSet->ShaderProgram);
         }
+        layout = programState->getMutableVertexLayout();
 
         // 頂点配列の設定
-        programState->setVertexAttrib("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
+        layout->setAttrib("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0,
+                          false);
         // テクスチャ頂点の設定
-        programState->setVertexAttrib("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
+        layout->setAttrib("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2,
+                          sizeof(csmFloat32) * 2, false);
 
         if (masked)
         {
@@ -1450,16 +1226,19 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         programState->setUniform(shaderSet->UniformBaseColorLocation, base, sizeof(float) * 4);
     }
 
-    programState->setVertexStride(sizeof(csmFloat32) * 4);
+    if (layout)
+        layout->setStride(sizeof(csmFloat32) * 4);
+
     blendDescriptor->blendEnabled = true;
     pipelineDescriptor->programState = programState;
 }
 
-ax::backend::Program* CubismShader_Cocos2dx::LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc)
+ax::backend::Program* CubismShader_Cocos2dx::LoadShaderProgram(const csmChar* vertShaderPath,
+                                                               const csmChar* fragShaderPath)
 {
     // cocos2dx対応
     // Create shader program.
-    return ax::backend::Device::getInstance()->newProgram(vertShaderSrc, fragShaderSrc);
+    return ProgramManager::getInstance()->loadProgram(vertShaderPath, fragShaderPath);
 }
 
 /*********************************************************************************************************************

--- a/extensions/Live2D/Framework/src/Rendering/axmol/CubismRenderer_Cocos2dx.hpp
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/CubismRenderer_Cocos2dx.hpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -306,7 +306,7 @@ private:
      *
      * @return  シェーダプログラムのアドレス
      */
-    ax::backend::Program* LoadShaderProgram(const csmChar* vertShaderSrc, const csmChar* fragShaderSrc);
+    ax::backend::Program* LoadShaderProgram(const csmChar* vertShaderPath, const csmChar* fragShaderPath);
 
 #ifdef CSM_TARGET_ANDROID_ES2
 public:

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d.frag
@@ -1,0 +1,22 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 color = texture(u_tex0 , v_texCoord) * u_baseColor;
+    FragColor = vec4(color.rgb * color.a,  color.a);
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d.vert
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d.vert
@@ -1,0 +1,18 @@
+#version 310 es
+
+layout(location = POSITION) in vec4 a_position;
+layout(location = TEXCOORD0) in vec2 a_texCoord;
+
+layout(location = TEXCOORD0) out vec2 v_texCoord;
+
+layout(std140) uniform vs_ub {
+    mat4 u_matrix;
+};
+
+void main()
+{
+    vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);
+    gl_Position = u_matrix * pos;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask.frag
@@ -1,0 +1,29 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask_inverted.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask_inverted.frag
@@ -1,0 +1,29 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask_inverted_premultiplied_alpha.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask_inverted_premultiplied_alpha.frag
@@ -1,0 +1,28 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask_premultiplied_alpha.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_mask_premultiplied_alpha.frag
@@ -1,0 +1,28 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_masked.vert
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_masked.vert
@@ -1,0 +1,25 @@
+#version 310 es
+
+layout(location = POSITION) in vec4 a_position;
+layout(location = TEXCOORD0) in vec2 a_texCoord;
+
+layout(location = TEXCOORD0) out vec2 v_texCoord;
+layout(location = TEXCOORD1) out vec4 v_clipPos;
+
+layout(std140) uniform vs_ub {
+    mat4 u_matrix;
+    mat4 u_clipMatrix;
+};
+
+
+void main()
+{
+    vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);
+    gl_Position = u_matrix * pos;
+    v_clipPos = u_clipMatrix * pos;
+#if defined(METAL)
+    v_clipPos = vec4(v_clipPos.x, 1.0 - v_clipPos.y, v_clipPos.zw);
+#endif
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_premultiplied_alpha.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_premultiplied_alpha.frag
@@ -1,0 +1,21 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    FragColor = texture(u_tex0 , v_texCoord) * u_baseColor;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_setup_mask.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_setup_mask.frag
@@ -1,0 +1,30 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = COLOR0) in vec4 v_color;
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_myPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    float isInside = 
+          step(u_baseColor.x, v_myPos.x/v_myPos.w)
+        * step(u_baseColor.y, v_myPos.y/v_myPos.w)
+        * step(v_myPos.x/v_myPos.w, u_baseColor.z)
+        * step(v_myPos.y/v_myPos.w, u_baseColor.w);
+
+    FragColor = u_channelFlag * texture(u_tex0 , v_texCoord).a * isInside;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_setup_mask.vert
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders/live2d_setup_mask.vert
@@ -1,0 +1,20 @@
+#version 310 es
+
+layout(location = POSITION) in vec4 a_position;
+layout(location = TEXCOORD0) in vec2 a_texCoord;
+
+layout(location = TEXCOORD0) out vec2 v_texCoord;
+layout(location = TEXCOORD1) out vec4 v_myPos;
+
+layout(std140) uniform vs_ub {
+    mat4 u_clipMatrix;
+};
+
+void main()
+{
+    vec4 pos = vec4(a_position.x, a_position.y, 0.0, 1.0);
+    gl_Position = u_clipMatrix * pos;
+    v_myPos = u_clipMatrix * pos;
+    v_texCoord = a_texCoord;
+    v_texCoord.y = 1.0 - v_texCoord.y;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_inverted_premultiplied_alpha_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_inverted_premultiplied_alpha_tegra.frag
@@ -1,0 +1,25 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_inverted_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_inverted_tegra.frag
@@ -1,0 +1,26 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * (1.0 - maskVal);
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_premultiplied_alpha_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_premultiplied_alpha_tegra.frag
@@ -1,0 +1,25 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_mask_tegra.frag
@@ -1,0 +1,26 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_clipPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+layout(binding = 1) uniform sampler2D u_tex1;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 col_formask = texture(u_tex0 , v_texCoord) * u_baseColor;
+    col_formask.rgb = col_formask.rgb  * col_formask.a ;
+    vec4 clipMask = (1.0 - texture(u_tex1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
+    float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
+    col_formask = col_formask * maskVal;
+    FragColor = col_formask;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_premultiplied_alpha_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_premultiplied_alpha_tegra.frag
@@ -1,0 +1,18 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    FragColor = texture(u_tex0 , v_texCoord) * u_baseColor;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_setup_mask_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_setup_mask_tegra.frag
@@ -1,0 +1,27 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = COLOR0) in vec4 v_color;
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+layout(location = TEXCOORD1) in vec4 v_myPos;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 u_channelFlag;
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    float isInside = 
+          step(u_baseColor.x, v_myPos.x/v_myPos.w)
+        * step(u_baseColor.y, v_myPos.y/v_myPos.w)
+        * step(v_myPos.x/v_myPos.w, u_baseColor.z)
+        * step(v_myPos.y/v_myPos.w, u_baseColor.w);
+
+    FragColor = u_channelFlag * texture(u_tex0 , v_texCoord).a * isInside;
+}

--- a/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_tegra.frag
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/shaders_tegra/live2d_tegra.frag
@@ -1,0 +1,19 @@
+#version 310 es
+#extension GL_NV_shader_framebuffer_fetch : enable
+precision mediump float;
+
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 u_baseColor;
+};
+
+void main()
+{
+    vec4 color = texture(u_tex0 , v_texCoord) * u_baseColor;
+    FragColor = vec4(color.rgb * color.a,  color.a);
+}

--- a/tests/live2d-tests/CMakeLists.txt
+++ b/tests/live2d-tests/CMakeLists.txt
@@ -29,6 +29,8 @@ set(APP_NAME live2d_tests)
 
 project(${APP_NAME})
 
+set(AX_ENABLE_EXT_LIVE2D ON CACHE BOOL "Build extension Live2D" FORCE)
+
 if(NOT DEFINED BUILD_ENGINE_DONE)
     if(XCODE)
         set(CMAKE_XCODE_GENERATE_TOP_LEVEL_PROJECT_ONLY TRUE)

--- a/tests/live2d-tests/Source/LAppLive2DManager.cpp
+++ b/tests/live2d-tests/Source/LAppLive2DManager.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -318,34 +318,33 @@ void LAppLive2DManager::ChangeScene(Csm::csmInt32 index)
 
 void LAppLive2DManager::CreateShader()
 {
-    const char* vertexShader =
-        "attribute vec3 position;"
-        "attribute vec2 uv;"
-        "varying vec2 vuv;"
-        "void main(void){"
-#if defined(AX_USE_METAL)
-        "    gl_Position = vec4(position.x, -position.y, position.z, 1.0);"
-#else
-        "    gl_Position = vec4(position, 1.0);"
-#endif
-        "    vuv = uv;"
-        "}";
+//    const char* vertexShader =
+//        "attribute vec3 position;"
+//        "attribute vec2 uv;"
+//        "varying vec2 vuv;"
+//        "void main(void){"
+//#if defined(AX_USE_METAL)
+//        "    gl_Position = vec4(position.x, -position.y, position.z, 1.0);"
+//#else
+//        "    gl_Position = vec4(position, 1.0);"
+//#endif
+//        "    vuv = uv;"
+//        "}";
+//
+//    const char* fragmentShader =
+//#if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID)
+//        "precision mediump float;"
+//#endif
+//        "varying vec2 vuv;"
+//        "uniform sampler2D texture;"
+//        "uniform vec4 baseColor;"
+//        "void main(void){"
+//        "    gl_FragColor = texture2D(texture, vuv) * baseColor;"
+//        "    gl_FragColor = vec4(gl_FragColor.rgb * gl_FragColor.a,  gl_FragColor.a);"
+//        "}";
 
-    const char* fragmentShader =
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID)
-        "precision mediump float;"
-#endif
-        "varying vec2 vuv;"
-        "uniform sampler2D texture;"
-        "uniform vec4 baseColor;"
-        "void main(void){"
-        "    gl_FragColor = texture2D(texture, vuv) * baseColor;"
-        "    gl_FragColor = vec4(gl_FragColor.rgb * gl_FragColor.a,  gl_FragColor.a);"
-        "}";
-
-    auto program = ax::backend::Device::getInstance()->newProgram(vertexShader, fragmentShader);
+    auto* program = ProgramManager::getInstance()->loadProgram("custom/live2d_test_vs", "custom/live2d_test_fs");
     _program = program;
-
 }
 
 void LAppLive2DManager::SetRenderTargetClearColor(float r, float g, float b)

--- a/tests/live2d-tests/Source/LAppLive2DManager.cpp
+++ b/tests/live2d-tests/Source/LAppLive2DManager.cpp
@@ -318,31 +318,6 @@ void LAppLive2DManager::ChangeScene(Csm::csmInt32 index)
 
 void LAppLive2DManager::CreateShader()
 {
-//    const char* vertexShader =
-//        "attribute vec3 position;"
-//        "attribute vec2 uv;"
-//        "varying vec2 vuv;"
-//        "void main(void){"
-//#if defined(AX_USE_METAL)
-//        "    gl_Position = vec4(position.x, -position.y, position.z, 1.0);"
-//#else
-//        "    gl_Position = vec4(position, 1.0);"
-//#endif
-//        "    vuv = uv;"
-//        "}";
-//
-//    const char* fragmentShader =
-//#if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID)
-//        "precision mediump float;"
-//#endif
-//        "varying vec2 vuv;"
-//        "uniform sampler2D texture;"
-//        "uniform vec4 baseColor;"
-//        "void main(void){"
-//        "    gl_FragColor = texture2D(texture, vuv) * baseColor;"
-//        "    gl_FragColor = vec4(gl_FragColor.rgb * gl_FragColor.a,  gl_FragColor.a);"
-//        "}";
-
     auto* program = ProgramManager::getInstance()->loadProgram("custom/live2d_test_vs", "custom/live2d_test_fs");
     _program = program;
 }

--- a/tests/live2d-tests/Source/LAppSprite.cpp
+++ b/tests/live2d-tests/Source/LAppSprite.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license
@@ -62,16 +62,18 @@ void LAppSprite::RenderImmidiate(Csm::Rendering::CubismCommandBuffer_Cocos2dx* c
         programState = new ax::backend::ProgramState(_program);
     }
 
+    auto layout = programState->getMutableVertexLayout();
     // attribute属性を登録
-    programState->setVertexAttrib("position", _program->getAttributeLocation("position"), backend::VertexFormat::FLOAT2, 0, false);
-    programState->setVertexAttrib("uv", _program->getAttributeLocation("uv"), backend::VertexFormat::FLOAT2, sizeof(float) * 2, false);
+    layout->setAttrib("a_position", _program->getAttributeLocation("a_position"), backend::VertexFormat::FLOAT2, 0, false);
+    layout->setAttrib("a_texCoord", _program->getAttributeLocation("a_texCoord"), backend::VertexFormat::FLOAT2,
+                            sizeof(float) * 2, false);
 
     // uniform属性の登録
-    programState->setTexture(_program->getUniformLocation("texture"), 0, texture);
+    programState->setTexture(_program->getUniformLocation("u_tex0"), 0, texture);
 
     programState->setUniform(_program->getUniformLocation("baseColor"), _spriteColor, sizeof(float) * 4);
 
-    programState->setVertexStride(sizeof(float) * 4);
+    layout->setStride(sizeof(float) * 4);
 
     blendDescriptor->sourceRGBBlendFactor = ax::backend::BlendFactor::ONE;
     blendDescriptor->destinationRGBBlendFactor = ax::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;

--- a/tests/live2d-tests/Source/shaders/live2d_test.frag
+++ b/tests/live2d-tests/Source/shaders/live2d_test.frag
@@ -1,0 +1,23 @@
+#version 310 es
+#ifdef GLES2
+precision mediump float;
+#else
+precision highp float;
+#endif
+
+layout(location = COLOR0) in vec4 v_color;
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(std140) uniform fs_ub {
+    vec4 baseColor;
+};
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+void main()
+{
+    FragColor = texture(u_tex0, v_texCoord) * baseColor;
+    FragColor = vec4(FragColor.rgb * FragColor.a,  FragColor.a);
+}

--- a/tests/live2d-tests/Source/shaders/live2d_test.vert
+++ b/tests/live2d-tests/Source/shaders/live2d_test.vert
@@ -1,0 +1,18 @@
+#version 310 es
+
+layout(location = POSITION) in vec4 a_position;
+layout(location = COLOR0) in vec4 a_color;
+layout(location = TEXCOORD0) in vec2 a_texCoord;
+
+layout(location = TEXCOORD0) out vec2 v_texCoord;
+
+void main()
+{
+#if defined(METAL)
+    gl_Position = vec4(a_position.x, -a_position.y, a_position.z, 1.0);
+#else
+    gl_Position = vec4(a_position.xyz, 1.0);
+#endif
+    v_texCoord = a_texCoord;
+}
+


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
Ensure that the Live2D extension is enabled for the Live2D test project.
Move shaders to individual files and update them to work with Axmol 2.x.

Note that the shaders in the `shaders_tegra` directory are not used at all, since there is code in the shaders that doesn't seem to be supported by glslcc, being this: `#extension GL_NV_shader_framebuffer_fetch : enable`.  The Tegra shaders were only ever being enabled for Android, and only if the define `CSM_TARGET_ANDROID_ES2` was enabled.  They are the same as the standard shaders, besides having the extra line `#extension GL_NV_shader_framebuffer_fetch : enable` and using `mediump` precision for float types.  I've updated the standard shaders with the following section and just set them to be used for Android too:

```
#ifdef GLES2
precision mediump float;
#else
precision highp float;
#endif
```
I'm assuming that will work, but I don't know what the purpose is for the `#extension GL_NV_shader_framebuffer_fetch : enable` line, or if it will impact the Live2D code if it isn't there.

## Issue ticket number and link
#1400
#1403 

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [x] I have added/adapted some tests too.
