### PR TITLE
[Android] Enable support for restarting application process if OpenGL context is lost

### DIFF
--- a/core/base/EventType.h
+++ b/core/base/EventType.h
@@ -47,5 +47,11 @@
 // cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp.
 #define EVENT_COME_TO_BACKGROUND "event_come_to_background"
 
+// The application will be restarted.
+// This message is used for notifying application code of a pending application restart.
+// This message is posted in core/platform/android/javaactivity.cpp
+#define EVENT_APP_RESTARTING "event_app_restarting"
+
+
 /// @endcond
 #endif  // __CCEVENT_TYPE_H__

--- a/core/platform/PlatformMacros.h
+++ b/core/platform/PlatformMacros.h
@@ -94,6 +94,16 @@ Copyright (c) 2021 Bytedance Inc.
 #    define AX_ENABLE_CACHE_TEXTURE_DATA 0
 #endif
 
+/** @def AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST
+ * Enable this if application should be restarted after the OpenGL context is lost
+ *
+ */
+#if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID && !AX_ENABLE_CACHE_TEXTURE_DATA)
+#    define AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST 1
+#else
+#    define AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST 0
+#endif
+
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID) || (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
 /** Application will crash in glDrawElements function on some win32 computers and some android devices.
  *  Indices should be bound again while drawing to avoid this bug.

--- a/core/platform/android/java/src/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/core/platform/android/java/src/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2014 Jake Wharton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jakewharton.processphoenix;
+
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Process;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+
+/**
+ * Process Phoenix facilitates restarting your application process. This should only be used for
+ * things like fundamental state changes in your debug builds (e.g., changing from staging to
+ * production).
+ * <p>
+ * Trigger process recreation by calling {@link #triggerRebirth} with a {@link Context} instance.
+ */
+public final class ProcessPhoenix extends Activity {
+    private static final String KEY_RESTART_INTENTS = "phoenix_restart_intents";
+    private static final String KEY_MAIN_PROCESS_PID = "phoenix_main_process_pid";
+
+    /**
+     * Call to restart the application process using the {@linkplain Intent#CATEGORY_DEFAULT default}
+     * activity as an intent.
+     * <p>
+     * Behavior of the current process after invoking this method is undefined.
+     */
+    public static void triggerRebirth(Context context) {
+        triggerRebirth(context, getRestartIntent(context));
+    }
+
+    /**
+     * Call to restart the application process using the specified intents.
+     * <p>
+     * Behavior of the current process after invoking this method is undefined.
+     */
+    public static void triggerRebirth(Context context, Intent... nextIntents) {
+        if (nextIntents.length < 1) {
+            throw new IllegalArgumentException("intents cannot be empty");
+        }
+        // create a new task for the first activity.
+        nextIntents[0].addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);
+
+        Intent intent = new Intent(context, ProcessPhoenix.class);
+        intent.addFlags(FLAG_ACTIVITY_NEW_TASK); // In case we are called with non-Activity context.
+        intent.putParcelableArrayListExtra(KEY_RESTART_INTENTS, new ArrayList<>(Arrays.asList(nextIntents)));
+        intent.putExtra(KEY_MAIN_PROCESS_PID, Process.myPid());
+        context.startActivity(intent);
+    }
+
+    private static Intent getRestartIntent(Context context) {
+        String packageName = context.getPackageName();
+        Intent defaultIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+        if (defaultIntent != null) {
+            return defaultIntent;
+        }
+
+        throw new IllegalStateException("Unable to determine default activity for "
+            + packageName
+            + ". Does an activity specify the DEFAULT category in its intent filter?");
+    }
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Process.killProcess(getIntent().getIntExtra(KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
+
+        ArrayList<Intent> intents = getIntent().getParcelableArrayListExtra(KEY_RESTART_INTENTS);
+        startActivities(intents.toArray(new Intent[intents.size()]));
+        finish();
+        Runtime.getRuntime().exit(0); // Kill kill kill!
+    }
+
+    /**
+     * Checks if the current process is a temporary Phoenix Process.
+     * This can be used to avoid initialisation of unused resources or to prevent running code that
+     * is not multi-process ready.
+     *
+     * @return true if the current process is a temporary Phoenix Process
+     */
+    public static boolean isPhoenixProcess(Context context) {
+        int currentPid = Process.myPid();
+        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> runningProcesses = manager.getRunningAppProcesses();
+        if (runningProcesses != null) {
+            for (ActivityManager.RunningAppProcessInfo processInfo : runningProcesses) {
+                if (processInfo.pid == currentPid && processInfo.processName.endsWith(":phoenix")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/core/platform/android/java/src/org/axmol/lib/AxmolEngine.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolEngine.java
@@ -60,6 +60,7 @@ import com.android.vending.expansion.zipfile.APKExpansionSupport;
 import com.android.vending.expansion.zipfile.ZipResourceFile;
 
 import com.enhance.gameservice.IGameTuningService;
+import com.jakewharton.processphoenix.ProcessPhoenix;
 
 import java.io.IOException;
 import java.io.File;
@@ -772,6 +773,10 @@ public class AxmolEngine {
 
     public static int getSDKVersion() {
         return Build.VERSION.SDK_INT;
+    }
+
+    public static void restartProcess() {
+        ProcessPhoenix.triggerRebirth(sActivity);
     }
 
     private static AxmolAccelerometer getAccelerometer() {

--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -98,17 +98,17 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
             final long now = System.nanoTime();
             final long interval = now - this.mLastTickInNanoSeconds;
 
-            /*
-             * Render time MUST be counted in, or the FPS will slower than appointed.
-            */
-            this.mLastTickInNanoSeconds = System.nanoTime();
-            AxmolRenderer.nativeRender();
             if (interval < AxmolRenderer.sAnimationInterval) {
                 try {
                     Thread.sleep((AxmolRenderer.sAnimationInterval - interval) / AxmolRenderer.NANOSECONDSPERMICROSECOND);
                 } catch (final Exception e) {
                 }
             }
+            /*
+             * Render time MUST be counted in, or the FPS will slower than appointed.
+            */
+            this.mLastTickInNanoSeconds = System.nanoTime();
+            AxmolRenderer.nativeRender();
         }
     }
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -73,7 +73,13 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
     public void onSurfaceCreated(final GL10 GL10, final EGLConfig EGLConfig) {
         AxmolRenderer.nativeInit(this.mScreenWidth, this.mScreenHeight);
         this.mLastTickInNanoSeconds = System.nanoTime();
-        mNativeInitCompleted = true;
+
+        if (mNativeInitCompleted) {
+            // This must be from an OpenGL context loss
+            nativeOnContextLost();
+        } else {
+            mNativeInitCompleted = true;
+        }
     }
 
     @Override
@@ -91,18 +97,18 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
         } else {
             final long now = System.nanoTime();
             final long interval = now - this.mLastTickInNanoSeconds;
-        
+
+            /*
+             * Render time MUST be counted in, or the FPS will slower than appointed.
+            */
+            this.mLastTickInNanoSeconds = System.nanoTime();
+            AxmolRenderer.nativeRender();
             if (interval < AxmolRenderer.sAnimationInterval) {
                 try {
                     Thread.sleep((AxmolRenderer.sAnimationInterval - interval) / AxmolRenderer.NANOSECONDSPERMICROSECOND);
                 } catch (final Exception e) {
                 }
             }
-            /*
-             * Render time MUST be counted in, or the FPS will slower than appointed.
-            */
-            this.mLastTickInNanoSeconds = System.nanoTime();
-            AxmolRenderer.nativeRender();
         }
     }
 
@@ -117,6 +123,7 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
     private static native boolean nativeKeyEvent(final int keyCode,boolean isPressed);
     private static native void nativeRender();
     private static native void nativeInit(final int width, final int height);
+    private static native void nativeOnContextLost();
     private static native void nativeOnSurfaceChanged(final int width, final int height);
     private static native void nativeOnPause();
     private static native void nativeOnResume();
@@ -147,12 +154,12 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
 
     public void handleOnPause() {
         /**
-         * onPause may be invoked before onSurfaceCreated, 
+         * onPause may be invoked before onSurfaceCreated,
          * and engine will be initialized correctly after
          * onSurfaceCreated is invoked. Can not invoke any
          * native method before onSurfaceCreated is invoked
          */
-        if (! mNativeInitCompleted)
+        if (!mNativeInitCompleted)
             return;
 
         AxmolRenderer.nativeOnPause();

--- a/core/platform/android/libaxmol/AndroidManifest.xml
+++ b/core/platform/android/libaxmol/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <application>
         <activity
-            android:name=".ProcessPhoenix"
+            android:name="com.jakewharton.processphoenix.ProcessPhoenix"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:process=":phoenix"
             android:exported="false"

--- a/core/platform/android/libaxmol/AndroidManifest.xml
+++ b/core/platform/android/libaxmol/AndroidManifest.xml
@@ -1,5 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.VIBRATE" />
+    <application>
+        <activity
+            android:name=".ProcessPhoenix"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:process=":phoenix"
+            android:exported="false"
+            />
+    </application>
 
 </manifest>


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
~~Call native renderer before the sleep in onDrawFrame due to possibility of invalid texture data after delay.~~ This will be in a separate PR

Added `ProcessPhoenix.java`, from this [project](https://github.com/JakeWharton/ProcessPhoenix), which allows the process to be restarted.

Dispatch event if application process will be restarted (`EVENT_APP_RESTARTING`). 

Added `AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST` configuration option, which is disabled if `AX_ENABLE_CACHE_TEXTURE_DATA` is enabled, since there is no point having both enabled.  The default is that `AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST` is disabled.

Question: Do we want the default to be that the application always restarts if the context is lost? That seems to be how other engines handle it (Unity3D, Godot etc).

## Issue ticket number and link
Related to #1211

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
