### PR TITLE
[UWP] Use Package to get app version information

### DIFF
--- a/core/platform/winrt/Application-winrt.cpp
+++ b/core/platform/winrt/Application-winrt.cpp
@@ -32,7 +32,9 @@ THE SOFTWARE.
 #include "platform/Application.h"
 
 #include "pugixml/pugixml.hpp"
+#include "fmt/format.h"
 
+#include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.System.UserProfile.h>
 #include <winrt/Windows.Foundation.Collections.h>
 
@@ -130,21 +132,11 @@ Application::Platform  Application::getTargetPlatform()
 
 std::string  Application::getVersion()
 {
-    std::string r;
-    std::string s = FileUtils::getInstance()->getStringFromFile("WMAppManifest.xml");
-    if (!s.empty()) {
-        pugi::xml_document doc;
-        if (doc.load_buffer_inplace(&s.front(), s.size())) {
-            auto app = doc.document_element().child("App");
-            if (app) {
-                auto version = app.attribute("Version").value();
-                if (!version.empty()) {
-                    r = version;
-                }
-            }
-        }
-    }
-    return r;
+    auto package   = winrt::Windows::ApplicationModel::Package::Current();
+    auto packageId = package.Id();
+    auto version   = packageId.Version();
+
+    return fmt::format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
 }
 
 bool Application::openURL(std::string_view url)


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
The existing code to get the application version does not seem to work, since the WM.xml file is missing, and perhaps it is the outdated method of reading the application version.

The way that seems to work correctly is using the Package, specifically from `winrt::Windows::ApplicationModel::Package::Current().Id().Version()`.

More info [here](https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.packageid?view=winrt-22621).

## Issue ticket number and link

## Checklist before requesting a review
-  [ ] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [ ] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
