### PR TITLE
[Android] Fix for TextField keyboard not opening on receiving focus

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -106,16 +106,19 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
             public void handleMessage(final Message msg) {
                 switch (msg.what) {
                     case HANDLER_OPEN_IME_KEYBOARD:
-                        if (null != AxmolGLSurfaceView.this.mEditText && AxmolGLSurfaceView.this.mEditText.requestFocus()) {
-                            AxmolGLSurfaceView.this.mEditText.removeTextChangedListener(AxmolGLSurfaceView.sTextInputWraper);
-                            AxmolGLSurfaceView.this.mEditText.setText("");
-                            final String text = (String) msg.obj;
-                            AxmolGLSurfaceView.this.mEditText.append(text);
-                            AxmolGLSurfaceView.sTextInputWraper.setOriginText(text);
-                            AxmolGLSurfaceView.this.mEditText.addTextChangedListener(AxmolGLSurfaceView.sTextInputWraper);
-                            final InputMethodManager imm = (InputMethodManager) AxmolGLSurfaceView.mGLSurfaceView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-                            imm.showSoftInput(AxmolGLSurfaceView.this.mEditText, 0);
-                            Log.d("GLSurfaceView", "showSoftInput");
+                        if (null != AxmolGLSurfaceView.this.mEditText) {
+                            AxmolGLSurfaceView.this.mEditText.setVisibility(View.VISIBLE);
+                            if (AxmolGLSurfaceView.this.mEditText.requestFocus()) {
+                                AxmolGLSurfaceView.this.mEditText.removeTextChangedListener(AxmolGLSurfaceView.sTextInputWraper);
+                                AxmolGLSurfaceView.this.mEditText.setText("");
+                                final String text = (String) msg.obj;
+                                AxmolGLSurfaceView.this.mEditText.append(text);
+                                AxmolGLSurfaceView.sTextInputWraper.setOriginText(text);
+                                AxmolGLSurfaceView.this.mEditText.addTextChangedListener(AxmolGLSurfaceView.sTextInputWraper);
+                                final InputMethodManager imm = (InputMethodManager) AxmolGLSurfaceView.mGLSurfaceView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                                imm.showSoftInput(AxmolGLSurfaceView.this.mEditText, 0);
+                                Log.d("GLSurfaceView", "showSoftInput");
+                            }
                         }
                         break;
 
@@ -126,6 +129,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
                             imm.hideSoftInputFromWindow(AxmolGLSurfaceView.this.mEditText.getWindowToken(), 0);
                             AxmolGLSurfaceView.this.requestFocus();
                             // can take effect after GLSurfaceView has focus
+                            AxmolGLSurfaceView.this.mEditText.setVisibility(View.GONE);
                             ((AxmolActivity)AxmolGLSurfaceView.mGLSurfaceView.getContext()).hideVirtualButton();
                             Log.d("GLSurfaceView", "HideSoftInput");
                         }


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
[Android] The AxmolEditBox created in the background to service `ax::TextField` nodes needs to be visible in order to receive focus, which in turn allows the soft keyboard to open.  The AxmolEditBox also needs to be hidden when it no longer has focus.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
