### PR TITLE
Add missing include guard in CommandBufferGLES2.h.

### DIFF
--- a/core/renderer/backend/opengl/CommandBufferGLES2.h
+++ b/core/renderer/backend/opengl/CommandBufferGLES2.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "CommandBufferGL.h"
 
 #if !defined(__APPLE__) && AX_TARGET_PLATFORM != AX_PLATFORM_WINRT


### PR DESCRIPTION
CommandBufferGLES2.h is missing an include guard.