### PR TITLE
Use execute_process instead of deprecated exec_program

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -342,18 +342,18 @@ if(WINDOWS)
     if(WINDOWS_STORE)
         file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR} AX_TOP_SOLUTION_DIR)
         configure_file(${_AX_ROOT}/cmake/CppWinRT.props.in ${CMAKE_BINARY_DIR}/CppWinRT.props @ONLY)
-       
+
         # intsall cppwinrt package for xaml apps
-        exec_program(${NUGET_EXE}
-                ARGS install "Microsoft.Windows.CppWinRT" -Version ${AX_CPPWINRT_VERISON} -ExcludeVersion -OutputDirectory "\"${CMAKE_BINARY_DIR}/packages\"")
+        execute_process(COMMAND "${NUGET_EXE}"
+                install "Microsoft.Windows.CppWinRT" -Version ${AX_CPPWINRT_VERISON} -ExcludeVersion -OutputDirectory "${CMAKE_BINARY_DIR}/packages")
         set_target_properties(${_AX_CORE_LIB} PROPERTIES
             VS_PROJECT_IMPORT ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.props
         )
         target_link_libraries(${_AX_CORE_LIB} ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.targets)
     endif()
     if(AX_ENABLE_MSEDGE_WEBVIEW2)
-        exec_program(${NUGET_EXE}
-            ARGS install "Microsoft.Web.WebView2" -Version 1.0.992.28 -ExcludeVersion -OutputDirectory "\"${CMAKE_BINARY_DIR}/packages\"")
+        execute_process(COMMAND "${NUGET_EXE}"
+            install "Microsoft.Web.WebView2" -Version 1.0.992.28 -ExcludeVersion -OutputDirectory "${CMAKE_BINARY_DIR}/packages")
 
         if(CMAKE_GENERATOR MATCHES "Ninja")
             target_link_libraries(${_AX_CORE_LIB} ${CMAKE_BINARY_DIR}/packages/Microsoft.Web.WebView2/build/native/${ARCH_ALIAS}/WebView2Loader.dll.lib)


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
CMake `exec_program` is deprecated, and causes an error if the minimum cmake version is set to 3.28 in the `CMakeLists.txt`.  This change is to use `execute_process` instead.

## Issue ticket number and link
#1448 

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
