### PR TITLE
Reduce memory usage when using getFileMD5Hash function

### DIFF
--- a/core/base/Utils.cpp
+++ b/core/base/Utils.cpp
@@ -468,23 +468,15 @@ std::string computeFileDigest(std::string_view filename, std::string_view algori
     }
 
     int bytesRead;
-    auto totalSize = 0;
     while ((bytesRead = fs->read(buffer.get(), bufferSize)) > 0)
     {
-        totalSize += bytesRead;
         EVP_DigestUpdate(mdctx, buffer.get(), bytesRead);
     }
 
-    if (totalSize > 0)
-    {
-        EVP_DigestFinal(mdctx, mdValue, &mdLen);
-        EVP_MD_CTX_destroy(mdctx);
-        return toHex ? bin2hex(std::string_view{(const char*)mdValue, (size_t)mdLen})
-                     : std::string{(const char*)mdValue, (size_t)mdLen};
-    }
-
+    EVP_DigestFinal(mdctx, mdValue, &mdLen);
     EVP_MD_CTX_destroy(mdctx);
-    return std::string{};
+    return toHex ? bin2hex(std::string_view{(const char*)mdValue, (size_t)mdLen})
+                 : std::string{(const char*)mdValue, (size_t)mdLen};
 }
 
 LanguageType getLanguageTypeByISO2(const char* code)

--- a/core/base/Utils.cpp
+++ b/core/base/Utils.cpp
@@ -402,13 +402,12 @@ Node* findChild(Node* levelRoot, int tag)
     return nullptr;
 }
 
-std::string getFileMD5Hash(std::string_view filename)
+std::string getFileMD5Hash(std::string_view filename, uint32_t bufferSize)
 {
     if (filename.empty())
         return std::string{};
 
-    constexpr auto bufferSize = 16 * 1024;
-    auto fs                   = FileUtils::getInstance()->openFileStream(filename, FileStream::Mode::READ);
+    auto fs = FileUtils::getInstance()->openFileStream(filename, FileStream::Mode::READ);
 
     if (!fs || !fs->isOpen())
         return std::string{};

--- a/core/base/Utils.cpp
+++ b/core/base/Utils.cpp
@@ -404,48 +404,7 @@ Node* findChild(Node* levelRoot, int tag)
 
 std::string getFileMD5Hash(std::string_view filename, uint32_t bufferSize)
 {
-    if (filename.empty())
-        return std::string{};
-
-    auto fs = FileUtils::getInstance()->openFileStream(filename, FileStream::Mode::READ);
-
-    if (!fs || !fs->isOpen())
-        return std::string{};
-
-    std::unique_ptr<uint8_t[]> buffer(new uint8_t[bufferSize]);
-    unsigned char mdValue[EVP_MAX_MD_SIZE] = {0};
-    unsigned int mdLen                     = 0;
-
-    OpenSSL_add_all_digests();
-    const EVP_MD* md = EVP_get_digestbyname("md5");
-    if (!md)
-        return std::string{};
-
-    EVP_MD_CTX* mdctx = EVP_MD_CTX_create();
-    auto ok           = EVP_DigestInit(mdctx, md);
-    if (!ok)
-    {
-        EVP_MD_CTX_destroy(mdctx);
-        return std::string{};
-    }
-
-    int bytesRead;
-    auto totalSize = 0;
-    while ((bytesRead = fs->read(buffer.get(), bufferSize)) > 0)
-    {
-        totalSize += bytesRead;
-        EVP_DigestUpdate(mdctx, buffer.get(), bytesRead);
-    }
-
-    if (totalSize > 0)
-    {
-        EVP_DigestFinal(mdctx, mdValue, &mdLen);
-        EVP_MD_CTX_destroy(mdctx);
-        return bin2hex(std::string_view{(const char*)mdValue, (size_t)mdLen});
-    }
-
-    EVP_MD_CTX_destroy(mdctx);
-    return std::string{};
+    return computeFileDigest(filename, "md5"sv, bufferSize);
 }
 
 std::string getDataMD5Hash(const Data& data)
@@ -479,6 +438,53 @@ std::string computeDigest(std::string_view data, std::string_view algorithm, boo
 
     return toHex ? bin2hex(std::string_view{(const char*)mdValue, (size_t)mdLen})
                  : std::string{(const char*)mdValue, (size_t)mdLen};
+}
+
+std::string computeFileDigest(std::string_view filename, std::string_view algorithm, uint32_t bufferSize, bool toHex)
+{
+    if (filename.empty())
+        return std::string{};
+
+    auto fs = FileUtils::getInstance()->openFileStream(filename, FileStream::Mode::READ);
+
+    if (!fs || !fs->isOpen())
+        return std::string{};
+
+    std::unique_ptr<uint8_t[]> buffer(new uint8_t[bufferSize]);
+    unsigned char mdValue[EVP_MAX_MD_SIZE] = {0};
+    unsigned int mdLen                     = 0;
+
+    OpenSSL_add_all_digests();
+    const EVP_MD* md = EVP_get_digestbyname(algorithm.data());
+    if (!md)
+        return std::string{};
+
+    EVP_MD_CTX* mdctx = EVP_MD_CTX_create();
+    auto ok           = EVP_DigestInit(mdctx, md);
+    if (!ok)
+    {
+        EVP_MD_CTX_destroy(mdctx);
+        return std::string{};
+    }
+
+    int bytesRead;
+    auto totalSize = 0;
+    while ((bytesRead = fs->read(buffer.get(), bufferSize)) > 0)
+    {
+        totalSize += bytesRead;
+        EVP_DigestUpdate(mdctx, buffer.get(), bytesRead);
+    }
+
+    if (totalSize > 0)
+    {
+        EVP_DigestFinal(mdctx, mdValue, &mdLen);
+        EVP_MD_CTX_destroy(mdctx);
+        return toHex ? bin2hex(std::string_view{(const char*)mdValue, (size_t)mdLen})
+                     : std::string{(const char*)mdValue, (size_t)mdLen};
+    }
+
+    EVP_MD_CTX_destroy(mdctx);
+    return std::string{};
 }
 
 LanguageType getLanguageTypeByISO2(const char* code)

--- a/core/base/Utils.h
+++ b/core/base/Utils.h
@@ -187,9 +187,10 @@ inline T findChild(Node* levelRoot, int tag)
 /**
  *  Gets the md5 hash for the given file.
  *  @param filename The file to calculate md5 hash.
+ *  @param bufferSize The size of buffer used for reading the file
  *  @return The md5 hash for the file
  */
-AX_DLL std::string getFileMD5Hash(std::string_view filename);
+AX_DLL std::string getFileMD5Hash(std::string_view filename, uint32_t bufferSize = 16 * 1024);
 
 /**
  *  Gets the md5 hash for the given buffer.

--- a/core/base/Utils.h
+++ b/core/base/Utils.h
@@ -201,11 +201,25 @@ AX_DLL std::string getDataMD5Hash(const Data& data);
 
 /**
  *  Gets the hash for the given buffer with specific algorithm.
- *  @param data The buffer to calculate md5 hash.
+ *  @param data The buffer to calculate the hash.
  *  @param algorithm The hash algorithm, support "md5", "sha1", "sha256", "sha512" and more
+ *  @param toHex Convert to lowercase hex string
  *  @return The hash for the data
  */
 AX_DLL std::string computeDigest(std::string_view data, std::string_view algorithm, bool toHex = true);
+
+/**
+ *  Gets the hash for the given file with specific algorithm.
+ *  @param filename The path of the file to hash.
+ *  @param algorithm The hash algorithm, support "md5", "sha1", "sha256", "sha512" and more
+ *  @param bufferSize Chunk size used for hashing
+ *  @param toHex Convert to lowercase hex string
+ *  @return The hash for the file
+ */
+AX_DLL std::string computeFileDigest(std::string_view filename,
+                                     std::string_view algorithm,
+                                     uint32_t bufferSize = 16 * 1024,
+                                     bool toHex          = true);
 
 /**
 @brief Converts language iso 639-1 code to LanguageType enum.


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
Currently, if `ax::utils::getFileMD5Hash()` is run on a file, then that entire file is loaded into memory.  If the file is very large, it results in sudden high memory usage spikes, which can cause memory issues.  To avoid this problem, I propose that we instead stream the file in smaller chunks.

The chunk size used is configurable, but is set at a default of 16KB.

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
