### PR TITLE
Replace 'CCAssert' with 'AXASSERT'

### DIFF
--- a/core/2d/FastTMXTiledMap.cpp
+++ b/core/2d/FastTMXTiledMap.cpp
@@ -136,7 +136,7 @@ TMXTilesetInfo* FastTMXTiledMap::tilesetForLayer(TMXLayerInfo* layerInfo, TMXMap
                     if (gid != 0)
                     {
                         // Optimization: quick return
-                        // if the layer is invalid (more than 1 tileset per layer) an CCAssert will be thrown later
+                        // if the layer is invalid (more than 1 tileset per layer) an AXASSERT will be thrown later
                         if ((gid & kTMXFlippedMask) >= static_cast<uint32_t>(tilesetInfo->_firstGid))
                         {
                             return tilesetInfo;

--- a/extensions/cocostudio/Skin.cpp
+++ b/extensions/cocostudio/Skin.cpp
@@ -83,7 +83,7 @@ Skin::Skin() : _bone(nullptr), _armature(nullptr), _displayName(), _skinTransfor
 
 bool Skin::initWithSpriteFrameName(std::string_view spriteFrameName)
 {
-    CCAssert(spriteFrameName != "", "");
+    AXASSERT(spriteFrameName != "", "");
 
     SpriteFrame* pFrame = SpriteFrameCache::getInstance()->findFrame(spriteFrameName);
     bool ret            = true;

--- a/extensions/cocostudio/TriggerObj.cpp
+++ b/extensions/cocostudio/TriggerObj.cpp
@@ -245,7 +245,7 @@ void TriggerObj::serialize(cocostudio::CocoLoader* pCocoLoader, cocostudio::stEx
                 }
                 BaseTriggerCondition* con =
                     dynamic_cast<BaseTriggerCondition*>(ObjectFactory::getInstance()->createObject(classname));
-                CCAssert(con != nullptr, "class named classname can not implement!");
+                AXASSERT(con != nullptr, "class named classname can not implement!");
                 con->serialize(pCocoLoader, &pConditionArray[1]);
                 con->init();
                 _cons.pushBack(con);
@@ -266,7 +266,7 @@ void TriggerObj::serialize(cocostudio::CocoLoader* pCocoLoader, cocostudio::stEx
                 }
                 BaseTriggerAction* act =
                     dynamic_cast<BaseTriggerAction*>(ObjectFactory::getInstance()->createObject(classname));
-                CCAssert(act != nullptr, "class named classname can not implement!");
+                AXASSERT(act != nullptr, "class named classname can not implement!");
                 act->serialize(pCocoLoader, &pActionArray[1]);
                 act->init();
                 _acts.pushBack(act);

--- a/extensions/scripting/lua-bindings/manual/LuaStack.cpp
+++ b/extensions/scripting/lua-bindings/manual/LuaStack.cpp
@@ -241,7 +241,7 @@ int LuaStack::executeString(const char* codes)
 
 int LuaStack::executeScriptFile(const char* filename)
 {
-    CCAssert(filename, "CCLuaStack::executeScriptFile() - invalid filename");
+    AXASSERT(filename, "CCLuaStack::executeScriptFile() - invalid filename");
 
     std::string filePath{filename};
     Data data = FileUtils::getInstance()->getDataFromFile(filePath);

--- a/tests/cpp-tests/Source/ExtensionsTest/TableViewTest/TableViewTestScene.cpp
+++ b/tests/cpp-tests/Source/ExtensionsTest/TableViewTest/TableViewTestScene.cpp
@@ -55,7 +55,7 @@ bool TableViewTest::init()
     testNode->setName("testNode");
     tableView->addChild(testNode);
     tableView->removeChild(testNode, true);
-    CCAssert(nullptr == tableView->getChildByName("testNode"), "The added child has been removed!");
+    AXASSERT(nullptr == tableView->getChildByName("testNode"), "The added child has been removed!");
 
     tableView = TableView::create(this, Size(60.0f, 250.0f));
     tableView->setDirection(ScrollView::Direction::VERTICAL);

--- a/tests/cpp-tests/Source/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Source/FileUtilsTest/FileUtilsTest.cpp
@@ -960,7 +960,7 @@ void TestIsDirectoryExistAsync::onEnter()
 
     dir = util->getWritablePath();
     util->isDirectoryExist(dir, [=](bool exists) {
-        CCAssert(exists, "Writable path should exist");
+        AXASSERT(exists, "Writable path should exist");
         auto label = Label::createWithSystemFont(getMsg(exists, dir), "", 20);
         label->setPosition(x, y * 2);
         this->addChild(label);

--- a/tests/cpp-tests/Source/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Source/NodeTest/NodeTest.cpp
@@ -1270,14 +1270,14 @@ void NodeNameTest::test(float dt)
         ++i;
         return false;
     });
-    CCAssert(i == 100, "");
+    AXASSERT(i == 100, "");
 
     i = 0;
     parent->enumerateChildren("node[[:digit:]]+", [&i](Node* node) -> bool {
         ++i;
         return true;
     });
-    CCAssert(i == 1, "");
+    AXASSERT(i == 1, "");
 
     // enumerateChildren
     // name = node[[digit]]+/node
@@ -1303,14 +1303,14 @@ void NodeNameTest::test(float dt)
         ++i;
         return false;
     });
-    CCAssert(i == 10, "");
+    AXASSERT(i == 10, "");
 
     i = 0;
     parent->enumerateChildren("node1/node", [&i](Node* node) -> bool {
         ++i;
         return true;
     });
-    CCAssert(i == 1, "");
+    AXASSERT(i == 1, "");
 
     // search from root
     parent = Node::create();
@@ -1334,14 +1334,14 @@ void NodeNameTest::test(float dt)
         ++i;
         return false;
     });
-    CCAssert(i == 100, "");
+    AXASSERT(i == 100, "");
 
     i = 0;
     parent->enumerateChildren("node[[:digit:]]+/node", [&i](Node* node) -> bool {
         ++i;
         return true;
     });
-    CCAssert(i == 1, "");
+    AXASSERT(i == 1, "");
 
     // search from parent
     // name is xxx/..
@@ -1350,14 +1350,14 @@ void NodeNameTest::test(float dt)
         ++i;
         return true;
     });
-    CCAssert(i == 1, "");
+    AXASSERT(i == 1, "");
 
     i = 0;
     parent->getChildByName("node1")->enumerateChildren("node[[:digit:]]+/node/..", [&i](Node* node) -> bool {
         ++i;
         return false;
     });
-    CCAssert(i == 100, "");
+    AXASSERT(i == 100, "");
 
     // name = //xxx : search recursively
     parent = Node::create();
@@ -1382,21 +1382,21 @@ void NodeNameTest::test(float dt)
         ++i;
         return false;
     });
-    CCAssert(i == 110, "");  // 100(children) + 10(parent)
+    AXASSERT(i == 110, "");  // 100(children) + 10(parent)
 
     i = 0;
     parent->enumerateChildren("//node[[:digit:]]+", [&i](Node* node) -> bool {
         ++i;
         return true;
     });
-    CCAssert(i == 1, "");
+    AXASSERT(i == 1, "");
 
     i = 0;
     parent->getChildByName("node1")->enumerateChildren("//node[[:digit:]]+/..", [&i](Node* node) -> bool {
         ++i;
         return false;
     });
-    CCAssert(i == 110, "");
+    AXASSERT(i == 110, "");
 
     // utils::findChildren()
 
@@ -1408,7 +1408,7 @@ void NodeNameTest::test(float dt)
         parent->addChild(child);
     }
     auto findChildren = utils::findChildren(*parent, "node");
-    CCAssert(findChildren.size() == 50, "");
+    AXASSERT(findChildren.size() == 50, "");
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features
- `1.x`: 1.x BugFixs

## Describe your changes
Replace 'CCAssert' with 'AXASSERT' => axmol should be cocos2dx free at most as possible #1

Only on 'Macros.h' and 'extension Spine' is CCAssert after replace with AXASSERT
![image](https://github.com/axmolengine/axmol/assets/8652787/6cdd700d-fab3-4637-a596-1fb91fb3161b)


## Issue ticket number and link
 issue  #1486

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
