### PR TITLE
[Live2D] Fix cmake project generation on platforms other than Android

### DIFF
--- a/extensions/Live2D/CMakeLists.txt
+++ b/extensions/Live2D/CMakeLists.txt
@@ -50,6 +50,10 @@ if (ANDROID)
     ax_target_compile_shaders(${LIB_NAME} FILES ${LIVE2D_TEGRA_SHADER_SOURCES} CUSTOM)
 endif()
 
-setup_ax_extension_config(${LIB_NAME} LINK_SCOPE PRIVATE)
+if (ANDROID)
+    setup_ax_extension_config(${LIB_NAME} LINK_SCOPE PRIVATE)
+else()
+    setup_ax_extension_config(${LIB_NAME})
+endif()
 
 unset(LIB_NAME)


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
Set Live2D library correct link scope for platforms other than Android.

The root cause of this issue was due to an oversight in PR #1407, which I added to fix the Android issue in the first place (sorry about that!).  The automated builds also didn't pick it up either because the Live2D extension is disabled by default.

## Issue ticket number and link
#1502

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
