### PR TITLE
Call Android native renderer while opengl context is still valid

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -97,6 +97,12 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
         } else {
             final long now = System.nanoTime();
             final long interval = now - this.mLastTickInNanoSeconds;
+            
+            /*
+             * Render time MUST be counted in, or the FPS will slower than appointed.
+            */
+            this.mLastTickInNanoSeconds = now;
+            AxmolRenderer.nativeRender();
 
             if (interval < AxmolRenderer.sAnimationInterval) {
                 try {
@@ -104,11 +110,6 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
                 } catch (final Exception e) {
                 }
             }
-            /*
-             * Render time MUST be counted in, or the FPS will slower than appointed.
-            */
-            this.mLastTickInNanoSeconds = System.nanoTime();
-            AxmolRenderer.nativeRender();
         }
     }
 


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
This change is part of a combination of changes that are required to ensure that the Android application does not crash due to an invalid OpenGL context.

The specific issue this PR addresses is that the Android native render was being called after a `Thread.sleep`, at which point the OpenGL context may not be valid.  This may be because of the app going to the background (for example, during a phone call etc.) during the `onDrawFrame` call, just prior to it exiting the `Thread.sleep`, and if for any reason Android invalidates the OpenGL context, this would cause a crash.

## Issue ticket number and link
#1211 

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
