### PR TITLE
Make FileUtils::openFileStream a const method

### DIFF
--- a/core/platform/FileUtils.cpp
+++ b/core/platform/FileUtils.cpp
@@ -1039,7 +1039,7 @@ void FileUtils::listFilesRecursivelyAsync(std::string_view dirPath,
         std::move(callback));
 }
 
-std::unique_ptr<IFileStream> FileUtils::openFileStream(std::string_view filePath, IFileStream::Mode mode)
+std::unique_ptr<IFileStream> FileUtils::openFileStream(std::string_view filePath, IFileStream::Mode mode) const
 {
     FileStream fs;
     return fs.open(filePath, mode) ? std::make_unique<FileStream>(std::move(fs)) : nullptr;

--- a/core/platform/FileUtils.h
+++ b/core/platform/FileUtils.h
@@ -775,7 +775,7 @@ public:
      *  @param mode The mode to open the file in, being READ | WRITE | APPEND
      *  @return Returns a pointer to the file stream
      */
-    virtual std::unique_ptr<IFileStream> openFileStream(std::string_view filePath, IFileStream::Mode mode);
+    virtual std::unique_ptr<IFileStream> openFileStream(std::string_view filePath, IFileStream::Mode mode) const;
 
 protected:
     /**


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
`FileUtils::openFileStream()` should be a const method, since it does not modify any data within that class. Also, it enables its usage from const methods in the same class, otherwise there is a compile error when attempting to call it directly within the same class (relevant to sub-classes of FileUtils).

## Issue ticket number and link

## Checklist before requesting a review
-  [x] I have performed a self-review of my code.
-  [ ] If it is a core feature, I have added thorough tests.
-  [x] I have checked readme and add important infos to this PR (if it needed).
-  [ ] I have added/adapted some tests too.
