### PR TITLE
Support setting of custom runtime output directory for project

### DIFF
--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -363,6 +363,9 @@ endfunction()
 
 # setup a ax application
 function(ax_setup_app_config app_name)
+    set(options RUNTIME_OUTPUT_DIR opt_RUNTIME_OUTPUT_DIR)
+    cmake_parse_arguments(opt "" "${options}" ""
+                          "" ${ARGN} )
     if (WINRT)
         target_include_directories(${app_name} 
             PRIVATE "proj.winrt"
@@ -371,8 +374,11 @@ function(ax_setup_app_config app_name)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         target_link_options(${app_name} PRIVATE "/STACK:4194304")
     endif()
-    # put all output app into bin/${app_name}
-    set_target_properties(${app_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${app_name}")
+    if(NOT opt_RUNTIME_OUTPUT_DIR)
+        # put all output app into bin/${app_name}
+        set(opt_RUNTIME_OUTPUT_DIR "${CMAKE_BINARY_DIR}/bin/${app_name}")
+    endif()
+    set_target_properties(${app_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${opt_RUNTIME_OUTPUT_DIR}")
     if(APPLE)
         # output macOS/iOS .app
         set_target_properties(${app_name} PROPERTIES MACOSX_BUNDLE 1)


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes
At the moment, the runtime output directory is hard-coded in the function `ax_setup_app_config`, located in file `AXBuildHelpers.cmake`.  This change allows the optional setting of a custom runtime output path.

The default call is as follows, and is unchanged:
`ax_setup_app_config(${APP_NAME})`

If the runtime output directory needs to be set, then this is an example of usage:
`ax_setup_app_config(${APP_NAME} RUNTIME_OUTPUT_DIR "${CMAKE_BINARY_DIR}/output")`

## Issue ticket number and link

## Checklist before requesting a review
### For each PR
-  [x] I have performed a self-review of my code.
       
   Optional:
   -  [ ] I have checked readme and add important infos to this PR.
   -  [ ] I have added/adapted some tests too.
          
### For core/new feature
-  [ ] I have checked readme and add important infos to this PR.
-  [ ] I have added thorough tests.

