### PR TITLE
Fix shader cache leak

### DIFF
--- a/core/renderer/Texture2D.cpp
+++ b/core/renderer/Texture2D.cpp
@@ -82,7 +82,6 @@ Texture2D::~Texture2D()
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     VolatileTextureMgr::removeTexture(this);
 #endif
-    AXLOGINFO("deallocing Texture2D: %p - id=%u", this, _name);
 
     AX_SAFE_DELETE(_ninePatchInfo);
 
@@ -237,7 +236,7 @@ bool Texture2D::updateWithImage(Image* image, backend::PixelFormat format, int i
     default:
         break;
     }
-#elif !AX_GLES_PROFILE 
+#elif !AX_GLES_PROFILE
     // Non-GLES doesn't support follow render formats, needs convert PixelFormat::RGBA8
     // Note: axmol-1.1 deprecated A8, L8, LA8 as renderFormat, preferred R8, RG8
     switch (renderFormat)

--- a/core/renderer/backend/ProgramManager.cpp
+++ b/core/renderer/backend/ProgramManager.cpp
@@ -69,7 +69,7 @@ ProgramManager::~ProgramManager()
         AX_SAFE_RELEASE(program.second);
     }
     AXLOGINFO("deallocing ProgramManager: %p", this);
-    backend::ShaderCache::destroyInstance();
+    backend::ShaderCache::purge();
 }
 
 // ### end of vertex layout setup functions

--- a/core/renderer/backend/ShaderCache.cpp
+++ b/core/renderer/backend/ShaderCache.cpp
@@ -28,38 +28,14 @@
 NS_AX_BACKEND_BEGIN
 
 std::unordered_map<std::size_t, backend::ShaderModule*> ShaderCache::_cachedShaders;
-ShaderCache* ShaderCache::_sharedShaderCache = nullptr;
 
-ShaderCache* ShaderCache::getInstance()
-{
-    if (!_sharedShaderCache)
-    {
-        _sharedShaderCache = new ShaderCache();
-        if (!_sharedShaderCache->init())
-        {
-            AX_SAFE_DELETE(_sharedShaderCache);
-        }
-    }
-    return _sharedShaderCache;
-}
-
-void ShaderCache::destroyInstance()
-{
-    AX_SAFE_RELEASE_NULL(_sharedShaderCache);
-}
-
-ShaderCache::~ShaderCache()
+void ShaderCache::purge()
 {
     for (auto&& shaderModule : _cachedShaders)
     {
         AX_SAFE_RELEASE(shaderModule.second);
     }
-    AXLOGINFO("deallocing ShaderCache: %p", this);
-}
-
-bool ShaderCache::init()
-{
-    return true;
+    AXLOGINFO("purging ShaderCache");
 }
 
 backend::ShaderModule* ShaderCache::newVertexShaderModule(std::string_view shaderSource)

--- a/core/renderer/backend/ShaderCache.h
+++ b/core/renderer/backend/ShaderCache.h
@@ -43,11 +43,8 @@ NS_AX_BACKEND_BEGIN
 class AX_DLL ShaderCache : public Ref
 {
 public:
-    /** returns the shared instance */
-    static ShaderCache* getInstance();
-
     /** purges the cache. It releases the retained instance. */
-    static void destroyInstance();
+    static void purge();
 
     /**
      * Create a vertex shader module and add it to cache.
@@ -69,14 +66,6 @@ public:
     void removeUnusedShader();
 
 protected:
-    virtual ~ShaderCache();
-
-    /**
-     * Initial shader cache.
-     * @return true if initial successful, otherwise false.
-     */
-    bool init();
-
     /**
      * New a shaderModule.
      * If it was created before, then just return the cached shader module.
@@ -88,7 +77,6 @@ protected:
     static backend::ShaderModule* newShaderModule(backend::ShaderStage stage, std::string_view shaderSource);
 
     static std::unordered_map<std::size_t, backend::ShaderModule*> _cachedShaders;
-    static ShaderCache* _sharedShaderCache;
 };
 
 // end of _backend group


### PR DESCRIPTION
The ShaderCache class had two static members: a map for the cache, and
a pointer to the single instance of ShaderCache. The map was
supposedly cleared in the destructor but there was actually no
instance of ShaderCache (getInstance() was never called and the other
functions accessed the map directly). This commit removes the
singleton "interface" such that only the map is used, then it cleared
the map upon request.
