### PR TITLE
templates: cpp: AppDelegate: Show stats only on debug mode

### DIFF
--- a/templates/cpp-template-default/Source/AppDelegate.cpp
+++ b/templates/cpp-template-default/Source/AppDelegate.cpp
@@ -70,8 +70,10 @@ bool AppDelegate::applicationDidFinishLaunching()
         director->setGLView(glView);
     }
 
+#if _AX_DEBUG > 0
     // turn on display FPS
     director->setStatsDisplay(true);
+#endif
 
     // set FPS. the default value is 1.0/60 if you don't call this
     director->setAnimationInterval(1.0f / 60);


### PR DESCRIPTION
## Changes
I added code which exclude stats from screen on Release mode


## Checklist
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
