### PR TITLE
Fix AXASSERT() not working with more complex msg arguments

### DIFF
--- a/core/base/Macros.h
+++ b/core/base/Macros.h
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 
@@ -45,8 +46,9 @@ extern bool AX_DLL cc_assert_script_compatible(const char* msg);
                 {                                                             \
                     if (!(cond))                                              \
                     {                                                         \
-                        if (msg && *msg && !cc_assert_script_compatible(msg)) \
-                            ax::log("Assert failed: %s", msg);           \
+                        const char* m = (msg);                                \
+                        if (m && *m && !cc_assert_script_compatible(m))       \
+                            ax::log("Assert failed: %s", m);                  \
                         AX_ASSERT(cond);                                      \
                     }                                                         \
                 } while (0)


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes

Fixes `AXASSERT()` not working with more complex `msg` arguments like ternary expressions, eg `AXASSERT(something, foo ? bar->baz() : "error")`. Also makes sure that the `msg` is evaluated only once.

## Issue ticket number and link

N/A

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
