### PR TITLE
Allow to override AX_USE_COMPAT_GL from user's CMakeLists.txt

### DIFF
--- a/cmake/Modules/AXPlatform.cmake
+++ b/cmake/Modules/AXPlatform.cmake
@@ -56,6 +56,10 @@ else()
     return()
 endif()
 
+if (NOT DEFINED WIN32)
+    set(WIN32 FALSE)
+endif()
+
 # generators that are capable of organizing into a hierarchy of folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # simplify generator condition, please use them everywhere

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -51,9 +51,7 @@ endif()
 include(CMakeDependentOption)
 
 # by default: use angle on win32
-if(NOT DEFINED AX_USE_COMPAT_GL)
-    cmake_dependent_option(AX_USE_COMPAT_GL "Whether use compatibility GL as render backend" ON "WIN32" OFF)
-endif()
+cmake_dependent_option(AX_USE_COMPAT_GL "Whether use compatibility GL as render backend" ${WIN32} "WIN32 OR APPLE" OFF)
 
 # choosing render backend for all target platforms: win32, winuwp, ios, tvos, android, linux, osx
 if(APPLE AND (NOT AX_USE_COMPAT_GL))

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -51,7 +51,9 @@ endif()
 include(CMakeDependentOption)
 
 # by default: use angle on win32
-cmake_dependent_option(AX_USE_COMPAT_GL "Whether use compatibility GL as render backend" ON "WIN32" OFF)
+if(NOT DEFINED AX_USE_COMPAT_GL)
+    cmake_dependent_option(AX_USE_COMPAT_GL "Whether use compatibility GL as render backend" ON "WIN32" OFF)
+endif()
 
 # choosing render backend for all target platforms: win32, winuwp, ios, tvos, android, linux, osx
 if(APPLE AND (NOT AX_USE_COMPAT_GL))


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features

## Describe your changes

This change enables users to override `AX_USE_COMPAT_GL` option from user's `CMakeLists.txt`. We need to be able to force the use of OpenGL on macOS, because we have shader graph editor, that generates and previews shaders in runtime.

Current fix is probably not optimal, so I'm willing to change it if you can suggest a better way to implement it.

## Issue ticket number and link

N/A

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
