### PR TITLE
Fix AudioPlayer seek to incorrect frame after setTime invoked

### DIFF
--- a/core/audio/AudioPlayer.cpp
+++ b/core/audio/AudioPlayer.cpp
@@ -326,7 +326,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
                     if (_timeDirty)
                     {
                         _timeDirty  = false;
-                        offsetFrame = _currTime * decoder->getSampleRate();
+                        offsetFrame = _currTime * decoder->getSampleRate() * decoder->getChannelCount();
                         decoder->seek(offsetFrame);
                     }
                     else


### PR DESCRIPTION
After call setTime，the decoder seek to the wrong frame, need multiplied by channel count

Which branch your pull-request should merge into?

- `dev`: Current 2.x BugFixs or Features
- `1.x`: 1.x BugFixs

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
