### PR TITLE
Ensure scissor state is set to the correct value prior to a buffer clear

### DIFF
--- a/core/renderer/Renderer.cpp
+++ b/core/renderer/Renderer.cpp
@@ -887,6 +887,8 @@ void Renderer::clear(ClearFlag flags, const Color4F& color, float depth, unsigne
         if (bitmask::any(flags, ClearFlag::STENCIL))
             descriptor.clearStencilValue = stencil;
 
+        _commandBuffer->setScissorRect(_scissorState.isEnabled, _scissorState.rect.x, _scissorState.rect.y,
+                                       _scissorState.rect.width, _scissorState.rect.height);
         _commandBuffer->beginRenderPass(_currentRT, descriptor);
         _commandBuffer->endRenderPass();
     };


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch
- `dev`: New features or remove deprecated features

## Describe your changes
Ensure scissor state is re-set to the correct value prior to clearing the current buffer

## Issue ticket number and link
#1627 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
