### PR TITLE
Fix memory leaks refreshed

### DIFF
--- a/core/2d/AnimationCache.cpp
+++ b/core/2d/AnimationCache.cpp
@@ -48,7 +48,7 @@ AnimationCache* AnimationCache::getInstance()
 
 void AnimationCache::destroyInstance()
 {
-    AX_SAFE_RELEASE_NULL(s_sharedAnimationCache);
+    AX_SAFE_DELETE(s_sharedAnimationCache);
 }
 
 bool AnimationCache::init()

--- a/core/2d/AnimationCache.cpp
+++ b/core/2d/AnimationCache.cpp
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/AnimationCache.h
+++ b/core/2d/AnimationCache.h
@@ -52,7 +52,7 @@ Before v0.99.5, the recommend way was to save them on the Sprite. Since v0.99.5,
 @since v0.99.5
 @js cc.animationCache
 */
-class AX_DLL AnimationCache : public Ref
+class AX_DLL AnimationCache
 {
 public:
     /**

--- a/core/2d/AnimationCache.h
+++ b/core/2d/AnimationCache.h
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/ParticleSystem.h
+++ b/core/2d/ParticleSystem.h
@@ -239,7 +239,7 @@ public:
  * Particle emission mask cache.
  * @since axmol-1.0.0b8
  */
-class AX_DLL ParticleEmissionMaskCache : public ax::Ref
+class AX_DLL ParticleEmissionMaskCache
 {
 public:
     static ParticleEmissionMaskCache* getInstance();

--- a/core/2d/SpriteFrameCache.cpp
+++ b/core/2d/SpriteFrameCache.cpp
@@ -60,7 +60,7 @@ SpriteFrameCache* SpriteFrameCache::getInstance()
 
 void SpriteFrameCache::destroyInstance()
 {
-    AX_SAFE_RELEASE_NULL(_sharedSpriteFrameCache);
+    AX_SAFE_DELETE(_sharedSpriteFrameCache);
 }
 
 bool SpriteFrameCache::init()

--- a/core/2d/SpriteFrameCache.cpp
+++ b/core/2d/SpriteFrameCache.cpp
@@ -6,6 +6,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/SpriteFrameCache.h
+++ b/core/2d/SpriteFrameCache.h
@@ -6,6 +6,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/SpriteFrameCache.h
+++ b/core/2d/SpriteFrameCache.h
@@ -88,7 +88,7 @@ class PolygonInfo;
  @since v0.9
  @js cc.spriteFrameCache
  */
-class AX_DLL SpriteFrameCache : public Ref
+class AX_DLL SpriteFrameCache
 {
 public:
     /** Returns the shared instance of the Sprite Frame cache.

--- a/core/base/Configuration.cpp
+++ b/core/base/Configuration.cpp
@@ -181,7 +181,7 @@ Configuration* Configuration::getInstance()
 
 void Configuration::destroyInstance()
 {
-    AX_SAFE_RELEASE_NULL(s_sharedConfiguration);
+    AX_SAFE_DELETE(s_sharedConfiguration);
 }
 
 //

--- a/core/base/Configuration.h
+++ b/core/base/Configuration.h
@@ -3,6 +3,7 @@ Copyright (c) 2010      Ricardo Quesada
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/base/Configuration.h
+++ b/core/base/Configuration.h
@@ -47,7 +47,7 @@ class EventCustom;
  * @since v0.99.0
  * @js NA
  */
-class AX_DLL Configuration : public Ref
+class AX_DLL Configuration
 {
 public:
     /** Returns a shared instance of Configuration.

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -77,7 +77,7 @@ class Console;
  Since the Director is a singleton, the standard way to use it is by calling:
  _ Director::getInstance()->methodName();
  */
-class AX_DLL Director : public Ref
+class AX_DLL Director
 {
 public:
     /** Director will trigger an event before set next scene. */
@@ -123,6 +123,7 @@ public:
      * @js _getInstance
      */
     static Director* getInstance();
+    static void destroyInstance();
 
     /**
      * @js ctor
@@ -531,8 +532,8 @@ protected:
     virtual void startAnimation(SetIntervalReason reason);
     virtual void setAnimationInterval(float interval, SetIntervalReason reason);
 
-    void purgeDirector();
-    bool _purgeDirectorInNextLoop = false;  // this flag will be set to true in end()
+    void cleanupDirector();
+    bool _cleanupDirectorInNextLoop = false;  // this flag will be set to true in end()
 
     void restartDirector();
     bool _restartDirectorInNextLoop = false;  // this flag will be set to true in restart()

--- a/core/base/Profiling.h
+++ b/core/base/Profiling.h
@@ -3,6 +3,7 @@ Copyright (c) 2010      Stuart Carnie
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/base/Profiling.h
+++ b/core/base/Profiling.h
@@ -50,7 +50,7 @@ class ProfilingTimer;
  To use it, enable set the AX_ENABLE_PROFILERS=1 in the ccConfig.h file
  */
 
-class AX_DLL Profiler : public Ref
+class AX_DLL Profiler
 {
 public:
     /**

--- a/core/platform/ApplicationBase.cpp
+++ b/core/platform/ApplicationBase.cpp
@@ -1,0 +1,11 @@
+#include "ApplicationBase.h"
+#include "base/Director.h"
+
+NS_AX_BEGIN
+
+ApplicationBase::~ApplicationBase()
+{
+    Director::destroyInstance();
+}
+
+NS_AX_END

--- a/core/platform/ApplicationBase.cpp
+++ b/core/platform/ApplicationBase.cpp
@@ -1,3 +1,30 @@
+/****************************************************************************
+Copyright (c) 2010-2012 cocos2d-x.org
+Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+https://axmolengine.github.io/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
 #include "ApplicationBase.h"
 #include "base/Director.h"
 

--- a/core/platform/ApplicationBase.h
+++ b/core/platform/ApplicationBase.h
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#ifndef __AX_APPLICATION_PROTOCOL_H__
-#define __AX_APPLICATION_PROTOCOL_H__
+#ifndef __AX_APPLICATION_BASE_H__
+#define __AX_APPLICATION_BASE_H__
 
 #include "platform/PlatformMacros.h"
 #include "base/AutoreleasePool.h"
@@ -38,7 +38,7 @@ NS_AX_BEGIN
  * @{
  */
 
-class AX_DLL ApplicationProtocol
+class AX_DLL ApplicationBase
 {
 public:
     /** Since WINDOWS and ANDROID are defined as macros, we could not just use these keywords in enumeration(Platform).
@@ -65,11 +65,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~ApplicationProtocol()
-    {
-        /** clean auto release pool. */
-        PoolManager::destroyInstance();
-    }
+    virtual ~ApplicationBase();
 
     /**
      * @brief    Implement Director and Scene init code here.
@@ -151,6 +147,8 @@ public:
      */
     virtual bool openURL(std::string_view url) = 0;
 };
+
+using ApplicationProtocol = ApplicationBase;
 
 // end of platform group
 /** @} */

--- a/core/platform/ApplicationBase.h
+++ b/core/platform/ApplicationBase.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -171,7 +171,7 @@ endif()
 set(_AX_PLATFORM_HEADER
     ${_AX_PLATFORM_SPECIFIC_HEADER}
     platform/Application.h
-    platform/ApplicationProtocol.h
+    platform/ApplicationBase.h
     platform/Common.h
     platform/Device.h
     platform/FileUtils.h
@@ -194,4 +194,5 @@ set(_AX_PLATFORM_SRC
     platform/FileUtils.cpp
     platform/Image.cpp
     platform/FileStream.cpp
+    platform/ApplicationBase.cpp
     )

--- a/core/platform/android/Application-android.h
+++ b/core/platform/android/Application-android.h
@@ -26,11 +26,11 @@ THE SOFTWARE.
 #pragma once
 
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 
 NS_AX_BEGIN
 
-class AX_DLL Application : public ApplicationProtocol
+class AX_DLL Application : public ApplicationBase
 {
 public:
     /**

--- a/core/platform/android/Application-android.h
+++ b/core/platform/android/Application-android.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/android/EnhanceAPI-android.h
+++ b/core/platform/android/EnhanceAPI-android.h
@@ -3,8 +3,9 @@
  * Developed by Game Engine part
  *
  * Copyright 2015 by Mobile Solution Lab, MSG, SRC-NJ.
- * Wang Ying
- * All rights reserved.
+ * Wang Ying, All rights reserved.
+ * Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+ * 
  *
  * This software is the confidential and proprietary information of
  * Samsung Electronics, Inc. ("Confidential Information"). You

--- a/core/platform/android/EnhanceAPI-android.h
+++ b/core/platform/android/EnhanceAPI-android.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 
 NS_AX_BEGIN
 

--- a/core/platform/ios/Application-ios.h
+++ b/core/platform/ios/Application-ios.h
@@ -26,11 +26,11 @@ THE SOFTWARE.
 #pragma once
 
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 
 NS_AX_BEGIN
 
-class AX_DLL Application : public ApplicationProtocol
+class AX_DLL Application : public ApplicationBase
 {
 public:
     /**

--- a/core/platform/ios/Application-ios.h
+++ b/core/platform/ios/Application-ios.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/linux/Application-linux.h
+++ b/core/platform/linux/Application-linux.h
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Laschweinski
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/linux/Application-linux.h
+++ b/core/platform/linux/Application-linux.h
@@ -26,14 +26,14 @@ THE SOFTWARE.
 #pragma once
 
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 #include <string>
 #include <chrono>
 
 NS_AX_BEGIN
 class Rect;
 
-class Application : public ApplicationProtocol
+class Application : public ApplicationBase
 {
 public:
     /**

--- a/core/platform/mac/Application-mac.h
+++ b/core/platform/mac/Application-mac.h
@@ -26,13 +26,13 @@ THE SOFTWARE.
 #pragma once
 
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 #include <string>
 #include <chrono>
 
 NS_AX_BEGIN
 
-class AX_DLL Application : public ApplicationProtocol
+class AX_DLL Application : public ApplicationBase
 {
 public:
     /**

--- a/core/platform/mac/Application-mac.h
+++ b/core/platform/mac/Application-mac.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/wasm/Application-wasm.h
+++ b/core/platform/wasm/Application-wasm.h
@@ -31,13 +31,13 @@ THE SOFTWARE.
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WASM
 
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 #include <string>
 
 NS_AX_BEGIN
 class Rect;
 
-class Application : public ApplicationProtocol
+class Application : public ApplicationBase
 {
 public:
     /**

--- a/core/platform/wasm/Application-wasm.h
+++ b/core/platform/wasm/Application-wasm.h
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Laschweinski
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 http://www.cocos2d-x.org
 

--- a/core/platform/win32/Application-win32.cpp
+++ b/core/platform/win32/Application-win32.cpp
@@ -128,6 +128,7 @@ int Application::run()
     }
     glView->release();
 
+
     return 0;
 }
 

--- a/core/platform/win32/Application-win32.h
+++ b/core/platform/win32/Application-win32.h
@@ -27,12 +27,12 @@ THE SOFTWARE.
 
 #include "platform/StdC.h"
 #include "platform/Common.h"
-#include "platform/ApplicationProtocol.h"
+#include "platform/ApplicationBase.h"
 #include <string>
 
 NS_AX_BEGIN
 
-class AX_DLL Application : public ApplicationProtocol
+class AX_DLL Application : public ApplicationBase
 {
 public:
     /**

--- a/core/platform/win32/Application-win32.h
+++ b/core/platform/win32/Application-win32.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/winrt/Application-winrt.cpp
+++ b/core/platform/winrt/Application-winrt.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2013 cocos2d-x.org
 Copyright (c) Microsoft Open Technologies, Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/winrt/Application-winrt.h
+++ b/core/platform/winrt/Application-winrt.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2013 cocos2d-x.org
 Copyright (c) Microsoft Open Technologies, Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/winrt/Application-winrt.h
+++ b/core/platform/winrt/Application-winrt.h
@@ -31,14 +31,14 @@ THE SOFTWARE.
 
 #    include "platform/StdC.h"
 #    include "platform/Common.h"
-#    include "platform/ApplicationProtocol.h"
+#    include "platform/ApplicationBase.h"
 #    include "platform/winrt/InputEvent.h"
 #    include <string>
 #    include <functional>
 
 NS_AX_BEGIN
 
-class AX_DLL Application : public ApplicationProtocol
+class AX_DLL Application : public ApplicationBase
 {
 public:
     Application();

--- a/core/renderer/QuadCommand.cpp
+++ b/core/renderer/QuadCommand.cpp
@@ -37,6 +37,12 @@ NS_AX_BEGIN
 int QuadCommand::__indexCapacity = -1;
 uint16_t* QuadCommand::__indices = nullptr;
 
+void QuadCommand::destroyIsolatedIndices()
+{
+    AX_SAFE_DELETE_ARRAY(__indices);
+    __indexCapacity = -1;
+}
+
 QuadCommand::QuadCommand() : _indexSize(-1), _ownedIndices() {}
 
 QuadCommand::~QuadCommand()

--- a/core/renderer/QuadCommand.cpp
+++ b/core/renderer/QuadCommand.cpp
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/renderer/QuadCommand.h
+++ b/core/renderer/QuadCommand.h
@@ -67,6 +67,8 @@ public:
               const Mat4& mv,
               uint32_t flags);
 
+    static void destroyIsolatedIndices();
+
 protected:
     void reIndex(int indices);
 

--- a/core/renderer/QuadCommand.h
+++ b/core/renderer/QuadCommand.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/renderer/backend/DriverBase.h
+++ b/core/renderer/backend/DriverBase.h
@@ -72,7 +72,7 @@ enum class FeatureType : uint32_t
 /**
  * New or create resources from DriverBase.
  */
-class AX_DLL DriverBase : public ax::Ref
+class AX_DLL DriverBase
 {
 public:
     friend class ProgramManager;

--- a/core/renderer/backend/DriverBase.h
+++ b/core/renderer/backend/DriverBase.h
@@ -82,6 +82,7 @@ public:
      * Returns a shared instance of the DriverBase.
      */
     static DriverBase* getInstance();
+    static void destroyInstance();
 
     virtual ~DriverBase() = default;
 

--- a/core/renderer/backend/ProgramManager.cpp
+++ b/core/renderer/backend/ProgramManager.cpp
@@ -52,7 +52,7 @@ ProgramManager* ProgramManager::getInstance()
 
 void ProgramManager::destroyInstance()
 {
-    AX_SAFE_RELEASE_NULL(_sharedProgramManager);
+    AX_SAFE_DELETE(_sharedProgramManager);
 }
 
 ProgramManager::ProgramManager()

--- a/core/renderer/backend/ProgramManager.cpp
+++ b/core/renderer/backend/ProgramManager.cpp
@@ -69,7 +69,7 @@ ProgramManager::~ProgramManager()
         AX_SAFE_RELEASE(program.second);
     }
     AXLOGINFO("deallocing ProgramManager: %p", this);
-    backend::ShaderCache::getInstance()->purge();
+    backend::ShaderCache::destroyInstance();
 }
 
 // ### end of vertex layout setup functions

--- a/core/renderer/backend/ProgramManager.h
+++ b/core/renderer/backend/ProgramManager.h
@@ -46,7 +46,7 @@ NS_AX_BACKEND_BEGIN
 /**
  * Cache and reuse program object.
  */
-class AX_DLL ProgramManager : public Ref
+class AX_DLL ProgramManager
 {
 public:
     /** returns the shared instance */

--- a/core/renderer/backend/ProgramStateRegistry.cpp
+++ b/core/renderer/backend/ProgramStateRegistry.cpp
@@ -21,7 +21,7 @@ ProgramStateRegistry* ProgramStateRegistry::getInstance()
 /** purges the cache. It releases the retained instance. */
 void ProgramStateRegistry::destroyInstance()
 {
-    AX_SAFE_RELEASE_NULL(_sharedStateRegistry);
+    AX_SAFE_DELETE(_sharedStateRegistry);
 }
 
 bool ProgramStateRegistry::init()

--- a/core/renderer/backend/ProgramStateRegistry.h
+++ b/core/renderer/backend/ProgramStateRegistry.h
@@ -15,7 +15,7 @@ NS_AX_BACKEND_BEGIN
  * @{
  * #todo: Rename to ProgramStateRegistry
  */
-class AX_DLL ProgramStateRegistry : public Ref
+class AX_DLL ProgramStateRegistry
 {
 public:
     /** returns the shared instance */

--- a/core/renderer/backend/ShaderCache.cpp
+++ b/core/renderer/backend/ShaderCache.cpp
@@ -27,10 +27,23 @@
 
 NS_AX_BACKEND_BEGIN
 
+static ShaderCache* s_instance;
+
 ShaderCache* ShaderCache::getInstance()
 {
-    static ShaderCache instance;
-    return &instance;
+    if (s_instance)
+        return s_instance;
+    return (s_instance = new ShaderCache());
+}
+
+void ShaderCache::destroyInstance()
+{
+    AX_SAFE_DELETE(s_instance);
+}
+
+ShaderCache::~ShaderCache()
+{
+    purge();
 }
 
 void ShaderCache::purge()
@@ -55,7 +68,7 @@ backend::ShaderModule* ShaderCache::newFragmentShaderModule(std::string_view sha
 backend::ShaderModule* ShaderCache::newShaderModule(backend::ShaderStage stage, std::string_view shaderSource)
 {
     const std::size_t key = std::hash<std::string_view>{}(shaderSource);
-    const auto iter = _cachedShaders.find(key);
+    const auto iter       = _cachedShaders.find(key);
 
     if (_cachedShaders.end() != iter)
         return iter->second;

--- a/core/renderer/backend/ShaderCache.cpp
+++ b/core/renderer/backend/ShaderCache.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/renderer/backend/ShaderCache.h
+++ b/core/renderer/backend/ShaderCache.h
@@ -40,10 +40,13 @@ NS_AX_BACKEND_BEGIN
 /**
  * Create and reuse shader module.
  */
-class AX_DLL ShaderCache : public Ref
+class AX_DLL ShaderCache
 {
 public:
     static ShaderCache* getInstance();
+    static void destroyInstance();
+
+    ~ShaderCache();
 
     /** purges the cache. It releases the retained instance. */
     void purge();

--- a/core/renderer/backend/ShaderCache.h
+++ b/core/renderer/backend/ShaderCache.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/renderer/backend/metal/DriverMTL.mm
+++ b/core/renderer/backend/metal/DriverMTL.mm
@@ -391,10 +391,15 @@ id<CAMetalDrawable> DriverMTL::_currentDrawable = nil;
 
 DriverBase* DriverBase::getInstance()
 {
-    if (!DriverBase::_instance)
-        DriverBase::_instance = new DriverMTL();
+    if (!_instance)
+        _instance = new DriverMTL();
 
-    return DriverBase::_instance;
+    return _instance;
+}
+
+void DriverBase::destroyInstance() 
+{
+    AX_SAFE_DELETE(_instance);
 }
 
 void DriverMTL::setCAMetalLayer(CAMetalLayer* metalLayer)

--- a/core/renderer/backend/opengl/DriverGL.cpp
+++ b/core/renderer/backend/opengl/DriverGL.cpp
@@ -94,6 +94,10 @@ DriverBase* DriverBase::getInstance()
     return _instance;
 }
 
+void DriverBase::destroyInstance() {
+    AX_SAFE_DELETE(_instance);
+}
+
 DriverGL::DriverGL()
 {
     /// driver info

--- a/extensions/scripting/lua-bindings/script/core/Constants.lua
+++ b/extensions/scripting/lua-bindings/script/core/Constants.lua
@@ -190,7 +190,7 @@ cc.UNIFORM_SAMPLER_S    = 'AX_Texture0'
 cc.UNIFORM_SIN_TIME_S   = 'AX_SinTime'
 cc.UNIFORM_TIME_S   = 'AX_Time'
 
--- refer to: ApplicationProtocol.h: enum class Platform
+-- refer to: ApplicationBase.h: enum class Platform
 cc.PLATFORM_UNKNOWN   = 0
 cc.PLATFORM_WIN32     = 1
 cc.PLATFORM_WINUWP    = 2


### PR DESCRIPTION
1. DriverBase no destroyInstance
2. Every object inherited from ax::Ref shoud destory before ScriptEngineManager, otherwise will trigger it's reinit and leak
3. QuadCommand always leak isolated indices
4. static singleton should'nt inhert from ax::Ref due to destory it before ScriptEngineManager impossible
5. Make Director don't inherit from ax::Ref due to it also cause ScriptEngineManager re-init, because we destroy ScriptEngineManger in destructor of Director
6. Explicit Director managed by Application and don't delete self at purgeDirector, since it will release at mainLoop and re-init in glView->pollEvents then leak
7. Rename ApplicationProtocol to ApplicationBase
8. Rename purgeDirector since we don't delete director self at it, maye rename to cleanup 
9. Change ShaderCache to new/delete singleton, managed by ProgramManager

Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch
- `dev`: New features or remove deprecated features

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
