### PR TITLE
Use different global names and #undef the #defines to stay unity build friendly.

### DIFF
--- a/core/platform/android/Application-android.cpp
+++ b/core/platform/android/Application-android.cpp
@@ -43,7 +43,7 @@ extern "C" size_t __ctype_get_mb_cur_max(void)
 }
 #endif
 
-static const char* helperClassName = "org.axmol.lib.AxmolEngine";
+static const char* applicationHelperClassName = "org.axmol.lib.AxmolEngine";
 
 NS_AX_BEGIN
 
@@ -96,7 +96,7 @@ Application* Application::sharedApplication()
 const char* Application::getCurrentLanguageCode()
 {
     static char code[3]  = {0};
-    std::string language = JniHelper::callStaticStringMethod(helperClassName, "getCurrentLanguage");
+    std::string language = JniHelper::callStaticStringMethod(applicationHelperClassName, "getCurrentLanguage");
     strncpy(code, language.c_str(), 2);
     code[2] = '\0';
     return code;
@@ -116,14 +116,17 @@ Application::Platform Application::getTargetPlatform()
 
 std::string Application::getVersion()
 {
-    return JniHelper::callStaticStringMethod(helperClassName, "getVersion");
+    return JniHelper::callStaticStringMethod(applicationHelperClassName, "getVersion");
 }
 
 bool Application::openURL(std::string_view url)
 {
-    return JniHelper::callStaticBooleanMethod(helperClassName, "openURL", url);
+    return JniHelper::callStaticBooleanMethod(applicationHelperClassName, "openURL", url);
 }
 
 void Application::applicationScreenSizeChanged(int newWidth, int newHeight) {}
 
 NS_AX_END
+
+#undef LOGD
+#undef LOG_TAG

--- a/core/platform/android/Device-android.cpp
+++ b/core/platform/android/Device-android.cpp
@@ -33,7 +33,7 @@ THE SOFTWARE.
 #include "platform/FileUtils.h"
 #include "yasio/string_view.hpp"
 
-static const char* helperClassName = "org.axmol.lib.AxmolEngine";
+static const char* deviceHelperClassName = "org.axmol.lib.AxmolEngine";
 
 NS_AX_BEGIN
 
@@ -42,12 +42,12 @@ int Device::getDPI()
     static int dpi = -1;
     if (dpi == -1)
     {
-        dpi = JniHelper::callStaticIntMethod(helperClassName, "getDPI");
+        dpi = JniHelper::callStaticIntMethod(deviceHelperClassName, "getDPI");
     }
     return dpi;
 }
 
-float Device::getPixelRatio() 
+float Device::getPixelRatio()
 {
     // refer to: https://developer.android.com/training/multiscreen/screendensities?hl=en-us
     return Device::getDPI() / 160.0f;
@@ -57,17 +57,17 @@ void Device::setAccelerometerEnabled(bool isEnabled)
 {
     if (isEnabled)
     {
-        JniHelper::callStaticVoidMethod(helperClassName, "enableAccelerometer");
+        JniHelper::callStaticVoidMethod(deviceHelperClassName, "enableAccelerometer");
     }
     else
     {
-        JniHelper::callStaticVoidMethod(helperClassName, "disableAccelerometer");
+        JniHelper::callStaticVoidMethod(deviceHelperClassName, "disableAccelerometer");
     }
 }
 
 void Device::setAccelerometerInterval(float interval)
 {
-    JniHelper::callStaticVoidMethod(helperClassName, "setAccelerometerInterval", interval);
+    JniHelper::callStaticVoidMethod(deviceHelperClassName, "setAccelerometerInterval", interval);
 }
 
 class BitmapDC
@@ -182,33 +182,33 @@ Data Device::getTextureDataForText(std::string_view text,
 
 void Device::setKeepScreenOn(bool value)
 {
-    JniHelper::callStaticVoidMethod(helperClassName, "setKeepScreenOn", value);
+    JniHelper::callStaticVoidMethod(deviceHelperClassName, "setKeepScreenOn", value);
 }
 
 void Device::vibrate(float duration)
 {
-    JniHelper::callStaticVoidMethod(helperClassName, "vibrate", duration);
+    JniHelper::callStaticVoidMethod(deviceHelperClassName, "vibrate", duration);
 }
 
 void Device::prepareImpactFeedbackGenerator(ImpactFeedbackStyle style) {}
 
 void Device::impactOccurred(ImpactFeedbackStyle style)
 {
-    JniHelper::callStaticVoidMethod(helperClassName, "impactOccurred", (int)style);
+    JniHelper::callStaticVoidMethod(deviceHelperClassName, "impactOccurred", (int)style);
 }
 
 void Device::prepareNotificationFeedbackGenerator() {}
 
 void Device::notificationOccurred(NotificationFeedbackType type)
 {
-    JniHelper::callStaticVoidMethod(helperClassName, "notificationOccurred", (int)type);
+    JniHelper::callStaticVoidMethod(deviceHelperClassName, "notificationOccurred", (int)type);
 }
 
 void Device::prepareSelectionFeedbackGenerator() {}
 
 void Device::selectionChanged()
 {
-    JniHelper::callStaticVoidMethod(helperClassName, "selectionChanged");
+    JniHelper::callStaticVoidMethod(deviceHelperClassName, "selectionChanged");
 }
 
 NS_AX_END

--- a/core/platform/android/FileUtils-android.cpp
+++ b/core/platform/android/FileUtils-android.cpp
@@ -320,3 +320,9 @@ std::string FileUtilsAndroid::getNativeWritableAbsolutePath() const
 }
 
 NS_AX_END
+
+#undef DECLARE_GUARD
+#undef ASSETS_FOLDER_NAME_LENGTH
+#undef ASSETS_FOLDER_NAME
+#undef LOGD
+#undef LOG_TAG

--- a/core/platform/android/jni/Java_org_axmol_lib_AxmolEngine.cpp
+++ b/core/platform/android/jni/Java_org_axmol_lib_AxmolEngine.cpp
@@ -184,3 +184,6 @@ void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharse
         methodInfo.env->DeleteLocalRef(methodInfo.classID);
     }
 }
+
+#undef LOGD
+#undef LOG_TAG

--- a/core/platform/android/jni/JniHelper.cpp
+++ b/core/platform/android/jni/JniHelper.cpp
@@ -349,3 +349,7 @@ void JniHelper::reportError(const char* className, const char* methodName, const
 }
 
 NS_AX_END  // namespace ax
+
+#undef LOGE
+#undef LOGD
+#undef LOG_TAG

--- a/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -249,4 +249,6 @@ const char* EditBoxImplAndroid::getNativeDefaultFontName()
 
 NS_AX_END
 
+#undef LOGD
+
 #endif /* #if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID) */


### PR DESCRIPTION
Hello, this PR changes the name of some global variables such that the files containing their definition can be included in a single .cpp file in the context of unity builds. For the same reasons, a couple of preprocessor definitions are undefined at the end of the file.