### PR TITLE
Add AX_USE_ALSOFT_STATIC CMake option to compile and link OpenAL Soft as a static library.

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -23,6 +23,16 @@ option(AX_WITH_OBOE "Build with oboe support" OFF)
 # by default, enable ios,macOS openal-soft framework for legal license LGPL-2.1
 option(ALSOFT_OSX_FRAMEWORK "" ON)
 
+# Enable static library for openal-soft. This has an impact on the
+# license of the final product since the source of the whole game must
+# then be available under terms compatible with the LGPL (e.g. GPL,
+# MPL). Consequently, we set it to OFF by default.
+option(
+  AX_USE_ALSOFT_STATIC
+  "Link with OpenAL as a static library (LGPL-compatible apps only)."
+  OFF
+)
+
 set(ANDROID_SHARED_LOADS "" CACHE INTERNAL "The android shared libraries load source code" )
 set(ANDROID_SHARED_LOAD_FILE_NAME "SharedLoader.java" CACHE INTERNAL "The android shared load java file name" )
 set(ANDROID_SHARED_LOAD_FILE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${ANDROID_SHARED_LOAD_FILE_NAME}.in" CACHE INTERNAL "The android shared libraries load config code file" )
@@ -58,11 +68,11 @@ if(AX_ISA_LEVEL)
     macro(ax_check_c_source source outputVar)
         if (NOT CMAKE_CROSSCOMPILING)
             check_c_source_runs("${source}" ${outputVar})
-        else() 
+        else()
             check_c_source_compiles("${source}" ${outputVar})
         endif()
     endmacro(ax_check_c_source source var)
-    
+
     # Checking intel SIMD Intrinsics
     include(CheckCSourceRuns)
     if(APPLE)
@@ -250,7 +260,7 @@ ax_add_3rd(fmt EXCLUDE_FROM_ALL TARGETS fmt-header-only)
 # bellow are non header only libs
 
 # cpufeatures
-if(ANDROID) 
+if(ANDROID)
     add_subdirectory(android-specific/cpufeatures)
 endif()
 
@@ -388,6 +398,11 @@ endif()
 # The openal-soft(LGPL 2.1)
 if(AX_USE_ALSOFT AND NOT EMSCRIPTEN)
     set(alsoft_opts "ALSOFT_DLOPEN OFF" "ALSOFT_UTILS OFF" "ALSOFT_EXAMPLES OFF" "ALSOFT_INSTALL OFF")
+
+    if (AX_USE_ALSOFT_STATIC)
+        list(APPEND alsoft_opts "LIBTYPE STATIC")
+    endif()
+
     if (ANDROID)
         if(AX_WITH_OBOE)
             _1kfetch(oboe)
@@ -408,7 +423,9 @@ if(AX_USE_ALSOFT AND NOT EMSCRIPTEN)
     target_compile_definitions(thirdparty INTERFACE AX_USE_ALSOFT=1)
     set_target_properties(OpenAL alcommon PROPERTIES CXX_STANDARD ${_AX_CXX_STD})
 
-    if(ANDROID)
+    if (AX_USE_ALSOFT_STATIC)
+        target_compile_definitions(thirdparty INTERFACE AL_LIBTYPE_STATIC=1)
+    elseif(ANDROID)
         set(ANDROID_SHARED_LOADS "${ANDROID_SHARED_LOADS}System.loadLibrary(\"openal\");" CACHE INTERNAL "Android Shared Loads" )
     endif()
 endif()


### PR DESCRIPTION
Hello, this PR adds a CMake option to compile and link OpenAL Soft as a static library. Because the license of OpenAL Soft is LGPL it makes sense to use a shared library, but for games released under a license compatible with the LGPL using a static library is easier.

The option is set to off by default, which means the the shared library is used.