### PR TITLE
Ability to disable default implementations of HTTP and WebSocket clients

### DIFF
--- a/CMakeOptions.md
+++ b/CMakeOptions.md
@@ -6,6 +6,8 @@
   - AX_ENABLE_MSEDGE_WEBVIEW2: whether enable msedge webview2, default: `TRUE`
   - AX_ENABLE_MFMEDIA: whether enable microsoft media foundation for windows video player support, default: `TRUE`
   - AX_ENABLE_VLC_MEDIA: whether enable libvlc media, default: `TRUE on Linux`, `FALSE on Windows`, not support other platforms
+  - AX_ENABLE_HTTP: whether enable http client, default: `TRUE`
+  - AX_ENABLE_WEBSOCKET: whether enable websockets client, default: `TRUE`
 - AX_USE_XXX:
   - AX_USE_ALSOFT: whether use openal-soft for all platforms
     - Apple platform: Use openal-soft instead system deprecated: `OpenAL.framework`

--- a/core/network/CMakeLists.txt
+++ b/core/network/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-option(AX_USE_HTTP "Build HTTP client based on yasio" ON)
-option(AX_USE_WEBSOCKET "Build Websocket client based on yasio" ON)
+option(AX_ENABLE_HTTP "Build HTTP client based on yasio" ON)
+option(AX_ENABLE_WEBSOCKET "Build Websocket client based on yasio" ON)
 
 if(EMSCRIPTEN)
     set(_AX_NETWORK_HEADER
@@ -16,7 +16,7 @@ if(EMSCRIPTEN)
         network/Uri.cpp
     )
     
-    if (AX_USE_HTTP)
+    if (AX_ENABLE_HTTP)
         list(APPEND _AX_NETWORK_HEADER
             network/HttpClient.h
             network/HttpResponse.h
@@ -30,7 +30,7 @@ if(EMSCRIPTEN)
         )    
     endif()
     
-    if (AX_USE_WEBSOCKET)
+    if (AX_ENABLE_WEBSOCKET)
         list(APPEND _AX_NETWORK_HEADER
             network/WebSocket.h
         )
@@ -54,7 +54,7 @@ else()
         network/Uri.cpp
     )
     
-    if (AX_USE_HTTP)
+    if (AX_ENABLE_HTTP)
         list(APPEND _AX_NETWORK_HEADER
             network/HttpClient.h
             network/HttpResponse.h
@@ -68,7 +68,7 @@ else()
         )    
     endif()
     
-    if (AX_USE_WEBSOCKET)
+    if (AX_ENABLE_WEBSOCKET)
         list(APPEND _AX_NETWORK_HEADER
             network/WebSocket.h
         )

--- a/core/network/CMakeLists.txt
+++ b/core/network/CMakeLists.txt
@@ -1,41 +1,82 @@
+
+option(AX_USE_HTTP "Build HTTP client based on yasio" ON)
+option(AX_USE_WEBSOCKET "Build Websocket client based on yasio" ON)
+
 if(EMSCRIPTEN)
     set(_AX_NETWORK_HEADER
         network/Downloader-wasm.h
         network/IDownloaderImpl.h
         network/Downloader.h
         network/Uri.h
-        network/HttpClient.h
-        network/HttpResponse.h
-        network/HttpRequest.h
     )
 
     set(_AX_NETWORK_SRC
-        network/HttpClient-wasm.cpp
         network/Downloader.cpp
         network/Downloader-wasm.cpp
-        network/HttpCookie.cpp
         network/Uri.cpp
-        network/WebSocket-wasm.cpp
     )
+    
+    if (AX_USE_HTTP)
+        list(APPEND _AX_NETWORK_HEADER
+            network/HttpClient.h
+            network/HttpResponse.h
+            network/HttpRequest.h
+            network/HttpCookie.h
+        )
+
+        list(APPEND _AX_NETWORK_SRC
+            network/HttpClient-wasm.cpp
+            network/HttpCookie.cpp
+        )    
+    endif()
+    
+    if (AX_USE_WEBSOCKET)
+        list(APPEND _AX_NETWORK_HEADER
+            network/WebSocket.h
+        )
+
+        list(APPEND _AX_NETWORK_SRC
+            network/WebSocket-wasm.cpp
+        )    
+    endif()
+    
 else()
     set(_AX_NETWORK_HEADER
         network/Downloader-curl.h
         network/IDownloaderImpl.h
         network/Downloader.h
         network/Uri.h
-        network/HttpClient.h
-        network/HttpResponse.h
-        network/HttpRequest.h
-        network/HttpCookie.h
-        network/WebSocket.h
     )
 
     set(_AX_NETWORK_SRC
-        network/HttpClient.cpp
         network/Downloader.cpp
         network/Downloader-curl.cpp
-        network/HttpCookie.cpp
         network/Uri.cpp
-        network/WebSocket.cpp
     )
+    
+    if (AX_USE_HTTP)
+        list(APPEND _AX_NETWORK_HEADER
+            network/HttpClient.h
+            network/HttpResponse.h
+            network/HttpRequest.h
+            network/HttpCookie.h
+        )
+
+        list(APPEND _AX_NETWORK_SRC
+            network/HttpClient.cpp
+            network/HttpCookie.cpp
+        )    
+    endif()
+    
+    if (AX_USE_WEBSOCKET)
+        list(APPEND _AX_NETWORK_HEADER
+            network/WebSocket.h
+        )
+
+        list(APPEND _AX_NETWORK_SRC
+            network/WebSocket.cpp
+        )    
+    endif()
 endif()
+
+

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -19,6 +19,7 @@ option(AX_WITH_CARES "Build with internal c-ares support" OFF)
 option(AX_WITH_YAML_CPP "Build with yaml-cpp support" OFF)
 option(AX_WITH_KCP "Build with internal kcp support" OFF)
 option(AX_WITH_OBOE "Build with oboe support" OFF)
+option(AX_WITH_LLHTTP "Build with internal LLHTTP support" ON)
 
 # by default, enable ios,macOS openal-soft framework for legal license LGPL-2.1
 option(ALSOFT_OSX_FRAMEWORK "" ON)
@@ -441,7 +442,9 @@ if(AX_WITH_CARES)
     ax_add_3rd(c-ares)
 endif()
 
-ax_add_3rd(llhttp)
+if(AX_WITH_LLHTTP)
+    ax_add_3rd(llhttp)
+endif()
 
 # libvlc
 if (AX_ENABLE_VLC_MEDIA AND (NOT _AX_HAVE_VLC))


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch

## Describe your changes
Allow the HttpClient and WebSocket implementations to be excluded from the build.  This may be because they are either not required, or the game project has its own implementations, so this would prevent build time conflicts in code.

Allow LLHTTP to be disabled if not required to avoid build time conflicts with game-side libraries.

## Issue ticket number and link
This may help with #1642

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
