### PR TITLE
Fix cross fade transition

### DIFF
--- a/core/2d/Transition.cpp
+++ b/core/2d/Transition.cpp
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/Transition.cpp
+++ b/core/2d/Transition.cpp
@@ -1079,7 +1079,7 @@ void TransitionCrossFade::onEnter()
 
     // create the first render texture for inScene
     RenderTexture* inTexture =
-        RenderTexture::create((int)size.width, (int)size.height, backend::PixelFormat::RGBA8, PixelFormat::D24S8);
+        RenderTexture::create((int)size.width, (int)size.height, backend::PixelFormat::RGBA8, PixelFormat::D24S8, false);
 
     if (nullptr == inTexture)
     {
@@ -1097,7 +1097,7 @@ void TransitionCrossFade::onEnter()
 
     // create the second render texture for outScene
     RenderTexture* outTexture =
-        RenderTexture::create((int)size.width, (int)size.height, backend::PixelFormat::RGBA8, PixelFormat::D24S8);
+        RenderTexture::create((int)size.width, (int)size.height, backend::PixelFormat::RGBA8, PixelFormat::D24S8, false);
     outTexture->getSprite()->setAnchorPoint(Vec2(0.5f, 0.5f));
     outTexture->setPosition(size.width / 2, size.height / 2);
     outTexture->setAnchorPoint(Vec2(0.5f, 0.5f));


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch

## Describe your changes
This is related to the issue described in #1663 with the cross-fade transition.  The render textures used for the transition cannot use a shared render target.  It's reproducible with the cpp-tests project (test menu `64: Transitions`, test 8).

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
