### PR TITLE
Remove duplicate CODE_SIGN_IDENTITY that is setting invalid value

### DIFF
--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -389,7 +389,6 @@ function(ax_setup_app_config app_name)
             # By default, explicit disable codesign for macOS PC
             set_xcode_property(${app_name} CODE_SIGN_IDENTITY "")
             set_xcode_property(${app_name} CODE_SIGNING_ALLOWED "NO")
-            set_xcode_property(${app_name} CODE_SIGN_IDENTITY "NO")
         endif()
     elseif(WINDOWS)
         # windows: visual studio/LLVM-clang default is Console app, but we need Windows app


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch

## Describe your changes
CODE_SIGN_IDENTITY was being set twice, the second time being to an invalid value. Removed invalid line.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
