### PR TITLE
Fix crash during scene transition due to invalid camera

### DIFF
--- a/core/2d/Node.h
+++ b/core/2d/Node.h
@@ -1139,7 +1139,7 @@ public:
      * @param parentFlags Renderer flag.
      */
     virtual void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags);
-    virtual void visit() final;
+    virtual void visit();
 
     /** Returns the Scene that contains the Node.
      It returns `nullptr` if the node doesn't belong to any Scene.

--- a/core/2d/Scene.cpp
+++ b/core/2d/Scene.cpp
@@ -258,6 +258,39 @@ void Scene::render(Renderer* renderer, const Mat4& eyeTransform, const Mat4* eye
     Camera::_visitingCamera = nullptr;
 }
 
+void Scene::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+{
+    Node::visit(renderer, parentTransform, parentFlags);
+}
+
+void Scene::visit()
+{
+    const auto eyeTransform = Mat4::IDENTITY;
+
+    for (const auto& camera : getCameras())
+    {
+        if (!camera->isVisible())
+            continue;
+
+        Camera::_visitingCamera = camera;
+
+        camera->setAdditionalTransform(eyeTransform.getInversed());
+        _director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
+        _director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION,
+                              Camera::_visitingCamera->getViewProjectionMatrix());
+
+        camera->apply();
+        // clear background with max depth
+        camera->clearBackground();
+        // visit the scene
+        Node::visit();
+
+        _director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
+    }
+
+    Camera::_visitingCamera = nullptr;
+}
+
 void Scene::removeAllChildren()
 {
     if (_defaultCamera)

--- a/core/2d/Scene.cpp
+++ b/core/2d/Scene.cpp
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/Scene.h
+++ b/core/2d/Scene.h
@@ -115,6 +115,9 @@ public:
      */
     virtual void render(Renderer* renderer, const Mat4& eyeTransform, const Mat4* eyeProjection = nullptr);
 
+    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit() override;
+
     /** override function */
     virtual void removeAllChildren() override;
 


### PR DESCRIPTION
Scene can now be visited correctly with valid cameras being set for child nodes when rendering outside of normal render loop.

Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch

## Describe your changes
Currently `Scene::visit()` is only used to draw a scene when rendering to a `RenderTexture`.  The issue with this is that there is no valid camera set for use by the child nodes, so if they access the camera during a call to `Node::visit(...)`, a crash will occur.  An example is `FastTMXLayer::draw` accessing the camera.

The fix in this PR allows the Scene to override `visit()`, and ensure that the camera is set correctly for all child nodes in that scene.

`Scene::visit()` is only ever called when attempting to render to a `RenderTexture`, so the changes in this PR should have no impact on any other functionality in Axmol.

## Issue ticket number and link
Crash issue is described in #1663 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
