### PR TITLE
Ensure correct video mode settings are applied when creating view

### DIFF
--- a/core/platform/GLViewImpl.cpp
+++ b/core/platform/GLViewImpl.cpp
@@ -624,6 +624,15 @@ bool GLViewImpl::initWithFullScreen(std::string_view viewName)
         return false;
 
     const GLFWvidmode* videoMode = glfwGetVideoMode(_monitor);
+    
+    // These are soft constraints. If the video mode is retrieved at runtime, the resulting window and context should
+    // match these exactly. If invalid attribs are passed (eg. from an outdated cache), window creation will NOT fail
+    // but the actual window/context may differ.
+    glfwWindowHint(GLFW_REFRESH_RATE, videoMode->refreshRate);
+    glfwWindowHint(GLFW_RED_BITS, videoMode->redBits);
+    glfwWindowHint(GLFW_BLUE_BITS, videoMode->blueBits);
+    glfwWindowHint(GLFW_GREEN_BITS, videoMode->greenBits);
+    
     return initWithRect(viewName, ax::Rect(0, 0, (float)videoMode->width, (float)videoMode->height), 1.0f, false);
 }
 


### PR DESCRIPTION
Which branch your pull-request should merge into?

- `2.1`: BugFixes and Improvements for Current LTS branch

## Describe your changes
When calling `GLViewImpl::initWithFullScreen(std::string_view viewName)`, the video mode of the current monitor was not being applied, so the refresh rate and frame buffer depth bits were not being set correctly.

## Issue ticket number and link
Issue described in https://github.com/axmolengine/axmol/discussions/1669#discussioncomment-8449160

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
