### PR TITLE
RichText enhancements

### DIFF
--- a/core/ui/UIRichText.cpp
+++ b/core/ui/UIRichText.cpp
@@ -620,27 +620,33 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText) : _fontElements(20), _richText(ri
     };
 
     MyXMLVisitor::setTagDescription(
-        "h1", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 34); },
+        "h1", true,
+        [headerTagEnterHandler](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 34); },
         [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
-        "h2", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 30); },
+        "h2", true,
+        [headerTagEnterHandler](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 30); },
         [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
-        "h3", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 24); },
+        "h3", true,
+        [headerTagEnterHandler](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 24); },
         [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
-        "h4", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 20); },
+        "h4", true,
+        [headerTagEnterHandler](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 20); },
         [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
-        "h5", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 18); },
+        "h5", true,
+        [headerTagEnterHandler](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 18); },
         [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
-        "h6", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 16); },
+        "h6", true,
+        [headerTagEnterHandler](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 16); },
         [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription("outline", true, [](const ValueMap& tagAttrValueMap) {

--- a/core/ui/UIRichText.cpp
+++ b/core/ui/UIRichText.cpp
@@ -288,12 +288,9 @@ RichElementNewLine* RichElementNewLine::create(int tag, const Color3B& color, ui
     return nullptr;
 }
 
-RichElementMultipleNewLine* RichElementMultipleNewLine::create(int tag,
-                                                               int quantity,
-                                                               const Color3B& color,
-                                                               uint8_t opacity)
+RichElementNewLine* RichElementNewLine::create(int tag, int quantity, const Color3B& color, uint8_t opacity)
 {
-    RichElementMultipleNewLine* element = new RichElementMultipleNewLine(quantity);
+    RichElementNewLine* element = new RichElementNewLine(quantity);
     if (element->init(tag, color, opacity))
     {
         element->autorelease();
@@ -593,7 +590,7 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText) : _fontElements(20), _richText(ri
     });
 
     MyXMLVisitor::setTagDescription("p", false, nullptr,
-                                    [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+                                    [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     constexpr auto headerTagEnterHandler = [](const ValueMap& tagAttrValueMap,
                                               float defaultFontSize) -> std::pair<ValueMap, RichElement*> {
@@ -624,27 +621,27 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText) : _fontElements(20), _richText(ri
 
     MyXMLVisitor::setTagDescription(
         "h1", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 34); },
-        [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+        [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
         "h2", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 30); },
-        [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+        [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
         "h3", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 24); },
-        [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+        [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
         "h4", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 20); },
-        [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+        [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
         "h5", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 18); },
-        [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+        [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription(
         "h6", true, [](const ValueMap& tagAttrValueMap) { return headerTagEnterHandler(tagAttrValueMap, 16); },
-        [] { return RichElementMultipleNewLine::create(0, 2, Color3B::WHITE, 255); });
+        [] { return RichElementNewLine::create(0, 2, Color3B::WHITE, 255); });
 
     MyXMLVisitor::setTagDescription("outline", true, [](const ValueMap& tagAttrValueMap) {
         // supported attributes:
@@ -1741,12 +1738,7 @@ void RichText::formatText(bool force)
                 }
                 case RichElement::Type::NEWLINE:
                 {
-                    addNewLine();
-                    break;
-                }
-                case RichElement::Type::NEWLINE_MULTI:
-                {
-                    auto* newLineMulti = static_cast<RichElementMultipleNewLine*>(element);
+                    auto* newLineMulti = static_cast<RichElementNewLine*>(element);
 
                     addNewLine(newLineMulti->_quantity);
                     break;
@@ -1795,12 +1787,7 @@ void RichText::formatText(bool force)
                 }
                 case RichElement::Type::NEWLINE:
                 {
-                    addNewLine();
-                    break;
-                }
-                case RichElement::Type::NEWLINE_MULTI:
-                {
-                    auto* newLineMulti = static_cast<RichElementMultipleNewLine*>(element);
+                    auto* newLineMulti = static_cast<RichElementNewLine*>(element);
 
                     addNewLine(newLineMulti->_quantity);
                     break;

--- a/core/ui/UIRichText.h
+++ b/core/ui/UIRichText.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2013 cocos2d-x.org
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 
@@ -22,9 +23,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-
-#ifndef __UIRICHTEXT_H__
-#define __UIRICHTEXT_H__
+#pragma once
 
 #include "ui/UIWidget.h"
 #include "ui/GUIExport.h"
@@ -53,10 +52,11 @@ public:
      */
     enum class Type
     {
-        TEXT,   /*!< RichElementText */
-        IMAGE,  /*!< RichElementImage */
-        CUSTOM, /*!< RichElementCustomNode */
-        NEWLINE /*!< RichElementNewLine */
+        TEXT,    /*!< RichElementText */
+        IMAGE,   /*!< RichElementImage */
+        CUSTOM,  /*!< RichElementCustomNode */
+        NEWLINE, /*!< RichElementNewLine */
+        NEWLINE_MULTI  /*!< RichElementNewLine */
     };
 
     /**
@@ -64,14 +64,14 @@ public:
      * @js ctor
      * @lua new
      */
-    RichElement(){};
+    RichElement() = default;
 
     /**
      * @brief Default destructor.
      * @js NA
      * @lua NA
      */
-    virtual ~RichElement(){};
+    ~RichElement() override = default;
 
     /**
      * @brief Initialize a rich element with different arguments.
@@ -105,7 +105,7 @@ public:
      * @js ctor
      * @lua new
      */
-    RichElementText() { _type = Type::TEXT; };
+    RichElementText() { _type = Type::TEXT; }
 
     enum
     {
@@ -124,7 +124,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~RichElementText(){};
+    ~RichElementText() override = default;
 
     /**
      * @brief Initialize a RichElementText with various arguments.
@@ -221,14 +221,14 @@ public:
      * @lua new
      *
      */
-    RichElementImage() { _type = Type::IMAGE; };
+    RichElementImage() { _type = Type::IMAGE; }
 
     /**
      * @brief Default destructor.
      * @js NA
      * @lua NA
      */
-    virtual ~RichElementImage(){};
+    ~RichElementImage() override = default;
 
     /**
      * @brief Initialize a RichElementImage with various arguments.
@@ -296,14 +296,14 @@ public:
      * @js ctor
      * @lua new
      */
-    RichElementCustomNode() { _type = Type::CUSTOM; };
+    RichElementCustomNode() { _type = Type::CUSTOM; }
 
     /**
      * @brief Default destructor.
      * @js NA
      * @lua NA
      */
-    virtual ~RichElementCustomNode() { AX_SAFE_RELEASE(_customNode); };
+    ~RichElementCustomNode() override { AX_SAFE_RELEASE(_customNode); }
 
     /**
      * @brief Initialize a RichElementCustomNode with various arguments.
@@ -344,14 +344,14 @@ public:
      * @lua new
      *
      */
-    RichElementNewLine() { _type = Type::NEWLINE; };
+    RichElementNewLine() { _type = Type::NEWLINE; }
 
     /**
      * @brief Default destructor.
      * @js NA
      * @lua NA
      */
-    virtual ~RichElementNewLine(){};
+    ~RichElementNewLine() override = default;
 
     /**
      * @brief Create a RichElementNewLine with various arguments.
@@ -366,6 +366,44 @@ public:
 protected:
     friend class RichText;
 };
+
+/**
+ *@brief Rich element for new line.
+ */
+class AX_GUI_DLL RichElementMultipleNewLine : public RichElement
+{
+public:
+    /**
+     * @brief Default constructor.
+     * @js ctor
+     * @lua new
+     *
+     */
+    RichElementMultipleNewLine(int quantity) : _quantity(quantity) { _type = Type::NEWLINE_MULTI; }
+
+    /**
+     * @brief Default destructor.
+     * @js NA
+     * @lua NA
+     */
+    ~RichElementMultipleNewLine() override = default;
+
+    /**
+     * @brief Create a RichElementNewLine with various arguments.
+     *
+     * @param tag A integer tag value.
+     * @param quantity Number of new lines to add
+     * @param color A color in Color3B.
+     * @param opacity A opacity in GLubyte.
+     * @return A RichElementNewLine instance.
+     */
+    static RichElementMultipleNewLine* create(int tag, int quantity, const Color3B& color, uint8_t opacity);
+
+protected:
+    friend class RichText;
+    int _quantity;
+};
+
 
 /**
  *@brief A container for displaying various RichElements.
@@ -406,6 +444,7 @@ public:
      * @result text attributes and RichElement
      */
     typedef std::function<std::pair<ValueMap, RichElement*>(const ValueMap& tagAttrValueMap)> VisitEnterHandler;
+    typedef std::function<RichElement*()> VisitExitHandler;
 
     static const std::string KEY_VERTICAL_SPACE;                   /*!< key of vertical space */
     static const std::string KEY_WRAP_MODE;                        /*!< key of per word, or per char */
@@ -460,7 +499,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~RichText();
+    ~RichText() override;
 
     /**
      * @brief Create a empty RichText.
@@ -522,8 +561,8 @@ public:
     void formatText(bool force = false);
 
     // override functions.
-    virtual void ignoreContentAdaptWithSize(bool ignore) override;
-    virtual std::string getDescription() const override;
+    void ignoreContentAdaptWithSize(bool ignore) override;
+    std::string getDescription() const override;
 
     void setWrapMode(WrapMode wrapMode); /*!< sets the wrapping mode: WRAP_PER_CHAR or WRAP_PER_WORD */
     WrapMode getWrapMode() const;        /*!< returns the current wrapping mode */
@@ -540,7 +579,7 @@ public:
     float getFontSize();                     /*!< return the current font size */
     void setFontFace(std::string_view face); /*!< Set the font face. @param face the font face. */
     std::string getFontFace();               /*!< return the current font face */
-    void setAnchorFontColor(std::string_view color); /*!< Set the font color of a-tag. @param face the font color. */
+    void setAnchorFontColor(std::string_view color); /*!< Set the font color of a-tag. @param color the font color. */
     std::string getAnchorFontColor();                /*!< return the current font color of a-tag */
     ax::Color3B getAnchorFontColor3B();              /*!< return the current font color of a-tag */
     void setAnchorTextBold(bool enable);             /*!< enable bold text of a-tag */
@@ -579,9 +618,13 @@ public:
      * @brief add a callback to own tag.
      * @param tag tag's name
      * @param isFontElement use attributes of text tag
-     * @param handleVisitEnter callback
+     * @param handleVisitEnter callback at opening tag
+     * @param handleVisitExit callback at closing tag
      */
-    static void setTagDescription(std::string_view tag, bool isFontElement, VisitEnterHandler handleVisitEnter);
+    static void setTagDescription(std::string_view tag,
+                                  bool isFontElement,
+                                  VisitEnterHandler handleVisitEnter,
+                                  VisitExitHandler handleVisitExit = nullptr);
 
     /**
      * @brief remove a callback to own tag.
@@ -598,7 +641,7 @@ public:
      */
     void setOpenUrlHandler(const OpenUrlHandler& handleOpenUrl);
 
-    virtual bool init() override;
+    bool init() override;
 
     bool initWithXML(std::string_view xml,
                      const ValueMap& defaults            = ValueMap(),
@@ -607,9 +650,9 @@ public:
     bool setString(std::string_view text);
 
 protected:
-    virtual void adaptRenderers() override;
+    void adaptRenderers() override;
 
-    virtual void initRenderer() override;
+    void initRenderer() override;
     void pushToContainer(Node* renderer);
     void handleTextRenderer(std::string_view text,
                             std::string_view fontName,
@@ -635,7 +678,7 @@ protected:
                              float scaleY = 1.f);
     void handleCustomRenderer(Node* renderer);
     void formatRenderers();
-    void addNewLine();
+    void addNewLine(int quantity = 1);
     void doHorizontalAlignment(const Vector<Node*>& row, float rowWidth);
     float stripTrailingWhitespace(const Vector<Node*>& row);
 
@@ -657,5 +700,3 @@ protected:
 // end of ui group
 /// @}
 NS_AX_END
-
-#endif /* defined(__UIRichText__) */

--- a/core/ui/UIRichText.h
+++ b/core/ui/UIRichText.h
@@ -59,20 +59,6 @@ public:
     };
 
     /**
-     * @brief Default constructor.
-     * @js ctor
-     * @lua new
-     */
-    RichElement() = default;
-
-    /**
-     * @brief Default destructor.
-     * @js NA
-     * @lua NA
-     */
-    ~RichElement() override = default;
-
-    /**
      * @brief Initialize a rich element with different arguments.
      *
      * @param tag A integer tag value.
@@ -86,10 +72,10 @@ public:
     void setColor(const Color3B& color);
 
 protected:
-    Type _type;       /*!< Rich element type. */
-    int _tag;         /*!< A integer tag value. */
-    Color3B _color;   /*!< A color in `Color3B`. */
-    uint8_t _opacity; /*!< A opacity value in `GLubyte`. */
+    Type _type{};       /*!< Rich element type. */
+    int _tag{};         /*!< A integer tag value. */
+    Color3B _color{};   /*!< A color in `Color3B`. */
+    uint8_t _opacity{}; /*!< A opacity value in `GLubyte`. */
     friend class RichText;
 };
 
@@ -104,7 +90,7 @@ public:
      * @js ctor
      * @lua new
      */
-    RichElementText() { _type = Type::TEXT; }
+    RichElementText() : _fontSize(0), _flags(0), _outlineSize(0), _shadowBlurRadius(0) { _type = Type::TEXT; }
 
     enum
     {
@@ -117,13 +103,6 @@ public:
         SHADOW_FLAG        = 1 << 6, /*!< shadow effect */
         GLOW_FLAG          = 1 << 7  /*!< glow effect */
     };
-
-    /**
-     *@brief Default destructor.
-     * @js NA
-     * @lua NA
-     */
-    ~RichElementText() override = default;
 
     /**
      * @brief Initialize a RichElementText with various arguments.
@@ -220,14 +199,7 @@ public:
      * @lua new
      *
      */
-    RichElementImage() { _type = Type::IMAGE; }
-
-    /**
-     * @brief Default destructor.
-     * @js NA
-     * @lua NA
-     */
-    ~RichElementImage() override = default;
+    RichElementImage(): _textureType(), _width(0), _height(0), _scaleX(0), _scaleY(0) { _type = Type::IMAGE; }
 
     /**
      * @brief Initialize a RichElementImage with various arguments.
@@ -267,9 +239,9 @@ public:
 
     void setWidth(int width);
     void setHeight(int height);
-    inline void setScale(float scale) { _scaleX = _scaleY = scale; }
-    inline void setScaleX(float scaleX) { _scaleX = scaleX; }
-    inline void setScaleY(float scaleY) { _scaleY = scaleY; }
+    void setScale(float scale) { _scaleX = _scaleY = scale; }
+    void setScaleX(float scaleX) { _scaleX = scaleX; }
+    void setScaleY(float scaleY) { _scaleY = scaleY; }
     void setUrl(std::string_view url);
 
 protected:
@@ -327,7 +299,7 @@ public:
     static RichElementCustomNode* create(int tag, const Color3B& color, uint8_t opacity, Node* customNode);
 
 protected:
-    Node* _customNode;
+    Node* _customNode{};
     friend class RichText;
 };
 

--- a/core/ui/UIRichText.h
+++ b/core/ui/UIRichText.h
@@ -52,11 +52,10 @@ public:
      */
     enum class Type
     {
-        TEXT,    /*!< RichElementText */
-        IMAGE,   /*!< RichElementImage */
-        CUSTOM,  /*!< RichElementCustomNode */
-        NEWLINE, /*!< RichElementNewLine */
-        NEWLINE_MULTI  /*!< RichElementNewLine */
+        TEXT,   /*!< RichElementText */
+        IMAGE,  /*!< RichElementImage */
+        CUSTOM, /*!< RichElementCustomNode */
+        NEWLINE /*!< RichElementNewLine */
     };
 
     /**
@@ -344,7 +343,7 @@ public:
      * @lua new
      *
      */
-    RichElementNewLine() { _type = Type::NEWLINE; }
+    RichElementNewLine(int quantity = 1) : _quantity(quantity) { _type = Type::NEWLINE; }
 
     /**
      * @brief Default destructor.
@@ -363,31 +362,6 @@ public:
      */
     static RichElementNewLine* create(int tag, const Color3B& color, uint8_t opacity);
 
-protected:
-    friend class RichText;
-};
-
-/**
- *@brief Rich element for new line.
- */
-class AX_GUI_DLL RichElementMultipleNewLine : public RichElement
-{
-public:
-    /**
-     * @brief Default constructor.
-     * @js ctor
-     * @lua new
-     *
-     */
-    RichElementMultipleNewLine(int quantity) : _quantity(quantity) { _type = Type::NEWLINE_MULTI; }
-
-    /**
-     * @brief Default destructor.
-     * @js NA
-     * @lua NA
-     */
-    ~RichElementMultipleNewLine() override = default;
-
     /**
      * @brief Create a RichElementNewLine with various arguments.
      *
@@ -397,13 +371,12 @@ public:
      * @param opacity A opacity in GLubyte.
      * @return A RichElementNewLine instance.
      */
-    static RichElementMultipleNewLine* create(int tag, int quantity, const Color3B& color, uint8_t opacity);
+    static RichElementNewLine* create(int tag, int quantity, const Color3B& color, uint8_t opacity);
 
 protected:
     friend class RichText;
     int _quantity;
 };
-
 
 /**
  *@brief A container for displaying various RichElements.

--- a/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 
@@ -50,6 +51,8 @@ UIRichTextTests::UIRichTextTests()
     ADD_TEST_CASE(UIRichTextXMLExtend);
     ADD_TEST_CASE(UIRichTextXMLSpace);
     ADD_TEST_CASE(UIRichTextNewline);
+    ADD_TEST_CASE(UIRichTextHeaders);
+    ADD_TEST_CASE(UIRichTextParagraph);
 }
 
 //
@@ -958,6 +961,86 @@ bool UIRichTextNewline::init()
         _richText->pushBackElement(textElement);
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(_defaultContentSize);
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+
+        _widget->addChild(_richText);
+
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+
+        return true;
+    }
+    return false;
+}
+
+bool UIRichTextHeaders::init()
+{
+    if (UIRichTextTestBase::init())
+    {
+        auto& widgetSize = _widget->getContentSize();
+
+        // Add the alert
+        Text* alert = Text::create("Header Tags", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(
+            Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+
+        createButtonPanel();
+
+#ifdef AX_PLATFORM_PC
+        _defaultContentSize = Size(290, 290);
+#endif
+
+        // RichText
+        _richText = RichText::createWithXML(
+            R"(<h1 face="fonts/arial.ttf">h1. HEADING</h1><h2 face="fonts/Marker Felt.ttf">h2. HEADING</h2><h3 face="fonts/American Typewriter.ttf">h3. HEADING</h3><h4>h4. HEADING</h4><h5>h5. HEADING</h5><h6>h6. HEADING</h6>)");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(_defaultContentSize);
+
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+
+        _widget->addChild(_richText);
+
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+
+        return true;
+    }
+    return false;
+}
+
+bool UIRichTextParagraph::init()
+{
+    if (UIRichTextTestBase::init())
+    {
+        auto& widgetSize = _widget->getContentSize();
+
+        // Add the alert
+        Text* alert = Text::create("Paragraph Tag", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(
+            Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+
+        createButtonPanel();
+
+#ifdef AX_PLATFORM_PC
+        _defaultContentSize = Size(290, 290);
+#endif
+
+        // RichText
+        _richText = RichText::createWithXML(
+            "<p><b>Paragraph1: </b>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et "
+            "dolore magna aliqua. Feugiat scelerisque varius morbi enim nunc. Dis parturient montes nascetur ridiculus "
+            "mus mauris vitae ultricies.</p><p><b>Paragraph2: </b>Lectus urna duis convallis convallis tellus id interdum velit. "
+            "Convallis a cras semper auctor neque vitae tempus quam pellentesque. Congue quisque egestas diam in arcu "
+            "cursus euismod quis.</p>");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(_defaultContentSize);
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
 

--- a/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 
@@ -199,6 +200,22 @@ class UIRichTextNewline : public UIRichTextTestBase
 {
 public:
     CREATE_FUNC(UIRichTextNewline);
+
+    bool init() override;
+};
+
+class UIRichTextHeaders : public UIRichTextTestBase
+{
+public:
+    CREATE_FUNC(UIRichTextHeaders);
+
+    bool init() override;
+};
+
+class UIRichTextParagraph : public UIRichTextTestBase
+{
+public:
+    CREATE_FUNC(UIRichTextParagraph);
 
     bool init() override;
 };


### PR DESCRIPTION
## Describe your changes

Add paragraph tag support.

Currently, to get this output:
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Feugiat scelerisque varius morbi enim nunc. Dis parturient montes nascetur ridiculus mus mauris vitae ultricies.

Egestas integer eget aliquet nibh. Diam in arcu cursus euismod quis viverra nibh. Dictum sit amet justo donec enim diam. At urna condimentum mattis pellentesque id nibh tortor id aliquet.

We would require 4 `</br>` tags (2 at the end of each line):
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Feugiat scelerisque varius morbi enim nunc. Dis parturient montes nascetur ridiculus mus mauris vitae ultricies.</br>
</br>
Egestas integer eget aliquet nibh. Diam in arcu cursus euismod quis viverra nibh. Dictum sit amet justo donec enim diam. At urna condimentum mattis pellentesque id nibh tortor id aliquet.</br>
</br>
```

With paragraph tag support, the following produces the correct output:
```
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Feugiat scelerisque varius morbi enim nunc. Dis parturient montes nascetur ridiculus mus mauris vitae ultricies.</p>
<p>Egestas integer eget aliquet nibh. Diam in arcu cursus euismod quis viverra nibh. Dictum sit amet justo donec enim diam. At urna condimentum mattis pellentesque id nibh tortor id aliquet.</p>
```

This will add 2 new line breaks at the end of the paragraph (similar to HTML renderer output).

Add HTML header tags support with default sizes (34, 30, 24, 20, 18, 16 from h1 to h6 respectively).  Header font face, size and color can be overriden via attributes:
```
<h1 face="fonts/Marker Felt.ttf" size="50">h1. HEADING</h1>
<h2>h2. HEADING</h2>
<h3>h3. HEADING</h3>
<h4>h4. HEADING</h4>
<h5>h5. HEADING</h5>
<h6>h6. HEADING</h6>
```
This will add 2 new line breaks at the end (similar to HTML renderer output).

Enhance `RichElementNewLine` to allow for more than 1 new line entries to be created, rather than having to create multiple individual `RichElementNewLine` elements.  

Add support for end of tag action.  Currently, on parsing a new tag, the parser will begin on the starting tag, and any RichText elements that need to be created are handled in this phase.  This is not ideal for all types of tags, such as the new paragraph and header tags, since they require the new line elements to be added after the text within the tags.  With the changes in this PR, this is now possible.

General code clean up.

Note that these changes should not affect any existing code using RichText.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [x] I have checked readme and add important infos to this PR.
- [x] I have added thorough tests.
