### PR TITLE
Trim leading and trailing whitespace characters for RichText XML text

### DIFF
--- a/core/platform/SAXParser.cpp
+++ b/core/platform/SAXParser.cpp
@@ -4,6 +4,9 @@
  Copyright (c) 2013 Martell Malone
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-2020 simdsoft.com, @HALX99
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+ https://axmolengine.github.io/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -134,8 +137,8 @@ bool SAXParser::parseIntrusive(char* xmlData, size_t dataLength, ParseOption opt
             break;
         case ParseOption::HTML:
             xsxml::xml_sax3_parser::parse<xsxml::parse_normal | xsxml::parse_html_entity_translation |
-                                          xsxml::parse_normalize_whitespace>(xmlData, static_cast<int>(dataLength),
-                                                                             handler);
+                                          xsxml::parse_normalize_whitespace | xsxml::parse_trim_whitespace>(
+                xmlData, static_cast<int>(dataLength), handler);
             break;
         case ParseOption::TRIM_WHITESPACE:
             xsxml::xml_sax3_parser::parse<xsxml::parse_normal | xsxml::parse_trim_whitespace>(


### PR DESCRIPTION
## Describe your changes
Trim leading and trailing whitespace characters during parsing XML input for RichText to prevent end-of-line characters being converted into a space character which is inserted into the resulting output. 

This change should not impact existing usage of RichText.

## Issue ticket number and link
#1686 

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
