### PR TITLE
Ensure valid whitespace is not trimmed when html parsing mode is used

### DIFF
--- a/thirdparty/xsxml/xsxml.hpp
+++ b/thirdparty/xsxml/xsxml.hpp
@@ -5,6 +5,8 @@
 /*
 The MIT License (MIT)
 Copyright (c) 2019 halx99
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/thirdparty/xsxml/xsxml.hpp
+++ b/thirdparty/xsxml/xsxml.hpp
@@ -924,7 +924,7 @@ private:
 
     // Trim trailing whitespace if flag is set; leading was already trimmed by whitespace skip after
     // >
-    if (Flags & parse_trim_whitespace)
+    if (Flags & parse_trim_whitespace && !(Flags & parse_html_entity_translation))
     {
       if (Flags & parse_normalize_whitespace)
       {


### PR DESCRIPTION
## Describe your changes
Consider the following input:

```
<p>This is a sentence with a link        <a href="">Click me</a>&nbsp;and      some more text.</p>
```
or
```
<p>This is a sentence with a link&nbsp;<a href="">Click me</a>&nbsp;and some more text.</p>
```

The correct output should be:

This is a sentence with a link <ins>Click me</ins> and some more text.

What is actually being produced is the following:

This is a sentence with a link<ins>Click me</ins>and some more text.

This is only an issue now that the leading and trailing whitespace trimming is enabled, but only affects HTML style parsing, since HTML has `&emsp;` and `&nbsp;`, which both insert spaces into the text.  Those spaces end up being trimmed, when they should not be.


The fix in this PR will *only* disable trailing whitespace trimming if and only if html mode is enabled, so it will not have any affect in any other scenario.  This fixes the issue with `&emsp;` and `&nbsp;`, ensuring the spaces generated by them are part of the output.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
