### PR TITLE
RichText and ScrollView enhancements

### DIFF
--- a/core/2d/ProtectedNode.cpp
+++ b/core/2d/ProtectedNode.cpp
@@ -128,6 +128,17 @@ Node* ProtectedNode::getProtectedChildByTag(int tag)
     return nullptr;
 }
 
+Node* ProtectedNode::getProtectedChildByName(std::string_view name)
+{
+    // AXASSERT(!name.empty(), "Invalid name");
+    for (auto&& child : _protectedChildren)
+    {
+        if (child && child->getName() == name)
+            return child;
+    }
+    return nullptr;
+}
+
 /* "remove" logic MUST only be on this method
  * If a class want's to extend the 'removeChild' behavior it only needs
  * to override this method

--- a/core/2d/ProtectedNode.h
+++ b/core/2d/ProtectedNode.h
@@ -94,6 +94,15 @@ public:
      */
     virtual Node* getProtectedChildByTag(int tag);
 
+    /**
+     * Gets a child from the container with its name.
+     *
+     * @param name An identifier to find the child node.
+     *
+     * @return a Node object whose name equals to the input parameter.
+     */
+    virtual Node* getProtectedChildByName(std::string_view name);
+
     ////// REMOVES //////
 
     /**

--- a/core/ui/UIListView.h
+++ b/core/ui/UIListView.h
@@ -1,6 +1,7 @@
 /****************************************************************************
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 
@@ -106,7 +107,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~ListView();
+    ~ListView() override;
 
     /**
      * Create an empty ListView.
@@ -288,31 +289,16 @@ public:
      */
     float getBottomPadding() const;
 
-    /**
-     * Set the time in seconds to scroll between items.
-     * Subsequent calls of function 'scrollToItem', will take 'time' seconds for scrolling.
-     * @param time The seconds needed to scroll between two items. 'time' must be >= 0
-     * @see scrollToItem(ssize_t, const Vec2&, const Vec2&)
-     */
-    void setScrollDuration(float time);
-
-    /**
-     * Get the time in seconds to scroll between items.
-     * @return The time in seconds to scroll between items
-     * @see setScrollDuration(float)
-     */
-    float getScrollDuration() const;
-
     // override methods
-    virtual void doLayout() override;
-    virtual void requestDoLayout() override;
-    virtual void addChild(Node* child) override;
-    virtual void addChild(Node* child, int localZOrder) override;
-    virtual void addChild(Node* child, int zOrder, int tag) override;
-    virtual void addChild(Node* child, int zOrder, std::string_view name) override;
-    virtual void removeAllChildren() override;
-    virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void removeChild(Node* child, bool cleanup = true) override;
+    void doLayout() override;
+    void requestDoLayout() override;
+    void addChild(Node* child) override;
+    void addChild(Node* child, int localZOrder) override;
+    void addChild(Node* child, int zOrder, int tag) override;
+    void addChild(Node* child, int zOrder, std::string_view name) override;
+    void removeAllChildren() override;
+    void removeAllChildrenWithCleanup(bool cleanup) override;
+    void removeChild(Node* child, bool cleanup = true) override;
 
     /**
      * @brief Query the closest item to a specific position in inner container.
@@ -367,17 +353,17 @@ public:
     /**
      * Override functions
      */
-    virtual void jumpToBottom() override;
-    virtual void jumpToTop() override;
-    virtual void jumpToLeft() override;
-    virtual void jumpToRight() override;
-    virtual void jumpToTopLeft() override;
-    virtual void jumpToTopRight() override;
-    virtual void jumpToBottomLeft() override;
-    virtual void jumpToBottomRight() override;
-    virtual void jumpToPercentVertical(float percent) override;
-    virtual void jumpToPercentHorizontal(float percent) override;
-    virtual void jumpToPercentBothDirection(const Vec2& percent) override;
+    void jumpToBottom() override;
+    void jumpToTop() override;
+    void jumpToLeft() override;
+    void jumpToRight() override;
+    void jumpToTopLeft() override;
+    void jumpToTopRight() override;
+    void jumpToBottomLeft() override;
+    void jumpToBottomRight() override;
+    void jumpToPercentVertical(float percent) override;
+    void jumpToPercentHorizontal(float percent) override;
+    void jumpToPercentBothDirection(const Vec2& percent) override;
 
     /**
      * @brief Jump to specific item
@@ -391,15 +377,20 @@ public:
      * @brief Scroll to specific item
      * @param positionRatioInView Specifies the position with ratio in list view's content size.
      * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
-     * @param timeInSec Scroll time
      */
     void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
+
+    /**
+     * @brief Scroll to specific item
+     * @param positionRatioInView Specifies the position with ratio in list view's content size.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     * @param timeInSec Scroll time
+     */
     void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec);
 
     /**
      * @brief Query current selected widget's index.
      *
-
      * @return An index of a selected item.
      */
     ssize_t getCurSelectedIndex() const;
@@ -423,14 +414,14 @@ public:
      *  Direction Direction::VERTICAL means vertical scroll, Direction::HORIZONTAL means horizontal scroll.
      * @param dir Set the list view's scroll direction.
      */
-    virtual void setDirection(Direction dir) override;
+    void setDirection(Direction dir) override;
 
-    virtual std::string getDescription() const override;
+    std::string getDescription() const override;
 
-    virtual bool init() override;
+    bool init() override;
 
 protected:
-    virtual void handleReleaseLogic(Touch* touch) override;
+    void handleReleaseLogic(Touch* touch) override;
 
     virtual void onItemListChanged();
 
@@ -439,19 +430,18 @@ protected:
     void remedyVerticalLayoutParameter(LinearLayoutParameter* layoutParameter, ssize_t itemIndex);
     void remedyHorizontalLayoutParameter(LinearLayoutParameter* layoutParameter, ssize_t itemIndex);
 
-    virtual void onSizeChanged() override;
-    virtual Widget* createCloneInstance() override;
-    virtual void copySpecialProperties(Widget* model) override;
-    virtual void copyClonedWidgetChildren(Widget* model) override;
+    void onSizeChanged() override;
+    Widget* createCloneInstance() override;
+    void copySpecialProperties(Widget* model) override;
+    void copyClonedWidgetChildren(Widget* model) override;
     void selectedItemEvent(TouchEventType event);
-    virtual void interceptTouchEvent(Widget::TouchEventType event, Widget* sender, Touch* touch) override;
+    void interceptTouchEvent(Widget::TouchEventType event, Widget* sender, Touch* touch) override;
 
-    virtual Vec2 getHowMuchOutOfBoundary(const Vec2& addition = Vec2::ZERO) override;
+    Vec2 getHowMuchOutOfBoundary(const Vec2& addition = Vec2::ZERO) override;
 
-    virtual void startAttenuatingAutoScroll(const Vec2& deltaMove, const Vec2& initialVelocity) override;
+    void startAttenuatingAutoScroll(const Vec2& deltaMove, const Vec2& initialVelocity) override;
 
     void startMagneticScroll();
-    Vec2 calculateItemDestination(const Vec2& positionRatioInView, Widget* item, const Vec2& itemAnchorPoint);
 
 protected:
     Widget* _model;
@@ -469,8 +459,6 @@ protected:
     float _topPadding;
     float _rightPadding;
     float _bottomPadding;
-
-    float _scrollTime;
 
     ssize_t _curSelectedIndex;
 

--- a/core/ui/UIRichText.h
+++ b/core/ui/UIRichText.h
@@ -264,7 +264,7 @@ protected:
     float _scaleX;
     float _scaleY;
     std::string _url; /*!< attributes of anchor tag */
-    std::string_view _id;
+    std::string _id;  /*!< attributes of anchor tag */
 };
 
 /**

--- a/core/ui/UIRichText.h
+++ b/core/ui/UIRichText.h
@@ -121,6 +121,7 @@ public:
      * @param shadowOffset shadow effect offset value
      * @param shadowBlurRadius the shadow effect blur radius
      * @param glowColor glow color
+     * @param id ID of element
      * @return True if initialize success, false otherwise.
      */
     bool init(int tag,
@@ -136,7 +137,8 @@ public:
               const Color3B& shadowColor  = Color3B::BLACK,
               const Vec2& shadowOffset    = Vec2(2.0, -2.0),
               int shadowBlurRadius        = 0,
-              const Color3B& glowColor    = Color3B::WHITE);
+              const Color3B& glowColor    = Color3B::WHITE,
+              std::string_view id         = ""sv);
 
     /**
      * @brief Create a RichElementText with various arguments.
@@ -155,6 +157,7 @@ public:
      * @param shadowOffset shadow effect offset value
      * @param shadowBlurRadius the shadow effect blur radius
      * @param glowColor glow color
+     * @param id ID of element
      * @return RichElementText instance.
      */
     static RichElementText* create(int tag,
@@ -170,7 +173,8 @@ public:
                                    const Color3B& shadowColor  = Color3B::BLACK,
                                    const Vec2& shadowOffset    = Vec2(2.0, -2.0),
                                    int shadowBlurRadius        = 0,
-                                   const Color3B& glowColor    = Color3B::WHITE);
+                                   const Color3B& glowColor    = Color3B::WHITE,
+                                   std::string_view id         = ""sv);
 
 protected:
     std::string _text;
@@ -184,6 +188,7 @@ protected:
     Vec2 _shadowOffset;    /*!< shadow effect offset value */
     int _shadowBlurRadius; /*!< the shadow effect blur radius */
     Color3B _glowColor;    /*!< attributes of glow tag */
+    std::string _id;       /*!< ID of this text field */
     friend class RichText;
 };
 
@@ -210,6 +215,7 @@ public:
      * @param filePath A image file name.
      * @param url uniform resource locator
      * @param texType texture type, may be a valid file path, or a sprite frame name
+     * @param id ID of element
      * @return True if initialize success, false otherwise.
      */
     bool init(int tag,
@@ -217,7 +223,8 @@ public:
               uint8_t opacity,
               std::string_view filePath,
               std::string_view url           = "",
-              Widget::TextureResType texType = Widget::TextureResType::LOCAL);
+              Widget::TextureResType texType = Widget::TextureResType::LOCAL,
+              std::string_view id            = ""sv);
 
     /**
      * @brief Create a RichElementImage with various arguments.
@@ -228,6 +235,7 @@ public:
      * @param filePath A image file name.
      * @param url uniform resource locator
      * @param texType texture type, may be a valid file path, or a sprite frame name
+     * @param id ID of element
      * @return A RichElementImage instance.
      */
     static RichElementImage* create(int tag,
@@ -235,7 +243,8 @@ public:
                                     uint8_t opacity,
                                     std::string_view filePath,
                                     std::string_view url           = "",
-                                    Widget::TextureResType texType = Widget::TextureResType::LOCAL);
+                                    Widget::TextureResType texType = Widget::TextureResType::LOCAL,
+                                    std::string_view id            = ""sv);
 
     void setWidth(int width);
     void setHeight(int height);
@@ -243,6 +252,7 @@ public:
     void setScaleX(float scaleX) { _scaleX = scaleX; }
     void setScaleY(float scaleY) { _scaleY = scaleY; }
     void setUrl(std::string_view url);
+    void setId(std::string_view id);
 
 protected:
     std::string _filePath;
@@ -254,6 +264,7 @@ protected:
     float _scaleX;
     float _scaleY;
     std::string _url; /*!< attributes of anchor tag */
+    std::string_view _id;
 };
 
 /**
@@ -283,9 +294,10 @@ public:
      * @param color A color in Color3B.
      * @param opacity A opacity in GLubyte.
      * @param customNode A custom node pointer.
+     * @param id ID of element
      * @return True if initialize success, false otherwise.
      */
-    bool init(int tag, const Color3B& color, uint8_t opacity, Node* customNode);
+    bool init(int tag, const Color3B& color, uint8_t opacity, Node* customNode, std::string_view id = ""sv);
 
     /**
      * @brief Create a RichElementCustomNode with various arguments.
@@ -294,12 +306,19 @@ public:
      * @param color A color in Color3B.
      * @param opacity A opacity in GLubyte.
      * @param customNode A custom node pointer.
+     * @param id ID of element
      * @return A RichElementCustomNode instance.
      */
-    static RichElementCustomNode* create(int tag, const Color3B& color, uint8_t opacity, Node* customNode);
+    static RichElementCustomNode* create(int tag,
+                                         const Color3B& color,
+                                         uint8_t opacity,
+                                         Node* customNode,
+                                         std::string_view id = ""sv);
 
 protected:
     Node* _customNode{};
+    std::string _id;
+
     friend class RichText;
 };
 
@@ -394,7 +413,7 @@ public:
     static const std::string KEY_VERTICAL_SPACE;                   /*!< key of vertical space */
     static const std::string KEY_WRAP_MODE;                        /*!< key of per word, or per char */
     static const std::string KEY_HORIZONTAL_ALIGNMENT;             /*!< key of left, right, or center */
-    static const std::string KEY_VERTICAL_ALIGNMENT;             /*!< key of left, right, or center */
+    static const std::string KEY_VERTICAL_ALIGNMENT;               /*!< key of left, right, or center */
     static const std::string KEY_FONT_COLOR_STRING;                /*!< key of font color */
     static const std::string KEY_FONT_SIZE;                        /*!< key of font size */
     static const std::string KEY_FONT_SMALL;                       /*!< key of font size small */
@@ -431,6 +450,7 @@ public:
     static const std::string KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT; /*!< key of shadow offset (height) of anchor tag */
     static const std::string KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS;   /*!< key of shadow blur radius of anchor tag */
     static const std::string KEY_ANCHOR_TEXT_GLOW_COLOR;           /*!< key of glow color of anchor tag */
+    static const std::string KEY_ID;                               /*!< key of id */
 
     /**
      * @brief Default constructor.
@@ -611,7 +631,8 @@ protected:
                             const Color3B& shadowColor  = Color3B::BLACK,
                             const Vec2& shadowOffset    = Vec2(2.0, -2.0),
                             int shadowBlurRadius        = 0,
-                            const Color3B& glowColor    = Color3B::WHITE);
+                            const Color3B& glowColor    = Color3B::WHITE,
+                            std::string_view id         = ""sv);
     void handleImageRenderer(std::string_view filePath,
                              Widget::TextureResType textureType,
                              const Color3B& color,
@@ -619,9 +640,10 @@ protected:
                              int width,
                              int height,
                              std::string_view url,
-                             float scaleX = 1.f,
-                             float scaleY = 1.f);
-    void handleCustomRenderer(Node* renderer);
+                             float scaleX        = 1.f,
+                             float scaleY        = 1.f,
+                             std::string_view id = ""sv);
+    void handleCustomRenderer(Node* renderer, std::string_view id = ""sv);
     void formatRenderers();
     void addNewLine(int quantity = 1);
     void doHorizontalAlignment(const Vector<Node*>& row, float rowWidth);

--- a/core/ui/UIScrollView.h
+++ b/core/ui/UIScrollView.h
@@ -1,6 +1,7 @@
 /****************************************************************************
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 
@@ -101,7 +102,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~ScrollView();
+    ~ScrollView() override;
 
     /**
      * Create an empty ScrollView.
@@ -340,24 +341,24 @@ public:
     virtual void addEventListener(const ccScrollViewCallback& callback);
 
     // override functions
-    virtual void addChild(Node* child) override;
-    virtual void addChild(Node* child, int localZOrder) override;
-    virtual void addChild(Node* child, int localZOrder, int tag) override;
-    virtual void addChild(Node* child, int localZOrder, std::string_view name) override;
-    virtual void removeAllChildren() override;
-    virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void removeChild(Node* child, bool cleanup = true) override;
-    virtual Vector<Node*>& getChildren() override;
-    virtual const Vector<Node*>& getChildren() const override;
-    virtual ssize_t getChildrenCount() const override;
-    virtual Node* getChildByTag(int tag) const override;
-    virtual Node* getChildByName(std::string_view name) const override;
+    void addChild(Node* child) override;
+    void addChild(Node* child, int localZOrder) override;
+    void addChild(Node* child, int localZOrder, int tag) override;
+    void addChild(Node* child, int localZOrder, std::string_view name) override;
+    void removeAllChildren() override;
+    void removeAllChildrenWithCleanup(bool cleanup) override;
+    void removeChild(Node* child, bool cleanup = true) override;
+    Vector<Node*>& getChildren() override;
+    const Vector<Node*>& getChildren() const override;
+    ssize_t getChildrenCount() const override;
+    Node* getChildByTag(int tag) const override;
+    Node* getChildByName(std::string_view name) const override;
     // touch event callback
-    virtual bool onTouchBegan(Touch* touch, Event* unusedEvent) override;
-    virtual void onTouchMoved(Touch* touch, Event* unusedEvent) override;
-    virtual void onTouchEnded(Touch* touch, Event* unusedEvent) override;
-    virtual void onTouchCancelled(Touch* touch, Event* unusedEvent) override;
-    virtual void update(float dt) override;
+    bool onTouchBegan(Touch* touch, Event* unusedEvent) override;
+    void onTouchMoved(Touch* touch, Event* unusedEvent) override;
+    void onTouchEnded(Touch* touch, Event* unusedEvent) override;
+    void onTouchCancelled(Touch* touch, Event* unusedEvent) override;
+    void update(float dt) override;
 
     /**
      * @brief Toggle bounce enabled when scroll to the edge.
@@ -453,7 +454,7 @@ public:
     /**
      * @brief Set the scroll bar's color
      *
-     * @param the scroll bar's color
+     * @param color the scroll bar's color
      */
     void setScrollBarColor(const Color3B& color);
 
@@ -467,7 +468,7 @@ public:
     /**
      * @brief Set the scroll bar's opacity
      *
-     * @param the scroll bar's opacity
+     * @param opacity the scroll bar's opacity
      */
     void setScrollBarOpacity(uint8_t opacity);
 
@@ -481,7 +482,7 @@ public:
     /**
      * @brief Set scroll bar auto hide state
      *
-     * @param scroll bar auto hide state
+     * @param autoHideEnabled scroll bar auto hide state
      */
     void setScrollBarAutoHideEnabled(bool autoHideEnabled);
 
@@ -495,7 +496,7 @@ public:
     /**
      * @brief Set scroll bar auto hide time
      *
-     * @param scroll bar auto hide time
+     * @param autoHideTime bar auto hide time
      */
     void setScrollBarAutoHideTime(float autoHideTime);
 
@@ -509,7 +510,7 @@ public:
     /**
      * @brief Set the touch total time threshold
      *
-     * @param the touch total time threshold
+     * @param touchTotalTimeThreshold the touch total time threshold
      */
     void setTouchTotalTimeThreshold(float touchTotalTimeThreshold);
 
@@ -526,7 +527,7 @@ public:
      * @see `Layout::Type`
      * @param type  Layout type enum.
      */
-    virtual void setLayoutType(Type type) override;
+    void setLayoutType(Type type) override;
 
     /**
      * Get the layout type for scrollview.
@@ -534,22 +535,22 @@ public:
      * @see `Layout::Type`
      * @return LayoutType
      */
-    virtual Type getLayoutType() const override;
+    Type getLayoutType() const override;
 
     /**
      * Return the "class name" of widget.
      */
-    virtual std::string getDescription() const override;
+    std::string getDescription() const override;
 
     /**
      * @lua NA
      */
-    virtual void onEnter() override;
+    void onEnter() override;
 
     /**
      * @lua NA
      */
-    virtual void onExit() override;
+    void onExit() override;
 
     /**
      *  When a widget is in a layout, you could call this method to get the next focused widget within a specified
@@ -558,7 +559,22 @@ public:
      *@param current  the current focused widget
      *@return the next focused widget in a layout
      */
-    virtual Widget* findNextFocusedWidget(FocusDirection direction, Widget* current) override;
+    Widget* findNextFocusedWidget(FocusDirection direction, Widget* current) override;
+
+    /**
+     * Set the time in seconds to scroll between items.
+     * Subsequent calls of function 'scrollToItem', will take 'time' seconds for scrolling.
+     * @param time The seconds needed to scroll between two items. 'time' must be >= 0
+     * @see scrollToItem(ssize_t, const Vec2&, const Vec2&)
+     */
+    void setScrollDuration(float time);
+
+    /**
+     * Get the time in seconds to scroll between items.
+     * @return The time in seconds to scroll between items
+     * @see setScrollDuration(float)
+     */
+    float getScrollDuration() const;
 
     /**
      * @return Whether the user is currently dragging the ScrollView to scroll it
@@ -569,7 +585,26 @@ public:
      */
     bool isAutoScrolling() const { return _autoScrolling; }
 
-    virtual bool init() override;
+    bool init() override;
+
+    /**
+     * @brief Scroll to specific item
+     * @param item Item to scroll to
+     * @param positionRatioInView Specifies the position with ratio in list view's content size.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     */
+    void scrollToItem(Node* item, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
+
+    /**
+     * @brief Scroll to specific item
+     * @param item Item to scroll to
+     * @param positionRatioInView Specifies the position with ratio in list view's content size.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     * @param timeInSec Scroll time
+     */
+    void scrollToItem(Node* item, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec);
+
+    static Vec2 calculateItemPositionWithAnchor(const Node* node, const Vec2& itemAnchorPoint);
 
 protected:
     enum class MoveDirection
@@ -580,14 +615,14 @@ protected:
         RIGHT,
     };
 
-    virtual void initRenderer() override;
+    void initRenderer() override;
 
-    virtual void onSizeChanged() override;
-    virtual void doLayout() override;
+    void onSizeChanged() override;
+    void doLayout() override;
 
-    virtual Widget* createCloneInstance() override;
-    virtual void copySpecialProperties(Widget* model) override;
-    virtual void copyClonedWidgetChildren(Widget* model) override;
+    Widget* createCloneInstance() override;
+    void copySpecialProperties(Widget* model) override;
+    void copyClonedWidgetChildren(Widget* model) override;
 
     virtual void initScrollBar();
     virtual void removeScrollBar();
@@ -622,7 +657,7 @@ protected:
     virtual void handleMoveLogic(Touch* touch);
     virtual void handleReleaseLogic(Touch* touch);
 
-    virtual void interceptTouchEvent(Widget::TouchEventType event, Widget* sender, Touch* touch) override;
+    void interceptTouchEvent(Widget::TouchEventType event, Widget* sender, Touch* touch) override;
 
     void processScrollEvent(MoveDirection dir, bool bounce);
     void processScrollingEvent();
@@ -630,6 +665,8 @@ protected:
     void dispatchEvent(EventType eventType);
 
     void updateScrollBar(const Vec2& outOfBoundary);
+
+    Vec2 calculateItemDestination(const Vec2& positionRatioInView, const Node* item, const Vec2& itemAnchorPoint);
 
 protected:
     virtual float getAutoScrollStopEpsilon() const;
@@ -678,6 +715,8 @@ protected:
 
     Ref* _scrollViewEventListener;
     ccScrollViewCallback _eventCallback;
+
+    float _scrollTime;
 };
 
 }  // namespace ui

--- a/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -53,6 +53,7 @@ UIRichTextTests::UIRichTextTests()
     ADD_TEST_CASE(UIRichTextNewline);
     ADD_TEST_CASE(UIRichTextHeaders);
     ADD_TEST_CASE(UIRichTextParagraph);
+    ADD_TEST_CASE(UIRichTextScrollTo);
 }
 
 //
@@ -1052,4 +1053,131 @@ bool UIRichTextParagraph::init()
         return true;
     }
     return false;
+}
+
+bool UIRichTextScrollTo::init()
+{
+    if (UIRichTextTestBase::init())
+    {
+        auto& widgetSize = _widget->getContentSize();
+
+        // Add the alert
+        Text* alert = Text::create("Paragraph Tag", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(
+            Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+
+        createButtonPanel();
+
+#ifdef AX_PLATFORM_PC
+        _defaultContentSize = Size(290, 150);
+#endif
+
+        // ScrollView
+        _scrollView = ScrollView::create();
+        _scrollView->setContentSize(_defaultContentSize);
+        _scrollView->setInnerContainerSize(_defaultContentSize);
+        _scrollView->setBounceEnabled(true);
+        _scrollView->setDirection(ScrollView::Direction::VERTICAL);
+        _scrollView->setLayoutType(Layout::Type::VERTICAL);
+        _scrollView->setScrollBarEnabled(true);
+        _scrollView->setScrollBarWidth(4);
+        _scrollView->setScrollBarPositionFromCorner(Vec2(2, 2));
+        _scrollView->setScrollBarColor(Color3B::WHITE);
+        _scrollView->setScrollBarAutoHideEnabled(false);
+        _scrollView->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+        _scrollView->setPosition(_widget->getContentSize() / 2);
+        _scrollView->setLocalZOrder(10);
+        _widget->addChild(_scrollView);
+
+        ValueMap valMap;
+        valMap[RichText::KEY_ANCHOR_FONT_COLOR_STRING] = "#00ffdd";
+        
+        // RichText
+        _richText = RichText::createWithXML(
+            R"(<h1>Quick Links</h1>
+<a href="#fancy_header">Jump To Fancy Header</a><br/>
+<a href="#paragraph_2">Jump To Second Paragraph</a><br/>
+<a href="#some_link">Jump To Web Search</a><br/>
+<br/>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et 
+dolore magna aliqua. 
+Purus faucibus ornare suspendisse sed nisi. Viverra aliquet eget sit amet tellus cras adipiscing. 
+Ut tellus elementum sagittis vitae. 
+Risus feugiat in ante metus dictum at. Semper eget duis at tellus at. Iaculis eu non diam phasellus vestibulum 
+lorem sed risus. 
+Sed vulputate odio ut enim. Morbi tristique senectus et netus et malesuada fames.</p>
+<h1 id="fancy_header">Fancy Header</h1>
+<p id="paragraph_2">This is the second paragraph! Cras sed felis eget velit aliquet sagittis id consectetur purus. 
+Turpis nunc eget lorem dolor sed viverra ipsum nunc. 
+Ultrices tincidunt arcu non sodales neque sodales ut etiam sit. Risus feugiat in ante metus dictum at tempor. 
+Id neque aliquam vestibulum morbi blandit cursus risus.</p>
+<p>Tortor condimentum lacinia quis vel eros donec ac. Molestie ac feugiat sed lectus. 
+Aliquam id diam maecenas ultricies mi eget mauris. 
+Ullamcorper malesuada proin libero nunc consequat interdum varius. 
+Sollicitudin nibh sit amet commodo nulla facilisi nullam vehicula ipsum. 
+Diam quam nulla porttitor massa id neque aliquam vestibulum morbi. Sed velit dignissim sodales ut. 
+Morbi leo urna molestie at elementum eu facilisis. 
+Cursus metus aliquam eleifend mi in. Euismod lacinia at quis risus sed vulputate odio. 
+Sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus.</p>
+<a id="some_link" href="https://google.com">Google!</a>)",
+            valMap);
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(_defaultContentSize.width, 0));
+        _richText->setAnchorPoint(Vec2::ANCHOR_MIDDLE_TOP);
+        _richText->setOpenUrlHandler([this](std::string_view url) {
+            // Check if the href starts with a "#" character
+            if (url.starts_with('#'))
+            {
+                auto* node = _richText->getProtectedChildByName(url.substr(1));
+                if (node)
+                {
+                    // Scroll to the location of that node, and the reason it works is because
+                    // the ScrollView inner container is the same height as the RichText
+                    _scrollView->scrollToItem(node, Vec2::ANCHOR_MIDDLE_TOP, Vec2::ANCHOR_MIDDLE_TOP);
+                }
+            }
+            else if (!url.empty())
+            {
+                Application::getInstance()->openURL(url);
+            }
+        });
+
+        const auto contentSize = _scrollView->getInnerContainerSize();
+        _richText->setPosition(Vec2(contentSize.width / 2, contentSize.height));
+        _richText->setLocalZOrder(10);
+
+        _richText->formatText();
+        _scrollView->addChild(_richText);
+
+        updateScrollViewSize();
+
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextScrollTo::updateScrollViewSize()
+{
+    auto newHeight  = 0.f;
+    auto&& children = _scrollView->getChildren();
+    for (auto&& child : children)
+    {
+        auto&& contentSize = child->getContentSize();
+        newHeight += contentSize.height;
+        if (const auto* widget = dynamic_cast<Widget*>(child))
+        {
+            if (const auto* layoutParam = widget->getLayoutParameter())
+            {
+                auto&& margin = layoutParam->getMargin();
+                newHeight += margin.top + margin.bottom;
+            }
+        }
+    }
+    _scrollView->setInnerContainerSize(Size(_scrollView->getInnerContainerSize().width, newHeight));
+    _scrollView->scrollToTop(0.f, false);
 }

--- a/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -220,4 +220,17 @@ public:
     bool init() override;
 };
 
+class UIRichTextScrollTo : public UIRichTextTestBase
+{
+public:
+    CREATE_FUNC(UIRichTextScrollTo);
+
+    bool init() override;
+
+protected:
+    void updateScrollViewSize();
+
+    ax::ui::ScrollView* _scrollView;
+};
+
 #endif /* defined(__TestCpp__UIRichTextTest__) */


### PR DESCRIPTION
## Describe your changes

Add support for the "id" attribute to `RichText` XML anchor, paragraph, header and custom tags.  The ID is saved as the name of the node (via `setName()`).

Add support for adjusting font/size/color of paragraph elements in RichText.

Move scroll to item support from `ListView` to the base class `ScrollView`, since it applies to `ScrollView` nodes as well.

Add support for finding a protected node in a `ScrollView` via the name.

All of the above changes can be combined together when a `RichText` is child of a `ScrollView`, allowing the user to click on a link that takes them directly to another section of the `RichText` (scrolling the `ScrollView` to that point).

For example, taking this input:
```
<h1>Quick Links</h1>
<a href="#fancy_header">Jump To Fancy Header</a><br/>
<a href="#paragraph_2">Jump To Second Paragraph</a><br/>
<a href="#some_link">Jump To Web Search</a><br/>
<br/>
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Purus faucibus ornare suspendisse sed nisi. Viverra aliquet eget sit amet tellus cras adipiscing. Ut tellus elementum sagittis vitae. Risus feugiat in ante metus dictum at. Semper eget duis at tellus at. Iaculis eu non diam phasellus vestibulum lorem sed risus. Sed vulputate odio ut enim. Morbi tristique senectus et netus et malesuada fames.</p>
<h1 id="fancy_header">Fancy Header</h1>
<p id="paragraph_2">Cras sed felis eget velit aliquet sagittis id consectetur purus. Turpis nunc eget lorem dolor sed viverra ipsum nunc. Ultrices tincidunt arcu non sodales neque sodales ut etiam sit. Risus feugiat in ante metus dictum at tempor. Id neque aliquam vestibulum morbi blandit cursus risus.</p>
<a id="some_link" href="https://google.com">Google!</a>
```

```
auto* richText = ax::ui::RichText::createWithXML(text);
scrollView->addChild(richText);
// ... some code to update the inner container size of the ScrollView to match the RichText size
// now add the hyperlink click handler
richText->setOpenUrlHandler([richText, scrollView](std::string_view url) {
        // Check if the href starts with a "#" character
	if (url.starts_with('#'))
	{
		auto* node = richText->getProtectedChildByName(url.substr(1));
		if (node)
		{
                        // Scroll to the location of that node, and the reason it works is because
                        // the ScrollView inner container is the same height as the RichText
			scrollView->scrollToItem(node, Vec2::ANCHOR_MIDDLE_TOP, Vec2::ANCHOR_MIDDLE_TOP);
		}
	}
	else if (!url.empty())
	{
		Application::getInstance()->openURL(url);
	}
});
```

A test case showcasing this functionality has been added to the `cpp-tests` project (RichText test 22).

This functionality should not impact any existing usage of ScrollView, ListView or RichText.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [x] I have checked readme and add important infos to this PR.
- [x] I have added thorough tests.
