### PR TITLE
Android build fixes

### DIFF
--- a/core/platform/android/libaxmol/axutils.gradle
+++ b/core/platform/android/libaxmol/axutils.gradle
@@ -118,9 +118,18 @@ class axutils {
 
         if (sdkRoot == null || !new File(sdkRoot).isDirectory()) {
             sdkRoot = Paths.get("${System.env.ANDROID_HOME}").toAbsolutePath().toString()
-            if (!new File(sdkRoot).isDirectory()) {
-                throw new  Exception('android sdk not specified properly in local.properties or system env ANDROID_HOME')
-            }
+            if (!new File(sdkRoot).isDirectory())
+                sdkRoot = null
+        }
+
+        if (sdkRoot == null) {
+            sdkRoot = Paths.get("${System.env.HOME}").toAbsolutePath().toString() + "/Library/android/sdk"
+            if (!new File(sdkRoot).isDirectory())
+                sdkRoot = null
+        }
+
+        if (sdkRoot == null) {
+            throw new Exception('Couldn\'t find android sdk. Specify path in local.properties or system env ANDROID_HOME')
         }
 
         def rets = new ArrayList(5) // ndkVer,ndkPath,cmakeVer,cmakeOptions(AX_USE_XXX, AX_ENABLE_XXX, AX_ENABLE_EXT_XXX),cmakeDir<nullable>

--- a/core/platform/android/libaxmol/axutils.gradle
+++ b/core/platform/android/libaxmol/axutils.gradle
@@ -298,27 +298,27 @@ class axutils {
         def found = null
         def properties = new Properties()
         File propertiesFile = new File("$ndkDir${File.separator}source.properties")
-        propertiesFile.withInputStream {
-            properties.load(it)
-            def foundNdkVer = properties['Pkg.Revision']
-            def ret = axutils.compareVersion(foundNdkVer, ndkVer)
-            if(ret == 0) {
-                println("Using found ndk (revision=$foundNdkVer,path=$ndkDir)")
-                found = true
-            }
-            else if(ret > 0){
-                if(allowNewerNdk) {
-                    println("Using found newer ndk (revision=$foundNdkVer,path=$ndkDir), (minimum required is: ${ndkVer})")
-                    ndkVer = foundNdkVer
+        try {
+            propertiesFile.withInputStream {
+                properties.load(it)
+                def foundNdkVer = properties['Pkg.Revision']
+                def ret = axutils.compareVersion(foundNdkVer, ndkVer)
+                if (ret == 0) {
+                    println("Using found ndk (revision=$foundNdkVer,path=$ndkDir)")
                     found = true
-                }
-                else {
-                    //throw new GradleException("The ndk ${ndkVer} is required, but $foundNdkVer found!")
+                } else if (ret > 0) {
+                    if (allowNewerNdk) {
+                        println("Using found newer ndk (revision=$foundNdkVer,path=$ndkDir), (minimum required is: ${ndkVer})")
+                        ndkVer = foundNdkVer
+                        found = true
+                    } else {
+                        //throw new GradleException("The ndk ${ndkVer} is required, but $foundNdkVer found!")
+                    }
+                } else {
+                    //throw new GradleException("The ndk ${ndkVer}+ is required, but $foundNdkVer found!")
                 }
             }
-            else {
-                //throw new GradleException("The ndk ${ndkVer}+ is required, but $foundNdkVer found!")
-            }
+        } catch (Exception) {
         }
         if (found) {
             rets[0] = ndkVer


### PR DESCRIPTION
## Describe your changes

This PR has two fixes to improve Android builds:

- If user hasn't specified Android SDK location, then it tries to find SDK at `~/Library/android/sdk`, which is a default location on macOS.
- `findNDKInDir()` tries to open `source.properties` file for a specified NDK, but it throws an exception if it doesn't exist and doesn't allow automatic NDK download. The fix catches the exception and allows build to continue with automatic NDK download.


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
