### PR TITLE
Logging colorful support

### DIFF
--- a/core/base/Console.h
+++ b/core/base/Console.h
@@ -73,9 +73,9 @@ enum class LogFmtFlag
     TimeStamp = 1 << 1,
     ProcessId = 1 << 2,
     ThreadId  = 1 << 3,
-    Full      = Level | TimeStamp | ProcessId | ThreadId,
+    Colored   = 1 << 4,
+    Full      = Level | TimeStamp | ProcessId | ThreadId | Colored,
 };
-
 AX_ENABLE_BITMASK_OPS(LogFmtFlag);
 
 class ILogOutput

--- a/core/platform/win32/EmbedConsole.h
+++ b/core/platform/win32/EmbedConsole.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+https://axmolengine.github.io/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+#pragma once
+
+#if defined(_WIN32)
+
+// A inline helper class for anyone want enable win32 console in main.cpp
+class EmbedConsole
+{
+public:
+    EmbedConsole()
+    {
+        ::AllocConsole();
+        freopen("CONIN$", "r", stdin);
+        freopen("CONOUT$", "w", stdout);
+        freopen("CONOUT$", "w", stderr);
+
+        ::SetConsoleOutputCP(CP_UTF8);
+
+        configConsoleMode(STD_OUTPUT_HANDLE);
+        configConsoleMode(STD_ERROR_HANDLE);
+    }
+
+    ~EmbedConsole() { ::FreeConsole(); }
+
+private:
+    void configConsoleMode(DWORD id)
+    {
+        auto handle = ::GetStdHandle(id);
+        if (handle)
+        {
+            DWORD mode{};
+            ::GetConsoleMode(handle, &mode);
+            mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            ::SetConsoleMode(handle, mode);
+        }
+    }
+};
+
+EmbedConsole __win32_embed_console;
+
+#endif

--- a/templates/common/proj.win32/main.cpp
+++ b/templates/common/proj.win32/main.cpp
@@ -27,6 +27,9 @@
 #include "AppDelegate.h"
 #include "axmol.h"
 
+// Uncomment to enable win32 console
+// #define USE_WIN32_CONSOLE
+
 USING_NS_AX;
 
 int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nCmdShow)
@@ -36,19 +39,12 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
 
     // create the application instance
 #ifdef USE_WIN32_CONSOLE
-    AllocConsole();
-    freopen("CONIN$", "r", stdin);
-    freopen("CONOUT$", "w", stdout);
-    freopen("CONOUT$", "w", stderr);
+#    include "platform/win32/EmbedConsole.h"
 #endif
 
     // create the application instance
     AppDelegate app;
     int ret = Application::getInstance()->run();
-
-#ifdef USE_WIN32_CONSOLE
-    FreeConsole();
-#endif
 
     return ret;
 }

--- a/tests/cpp-tests/proj.win32/main.cpp
+++ b/tests/cpp-tests/proj.win32/main.cpp
@@ -34,6 +34,8 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
 
     #include "platform/win32/EmbedConsole.h"
 
+    ax::setLogFmtFlag(ax::LogFmtFlag::Full);
+
     // create the application instance
     AppDelegate app;
     return Application::getInstance()->run();

--- a/tests/cpp-tests/proj.win32/main.cpp
+++ b/tests/cpp-tests/proj.win32/main.cpp
@@ -32,6 +32,8 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 
+    #include "platform/win32/EmbedConsole.h"
+
     // create the application instance
     AppDelegate app;
     return Application::getInstance()->run();


### PR DESCRIPTION
## Describe your changes

<img width="735" alt="f326f483ed3d6cdf6d543d2e0e61258f" src="https://github.com/axmolengine/axmol/assets/6977319/8adb66fa-25ce-481d-bb8e-81972bb2e308">

```cpp
constexpr auto colorCodeOfLevel = [](LogLevel level) ->std::string_view
{
    switch (level)
    {
    case LogLevel::Info:
        return "\x1b[92m"sv; // rgb: \x1b[38;2;144;238;144m"sv
    case LogLevel::Warn:
        return "\x1b[33m"sv; // rgb: "\x1b[38;2;255;255;000m"sv
    case LogLevel::Error:
        return  "\x1b[31m"sv; // rgb: "\x1b[38;2;255;000;000m"sv
    default:
        return std::string_view{};
    }
};
```

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Further works

check does in terminal and is color terminal
```cpp
// Determine if the terminal supports colors
bool is_color_terminal() {
#ifdef _WIN32
    return true;
#else

    static const bool result = []() {
        const char *env_colorterm_p = std::getenv("COLORTERM");
        if (env_colorterm_p != nullptr) {
            return true;
        }

        static constexpr std::array<const char *, 16> terms = {
            {"ansi", "color", "console", "cygwin", "gnome", "konsole", "kterm", "linux", "msys",
             "putty", "rxvt", "screen", "vt100", "xterm", "alacritty", "vt102"}};

        const char *env_term_p = std::getenv("TERM");
        if (env_term_p == nullptr) {
            return false;
        }

        return std::any_of(terms.begin(), terms.end(), [&](const char *term) {
            return std::strstr(env_term_p, term) != nullptr;
        });
    }();

    return result;
#endif
}

// Determine if the terminal attached
bool in_terminal(FILE *file) {
#ifdef _WIN32
    return ::_isatty(_fileno(file)) != 0;
#else
    return ::isatty(fileno(file)) != 0;
#endif
}
```