### PR TITLE
Removing EditBox should not result in logging an error message

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/EditBoxHelper.java
+++ b/core/platform/android/java/src/org/axmol/lib/EditBoxHelper.java
@@ -227,7 +227,7 @@ public class EditBoxHelper {
                 if (editBox != null) {
                     mEditBoxArray.remove(index);
                     mFrameLayout.removeView(editBox);
-                    Log.e(TAG, "remove EditBox");
+                    Log.d(TAG, "remove EditBox");
                 }
             }
         });

--- a/core/platform/android/java/src/org/axmol/lib/EditBoxHelper.java
+++ b/core/platform/android/java/src/org/axmol/lib/EditBoxHelper.java
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 


### PR DESCRIPTION
## Describe your changes
At the moment, when an EditBox is removed, an error message is logged, but this isn't an error.
![image](https://github.com/axmolengine/axmol/assets/8603230/ef066991-2b7a-4e6e-8074-fa32589a06f1)

The change is to make this a debug log message instead of an error message.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
