### PR TITLE
Update Console.cpp (removed the '\n' which creates a second (empty) line.

### DIFF
--- a/core/base/Console.cpp
+++ b/core/base/Console.cpp
@@ -267,7 +267,7 @@ AX_API void print(const char* format, ...)
     va_end(args);
 
     if (!message.empty())
-        outputLog(LogItem::vformat(FMT_COMPILE("{}{}\n"), preprocessLog(LogItem{LogLevel::Silent}), message),
+        outputLog(LogItem::vformat(FMT_COMPILE("{}{}"), preprocessLog(LogItem{LogLevel::Silent}), message),
                   "axmol debug info");
 }
 


### PR DESCRIPTION
## Describe your changes

Output with '\n':
```
I/[2024-03-15 10:43:34.890][PID:66a8][TID:5cb0]Console: IPV4 server is listening on 0.0.0.0:5678
D/[2024-03-15 10:43:35.011][PID:66a8][TID:5cb0]Loading shader: 5 positionTextureColor_vs, positionTextureColor_fs ...
D/[2024-03-15 10:43:35.260][PID:66a8][TID:5cb0]Loading shader: 9 positionTextureColor_vs, label_distanceNormal_fs ...
?/[2024-03-15 10:43:35.752][PID:66a8][TID:5cb0]axmol: QuadCommand: resizing index size from [-1] to [2560]

?/[2024-03-15 10:44:14.528][PID:66a8][TID:5cb0]56.500000, 43.599998,

?/[2024-03-15 10:44:14.529][PID:66a8][TID:5cb0]70.500000, 56.599998,

?/[2024-03-15 10:44:14.530][PID:66a8][TID:5cb0]70.500000, 63.299999,

?/[2024-03-15 10:44:14.531][PID:66a8][TID:5cb0]58.299999, 75.500000,

?/[2024-03-15 10:44:14.531][PID:66a8][TID:5cb0]53.700001, 75.500000,
```
Output without '\n':
```
I/[2024-03-15 10:45:08.996][PID:5890][TID:64dc]Console: IPV4 server is listening on 0.0.0.0:5678
D/[2024-03-15 10:45:09.003][PID:5890][TID:64dc]Loading shader: 5 positionTextureColor_vs, positionTextureColor_fs ...
D/[2024-03-15 10:45:09.027][PID:5890][TID:64dc]Loading shader: 9 positionTextureColor_vs, label_distanceNormal_fs ...
?/[2024-03-15 10:45:09.481][PID:5890][TID:64dc]axmol: QuadCommand: resizing index size from [-1] to [2560]
?/[2024-03-15 10:45:16.385][PID:5890][TID:64dc]56.500000, 43.599998,
?/[2024-03-15 10:45:16.385][PID:5890][TID:64dc]70.500000, 56.599998,
?/[2024-03-15 10:45:16.387][PID:5890][TID:64dc]70.500000, 63.299999,
?/[2024-03-15 10:45:16.389][PID:5890][TID:64dc]58.299999, 75.500000,
?/[2024-03-15 10:45:16.389][PID:5890][TID:64dc]53.700001, 75.500000
```,

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
