### PR TITLE
Fix data race in AudioCache

### DIFF
--- a/core/audio/AudioCache.cpp
+++ b/core/audio/AudioCache.cpp
@@ -105,7 +105,7 @@ AudioCache::~AudioCache()
     }
     else
     {
-        ALOGW("AudioCache (%p), id=%u, buffer isn't ready, state=%d", this, _id, (int)_state);
+        ALOGW("AudioCache (%p), id=%u, buffer isn't ready, state=%d", this, _id, (int)_state.load());
     }
 
     if (_queBufferFrames > 0)
@@ -358,7 +358,7 @@ void AudioCache::addPlayCallback(const std::function<void()>& callback)
         break;
 
     default:
-        ALOGE("Invalid state: %d", (int)_state);
+        ALOGE("Invalid state: %d", (int)_state.load());
         break;
     }
 }
@@ -392,7 +392,7 @@ void AudioCache::addLoadCallback(const std::function<void(bool)>& callback)
         break;
 
     default:
-        ALOGE("Invalid state: %d", (int)_state);
+        ALOGE("Invalid state: %d", (int)_state.load());
         break;
     }
 }

--- a/core/audio/AudioCache.h
+++ b/core/audio/AudioCache.h
@@ -95,7 +95,7 @@ protected:
 
     std::mutex _readDataTaskMutex;
 
-    State _state;
+    std::atomic<State> _state;
 
     std::shared_ptr<bool> _isDestroyed;
     std::string _fileFullPath;


### PR DESCRIPTION
## Describe your changes

Fix data race
```
ARNING: ThreadSanitizer: data race (pid=8716)
  Write of size 4 at 0x00011480ac30 by thread T38 (mutexes: write M0):
    #0 ax::AudioCache::readDataTask(unsigned int) AudioCache.cpp:128 (cpp-tests:arm64+0x101e91bc4)
    #1 ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1::operator()() const AudioEngineImpl.cpp:516 (cpp-tests:arm64+0x101ed9e68)
    #2 decltype(std::declval<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&>()()) std::__1::__invoke[abi:v160006]<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&>(ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&) invoke.h:394 (cpp-tests:arm64+0x101ed9d78)
    #3 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&>(ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&) invoke.h:487 (cpp-tests:arm64+0x101ed9cdc)
    #4 std::__1::__function::__alloc_func<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1, std::__1::allocator<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1>, void ()>::operator()[abi:v160006]() function.h:185 (cpp-tests:arm64+0x101ed9c88)
    #5 std::__1::__function::__func<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1, std::__1::allocator<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1>, void ()>::operator()() function.h:356 (cpp-tests:arm64+0x101ed7b80)
    #6 std::__1::__function::__value_func<void ()>::operator()[abi:v160006]() const function.h:510 (cpp-tests:arm64+0x1019d556c)
    #7 std::__1::function<void ()>::operator()() const function.h:1156 (cpp-tests:arm64+0x1019d3674)
    #8 ax::AudioEngine::AudioEngineThreadPool::threadFunc() AudioEngine.cpp:126 (cpp-tests:arm64+0x101ea971c)
    #9 decltype(*std::declval<ax::AudioEngine::AudioEngineThreadPool*&>().*std::declval<void (ax::AudioEngine::AudioEngineThreadPool::*&)()>()()) std::__1::__invoke[abi:v160006]<void (ax::AudioEngine::AudioEngineThreadPool::*&)(), ax::AudioEngine::AudioEngineThreadPool*&, void>(void (ax::AudioEngine::AudioEngineThreadPool::*&)(), ax::AudioEngine::AudioEngineThreadPool*&) invoke.h:359 (cpp-tests:arm64+0x101eadb04)
    #10 std::__1::__bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>, __is_valid_bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>>::value>::type std::__1::__apply_functor[abi:v160006]<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, 0ul, std::__1::tuple<>>(void (ax::AudioEngine::AudioEngineThreadPool::*&)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) bind.h:263 (cpp-tests:arm64+0x101eada24)
    #11 std::__1::__bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>, __is_valid_bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>>::value>::type std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>::operator()[abi:v160006]<>() bind.h:295 (cpp-tests:arm64+0x101ead99c)
    #12 decltype(std::declval<std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>()()) std::__1::__invoke[abi:v160006]<std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>(std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>&&) invoke.h:394 (cpp-tests:arm64+0x101ead8f0)
    #13 void std::__1::__thread_execute[abi:v160006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>&, std::__1::__tuple_indices<>) thread:288 (cpp-tests:arm64+0x101ead89c)
    #14 void* std::__1::__thread_proxy[abi:v160006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>>(void*) thread:299 (cpp-tests:arm64+0x101ead330)

  Previous read of size 4 at 0x00011480ac30 by main thread (mutexes: write M1):
    #0 ax::AudioCache::addPlayCallback(std::__1::function<void ()> const&) AudioCache.cpp:346 (cpp-tests:arm64+0x101e9337c)
    #1 ax::AudioEngineImpl::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, float) AudioEngineImpl.cpp:571 (cpp-tests:arm64+0x101ec24c4)
    #2 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, ax::AudioPlayerSettings const&, ax::AudioProfile const*) AudioEngine.cpp:252 (cpp-tests:arm64+0x101ea2d24)
    #3 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, ax::AudioProfile const*) AudioEngine.cpp:185 (cpp-tests:arm64+0x101ea2860)
    #4 AudioWavTest::onEnter() NewAudioEngineTest.cpp:518 (cpp-tests:arm64+0x100967d1c)
    #5 ax::Director::setNextScene() Director.cpp:1158 (cpp-tests:arm64+0x101f53170)
    #6 ax::Director::drawScene() Director.cpp:302 (cpp-tests:arm64+0x101f528bc)
    #7 ax::Director::mainLoop() Director.cpp:1547 (cpp-tests:arm64+0x101f59da0)
    #8 ax::Application::run() Application-mac.mm:76 (cpp-tests:arm64+0x10236560c)
    #9 main main.cpp:32 (cpp-tests:arm64+0x1019a6ce4)

  Location is heap block of size 296 at 0x00011480ab40 allocated by main thread:
    #0 operator new(unsigned long) <null>:264457860 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x84420)
    #1 ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>) AudioEngineImpl.cpp:504 (cpp-tests:arm64+0x101ec199c)
    #2 ax::AudioEngineImpl::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, float) AudioEngineImpl.cpp:559 (cpp-tests:arm64+0x101ec230c)
    #3 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, ax::AudioPlayerSettings const&, ax::AudioProfile const*) AudioEngine.cpp:252 (cpp-tests:arm64+0x101ea2d24)
    #4 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, ax::AudioProfile const*) AudioEngine.cpp:185 (cpp-tests:arm64+0x101ea2860)
    #5 AudioWavTest::onEnter() NewAudioEngineTest.cpp:518 (cpp-tests:arm64+0x100967d1c)
    #6 ax::Director::setNextScene() Director.cpp:1158 (cpp-tests:arm64+0x101f53170)
    #7 ax::Director::drawScene() Director.cpp:302 (cpp-tests:arm64+0x101f528bc)
    #8 ax::Director::mainLoop() Director.cpp:1547 (cpp-tests:arm64+0x101f59da0)
    #9 ax::Application::run() Application-mac.mm:76 (cpp-tests:arm64+0x10236560c)
    #10 main main.cpp:32 (cpp-tests:arm64+0x1019a6ce4)

  Mutex M0 (0x00011480abf0) created at:
    #0 pthread_mutex_lock <null>:264457860 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x3cf8c)
    #1 std::__1::mutex::lock() <null>:264457860 (libc++.1.dylib:arm64e+0x16710)
    #2 ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1::operator()() const AudioEngineImpl.cpp:516 (cpp-tests:arm64+0x101ed9e68)
    #3 decltype(std::declval<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&>()()) std::__1::__invoke[abi:v160006]<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&>(ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&) invoke.h:394 (cpp-tests:arm64+0x101ed9d78)
    #4 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&>(ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1&) invoke.h:487 (cpp-tests:arm64+0x101ed9cdc)
    #5 std::__1::__function::__alloc_func<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1, std::__1::allocator<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1>, void ()>::operator()[abi:v160006]() function.h:185 (cpp-tests:arm64+0x101ed9c88)
    #6 std::__1::__function::__func<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1, std::__1::allocator<ax::AudioEngineImpl::preload(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void (bool)>)::$_1>, void ()>::operator()() function.h:356 (cpp-tests:arm64+0x101ed7b80)
    #7 std::__1::__function::__value_func<void ()>::operator()[abi:v160006]() const function.h:510 (cpp-tests:arm64+0x1019d556c)
    #8 std::__1::function<void ()>::operator()() const function.h:1156 (cpp-tests:arm64+0x1019d3674)
    #9 ax::AudioEngine::AudioEngineThreadPool::threadFunc() AudioEngine.cpp:126 (cpp-tests:arm64+0x101ea971c)
    #10 decltype(*std::declval<ax::AudioEngine::AudioEngineThreadPool*&>().*std::declval<void (ax::AudioEngine::AudioEngineThreadPool::*&)()>()()) std::__1::__invoke[abi:v160006]<void (ax::AudioEngine::AudioEngineThreadPool::*&)(), ax::AudioEngine::AudioEngineThreadPool*&, void>(void (ax::AudioEngine::AudioEngineThreadPool::*&)(), ax::AudioEngine::AudioEngineThreadPool*&) invoke.h:359 (cpp-tests:arm64+0x101eadb04)
    #11 std::__1::__bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>, __is_valid_bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>>::value>::type std::__1::__apply_functor[abi:v160006]<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, 0ul, std::__1::tuple<>>(void (ax::AudioEngine::AudioEngineThreadPool::*&)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) bind.h:263 (cpp-tests:arm64+0x101eada24)
    #12 std::__1::__bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>, __is_valid_bind_return<void (ax::AudioEngine::AudioEngineThreadPool::*)(), std::__1::tuple<ax::AudioEngine::AudioEngineThreadPool*>, std::__1::tuple<>>::value>::type std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>::operator()[abi:v160006]<>() bind.h:295 (cpp-tests:arm64+0x101ead99c)
    #13 decltype(std::declval<std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>()()) std::__1::__invoke[abi:v160006]<std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>(std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>&&) invoke.h:394 (cpp-tests:arm64+0x101ead8f0)
    #14 void std::__1::__thread_execute[abi:v160006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>&, std::__1::__tuple_indices<>) thread:288 (cpp-tests:arm64+0x101ead89c)
    #15 void* std::__1::__thread_proxy[abi:v160006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>>>(void*) thread:299 (cpp-tests:arm64+0x101ead330)

  Mutex M1 (0x00011480ab80) created at:
    #0 pthread_mutex_lock <null>:264457860 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x3cf8c)
    #1 std::__1::mutex::lock() <null>:264457860 (libc++.1.dylib:arm64e+0x16710)
    #2 std::__1::lock_guard<std::__1::mutex>::lock_guard[abi:v160006](std::__1::mutex&) __mutex_base:94 (cpp-tests:arm64+0x101e934b8)
    #3 ax::AudioCache::addPlayCallback(std::__1::function<void ()> const&) AudioCache.cpp:345 (cpp-tests:arm64+0x101e9336c)
    #4 ax::AudioEngineImpl::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, float) AudioEngineImpl.cpp:571 (cpp-tests:arm64+0x101ec24c4)
    #5 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, ax::AudioPlayerSettings const&, ax::AudioProfile const*) AudioEngine.cpp:252 (cpp-tests:arm64+0x101ea2d24)
    #6 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, ax::AudioProfile const*) AudioEngine.cpp:185 (cpp-tests:arm64+0x101ea2860)
    #7 AudioWavTest::onEnter() NewAudioEngineTest.cpp:518 (cpp-tests:arm64+0x100967d1c)
    #8 ax::Director::setNextScene() Director.cpp:1158 (cpp-tests:arm64+0x101f53170)
    #9 ax::Director::drawScene() Director.cpp:302 (cpp-tests:arm64+0x101f528bc)
    #10 ax::Director::mainLoop() Director.cpp:1547 (cpp-tests:arm64+0x101f59da0)
    #11 ax::Application::run() Application-mac.mm:76 (cpp-tests:arm64+0x10236560c)
    #12 main main.cpp:32 (cpp-tests:arm64+0x1019a6ce4)

  Thread T38 (tid=2164248, running) created by main thread at:
    #0 pthread_create <null>:264457860 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x3062c)
    #1 std::__1::__libcpp_thread_create[abi:v160006](_opaque_pthread_t**, void* (*)(void*), void*) __threading_support:378 (cpp-tests:arm64+0x100418f88)
    #2 std::__1::thread::thread<std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>, void>(std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>&&) thread:315 (cpp-tests:arm64+0x101ead114)
    #3 std::__1::thread::thread<std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>, void>(std::__1::__bind<void (ax::AudioEngine::AudioEngineThreadPool::*)(), ax::AudioEngine::AudioEngineThreadPool*>&&) thread:307 (cpp-tests:arm64+0x101ea97fc)
    #4 ax::AudioEngine::AudioEngineThreadPool::AudioEngineThreadPool(int) AudioEngine.cpp:77 (cpp-tests:arm64+0x101ea9354)
    #5 ax::AudioEngine::AudioEngineThreadPool::AudioEngineThreadPool(int) AudioEngine.cpp:74 (cpp-tests:arm64+0x101ea2798)
    #6 ax::AudioEngine::lazyInit() AudioEngine.cpp:176 (cpp-tests:arm64+0x101ea26a8)
    #7 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, ax::AudioPlayerSettings const&, ax::AudioProfile const*) AudioEngine.cpp:199 (cpp-tests:arm64+0x101ea290c)
    #8 ax::AudioEngine::play2d(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, float, ax::AudioProfile const*) AudioEngine.cpp:185 (cpp-tests:arm64+0x101ea2860)
    #9 AudioControlTest::init()::$_20::operator()((anonymous namespace)::TextButton*) const NewAudioEngineTest.cpp:246 (cpp-tests:arm64+0x1009b4e84)
    #10 decltype(std::declval<AudioControlTest::init()::$_20&>()(std::declval<(anonymous namespace)::TextButton*>())) std::__1::__invoke[abi:v160006]<AudioControlTest::init()::$_20&, (anonymous namespace)::TextButton*>(AudioControlTest::init()::$_20&, (anonymous namespace)::TextButton*&&) invoke.h:394 (cpp-tests:arm64+0x1009b4d74)
    #11 void std::__1::__invoke_void_return_wrapper<void, true>::__call<AudioControlTest::init()::$_20&, (anonymous namespace)::TextButton*>(AudioControlTest::init()::$_20&, (anonymous namespace)::TextButton*&&) invoke.h:487 (cpp-tests:arm64+0x1009b4cb0)
    #12 std::__1::__function::__alloc_func<AudioControlTest::init()::$_20, std::__1::allocator<AudioControlTest::init()::$_20>, void ((anonymous namespace)::TextButton*)>::operator()[abi:v160006]((anonymous namespace)::TextButton*&&) function.h:185 (cpp-tests:arm64+0x1009b4c4c)
    #13 std::__1::__function::__func<AudioControlTest::init()::$_20, std::__1::allocator<AudioControlTest::init()::$_20>, void ((anonymous namespace)::TextButton*)>::operator()((anonymous namespace)::TextButton*&&) function.h:356 (cpp-tests:arm64+0x1009b2b34)
    #14 std::__1::__function::__value_func<void ((anonymous namespace)::TextButton*)>::operator()[abi:v160006]((anonymous namespace)::TextButton*&&) const function.h:510 (cpp-tests:arm64+0x100971a88)
    #15 std::__1::function<void ((anonymous namespace)::TextButton*)>::operator()((anonymous namespace)::TextButton*) const function.h:1156 (cpp-tests:arm64+0x100971960)
    #16 (anonymous namespace)::TextButton::onTouchEnded(ax::Touch*, ax::Event*) NewAudioEngineTest.cpp:140 (cpp-tests:arm64+0x10096d6b0)
    #17 decltype(*std::declval<(anonymous namespace)::TextButton*&>().*std::declval<void ((anonymous namespace)::TextButton::*&)(ax::Touch*, ax::Event*)>()(std::declval<ax::Touch*>(), std::declval<ax::Event*>())) std::__1::__invoke[abi:v160006]<void ((anonymous namespace)::TextButton::*&)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*&, ax::Touch*, ax::Event*, void>(void ((anonymous namespace)::TextButton::*&)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*&, ax::Touch*&&, ax::Event*&&) invoke.h:359 (cpp-tests:arm64+0x100974bcc)
    #18 std::__1::__bind_return<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), std::__1::tuple<(anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1>, std::__1::placeholders::__ph<2>>, std::__1::tuple<ax::Touch*&&, ax::Event*&&>, __is_valid_bind_return<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), std::__1::tuple<(anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1>, std::__1::placeholders::__ph<2>>, std::__1::tuple<ax::Touch*&&, ax::Event*&&>>::value>::type std::__1::__apply_functor[abi:v160006]<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), std::__1::tuple<(anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1>, std::__1::placeholders::__ph<2>>, 0ul, 1ul, 2ul, std::__1::tuple<ax::Touch*&&, ax::Event*&&>>(void ((anonymous namespace)::TextButton::*&)(ax::Touch*, ax::Event*), std::__1::tuple<(anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1>, std::__1::placeholders::__ph<2>>&, std::__1::__tuple_indices<0ul, 1ul, 2ul>, std::__1::tuple<ax::Touch*&&, ax::Event*&&>&&) bind.h:263 (cpp-tests:arm64+0x100974a9c)
    #19 std::__1::__bind_return<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), std::__1::tuple<(anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1>, std::__1::placeholders::__ph<2>>, std::__1::tuple<ax::Touch*&&, ax::Event*&&>, __is_valid_bind_return<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), std::__1::tuple<(anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1>, std::__1::placeholders::__ph<2>>, std::__1::tuple<ax::Touch*&&, ax::Event*&&>>::value>::type std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>::operator()[abi:v160006]<ax::Touch*, ax::Event*>(ax::Touch*&&, ax::Event*&&) bind.h:295 (cpp-tests:arm64+0x1009749e4)
    #20 decltype(std::declval<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>&>()(std::declval<ax::Touch*>(), std::declval<ax::Event*>())) std::__1::__invoke[abi:v160006]<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>&, ax::Touch*, ax::Event*>(std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>&, ax::Touch*&&, ax::Event*&&) invoke.h:394 (cpp-tests:arm64+0x100974950)
    #21 void std::__1::__invoke_void_return_wrapper<void, true>::__call<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>&, ax::Touch*, ax::Event*>(std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>&, ax::Touch*&&, ax::Event*&&) invoke.h:487 (cpp-tests:arm64+0x100974894)
    #22 std::__1::__function::__alloc_func<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>, std::__1::allocator<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>>, void (ax::Touch*, ax::Event*)>::operator()[abi:v160006](ax::Touch*&&, ax::Event*&&) function.h:185 (cpp-tests:arm64+0x100974820)
    #23 std::__1::__function::__func<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>, std::__1::allocator<std::__1::__bind<void ((anonymous namespace)::TextButton::*)(ax::Touch*, ax::Event*), (anonymous namespace)::TextButton*, std::__1::placeholders::__ph<1> const&, std::__1::placeholders::__ph<2> const&>>, void (ax::Touch*, ax::Event*)>::operator()(ax::Touch*&&, ax::Event*&&) function.h:356 (cpp-tests:arm64+0x100972ab4)
    #24 std::__1::__function::__value_func<void (ax::Touch*, ax::Event*)>::operator()[abi:v160006](ax::Touch*&&, ax::Event*&&) const function.h:510 (cpp-tests:arm64+0x101fb12b4)
    #25 std::__1::function<void (ax::Touch*, ax::Event*)>::operator()(ax::Touch*, ax::Event*) const function.h:1156 (cpp-tests:arm64+0x101faee7c)
    #26 ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3::operator()(ax::EventListener*) const EventDispatcher.cpp:1085 (cpp-tests:arm64+0x101fae460)
    #27 decltype(std::declval<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3&>()(std::declval<ax::EventListener*>())) std::__1::__invoke[abi:v160006]<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3&, ax::EventListener*>(ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3&, ax::EventListener*&&) invoke.h:394 (cpp-tests:arm64+0x101fae040)
    #28 bool std::__1::__invoke_void_return_wrapper<bool, false>::__call<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3&, ax::EventListener*>(ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3&, ax::EventListener*&&) invoke.h:478 (cpp-tests:arm64+0x101fadf70)
    #29 std::__1::__function::__alloc_func<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3, std::__1::allocator<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3>, bool (ax::EventListener*)>::operator()[abi:v160006](ax::EventListener*&&) function.h:185 (cpp-tests:arm64+0x101fadf00)
    #30 std::__1::__function::__func<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3, std::__1::allocator<ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*)::$_3>, bool (ax::EventListener*)>::operator()(ax::EventListener*&&) function.h:356 (cpp-tests:arm64+0x101fac198)
    #31 std::__1::__function::__value_func<bool (ax::EventListener*)>::operator()[abi:v160006](ax::EventListener*&&) const function.h:510 (cpp-tests:arm64+0x101fa7dcc)
    #32 std::__1::function<bool (ax::EventListener*)>::operator()(ax::EventListener*) const function.h:1156 (cpp-tests:arm64+0x101f79264)
    #33 ax::EventDispatcher::dispatchTouchEventToListeners(ax::EventDispatcher::EventListenerVector*, std::__1::function<bool (ax::EventListener*)> const&) EventDispatcher.cpp:927 (cpp-tests:arm64+0x101f7988c)
    #34 ax::EventDispatcher::dispatchTouchEvent(ax::EventTouch*) EventDispatcher.cpp:1132 (cpp-tests:arm64+0x101f7a5b4)
    #35 ax::EventDispatcher::dispatchEvent(ax::Event*) EventDispatcher.cpp:973 (cpp-tests:arm64+0x101f79dbc)
    #36 ax::GLView::handleTouchesOfEndOrCancel(ax::EventTouch::EventCode, int, long*, float*, float*) GLView.cpp:454 (cpp-tests:arm64+0x1023141d8)
    #37 ax::GLView::handleTouchesEnd(int, long*, float*, float*) GLView.cpp:465 (cpp-tests:arm64+0x10231443c)
    #38 ax::GLViewImpl::onGLFWMouseCallBack(GLFWwindow*, int, int, int) GLViewImpl.cpp:1047 (cpp-tests:arm64+0x10231c760)
    #39 ax::GLFWEventHandler::onGLFWMouseCallBack(GLFWwindow*, int, int, int) GLViewImpl.cpp:100 (cpp-tests:arm64+0x102319c40)
    #40 ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow*, int, int, int) imgui_impl_ax.cpp:406 (cpp-tests:arm64+0x102997820)
    #41 _glfwInputMouseClick input.c:367 (cpp-tests:arm64+0x103926298)
    #42 -[GLFWContentView mouseUp:] cocoa_window.m:419 (cpp-tests:arm64+0x10391391c)
    #43 _routeMouseUpEvent <null>:264457860 (AppKit:arm64e+0xb73830)
    #44 glfwPollEvents window.c:1154 (cpp-tests:arm64+0x103940b20)
    #45 ax::GLViewImpl::pollEvents() GLViewImpl.cpp:678 (cpp-tests:arm64+0x10231a534)
    #46 ax::Director::drawScene() Director.cpp:282 (cpp-tests:arm64+0x101f52760)
    #47 ax::Director::mainLoop() Director.cpp:1547 (cpp-tests:arm64+0x101f59da0)
    #48 ax::Application::run() Application-mac.mm:76 (cpp-tests:arm64+0x10236560c)
    #49 main main.cpp:32 (cpp-tests:arm64+0x1019a6ce4)

SUMMARY: ThreadSanitizer: data race AudioCache.cpp:128 in ax::AudioCache::readDataTask(unsigned int)

```
## Issue ticket number and link
https://github.com/axmolengine/axmol/issues/1752

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
