### PR TITLE
Fix texture recreation when GL context is lost

### DIFF
--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -115,14 +115,15 @@ GLuint TextureInfoGL::ensure(int index, GLenum target)
     return texID;
 }
 
-void TextureInfoGL::recreateAll(GLenum target)
+void TextureInfoGL::onRendererRecreated(GLenum target)
 {
     int idx = 0;
     for (auto&& texID : textures)
     {
         if (texID)
         {
-            __gl->deleteTexture(target, texID);
+            // NOTE: glDeleteTextures() doesn't need to be called here, because the textures were
+            // destroyed when the GL context was lost.
             texID = 0;
             ensure(idx, target);
         }
@@ -137,11 +138,11 @@ Texture2DGL::Texture2DGL(const TextureDescriptor& descriptor)
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     // Listen this event to restored texture id after coming to foreground on Android.
-    _backToForegroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
-        _textureInfo.recreateAll(GL_TEXTURE_2D);
+    _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
+        _textureInfo.onRendererRecreated(GL_TEXTURE_2D);
         this->initWithZeros();
     });
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
+    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
 }
 
@@ -181,7 +182,7 @@ void Texture2DGL::initWithZeros()
 Texture2DGL::~Texture2DGL()
 {
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
+    Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
     _textureInfo.destroy(GL_TEXTURE_2D);
 }
@@ -317,9 +318,9 @@ TextureCubeGL::TextureCubeGL(const TextureDescriptor& descriptor)
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     // Listen this event to restored texture id after coming to foreground on Android.
-    _backToForegroundListener = EventListenerCustom::create(
-        EVENT_COME_TO_FOREGROUND, [this](EventCustom*) { _textureInfo.recreateAll(GL_TEXTURE_CUBE_MAP); });
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
+    _rendererRecreatedListener = EventListenerCustom::create(
+        EVENT_RENDERER_RECREATED, [this](EventCustom*) { _textureInfo.onRendererRecreated(GL_TEXTURE_CUBE_MAP); });
+    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
     CHECK_GL_ERROR_DEBUG();
 }
@@ -337,7 +338,7 @@ void TextureCubeGL::updateTextureDescriptor(const ax::backend::TextureDescriptor
 TextureCubeGL::~TextureCubeGL()
 {
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
+    Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
     _textureInfo.destroy(GL_TEXTURE_CUBE_MAP);
 }

--- a/core/renderer/backend/opengl/TextureGL.h
+++ b/core/renderer/backend/opengl/TextureGL.h
@@ -54,7 +54,7 @@ struct TextureInfoGL
     }
 
     GLuint ensure(int index, GLenum target);
-    void recreateAll(GLenum target);
+    void onRendererRecreated(GLenum target);
 
     void destroy(GLenum target)
     {
@@ -205,7 +205,7 @@ private:
     void initWithZeros();
 
     TextureInfoGL _textureInfo;
-    EventListener* _backToForegroundListener = nullptr;
+    EventListener* _rendererRecreatedListener = nullptr;
 };
 
 /**
@@ -258,7 +258,7 @@ public:
 
 private:
     TextureInfoGL _textureInfo;
-    EventListener* _backToForegroundListener = nullptr;
+    EventListener* _rendererRecreatedListener = nullptr;
 };
 
 // end of _opengl group

--- a/core/renderer/backend/opengl/TextureGL.h
+++ b/core/renderer/backend/opengl/TextureGL.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 


### PR DESCRIPTION
## Describe your changes

This PR contains 3 changes:

* When GL context is lost on Android all textures in the context are destroyed implicitly. But `TextureInfoGL::onRendererRecreated()` calls `glDeleteTextures()` on old texture IDs and if other new textures have already allocated these IDs, then it ends up deleting those new textures corrupting their state. and the OpenGLState was reset before event `EVENT_RENDERER_RECREATED` fired in `core/platform/android/javaactivity-android.cpp`

* `TextureCubeGL` seems to listen to `EVENT_COME_TO_FOREGROUND` when it should listen to `EVENT_RENDERER_RECREATED`, so fixed that.

* Did some renaming to reflect that things are being used for renderer recreated event.


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
