### PR TITLE
Add support for verbose trace level logging

### DIFF
--- a/core/base/Console.cpp
+++ b/core/base/Console.cpp
@@ -118,6 +118,9 @@ AX_API LogItem& preprocessLog(LogItem&& item)
             std::string_view levelName;
             switch (item.level_)
             {
+            case LogLevel::Trace:
+                levelName = "T/"sv;
+                break;
             case LogLevel::Debug:
                 levelName = "D/"sv;
                 break;

--- a/core/base/Console.cpp
+++ b/core/base/Console.cpp
@@ -143,6 +143,10 @@ AX_API LogItem& preprocessLog(LogItem&& item)
                 constexpr auto colorCodeOfLevel = [](LogLevel level) -> std::string_view {
                     switch (level)
                     {
+                    case LogLevel::Trace:
+                        return "\x1b[37m"sv;
+                    case LogLevel::Debug:
+                        return "\x1b[36m"sv;
                     case LogLevel::Info:
                         return "\x1b[92m"sv;
                     case LogLevel::Warn:

--- a/core/base/Console.h
+++ b/core/base/Console.h
@@ -59,6 +59,7 @@ NS_AX_BEGIN
 
 enum class LogLevel
 {
+    Trace,
     Debug,
     Info,
     Warn,
@@ -163,6 +164,7 @@ inline void printLogT(_FmtType&& fmt, LogItem& item, _Types&&... args)
 #define AXLOG_WITH_LEVEL(level, fmtOrMsg, ...) \
     ax::printLogT(FMT_COMPILE("{}" fmtOrMsg), ax::preprocessLog(ax::LogItem{level}), ##__VA_ARGS__)
 
+#define AXLOGT(fmtOrMsg, ...) AXLOG_WITH_LEVEL(ax::LogLevel::Trace, fmtOrMsg, ##__VA_ARGS__)
 #define AXLOGD(fmtOrMsg, ...) AXLOG_WITH_LEVEL(ax::LogLevel::Debug, fmtOrMsg, ##__VA_ARGS__)
 #define AXLOGI(fmtOrMsg, ...) AXLOG_WITH_LEVEL(ax::LogLevel::Info, fmtOrMsg, ##__VA_ARGS__)
 #define AXLOGW(fmtOrMsg, ...) AXLOG_WITH_LEVEL(ax::LogLevel::Warn, fmtOrMsg, ##__VA_ARGS__)


### PR DESCRIPTION
## Describe your changes

The most verbose log level at the moment is `LogLevel::Debug`, and while this serves its purpose, it is not suitable for trace-level logging, as it would end up with too much log spam, along with the possibility of revealing information that otherwise should not be revealed in a release/production version of an application.

This PR adds `LogLevel::Trace`, which is specifically for the purpose of verbose logging.

@halx99 If you accept this PR, do you want a color associated with the trace messages? If so, which color should be used for this?

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
