### PR TITLE
Fix same uniforms in fragment and vertex shaders not working in Metal

### DIFF
--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -230,16 +230,10 @@ void ProgramState::setCallbackUniform(const backend::UniformLocation& uniformLoc
 
 void ProgramState::setUniform(const backend::UniformLocation& uniformLocation, const void* data, std::size_t size)
 {
-    switch (uniformLocation.shaderStage)
-    {
-    case backend::ShaderStage::VERTEX:
-        setVertexUniform(uniformLocation.location[0], data, size, uniformLocation.location[1]);
-        break;
-    case backend::ShaderStage::FRAGMENT:
-        setFragmentUniform(uniformLocation.location[0], data, size, uniformLocation.location[1]);
-        break;
-    default:;
-    }
+    if (uniformLocation.vertStage)
+        setVertexUniform(uniformLocation.vertStage.location, data, size, uniformLocation.vertStage.offset);
+    if (uniformLocation.fragStage)
+        setFragmentUniform(uniformLocation.fragStage.location, data, size, uniformLocation.fragStage.offset);
 }
 
 void ProgramState::setVertexUniform(int location, const void* data, std::size_t size, std::size_t offset)
@@ -337,32 +331,20 @@ void ProgramState::setTexture(const backend::UniformLocation& uniformLocation,
                               int index,
                               backend::TextureBackend* texture)
 {
-    switch (uniformLocation.shaderStage)
-    {
-    case backend::ShaderStage::VERTEX:
-        setTexture(uniformLocation.location[0], slot, index, texture, _vertexTextureInfos);
-        break;
-    case backend::ShaderStage::FRAGMENT:
-        setTexture(uniformLocation.location[0], slot, index, texture, _fragmentTextureInfos);
-        break;
-    default:;
-    }
+    if (uniformLocation.vertStage)
+        setTexture(uniformLocation.vertStage.location, slot, index, texture, _vertexTextureInfos);
+    if (uniformLocation.fragStage)
+        setTexture(uniformLocation.fragStage.location, slot, index, texture, _fragmentTextureInfos);
 }
 
 void ProgramState::setTextureArray(const backend::UniformLocation& uniformLocation,
                                    std::vector<int> slots,
                                    std::vector<backend::TextureBackend*> textures)
 {
-    switch (uniformLocation.shaderStage)
-    {
-    case backend::ShaderStage::VERTEX:
-        setTextureArray(uniformLocation.location[0], std::move(slots), std::move(textures), _vertexTextureInfos);
-        break;
-    case backend::ShaderStage::FRAGMENT:
-        setTextureArray(uniformLocation.location[0], std::move(slots), std::move(textures), _fragmentTextureInfos);
-        break;
-    default:;
-    }
+    if (uniformLocation.vertStage)
+        setTextureArray(uniformLocation.vertStage.location, std::move(slots), std::move(textures), _vertexTextureInfos);
+    if (uniformLocation.fragStage)
+        setTextureArray(uniformLocation.fragStage.location, std::move(slots), std::move(textures), _fragmentTextureInfos);
 }
 
 void ProgramState::setTexture(int location,

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -232,8 +232,10 @@ void ProgramState::setUniform(const backend::UniformLocation& uniformLocation, c
 {
     if (uniformLocation.vertStage)
         setVertexUniform(uniformLocation.vertStage.location, data, size, uniformLocation.vertStage.offset);
+#ifdef AX_USE_METAL
     if (uniformLocation.fragStage)
         setFragmentUniform(uniformLocation.fragStage.location, data, size, uniformLocation.fragStage.offset);
+#endif
 }
 
 void ProgramState::setVertexUniform(int location, const void* data, std::size_t size, std::size_t offset)
@@ -249,17 +251,15 @@ void ProgramState::setVertexUniform(int location, const void* data, std::size_t 
 #endif
 }
 
+#ifdef AX_USE_METAL
 void ProgramState::setFragmentUniform(int location, const void* data, std::size_t size, std::size_t offset)
 {
     if (location < 0)
         return;
 
-#ifdef AX_USE_METAL
     memcpy(_uniformBuffers.data() + _vertexUniformBufferSize + location + offset, data, size);
-#else
-    assert(false);
-#endif
 }
+#endif
 
 void ProgramState::setVertexAttrib(std::string_view name,
                                    std::size_t index,
@@ -333,8 +333,10 @@ void ProgramState::setTexture(const backend::UniformLocation& uniformLocation,
 {
     if (uniformLocation.vertStage)
         setTexture(uniformLocation.vertStage.location, slot, index, texture, _vertexTextureInfos);
+#ifdef AX_USE_METAL
     if (uniformLocation.fragStage)
         setTexture(uniformLocation.fragStage.location, slot, index, texture, _fragmentTextureInfos);
+#endif
 }
 
 void ProgramState::setTextureArray(const backend::UniformLocation& uniformLocation,
@@ -343,8 +345,10 @@ void ProgramState::setTextureArray(const backend::UniformLocation& uniformLocati
 {
     if (uniformLocation.vertStage)
         setTextureArray(uniformLocation.vertStage.location, std::move(slots), std::move(textures), _vertexTextureInfos);
+#ifdef AX_USE_METAL
     if (uniformLocation.fragStage)
         setTextureArray(uniformLocation.fragStage.location, std::move(slots), std::move(textures), _fragmentTextureInfos);
+#endif
 }
 
 void ProgramState::setTexture(int location,

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -332,6 +332,7 @@ protected:
      */
     void setVertexUniform(int location, const void* data, std::size_t size, std::size_t offset);
 
+#ifdef AX_USE_METAL
     /**
      * Set the fargment uniform data.
      * @param location Specifies the uniform location.
@@ -339,6 +340,7 @@ protected:
      * @param size Specifies the uniform data size.
      */
     void setFragmentUniform(int location, const void* data, std::size_t size, std::size_t offset);
+#endif
 
     /**
      * Set texture.

--- a/core/renderer/backend/Types.cpp
+++ b/core/renderer/backend/Types.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/renderer/backend/Types.cpp
+++ b/core/renderer/backend/Types.cpp
@@ -26,14 +26,19 @@
 
 NS_AX_BACKEND_BEGIN
 
+bool StageUniformLocation::operator==(const StageUniformLocation& other) const
+{
+    return location == other.location && offset == other.offset;
+}
+
 bool UniformLocation::operator==(const UniformLocation& other) const
 {
-    return (shaderStage == other.shaderStage && location[0] == other.location[0] && location[1] == other.location[1]);
+    return vertStage == other.vertStage && fragStage == other.fragStage;
 }
 
 std::size_t UniformLocation::operator()(const UniformLocation& uniform) const
 {
-    return (((size_t)shaderStage) & 0xF) | ((size_t)(location[0] << 4)) | ((size_t)(location[1] << 8));
+    return size_t(vertStage.location) ^ size_t(fragStage.location << 16);
 }
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -76,30 +76,24 @@ struct UniformInfo
     unsigned int bufferOffset = 0;
 };
 
+struct StageUniformLocation
+{
+    int location = -1;
+    int offset = -1;
+
+    operator bool() const { return location != -1; }
+    bool operator==(const StageUniformLocation& other) const;
+};
+
 struct UniformLocation
 {
-    UniformLocation()
-    {
-        location[0] = -1;
-        location[1] = -1;
-        shaderStage = ShaderStage::UNKNOWN;
-    }
-    UniformLocation(int loc, int offset, ShaderStage stage = ShaderStage::VERTEX)
-    {
-        location[0] = loc;
-        location[1] = offset;
-        shaderStage = stage;
-    }
-    /**
-     * both opengl and metal, location[0] represent the location, and location[1] represent location offset in uniform
-     * block.
-     */
-    int location[2];
-    ShaderStage shaderStage;
-    operator bool() { return shaderStage != ShaderStage::UNKNOWN; }
-    void reset() { location[0] = location[1] = -1; }
+    StageUniformLocation vertStage;
+    StageUniformLocation fragStage;
+
+    operator bool() const { return vertStage or fragStage; }
+    void reset() { vertStage = {}; fragStage = {}; }
     bool operator==(const UniformLocation& other) const;
-    std::size_t operator()(const UniformLocation& uniform) const;
+    std::size_t operator()(const UniformLocation& uniform) const; // used as a hash function
 };
 
 struct AttributeBindInfo

--- a/core/renderer/backend/metal/ProgramMTL.mm
+++ b/core/renderer/backend/metal/ProgramMTL.mm
@@ -62,20 +62,28 @@ int ProgramMTL::getAttributeLocation(std::string_view name) const
 
 UniformLocation ProgramMTL::getUniformLocation(backend::Uniform name) const
 {
-    UniformLocation uniformLocation;
-    uniformLocation = _vertexShader->getUniformLocation(name);
-    if (uniformLocation.location[0] != -1)
-        return uniformLocation;
-    return _fragmentShader->getUniformLocation(name);
+    auto& vert = _vertexShader->getUniformInfo(name);
+    auto& frag = _fragmentShader->getUniformInfo(name);
+
+    return UniformLocation {
+        { vert.location, vert.location == -1 ? -1 : static_cast<int>(vert.bufferOffset) },
+        { frag.location, frag.location == -1 ? -1 : static_cast<int>(frag.bufferOffset) }
+    };
 }
 
 UniformLocation ProgramMTL::getUniformLocation(std::string_view uniform) const
 {
-    UniformLocation uniformLocation;
-    uniformLocation = _vertexShader->getUniformLocation(uniform);
-    if (uniformLocation.location[0] != -1)
-        return uniformLocation;
-    return _fragmentShader->getUniformLocation(uniform);
+    auto& vert = _vertexShader->getUniformInfo(uniform);
+    auto& frag = _fragmentShader->getUniformInfo(uniform);
+
+    if (vert.location != -1 && frag.location != -1)
+        AXASSERT(vert.type == frag.type && vert.count == frag.count && vert.size == frag.size,
+            "Same vertex and fragment uniform must much in type and size");
+
+    return UniformLocation {
+        { vert.location, vert.location == -1 ? -1 : static_cast<int>(vert.bufferOffset) },
+        { frag.location, frag.location == -1 ? -1 : static_cast<int>(frag.bufferOffset) }
+    };
 }
 
 int ProgramMTL::getMaxVertexLocation() const

--- a/core/renderer/backend/metal/ShaderModuleMTL.h
+++ b/core/renderer/backend/metal/ShaderModuleMTL.h
@@ -81,18 +81,18 @@ public:
     inline const hlookup::string_map<AttributeBindInfo>& getAttributeInfo() const { return _attributeInfo; }
 
     /**
-     * Get uniform location by engine built-in uniform enum name.
+     * Get uniform info by engine built-in uniform enum name.
      * @param name Specifies the engine built-in uniform enum name.
      * @return The uniform location.
      */
-    UniformLocation getUniformLocation(Uniform name) const;
+    const UniformInfo& getUniformInfo(Uniform name) const;
 
     /**
-     * Get uniform location by name.
+     * Get uniform info by name.
      * @param uniform Specifies the uniform name.
      * @return The uniform location.
      */
-    UniformLocation getUniformLocation(std::string_view name) const;
+    const UniformInfo& getUniformInfo(std::string_view name) const;
 
     /**
      * Get attribute location by engine built-in attribute enum name.
@@ -128,8 +128,8 @@ private:
     int _attributeLocation[ATTRIBUTE_MAX];
     
     int _maxLocation = -1;
-    UniformLocation _uniformLocation[UNIFORM_MAX]; // the builtin uniform locations
-    
+    UniformInfo _builtinUniforms[UNIFORM_MAX];
+
     std::size_t _uniformBufferSize = 0;
 };
 

--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -260,20 +260,18 @@ void ShaderModuleMTL::parseTexture(SLCReflectContext* context)
     }
 }
 
-UniformLocation ShaderModuleMTL::getUniformLocation(Uniform name) const
+const UniformInfo& ShaderModuleMTL::getUniformInfo(Uniform name) const
 {
-    return _uniformLocation[name];
+    return _builtinUniforms[name];
 }
 
-UniformLocation ShaderModuleMTL::getUniformLocation(std::string_view name) const
+const UniformInfo& ShaderModuleMTL::getUniformInfo(std::string_view name) const
 {
+    static UniformInfo none;
     auto iter = _activeUniformInfos.find(name);
     if (iter != _activeUniformInfos.end())
-    {
-        return UniformLocation{static_cast<int>(iter->second.location),
-            static_cast<int>(iter->second.bufferOffset), _stage};
-    }
-    return UniformLocation{};
+        return iter->second;
+    return none;
 }
 
 void ShaderModuleMTL::setBuiltinLocations()
@@ -295,22 +293,22 @@ void ShaderModuleMTL::setBuiltinLocations()
     /*--- Builtin Uniforms ---*/
 
     /// u_MVPMatrix
-    _uniformLocation[Uniform::MVP_MATRIX] = getUniformLocation(UNIFORM_NAME_MVP_MATRIX);
+    _builtinUniforms[Uniform::MVP_MATRIX] = getUniformInfo(UNIFORM_NAME_MVP_MATRIX);
 
     /// u_tex0
-    _uniformLocation[Uniform::TEXTURE] = getUniformLocation(UNIFORM_NAME_TEXTURE);
+    _builtinUniforms[Uniform::TEXTURE] = getUniformInfo(UNIFORM_NAME_TEXTURE);
 
     /// u_tex1
-    _uniformLocation[Uniform::TEXTURE1] = getUniformLocation(UNIFORM_NAME_TEXTURE1);
+    _builtinUniforms[Uniform::TEXTURE1] = getUniformInfo(UNIFORM_NAME_TEXTURE1);
 
     /// u_textColor
-    _uniformLocation[Uniform::TEXT_COLOR] = getUniformLocation(UNIFORM_NAME_TEXT_COLOR);
+    _builtinUniforms[Uniform::TEXT_COLOR] = getUniformInfo(UNIFORM_NAME_TEXT_COLOR);
 
     /// u_effectColor
-    _uniformLocation[Uniform::EFFECT_COLOR] = getUniformLocation(UNIFORM_NAME_EFFECT_COLOR);
+    _builtinUniforms[Uniform::EFFECT_COLOR] = getUniformInfo(UNIFORM_NAME_EFFECT_COLOR);
 
     /// u_effectType
-    _uniformLocation[Uniform::EFFECT_TYPE] = getUniformLocation(UNIFORM_NAME_EFFECT_TYPE);
+    _builtinUniforms[Uniform::EFFECT_TYPE] = getUniformInfo(UNIFORM_NAME_EFFECT_TYPE);
 }
 
 int ShaderModuleMTL::getAttributeLocation(Attribute name) const

--- a/core/renderer/backend/opengl/ProgramGL.cpp
+++ b/core/renderer/backend/opengl/ProgramGL.cpp
@@ -500,15 +500,13 @@ UniformLocation ProgramGL::getUniformLocation(std::string_view uniform) const
     auto iter = _activeUniformInfos.find(uniform);
     if (iter != _activeUniformInfos.end())
     {
-        uniformLocation.shaderStage = ShaderStage::VERTEX;
-
         const auto& uniformInfo = iter->second;
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-        uniformLocation.location[0] = _mapToOriginalLocation.at(uniformInfo.location);
+        uniformLocation.vertStage.location = _mapToOriginalLocation.at(uniformInfo.location);
 #else
-        uniformLocation.location[0] = uniformInfo.location;
+        uniformLocation.vertStage.location = uniformInfo.location;
 #endif
-        uniformLocation.location[1] = uniformInfo.bufferOffset;
+        uniformLocation.vertStage.offset = uniformInfo.bufferOffset;
     }
 
     return uniformLocation;

--- a/core/renderer/shaders/positionNormalTexture.vert
+++ b/core/renderer/shaders/positionNormalTexture.vert
@@ -32,11 +32,11 @@ layout(location = NORMAL) out vec3 v_normal;
 
 layout(std140) uniform vs_ub {
 #ifdef USE_NORMAL_MAPPING
-    vec3 u_DirLightSourceDirection[MAX_DIRECTIONAL_LIGHT_NUM];
-    vec3 u_SpotLightSourceDirection[MAX_SPOT_LIGHT_NUM];
+    vvec3_def(u_DirLightSourceDirection, MAX_DIRECTIONAL_LIGHT_NUM);
+    vvec3_def(u_SpotLightSourceDirection, MAX_SPOT_LIGHT_NUM);
 #endif
-    vec3 u_PointLightSourcePosition[MAX_POINT_LIGHT_NUM];
-    vec3 u_SpotLightSourcePosition[MAX_SPOT_LIGHT_NUM];
+    vvec3_def(u_PointLightSourcePosition, MAX_POINT_LIGHT_NUM);
+    vvec3_def(u_SpotLightSourcePosition, MAX_SPOT_LIGHT_NUM);
     mat4 u_MVPMatrix;
     mat4 u_MVMatrix;
     mat4 u_PMatrix;
@@ -52,14 +52,14 @@ void main(void)
     vec3 eNormal = normalize(u_NormalMatrix * a_normal);
     for (int i = 0; i < MAX_DIRECTIONAL_LIGHT_NUM; ++i)
     {
-        v_dirLightDirection[i].x = dot(eTangent, u_DirLightSourceDirection[i]);
-        v_dirLightDirection[i].y = dot(eBinormal, u_DirLightSourceDirection[i]);
-        v_dirLightDirection[i].z = dot(eNormal, u_DirLightSourceDirection[i]);
+        v_dirLightDirection[i].x = dot(eTangent, vvec3_at(u_DirLightSourceDirection, i));
+        v_dirLightDirection[i].y = dot(eBinormal, vvec3_at(u_DirLightSourceDirection, i));
+        v_dirLightDirection[i].z = dot(eNormal, vvec3_at(u_DirLightSourceDirection, i));
     }
 
     for (int i = 0; i < MAX_POINT_LIGHT_NUM; ++i)
     {
-        vec3 pointLightDir = u_PointLightSourcePosition[i].xyz - ePosition.xyz;
+        vec3 pointLightDir = vvec3_at(u_PointLightSourcePosition, i).xyz - ePosition.xyz;
         v_vertexToPointLightDirection[i].x = dot(eTangent, pointLightDir);
         v_vertexToPointLightDirection[i].y = dot(eBinormal, pointLightDir);
         v_vertexToPointLightDirection[i].z = dot(eNormal, pointLightDir);
@@ -67,24 +67,24 @@ void main(void)
 
     for (int i = 0; i < MAX_SPOT_LIGHT_NUM; ++i)
     {
-        vec3 spotLightDir = u_SpotLightSourcePosition[i] - ePosition.xyz;
+        vec3 spotLightDir = vvec3_at(u_SpotLightSourcePosition, i) - ePosition.xyz;
         v_vertexToSpotLightDirection[i].x = dot(eTangent, spotLightDir);
         v_vertexToSpotLightDirection[i].y = dot(eBinormal, spotLightDir);
         v_vertexToSpotLightDirection[i].z = dot(eNormal, spotLightDir);
 
-        v_spotLightDirection[i].x = dot(eTangent, u_SpotLightSourceDirection[i]);
-        v_spotLightDirection[i].y = dot(eBinormal, u_SpotLightSourceDirection[i]);
-        v_spotLightDirection[i].z = dot(eNormal, u_SpotLightSourceDirection[i]);
+        v_spotLightDirection[i].x = dot(eTangent, vvec3_at(u_SpotLightSourceDirection, i));
+        v_spotLightDirection[i].y = dot(eBinormal, vvec3_at(u_SpotLightSourceDirection, i));
+        v_spotLightDirection[i].z = dot(eNormal, vvec3_at(u_SpotLightSourceDirection, i));
     }
 #else
     for (int i = 0; i < MAX_POINT_LIGHT_NUM; ++i)
     {
-        v_vertexToPointLightDirection[i] = u_PointLightSourcePosition[i].xyz - ePosition.xyz;
+        v_vertexToPointLightDirection[i] = vvec3_at(u_PointLightSourcePosition, i).xyz - ePosition.xyz;
     }
 
     for (int i = 0; i < MAX_SPOT_LIGHT_NUM; ++i)
     {
-        v_vertexToSpotLightDirection[i] = u_SpotLightSourcePosition[i] - ePosition.xyz;
+        v_vertexToSpotLightDirection[i] = vvec3_at(u_SpotLightSourcePosition, i) - ePosition.xyz;
     }
 
     v_normal = u_NormalMatrix * a_normal;

--- a/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -3089,34 +3089,70 @@ bool luaval_to_samplerDescriptor(lua_State* L,
     return true;
 }
 
+bool luaval_to_stageUniformLocation(lua_State* L, int pos, ax::backend::StageUniformLocation& loc, const char* message)
+{
+    if (L == nullptr)
+        return false;
+
+    if (pos < 0)
+        pos -= 1; // since we'll be pushing keys for table access
+
+    lua_pushstring(L, "location");
+    if (lua_gettable(L, pos) == LUA_TNIL)
+    {
+        AXASSERT(false, "invalidate UniformLocation value");
+    }
+    loc.location = int(lua_tointeger(L, -1));
+    lua_pop(L, 1);
+
+    lua_pushstring(L, "offset");
+    if (lua_gettable(L, pos) == LUA_TNIL)
+    {
+        AXASSERT(false, "invalidate UniformLocation value");
+    }
+    loc.offset = int(lua_tointeger(L, -1));
+    lua_pop(L, 1);
+
+    return true;
+}
+
+void stageUniformLocation_to_luaval(lua_State* L, const ax::backend::StageUniformLocation& loc)
+{
+    if (L == nullptr)
+        return;
+
+    lua_newtable(L);
+
+    lua_pushstring(L, "location");
+    lua_pushinteger(L, loc.location);
+    lua_rawset(L, -3);
+
+    lua_pushstring(L, "offset");
+    lua_pushinteger(L, loc.offset);
+    lua_rawset(L, -3);
+}
+
 bool luaval_to_uniformLocation(lua_State* L, int pos, ax::backend::UniformLocation& loc, const char* message)
 {
     if (L == nullptr)
         return false;
 
-    lua_pushstring(L, "location");
-    lua_gettable(L, pos);
-    if (lua_isnil(L, -1))
+    lua_pushstring(L, "vertStage");
+    if (lua_gettable(L, pos) == LUA_TNIL)
     {
         AXASSERT(false, "invalidate UniformLocation value");
     }
-    int len = lua_objlen(L, -1);
-    for (int i = 0; i < len; i++)
-    {
-        lua_rawgeti(L, -1, i + 1);
-        loc.location[i] = lua_tointeger(L, -1);
-        lua_pop(L, 1);
-    }
+    luaval_to_stageUniformLocation(L, -1, loc.vertStage, "");
     lua_pop(L, 1);
 
-    lua_pushstring(L, "shaderStage");
-    lua_gettable(L, pos);
-    if (lua_isnil(L, -1))
+    lua_pushstring(L, "fragStage");
+    if (lua_gettable(L, pos) == LUA_TNIL)
     {
         AXASSERT(false, "invalidate UniformLocation value");
     }
-    loc.shaderStage = static_cast<ax::backend::ShaderStage>(lua_tointeger(L, -1));
+    luaval_to_stageUniformLocation(L, -1, loc.fragStage, "");
     lua_pop(L, 1);
+
     return true;
 }
 
@@ -3126,18 +3162,13 @@ void uniformLocation_to_luaval(lua_State* L, const ax::backend::UniformLocation&
         return;
 
     lua_newtable(L);
-    lua_pushstring(L, "location");
-    lua_newtable(L);
-    for (int i = 1; i <= 2; i++)
-    {
-        lua_pushnumber(L, i);
-        lua_pushinteger(L, static_cast<int>(loc.location[i - 1]));
-        lua_rawset(L, -3);
-    }
+
+    lua_pushstring(L, "vertStage");
+    stageUniformLocation_to_luaval(L, loc.vertStage);
     lua_rawset(L, -3);
 
-    lua_pushstring(L, "shaderStage");
-    lua_pushinteger(L, static_cast<int>(loc.shaderStage));
+    lua_pushstring(L, "fragStage");
+    stageUniformLocation_to_luaval(L, loc.fragStage);
     lua_rawset(L, -3);
 }
 


### PR DESCRIPTION
## Describe your changes

Context: in OpenGL API setting shader uniforms works at the program level, which means that same named uniforms in vertex and fragment shaders are treated as the same variable, so when you set a uniform it is set in both shaders at once. In Metal API uniforms are set for vertex and fragment shaders separately.

In current Axmol's Metal implementation if you have a same named uniform in vertex and fragment shaders, then only the vertex shader's variable is set, which is different from OpenGL. This PR fixes Metal part to match OpenGL semantics.

This PR may have breaking changes as it modifies `UniformLocation` and `ShaderModuleMTL::getUniformLocation()`. But probably it's not a common thing to access `UniformLocation` internals or calling `ShaderModuleMTL::getUniformLocation()`.


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
