### PR TITLE
[Improvement] Add Borderless Windowed Mode

### DIFF
--- a/core/platform/GLViewImpl.cpp
+++ b/core/platform/GLViewImpl.cpp
@@ -827,10 +827,12 @@ void GLViewImpl::setFullscreen(GLFWmonitor* monitor, int w, int h, int refreshRa
     glfwSetWindowMonitor(_mainWindow, _monitor, 0, 0, w, h, refreshRate);
 }
 
-void GLViewImpl::setWindowed(int width, int height)
+void GLViewImpl::setWindowed(int width, int height, bool borderless)
 {
     if (!this->isFullscreen())
     {
+        glfwSetWindowAttrib(_mainWindow, GLFW_DECORATED, borderless ? GLFW_FALSE : GLFW_TRUE);
+
         if (glfwGetWindowAttrib(_mainWindow, GLFW_MAXIMIZED))
             glfwRestoreWindow(_mainWindow);
         this->setFrameSize((float)width, (float)height);
@@ -845,6 +847,7 @@ void GLViewImpl::setWindowed(int width, int height)
         xpos += (int)((videoMode->width - width) * 0.5f);
         ypos += (int)((videoMode->height - height) * 0.5f);
         _monitor = nullptr;
+        glfwSetWindowAttrib(_mainWindow, GLFW_DECORATED, borderless ? GLFW_FALSE : GLFW_TRUE);
         glfwSetWindowMonitor(_mainWindow, nullptr, xpos, ypos, width, height, GLFW_DONT_CARE);
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
         // on mac window will sometimes lose title when windowed

--- a/core/platform/GLViewImpl.h
+++ b/core/platform/GLViewImpl.h
@@ -93,7 +93,7 @@ public:
 
     /* for internal use */
     void setFullscreen(GLFWmonitor* monitor, int w, int h, int refreshRate);
-    void setWindowed(int width, int height);
+    void setWindowed(int width, int height, bool borderless = false);
 
     void getWindowPosition(int* xpos, int* ypos);
     void getWindowSize(int* width, int* height);


### PR DESCRIPTION
## Describe your changes
This PR adds borderless windowed mode support to the GLViewImpl class. For backwards compatibility the setWindowed function uses a default parameter of 'false' for borderless.

## Issue ticket number and link
N/A

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
