### PR TITLE
Fixed issue where UIWidget couldn't be reselected

### DIFF
--- a/core/ui/UIWidget.cpp
+++ b/core/ui/UIWidget.cpp
@@ -1284,6 +1284,8 @@ void Widget::setFocused(bool focus)
         {
             _focusNavigationController->setFirstFocusedWidget(this);
         }
+    } else if(_focusedWidget == this) {
+        _focusedWidget = nullptr;
     }
 }
 


### PR DESCRIPTION
## Describe your changes
If a UIWidget gets focus, and then loses focus (but another UIWidget doesn't gain focus when it does so). Then that original UIWidget cannot be re-focused until a different UIWidget gets focus first. This change fixes this problem.

## Issue ticket number and link
N/A

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
