### PR TITLE
Fix FileUtilsApple::getPathForDirectory() checking wrong path

### DIFF
--- a/core/platform/apple/FileUtils-apple.mm
+++ b/core/platform/apple/FileUtils-apple.mm
@@ -186,7 +186,7 @@ std::string FileUtilsApple::getPathForDirectory(std::string_view dir,
     if (path[0] == '/')
     {
         BOOL isDir = false;
-        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:dir.data()] isDirectory:&isDir])
+        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:path.data()] isDirectory:&isDir])
         {
             return isDir ? path : "";
         }


### PR DESCRIPTION
## Describe your changes

FileUtilsApple::getPathForDirectory() is checking the given directory without appending a search path. This fixes it.


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
