### PR TITLE
Fixed ClippingNode stencil needing global z set manually

### DIFF
--- a/core/2d/ClippingNode.cpp
+++ b/core/2d/ClippingNode.cpp
@@ -227,6 +227,16 @@ void ClippingNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32
     _director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
 }
 
+void ClippingNode::setGlobalZOrder(float globalZOrder)
+{
+    Node::setGlobalZOrder(globalZOrder);
+    
+    if (_stencil) {
+        // Make sure our stencil stays on the same globalZOrder:
+        _stencil->setGlobalZOrder(globalZOrder);
+    }
+}
+
 void ClippingNode::setCameraMask(unsigned short mask, bool applyChildren)
 {
     Node::setCameraMask(mask, applyChildren);
@@ -279,6 +289,9 @@ void ClippingNode::setStencil(Node* stencil)
 
     if (_stencil != nullptr)
     {
+        // Make sure our stencil stays on the same globalZOrder:
+        _stencil->setGlobalZOrder(getGlobalZOrder());
+        
         _originalStencilProgramState[_stencil] = _stencil->getProgramState();
         auto& children                         = _stencil->getChildren();
         for (const auto& child : children)

--- a/core/2d/ClippingNode.h
+++ b/core/2d/ClippingNode.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2012      cocos2d-x.org
  * Copyright (c) 2013-2016 Chukong Technologies Inc.
  * Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ * Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
  *
  * https://axmolengine.github.io/
  *
@@ -133,6 +134,8 @@ public:
     virtual void onExit() override;
     virtual void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
 
+    virtual void setGlobalZOrder(float globalZOrder) override;
+    
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
 
     ClippingNode();


### PR DESCRIPTION
## Describe your changes
This bug has existed since the Cocos2d-x 3.x days. If you set the global z order of a ClippingNode to anything other than the default value, then the ClippingNode fails to clip anything unless the global z order is also set for the Stencil of that ClippingNode. This change makes the ClippingNode._stencil's global z order to follow the ClippingNode's.

Note: you can still manually set the global z order of the stencil as desired so as to break the clipping. But now the default behavior works correctly and the way one would expect, rather than the default behavior being broken and needing to set the global z order of the stencil to match so as to fix the clipping.

## Issue ticket number and link
N/A

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
