### PR TITLE
Fix glfw crash on macOS for large mouse button ids

### DIFF
--- a/3rdparty/glfw/src/input.c
+++ b/3rdparty/glfw/src/input.c
@@ -348,7 +348,6 @@ void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods)
 {
     assert(window != NULL);
     assert(button >= 0);
-    assert(button <= GLFW_MOUSE_BUTTON_LAST);
     assert(action == GLFW_PRESS || action == GLFW_RELEASE);
     assert(mods == (mods & GLFW_MOD_MASK));
 


### PR DESCRIPTION
## Describe your changes

On macOS GLFW crashes with mouse button id 8. This PR is a temporary workaround until GLFW will release a fix. Crash is at `assert(button <= GLFW_MOUSE_BUTTON_LAST);` in this function:

https://github.com/axmolengine/axmol/blob/d03c823573254c04338bff6e06025727448f35db/3rdparty/glfw/src/input.c#L345-L368

GLFW_MOUSE_BUTTON_LAST is 7, so assert is triggered. GLFW seems has fixed this a month ago by also removing this assert, but it's not released yet. Fix commit is here: https://github.com/glfw/glfw/commit/bf945f1213728a98f7647380616f9cff9f6b3611

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
