### PR TITLE
Fix failed assertion and memory leak with event listeners

### DIFF
--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -226,8 +226,8 @@ void Node::cleanup()
 
     // This will stop Axmol from leaking event listeners on any objects that create them:
     //
-    // Note: If you're moving a Node from one parent to another then you must remember to always call either removeChild,
-    // or removeFromParentWithCleanup with a cleanup bool parameter of false. Otherwise Nodes with listeners (e.g. buttons)
+    // Note: If you're moving a Node from one parent to another then you must remember to always call either removeChild(),
+    // or removeFromParentAndCleanup() with a cleanup bool parameter of false. Otherwise Nodes with listeners (e.g. buttons)
     // will stop working when it's removed from it's parent and then added as a child to any Node.
     //
     // For more details read: https://discuss.cocos2d-x.org/t/note-compatibility-issue-of-node-cleanup-in-cocos2d-x-v3-16

--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -224,15 +224,14 @@ void Node::cleanup()
     // timers
     this->unscheduleAllCallbacks();
 
-    // NOTE: Although it was correct that removing event listeners associated with current node in Node::cleanup.
-    // But it broke the compatibility to the versions before v3.16 .
-    // User code may call `node->removeFromParent(true)` which will trigger node's cleanup method, when the node
-    // is added to scene again, event listeners like EventListenerTouchOneByOne will be lost.
-    // In fact, user's code should use `node->removeFromParent(false)` in order not to do a cleanup and just remove node
-    // from its parent. For more discussion about why we revert this change is at
-    // https://github.com/cocos2d/cocos2d-x/issues/18104. We need to consider more before we want to correct the old and
-    // wrong logic code. For now, compatiblity is the most important for our users.
-    //    _eventDispatcher->removeEventListenersForTarget(this);
+    // This will stop Axmol from leaking event listeners on any objects that create them:
+    //
+    // Note: If you're moving a Node from one parent to another then you must remember to always call either removeChild,
+    // or removeFromParentWithCleanup with a cleanup bool parameter of false. Otherwise Nodes with listeners (e.g. buttons)
+    // will stop working when it's removed from it's parent and then added as a child to any Node.
+    //
+    // For more details read: https://discuss.cocos2d-x.org/t/note-compatibility-issue-of-node-cleanup-in-cocos2d-x-v3-16
+    _eventDispatcher->removeEventListenersForTarget(this);
 
     for (const auto& child : _children)
         child->cleanup();


### PR DESCRIPTION
## Describe your changes
This solves an issue that was fixed for Cocos2d-x v3.16 and then reverted afterwards for "backwards compatibility".

I don't think we need this backwards compatibility anymore, and the benefits to cleaning up this memory outweigh the potential for some developers to need to refactor their code.

Specifically this also solves an ASSERT that fails when quitting the game on a scene which has nodes with Event Listeners that I experienced without this change, and with the Config.h setting AX_NODE_DEBUG_VERIFY_EVENT_LISTENERS enabled.

The issue I opened for this is listed below for additional discussion if this is the right solution or not (though I don't personally see much harm in doing this, perhaps this will require many of you to refactor your code that moves a Node from one parent to another).

I did replace the old Cocos2d-x comment here with one that describes the issue and what to do to avoid the cleanup if desired as well to hopefully help anyone who might update who relied on the old behavior.

## Issue ticket number and link
#1836

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
