### PR TITLE
Remove Node::removeFromParentAndCleanup and Refactor Node::removeFromParent

### DIFF
--- a/core/2d/ActionInstant.cpp
+++ b/core/2d/ActionInstant.cpp
@@ -4,6 +4,7 @@
  Copyright (c) 2011      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 
@@ -164,7 +165,7 @@ bool RemoveSelf::init(bool isNeedCleanUp)
 void RemoveSelf::update(float time)
 {
     ActionInstant::update(time);
-    _target->removeFromParentAndCleanup(_isNeedCleanUp);
+    _target->removeFromParent(_isNeedCleanUp);
 }
 
 RemoveSelf* RemoveSelf::reverse() const

--- a/core/2d/ActionInstant.h
+++ b/core/2d/ActionInstant.h
@@ -4,6 +4,7 @@
  Copyright (c) 2011      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/MenuItem.cpp
+++ b/core/2d/MenuItem.cpp
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 
@@ -816,7 +817,7 @@ void MenuItemToggle::setSelectedIndex(unsigned int index)
         _selectedIndex = index;
         if (_selectedItem)
         {
-            _selectedItem->removeFromParentAndCleanup(false);
+            _selectedItem->removeFromParent(false);
         }
 
         _selectedItem = _subItems.at(_selectedIndex);

--- a/core/2d/MenuItem.h
+++ b/core/2d/MenuItem.h
@@ -4,6 +4,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -1057,12 +1057,7 @@ void Node::addChild(Node* child)
     this->addChild(child, child->getLocalZOrder(), child->_name);
 }
 
-void Node::removeFromParent()
-{
-    this->removeFromParentAndCleanup(true);
-}
-
-void Node::removeFromParentAndCleanup(bool cleanup)
+void Node::removeFromParent(bool cleanup)
 {
     if (_parent != nullptr)
     {

--- a/core/2d/Node.h
+++ b/core/2d/Node.h
@@ -870,19 +870,13 @@ public:
     ////// REMOVES //////
 
     /**
-     * Removes this node itself from its parent node with a cleanup.
-     * If the node orphan, then nothing happens.
-     * @see `removeFromParentAndCleanup(bool)`
-     */
-    virtual void removeFromParent();
-    /**
-     * Removes this node itself from its parent node.
+     * Removes this node itself from its parent node with an optional cleanup, defaulting to true.
      * If the node orphan, then nothing happens.
      * @param cleanup   true if all actions and callbacks on this node should be removed, false otherwise.
      * @js removeFromParent
      * @lua removeFromParent
      */
-    virtual void removeFromParentAndCleanup(bool cleanup);
+    virtual void removeFromParent(bool cleanup = true);
 
     /**
      * Removes a child from the container. It will also cleanup all running actions depending on the cleanup parameter.

--- a/extensions/Inspector/src/Inspector/Inspector.cpp
+++ b/extensions/Inspector/src/Inspector/Inspector.cpp
@@ -1,27 +1,3 @@
-/****************************************************************************
- Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-
- https://axmolengine.github.io/
-
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
-
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
- ****************************************************************************/
-
 #include "Inspector.h"
 #include "ImGuiPresenter.h"
 #include "axmol.h"

--- a/extensions/Inspector/src/Inspector/Inspector.cpp
+++ b/extensions/Inspector/src/Inspector/Inspector.cpp
@@ -1,3 +1,27 @@
+/****************************************************************************
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+ https://axmolengine.github.io/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
 #include "Inspector.h"
 #include "ImGuiPresenter.h"
 #include "axmol.h"
@@ -320,7 +344,7 @@ void Inspector::drawProperties()
 
     if (ImGui::Button("Delete"))
     {
-        _selected_node->removeFromParentAndCleanup(true);
+        _selected_node->removeFromParent();
         _selected_node = nullptr;
         return;
     }

--- a/extensions/Inspector/src/Inspector/Inspector.h
+++ b/extensions/Inspector/src/Inspector/Inspector.h
@@ -1,3 +1,27 @@
+/****************************************************************************
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+ https://axmolengine.github.io/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
 #pragma once
 
 #include <memory>

--- a/extensions/Inspector/src/Inspector/Inspector.h
+++ b/extensions/Inspector/src/Inspector/Inspector.h
@@ -1,27 +1,3 @@
-/****************************************************************************
- Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-
- https://axmolengine.github.io/
-
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
-
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
- ****************************************************************************/
-
 #pragma once
 
 #include <memory>

--- a/extensions/cocostudio/src/cocostudio/DisplayManager.cpp
+++ b/extensions/cocostudio/src/cocostudio/DisplayManager.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
 Copyright (c) 2013-2017 Chukong Technologies Inc.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 
@@ -62,7 +63,7 @@ DisplayManager::~DisplayManager()
 
     if (_displayRenderNode)
     {
-        _displayRenderNode->removeFromParentAndCleanup(true);
+        _displayRenderNode->removeFromParent();
         if (_displayRenderNode->getReferenceCount() > 0)
             AX_SAFE_RELEASE_NULL(_displayRenderNode);
     }
@@ -228,7 +229,7 @@ void DisplayManager::changeDisplayWithIndex(int index, bool force)
     {
         if (_displayRenderNode)
         {
-            _displayRenderNode->removeFromParentAndCleanup(true);
+            _displayRenderNode->removeFromParent();
             setCurrentDecorativeDisplay(nullptr);
         }
         return;
@@ -276,7 +277,7 @@ void DisplayManager::setCurrentDecorativeDisplay(DecorativeDisplay* decoDisplay)
         {
             _bone->setChildArmature(nullptr);
         }
-        _displayRenderNode->removeFromParentAndCleanup(true);
+        _displayRenderNode->removeFromParent();
         _displayRenderNode->release();
     }
 

--- a/extensions/cocostudio/src/cocostudio/DisplayManager.h
+++ b/extensions/cocostudio/src/cocostudio/DisplayManager.h
@@ -1,5 +1,6 @@
 /****************************************************************************
 Copyright (c) 2013-2017 Chukong Technologies Inc.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -7018,7 +7018,7 @@ int lua_ax_base_Node_getParent(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Node_removeFromParentAndCleanup(lua_State* tolua_S)
+int lua_ax_base_Node_removeFromParent(lua_State* tolua_S)
 {
     int argc = 0;
     ax::Node* cobj = nullptr;
@@ -7034,7 +7034,7 @@ int lua_ax_base_Node_removeFromParentAndCleanup(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Node_removeFromParentAndCleanup'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Node_removeFromParent'", nullptr);
         return 0;
     }
 #endif
@@ -7042,10 +7042,10 @@ int lua_ax_base_Node_removeFromParentAndCleanup(lua_State* tolua_S)
     do{
         if (argc == 1) {
             bool arg0;
-            ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.Node:removeFromParentAndCleanup");
+            ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.Node:removeFromParent");
 
             if (!ok) { break; }
-            cobj->removeFromParentAndCleanup(arg0);
+            cobj->removeFromParent(arg0);
             lua_settop(tolua_S, 1);
             return 1;
         }
@@ -7059,12 +7059,12 @@ int lua_ax_base_Node_removeFromParentAndCleanup(lua_State* tolua_S)
         }
     }while(0);
     ok  = true;
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.Node:removeFromParent",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d or %d \n",  "ax.Node:removeFromParent",argc, 0, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Node_removeFromParentAndCleanup'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Node_removeFromParent'.",&tolua_err);
 #endif
 
     return 0;
@@ -11821,7 +11821,7 @@ int lua_register_ax_base_Node(lua_State* tolua_S)
         tolua_function(tolua_S,"getChildrenCount",lua_ax_base_Node_getChildrenCount);
         tolua_function(tolua_S,"setParent",lua_ax_base_Node_setParent);
         tolua_function(tolua_S,"getParent",lua_ax_base_Node_getParent);
-        tolua_function(tolua_S,"removeFromParent",lua_ax_base_Node_removeFromParentAndCleanup);
+        tolua_function(tolua_S,"removeFromParent",lua_ax_base_Node_removeFromParent);
         tolua_function(tolua_S,"removeChild",lua_ax_base_Node_removeChild);
         tolua_function(tolua_S,"removeChildByTag",lua_ax_base_Node_removeChildByTag);
         tolua_function(tolua_S,"removeChildByName",lua_ax_base_Node_removeChildByName);


### PR DESCRIPTION
## Describe your changes
This change removes the Node::removeFromParentAndCleanup function, and instead gives Node::removeFromParent and optional bool for if the node should be cleaned up or not.

This defaults to true, since the original intention was that it would cleanup the memory by default, and only not cleanup the memory when told to do so by the programmer with the old Node::removeFromParentAndCleanup function.

I've also added missing licenses for the Inspector.cpp/.h files, and the other C++ and header files I had to modify that were using the old function.

Now that I'm thinking about it, this will probably cause some tests to fail to be compiled. This PR is likely going to need some additional work, but I don't have time this week to work on this issue more. If anyone else wants to take it upon themselves to fix any broken tests, then feel free! Otherwise, I might have time next week to fix any broken tests caused by this refactor.

## Issue ticket number and link
#1837 Specifically the suggestion that @smilediver had, well mostly anyways. I've described why I believe defaulting it to true is better than requiring the programmer to manually add a bool for cleanup on that thread.

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
