### PR TITLE
Cleanup cc stubs

### DIFF
--- a/core/2d/Grid.cpp
+++ b/core/2d/Grid.cpp
@@ -51,8 +51,8 @@ bool GridBase::initWithSize(const Vec2& gridSize, const ax::Rect& rect)
     Director* director = Director::getInstance();
     Vec2 s             = director->getWinSizeInPixels();
 
-    auto POTWide = ccNextPOT((unsigned int)s.width);
-    auto POTHigh = ccNextPOT((unsigned int)s.height);
+    auto POTWide = utils::nextPOT((unsigned int)s.width);
+    auto POTHigh = utils::nextPOT((unsigned int)s.height);
 
     Texture2D* texture = new Texture2D();
 

--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -180,8 +180,8 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         }
         else
         {
-            powW = ccNextPOT(w);
-            powH = ccNextPOT(h);
+            powW = utils::nextPOT(w);
+            powH = utils::nextPOT(h);
         }
 
         backend::TextureDescriptor descriptor;

--- a/core/base/Utils.cpp
+++ b/core/base/Utils.cpp
@@ -78,13 +78,13 @@ inline int decBound(int sourceLen)
 
 int nextPOT(int x)
 {
-    x = x - 1;
-    x = x | (x >> 1);
-    x = x | (x >> 2);
-    x = x | (x >> 4);
-    x = x | (x >> 8);
-    x = x | (x >> 16);
-    return x + 1;
+    --x;
+    x |= (x >> 1);
+    x |= (x >> 2);
+    x |= (x >> 4);
+    x |= (x >> 8);
+    x |= (x >> 16);
+    return ++x;
 }
 
 /*

--- a/core/base/Utils.cpp
+++ b/core/base/Utils.cpp
@@ -62,17 +62,6 @@ using namespace std::string_view_literals;
 
 NS_AX_BEGIN
 
-int ccNextPOT(int x)
-{
-    x = x - 1;
-    x = x | (x >> 1);
-    x = x | (x >> 2);
-    x = x | (x >> 4);
-    x = x | (x >> 8);
-    x = x | (x >> 16);
-    return x + 1;
-}
-
 namespace utils
 {
 namespace base64
@@ -86,6 +75,17 @@ inline int decBound(int sourceLen)
     return sourceLen / 4 * 3 + 1;
 }
 }  // namespace base64
+
+int nextPOT(int x)
+{
+    x = x - 1;
+    x = x | (x >> 1);
+    x = x | (x >> 2);
+    x = x | (x >> 4);
+    x = x | (x >> 8);
+    x = x | (x >> 16);
+    return x + 1;
+}
 
 /*
  * Capture screen interface

--- a/core/base/Utils.h
+++ b/core/base/Utils.h
@@ -43,10 +43,12 @@ Misc free functions
 */
 
 NS_AX_BEGIN
-/*
-ccNextPOT function is licensed under the same license that is used in Texture2D.m.
-*/
 
+class Sprite;
+class Image;
+
+namespace utils
+{
 /** Returns the Next Power of Two value.
 
 Examples:
@@ -55,16 +57,10 @@ Examples:
 - If "value" is 17, it will return 32.
 @param value The value to get next power of two.
 @return Returns the next power of two value.
-@since v0.99.5
+@since axmol-2.1.3: move ax::ccNextPOT to ax::utils::nextPOT
 */
+int nextPOT(int value);
 
-int ccNextPOT(int value);
-
-class Sprite;
-class Image;
-
-namespace utils
-{
 /** Capture the entire screen.
  * To ensure the snapshot is applied after everything is updated and rendered in the current frame,
  * we need to wrap the operation with a custom command which is then inserted into the tail of the render queue.

--- a/core/platform/Common.h
+++ b/core/platform/Common.h
@@ -38,14 +38,9 @@ NS_AX_BEGIN
  */
 
 /**
- * lua can not deal with ...
- */
-void AX_DLL LuaLog(const char* format);
-
-/**
 @brief Pop out a message box
 */
-void AX_DLL ccMessageBox(const char* msg, const char* title);
+void AX_DLL messageBox(const char* msg, const char* title);
 
 /**
 @brief Enum the language type supported now

--- a/core/platform/GLViewImpl.cpp
+++ b/core/platform/GLViewImpl.cpp
@@ -493,7 +493,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
             message.append(_glfwError);
         }
 
-        ccMessageBox(message.c_str(), "Error launch application");
+        messageBox(message.c_str(), "Error launch application");
         utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
         return false;
     }

--- a/core/platform/Image.cpp
+++ b/core/platform/Image.cpp
@@ -1481,8 +1481,8 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
         AXLOG("axmol: WARNING: Image is flipped. Regenerate it using PVRTexTool");
     }
 
-    if (!configuration->supportsNPOT() && (static_cast<int>(header->width) != ccNextPOT(header->width) ||
-                                           static_cast<int>(header->height) != ccNextPOT(header->height)))
+    if (!configuration->supportsNPOT() && (static_cast<int>(header->width) != utils::nextPOT(header->width) ||
+                                           static_cast<int>(header->height) != utils::nextPOT(header->height)))
     {
         AXLOG("axmol: ERROR: Loading an NPOT texture (%dx%d) but is not supported on this device", header->width,
               header->height);

--- a/core/platform/android/Common-android.cpp
+++ b/core/platform/android/Common-android.cpp
@@ -33,14 +33,9 @@ NS_AX_BEGIN
 
 #define MAX_LEN (ax::kMaxLogLen + 1)
 
-void ccMessageBox(const char* pszMsg, const char* pszTitle)
+void messageBox(const char* pszMsg, const char* pszTitle)
 {
     JniHelper::callStaticVoidMethod("org.axmol.lib.AxmolEngine", "showDialog", pszTitle, pszMsg);
-}
-
-void LuaLog(const char* pszFormat)
-{
-    __android_log_write(ANDROID_LOG_DEBUG, "cocos2d-x debug info", pszFormat);
 }
 
 NS_AX_END

--- a/core/platform/ios/Common-ios.mm
+++ b/core/platform/ios/Common-ios.mm
@@ -36,7 +36,7 @@
 NS_AX_BEGIN
 
 // ios no MessageBox, use log instead
-void ccMessageBox(const char* msg, const char* title)
+void messageBox(const char* msg, const char* title)
 {
     // only enable it on iOS.
     // FIXME: Implement it for tvOS
@@ -57,11 +57,6 @@ void ccMessageBox(const char* msg, const char* title)
     auto rootViewController = [UIApplication sharedApplication].windows[0].rootViewController;
     [rootViewController presentViewController:alertController animated:YES completion:nil];
 #endif
-}
-
-void LuaLog(const char* format)
-{
-    puts(format);
 }
 
 NS_AX_END

--- a/core/platform/linux/Common-linux.cpp
+++ b/core/platform/linux/Common-linux.cpp
@@ -30,14 +30,9 @@ THE SOFTWARE.
 
 NS_AX_BEGIN
 
-void ccMessageBox(const char* msg, const char* title)
+void messageBox(const char* msg, const char* title)
 {
     AXLOGE("{}: {}", title, msg);
-}
-
-void LuaLog(const char* format)
-{
-    puts(format);
 }
 
 NS_AX_END

--- a/core/platform/mac/Common-mac.mm
+++ b/core/platform/mac/Common-mac.mm
@@ -33,13 +33,8 @@ THE SOFTWARE.
 
 NS_AX_BEGIN
 
-void LuaLog(const char* format)
-{
-    puts(format);
-}
-
 // ios no MessageBox, use log instead
-void ccMessageBox(const char* msg, const char* title)
+void messageBox(const char* msg, const char* title)
 {
     NSString* tmpTitle = (title) ? [NSString stringWithUTF8String:title] : nil;
     NSString* tmpMsg   = (msg) ? [NSString stringWithUTF8String:msg] : nil;

--- a/core/platform/wasm/Common-wasm.cpp
+++ b/core/platform/wasm/Common-wasm.cpp
@@ -35,16 +35,11 @@ THE SOFTWARE.
 
 NS_AX_BEGIN
 
-void ccMessageBox(const char * msg, const char * title)
+void messageBox(const char * msg, const char * title)
 {
     EM_ASM_ARGS({
         window.alert(UTF8ToString($0) + ": " + UTF8ToString($1));
     }, title, msg);
-}
-
-void LuaLog(const char * format)
-{
-    puts(format);
 }
 
 NS_AX_END

--- a/core/platform/win32/Common-win32.cpp
+++ b/core/platform/win32/Common-win32.cpp
@@ -31,20 +31,11 @@ NS_AX_BEGIN
 
 #define MAX_LEN (ax::kMaxLogLen + 1)
 
-void ccMessageBox(const char* pszMsg, const char* pszTitle)
+void messageBox(const char* pszMsg, const char* pszTitle)
 {
     std::wstring wsMsg   = ntcvt::from_chars(pszMsg);
     std::wstring wsTitle = ntcvt::from_chars(pszTitle);
     MessageBoxW(nullptr, wsMsg.c_str(), wsTitle.c_str(), MB_OK);
-}
-
-void LuaLog(const char* pszMsg)
-{
-    auto wsMsg = ntcvt::from_chars(pszMsg);
-    OutputDebugStringW(wsMsg.c_str());
-    OutputDebugStringW(L"\n");
-
-    _putws(wsMsg.c_str());
 }
 
 NS_AX_END

--- a/core/platform/winrt/Common-winrt.cpp
+++ b/core/platform/winrt/Common-winrt.cpp
@@ -34,36 +34,12 @@ THE SOFTWARE.
 
 NS_AX_BEGIN
 
-
-void ccMessageBox(const char * pszMsg, const char * pszTitle)
+void messageBox(const char * pszMsg, const char * pszTitle)
 {
     // Create the message dialog and set its content
     auto message = PlatformStringFromString(pszMsg);
     auto title = PlatformStringFromString(pszTitle);
     GLViewImpl::sharedGLView()->ShowMessageBox(title, message);
-}
-
-void LuaLog(const char *pszMsg)
-{
-#if defined(_AX_DEBUG)
-    int bufflen = MultiByteToWideChar(CP_UTF8, 0, pszMsg, -1, NULL, 0);
-    WCHAR* widebuff = new WCHAR[bufflen + 1];
-    memset(widebuff, 0, sizeof(WCHAR) * (bufflen + 1));
-    MultiByteToWideChar(CP_UTF8, 0, pszMsg, -1, widebuff, bufflen);
-
-
-    OutputDebugStringW(widebuff);
-    OutputDebugStringA("\n");
-
-	bufflen = WideCharToMultiByte(CP_ACP, 0, widebuff, -1, NULL, 0, NULL, NULL);
-	char* buff = new char[bufflen + 1];
-	memset(buff, 0, sizeof(char) * (bufflen + 1));
-	WideCharToMultiByte(CP_ACP, 0, widebuff, -1, buff, bufflen, NULL, NULL);
-	puts(buff);
-
-	delete[] widebuff;
-	delete[] buff;
-#endif
 }
 
 NS_AX_END

--- a/core/renderer/Texture2D.cpp
+++ b/core/renderer/Texture2D.cpp
@@ -398,7 +398,7 @@ bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
             outDataLen = 0;
         }
 
-        if (i > 0 && (width != height || ccNextPOT(width) != width))
+        if (i > 0 && (width != height || utils::nextPOT(width) != width))
         {
             AXLOG(
                 "axmol: Texture2D. WARNING. Mipmap level %u is not squared. Texture won't render correctly. width=%d "
@@ -727,7 +727,7 @@ void Texture2D::setTexParameters(const Texture2D::TexParams& desc)
 
 void Texture2D::generateMipmap()
 {
-    AXASSERT(_pixelsWide == ccNextPOT(_pixelsWide) && _pixelsHigh == ccNextPOT(_pixelsHigh),
+    AXASSERT(_pixelsWide == utils::nextPOT(_pixelsWide) && _pixelsHigh == utils::nextPOT(_pixelsHigh),
              "Mipmap texture only works in POT textures");
 
     _texture->generateMipmaps();

--- a/core/renderer/backend/opengl/DriverGL.cpp
+++ b/core/renderer/backend/opengl/DriverGL.cpp
@@ -137,7 +137,7 @@ DriverGL::DriverGL()
                 "OpeGL ES %d.%d+ is required (your version is %s). Please upgrade the driver of your video card.",
                 REQUIRED_GLES_MAJOR, AX_GLES_PROFILE % AX_GLES_PROFILE, _version);
 #endif
-        ccMessageBox(strComplain, "OpenGL version too old");
+        messageBox(strComplain, "OpenGL version too old");
         utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
         return;
     }

--- a/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
@@ -1,5 +1,6 @@
 
 #include "EffekseerForCocos2d-x.h"
+#include "base/Utils.h"
 
 #ifdef AX_USE_METAL
 #include "renderer/backend/DriverBase.h"
@@ -41,17 +42,6 @@ void CleanupTextureData(::Effekseer::TextureRef textureData);
 ::EffekseerRenderer::DistortingCallback* CreateDistortingCallback(::EffekseerRenderer::RendererRef, Effekseer::RefPtr<::EffekseerRenderer::CommandList>);
 
 void ResetBackground(::EffekseerRenderer::RendererRef renderer);
-
-int ccNextPOT(int x)
-{
-	x = x - 1;
-	x = x | (x >> 1);
-	x = x | (x >> 2);
-	x = x | (x >> 4);
-	x = x | (x >> 8);
-	x = x | (x >> 16);
-	return x + 1;
-}
 
 static std::u16string getFilenameWithoutExt(const char16_t* path)
 {
@@ -216,8 +206,8 @@ Effekseer::TextureRef TextureLoader::Load(const EFK_CHAR* path, ::Effekseer::Tex
 #ifdef AX_USE_METAL
 					texture->generateMipmap();
 #else
-					if (texture->getPixelsWide() == ccNextPOT(texture->getPixelsWide()) &&
-						texture->getPixelsHigh() == ccNextPOT(texture->getPixelsHigh()))
+					if (texture->getPixelsWide() == ax::utils::nextPOT(texture->getPixelsWide()) &&
+						texture->getPixelsHigh() == ax::utils::nextPOT(texture->getPixelsHigh()))
 					{
 						texture->generateMipmap();
 					}


### PR DESCRIPTION
1. Rename ax::ccMessageBox to ax::messageBox
2. Remove unused API: ax::LuaLog
3. Move ax::ccNextPOT to ax::utils::nextPOT

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
