### PR TITLE
[Apple] Fix media controls not appearing

### DIFF
--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -817,8 +817,6 @@ void BasicMediaController::updateControlsForContentSize(const Vec2& contentSize)
     _fullScreenExitButton->setPositionNormalized(Vec2(0.03f, 0.97f));
 }
 
-const char* MediaPlayer::FULLSCREEN_SWITCH = "__ax_VIDEO_FULLSCREEN_SWITCH";
-
 MediaPlayer::MediaPlayer()
 {
     auto pvd      = new PrivateVideoDescriptor{};
@@ -1140,8 +1138,7 @@ void MediaPlayer::setFullScreenEnabled(bool enabled)
             _mediaController->setContentSize(contentSize);
         }
 
-        auto eventDispatcher = Director::getInstance()->getEventDispatcher();
-        eventDispatcher->dispatchCustomEvent(FULLSCREEN_SWITCH, this);
+        sendEvent((int)EventType::FULLSCREEN_SWITCH);
     }
 }
 
@@ -1315,6 +1312,11 @@ void MediaPlayer::onPlayEvent(int event)
 {
     _isPlaying = (event == (int)MediaPlayer::EventType::PLAYING);
 
+    sendEvent(event);
+}
+
+void MediaPlayer::sendEvent(int event)
+{
     if (_eventCallback)
     {
         _director->getScheduler()->runOnAxmolThread(std::bind(_eventCallback, this, (MediaPlayer::EventType)event));

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -469,6 +469,14 @@ bool BasicMediaController::init()
 void BasicMediaController::initRenderer()
 {
     Widget::initRenderer();
+    
+    // scheduleOnce is used to create the controls on the next update
+    // loop. This is a work-around for a RenderTexture issue
+    // when being created such places as a button click event handler
+    // on Apple platforms/Metal renderer backend
+    scheduleOnce([this](float){
+        createControls();
+    }, 0.f, "__create_video_controls"sv);
 }
 
 void BasicMediaController::onPressStateChangedToPressed()
@@ -517,7 +525,6 @@ void BasicMediaController::update(float delta)
 void BasicMediaController::onEnter()
 {
     Widget::onEnter();
-    createControls();
     scheduleUpdate();
 }
 

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -677,7 +677,7 @@ void BasicMediaController::createControls()
     });
     _fullScreenEnterButton->setSwallowTouches(false);
     _fullScreenEnterButton->setAnchorPoint(Vec2::ANCHOR_TOP_LEFT);
-    _fullScreenEnterButton->setPositionNormalized(Vec2(0.05f, 0.95f));
+    _fullScreenEnterButton->setPositionNormalized(Vec2(0.03f, 0.97f));
     _fullScreenEnterButton->setCascadeOpacityEnabled(true);
     _fullScreenEnterButton->setVisible(false);
     _fullScreenEnterButton->setScale(1 / scale);
@@ -693,7 +693,7 @@ void BasicMediaController::createControls()
     });
     _fullScreenExitButton->setSwallowTouches(false);
     _fullScreenExitButton->setAnchorPoint(Vec2::ANCHOR_TOP_LEFT);
-    _fullScreenExitButton->setPositionNormalized(Vec2(0.15f, 0.95f));
+    _fullScreenExitButton->setPositionNormalized(Vec2(0.03f, 0.97f));
     _fullScreenExitButton->setCascadeOpacityEnabled(true);
     _fullScreenExitButton->setVisible(false);
     _fullScreenExitButton->setScale(1 / scale);

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -278,7 +278,7 @@ void createMediaControlTexture()
         Vec2(border + (i * panelW) + (i * gap) + (panelW / 2.f), imageSize.height - border - (panelH / 2.f));
         item.second(midPoint);
 
-#if defined(AX_USE_GL) || defined(AX_USE_GLES)
+#if defined(AX_USE_GL)
         g_mediaControlTextureRegions[item.first] =
         Rect(border + (panelW * i) + (gap * i), imageSize.height - border - panelH, panelW, panelH);
 #else // For Metal renderer

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -433,7 +433,7 @@ void MediaPlayerControl::onPressStateChangedToDisabled()
 }
 
 BasicMediaController::BasicMediaController(MediaPlayer* player)
-    : MediaController(player)
+    : MediaController(player), _timelineBarHeight(TIMELINE_BAR_HEIGHT)
 {
 }
 
@@ -573,6 +573,15 @@ void BasicMediaController::updateControllerState()
     }
 }
 
+void BasicMediaController::setTimelineBarHeight(float height)
+{
+    _timelineBarHeight = height;
+    if (_timelineBarHeight < TIMELINE_BAR_HEIGHT)
+        _timelineBarHeight = TIMELINE_BAR_HEIGHT;
+
+    updateControlsForContentSize(getContentSize());
+}
+
 void BasicMediaController::createControls()
 {
     createMediaControlTexture();
@@ -697,7 +706,7 @@ void BasicMediaController::createControls()
     _timelineTotal->setColor(Color3B::GRAY);
     _timelineTotal->setVisible(false);
     _timelineTotal->setCascadeOpacityEnabled(true);
-    _timelineTotal->setContentSize(Size(contentSize.width - 40, TIMELINE_BAR_HEIGHT / scale));
+    _timelineTotal->setContentSize(Size(contentSize.width - 40, _timelineBarHeight / scale));
     _controlPanel->addProtectedChild(_timelineTotal, 1);
 
     _timelinePlayed = utils::createSpriteFromBase64Cached(BODY_IMAGE_1_PIXEL_HEIGHT, BODY_IMAGE_1_PIXEL_HEIGHT_KEY);
@@ -714,7 +723,7 @@ void BasicMediaController::createControls()
     _timelineSelector->setPositionNormalized(Vec2(1.f, 0.5f));
     _timelineSelector->setCascadeOpacityEnabled(true);
     _timelineSelector->setStretchEnabled(true);
-    _timelineSelector->setContentSize(Size(TIMELINE_BAR_HEIGHT, TIMELINE_BAR_HEIGHT) * 1.5f / scale);
+    _timelineSelector->setContentSize(Size(_timelineBarHeight, _timelineBarHeight) * 1.5f / scale);
     _timelineSelector->setVisible(false);
     _timelinePlayed->addChild(_timelineSelector, 10);
 
@@ -790,8 +799,8 @@ void BasicMediaController::updateControlsForContentSize(const Vec2& contentSize)
 
     auto scale = Director::getInstance()->getGLView()->getScaleY();
     _primaryButtonPanel->setScale(1 / scale);
-    _timelineTotal->setContentSize(Size(contentSize.width - 40, TIMELINE_BAR_HEIGHT / scale));
-    _timelineSelector->setContentSize(Size(TIMELINE_BAR_HEIGHT, TIMELINE_BAR_HEIGHT) * 1.5f / scale);
+    _timelineTotal->setContentSize(Size(contentSize.width - 40, _timelineBarHeight / scale));
+    _timelineSelector->setContentSize(Size(_timelineBarHeight, _timelineBarHeight) * 1.5f / scale);
     _fullScreenEnterButton->setScale(1 / scale);
     _fullScreenExitButton->setScale(1 / scale);
 

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -817,6 +817,7 @@ void BasicMediaController::updateControlsForContentSize(const Vec2& contentSize)
     _fullScreenExitButton->setPositionNormalized(Vec2(0.03f, 0.97f));
 }
 
+const char* MediaPlayer::FULLSCREEN_SWITCH = "__ax_VIDEO_FULLSCREEN_SWITCH";
 
 MediaPlayer::MediaPlayer()
 {
@@ -1138,6 +1139,9 @@ void MediaPlayer::setFullScreenEnabled(bool enabled)
         {
             _mediaController->setContentSize(contentSize);
         }
+
+        auto eventDispatcher = Director::getInstance()->getEventDispatcher();
+        eventDispatcher->dispatchCustomEvent(FULLSCREEN_SWITCH, this);
     }
 }
 

--- a/core/ui/UIMediaPlayer.h
+++ b/core/ui/UIMediaPlayer.h
@@ -144,8 +144,6 @@ protected:
 class AX_GUI_DLL MediaPlayer : public ax::ui::Widget
 {
 public:
-    static const char* FULLSCREEN_SWITCH;
-
     /**
      * Videoplayer play event type.
      */
@@ -155,7 +153,8 @@ public:
         PAUSED,
         STOPPED,
         COMPLETED,
-        ERROR
+        ERROR,
+        FULLSCREEN_SWITCH
     };
 
     enum class MediaState
@@ -346,6 +345,7 @@ public:
      * @param event @see MediaPlayer::EventType.
      */
     virtual void onPlayEvent(int event);
+
     void setVisible(bool visible) override;
     void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
     void onEnter() override;
@@ -370,6 +370,7 @@ protected:
     ax::ui::Widget* createCloneInstance() override;
     void copySpecialProperties(Widget* model) override;
     virtual void updateMediaController();
+    void sendEvent(int event);
 
 #    if AX_VIDEOPLAYER_DEBUG_DRAW
     DrawNode* _debugDrawNode;

--- a/core/ui/UIMediaPlayer.h
+++ b/core/ui/UIMediaPlayer.h
@@ -144,6 +144,8 @@ protected:
 class AX_GUI_DLL MediaPlayer : public ax::ui::Widget
 {
 public:
+    static const char* FULLSCREEN_SWITCH;
+
     /**
      * Videoplayer play event type.
      */

--- a/core/ui/UIMediaPlayer.h
+++ b/core/ui/UIMediaPlayer.h
@@ -127,6 +127,7 @@ protected:
     EventListenerTouchOneByOne* _timelineTouchListener = nullptr;
     float _playRate                                    = 1.f;
     std::chrono::steady_clock::time_point _lastTouch;
+    bool _controlsReady = false;
 };
 
 /**

--- a/core/ui/UIMediaPlayer.h
+++ b/core/ui/UIMediaPlayer.h
@@ -58,6 +58,7 @@ public:
     ~MediaController() override = 0;
 
     virtual void updateControllerState() = 0;
+    virtual void setTimelineBarHeight(float height) = 0;
 
 protected:
     MediaPlayer* _mediaPlayer = nullptr;
@@ -103,6 +104,7 @@ public:
     void setGlobalZOrder(float globalZOrder) override;
 
     void updateControllerState() override;
+    void setTimelineBarHeight(float height) override;
 
     virtual void createControls();
     virtual void updateControlsGlobalZ(float globalZOrder);
@@ -127,7 +129,8 @@ protected:
     EventListenerTouchOneByOne* _timelineTouchListener = nullptr;
     float _playRate                                    = 1.f;
     std::chrono::steady_clock::time_point _lastTouch;
-    bool _controlsReady = false;
+    bool _controlsReady      = false;
+    float _timelineBarHeight;
 };
 
 /**
@@ -356,6 +359,7 @@ public:
     MediaState getState() const;
 
     void setMediaController(MediaController* controller);
+    MediaController* getMediaController() const { return _mediaController; }
 
     MediaPlayer();
     ~MediaPlayer() override;


### PR DESCRIPTION
## Describe your changes
This allows the media controls texture to be created correctly on both OpenGL and Metal renderer backends.

Added support for changing the height of the media timeline bar.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
