### PR TITLE
Fix Upload to MacAppStore

### DIFF
--- a/templates/cpp/CMakeLists.txt
+++ b/templates/cpp/CMakeLists.txt
@@ -152,7 +152,6 @@ elseif(APPLE)
     elseif(MACOSX)
         set(APP_UI_RES
             proj.ios_mac/mac/Icon.icns
-            proj.ios_mac/mac/Info.plist
             )
         list(APPEND GAME_SOURCE
              proj.ios_mac/mac/main.cpp


### PR DESCRIPTION

## Describe your changes
Info.plist  is set multiple times in the CMake project and this causes a failure to upload to the MacAppStore with shared bundle path failure as the same asset is in 2 places.

Removed  one instance of Info.plist from CMakelists.txt so it's not double included in a mac project - shouldn't be in the Resources folder should just be in the root of the app folder

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x ] I have performed a self-review of my code.
       
   Optional:
   - [x ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ x] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
