### PR TITLE
Fix accidental removal of break statement

### DIFF
--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -1191,6 +1191,7 @@ void MediaPlayer::play()
             case MEMediaState::Closed:
                 engine->setAutoPlay(true);
                 engine->open(_videoURL);
+                break;
             default:
                 engine->play();
             }


### PR DESCRIPTION
## Describe your changes

Re-add `break` statement that was accidentally removed.
 
## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
