### PR TITLE
Fix FileUtils on macOS

### DIFF
--- a/core/platform/FileUtils.cpp
+++ b/core/platform/FileUtils.cpp
@@ -754,14 +754,14 @@ std::string FileUtils::fullPathForDirectory(std::string_view dir) const
                 }
             }
 
-            if (result.empty() and isPopupNotify())
+            if (result.empty() && isPopupNotify())
             {
                 AXLOG("axmol: fullPathForDirectory: No directory found at %s. Possible missing directory.", dir.data());
             }
         }
     }
 
-    if (not result.empty() and result.back() != '/')
+    if (!result.empty() && result.back() != '/')
     {
         result += '/';
     }

--- a/core/platform/FileUtils.cpp
+++ b/core/platform/FileUtils.cpp
@@ -715,48 +715,58 @@ std::string FileUtils::fullPathForDirectory(std::string_view dir) const
 {
     DECLARE_GUARD;
 
+    auto result = std::string();
+
     if (dir.empty())
     {
-        return "";
+        // result is ""
     }
-
-    if (isAbsolutePath(dir))
+    else if (isAbsolutePath(dir))
     {
-        return std::string{dir};
+        result = dir;
     }
-
-    // Already Cached ?
-    auto cacheIter = _fullPathCacheDir.find(dir);
-    if (cacheIter != _fullPathCacheDir.end())
+    else
     {
-        return cacheIter->second;
-    }
-    std::string longdir{dir};
-    std::string fullpath;
-
-    if (longdir[longdir.length() - 1] != '/')
-    {
-        longdir += "/";
-    }
-
-    for (const auto& searchIt : _searchPathArray)
-    {
-        fullpath = this->getPathForDirectory(longdir, searchIt);
-        if (!fullpath.empty() && isDirectoryExistInternal(fullpath))
+        // Already Cached ?
+        auto cacheIter = _fullPathCacheDir.find(dir);
+        if (cacheIter != _fullPathCacheDir.end())
         {
-            // Using the filename passed in as key.
-            _fullPathCacheDir.emplace(dir, fullpath);
-            return fullpath;
+            result = cacheIter->second;
+        }
+        else
+        {
+            std::string longdir{dir};
+
+            if (longdir[longdir.length() - 1] != '/')
+            {
+                longdir += "/";
+            }
+
+            for (const auto& searchIt : _searchPathArray)
+            {
+                auto fullpath = this->getPathForDirectory(longdir, searchIt);
+                if (!fullpath.empty() && isDirectoryExistInternal(fullpath))
+                {
+                    // Using the filename passed in as key.
+                    _fullPathCacheDir.emplace(dir, fullpath);
+                    result = fullpath;
+                    break;
+                }
+            }
+
+            if (result.empty() and isPopupNotify())
+            {
+                AXLOG("axmol: fullPathForDirectory: No directory found at %s. Possible missing directory.", dir.data());
+            }
         }
     }
 
-    if (isPopupNotify())
+    if (not result.empty() and result.back() != '/')
     {
-        AXLOG("axmol: fullPathForDirectory: No directory found at %s. Possible missing directory.", dir.data());
+        result += '/';
     }
 
-    // The file wasn't found, return empty string.
-    return "";
+    return result;
 }
 
 std::string FileUtils::fullPathFromRelativeFile(std::string_view filename, std::string_view relativeFile) const

--- a/core/platform/FileUtils.cpp
+++ b/core/platform/FileUtils.cpp
@@ -1330,7 +1330,7 @@ int64_t FileUtils::getFileSize(std::string_view filepath) const
     {
         fullpath = fullPathForFilename(filepath);
         if (fullpath.empty())
-            return 0;
+            return -1;
         path = fullpath;
     }
     else

--- a/core/platform/apple/FileUtils-apple.h
+++ b/core/platform/apple/FileUtils-apple.h
@@ -48,7 +48,9 @@ class AX_DLL FileUtilsApple : public FileUtils
 public:
     FileUtilsApple();
     virtual ~FileUtilsApple();
-    /* override functions */
+
+    virtual bool init() override;
+
     virtual std::string getWritablePath() const override;
     virtual std::string getNativeWritableAbsolutePath() const override;
     virtual std::string getFullPathForFilenameWithinDirectory(std::string_view directory,

--- a/core/platform/apple/FileUtils-apple.mm
+++ b/core/platform/apple/FileUtils-apple.mm
@@ -63,6 +63,14 @@ FileUtilsApple::FileUtilsApple() : pimpl_(new IMPL([NSBundle mainBundle])) {}
 
 FileUtilsApple::~FileUtilsApple() = default;
 
+bool FileUtilsApple::init()
+{
+    _defaultResRootPath = appendTrailingSlashToDir([[[NSBundle mainBundle] resourcePath] UTF8String]);
+
+    bool ret = FileUtils::init();
+    return ret;
+}
+
 #if AX_FILEUTILS_APPLE_ENABLE_OBJC
 void FileUtilsApple::setBundle(NSBundle* bundle)
 {

--- a/core/platform/apple/FileUtils-apple.mm
+++ b/core/platform/apple/FileUtils-apple.mm
@@ -51,6 +51,14 @@ private:
     NSBundle* bundle_;
 };
 
+static std::string appendTrailingSlashToDir(std::string_view dir)
+{
+    auto result = std::string(dir);
+    if (not result.empty() and result.back() != '/')
+        result.push_back('/');
+    return result;
+}
+
 FileUtilsApple::FileUtilsApple() : pimpl_(new IMPL([NSBundle mainBundle])) {}
 
 FileUtilsApple::~FileUtilsApple() = default;
@@ -188,7 +196,7 @@ std::string FileUtilsApple::getPathForDirectory(std::string_view dir,
         BOOL isDir = false;
         if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:path.data()] isDirectory:&isDir])
         {
-            return isDir ? path : "";
+            return appendTrailingSlashToDir(isDir ? path : "");
         }
     }
     else
@@ -197,7 +205,7 @@ std::string FileUtilsApple::getPathForDirectory(std::string_view dir,
                                                            ofType:nil];
         if (fullpath != nil)
         {
-            return [fullpath UTF8String];
+            return appendTrailingSlashToDir([fullpath UTF8String]);
         }
     }
     return "";


### PR DESCRIPTION
This PR fixes the following issues that `unit-tests` have exposed on macOS.

* Fix `FileUtils::getFileSize()` returning 0 instead of -1 when file is not found
* Fix `FileUtils::fullPathForDirectory()` not returning path with a trailing slash
* Fix `FileUtils::getDefaultResourceRootPath()` returning empty string on macOS
* Fix `FileUtils::isFileExist()` returning true for directories on macOS