### PR TITLE
Media controller content size should be based on video size not media player size

### DIFF
--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -1146,10 +1146,6 @@ void MediaPlayer::setFullScreenEnabled(bool enabled)
         auto pvd               = reinterpret_cast<PrivateVideoDescriptor*>(_videoContext);
         const auto contentSize = enabled ? _director->getGLView()->getDesignResolutionSize() : pvd->_originalViewSize;
         Widget::setContentSize(contentSize);
-        if (_mediaController)
-        {
-            _mediaController->setContentSize(contentSize);
-        }
 
         sendEvent((int)EventType::FULLSCREEN_SWITCH);
     }


### PR DESCRIPTION
## Describe your changes
This change will ensure that the media controller buttons remain within the video frame boundary.  The `MediaPlayer` size is not relevant in this case, since the controls need to be within the rendered frame size, which is controlled in `PrivateVideoDescriptor::rescaleTo()`.  

This fixes the issue of the media controls moving out of the boundary of the video frame.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
