### PR TITLE
[Spine] Fix two color tint data not being copied across to backend buffer on first frame

### DIFF
--- a/extensions/spine/src/spine/SkeletonRenderer.cpp
+++ b/extensions/spine/src/spine/SkeletonRenderer.cpp
@@ -406,25 +406,28 @@ namespace spine {
 					triangles.indices = batch->allocateIndices(triangles.indexCount);
 					memcpy(triangles.indices, _clipper->getClippedTriangles().buffer(), sizeof(unsigned short) * _clipper->getClippedTriangles().size());
 
-					axmol::TrianglesCommand *batchedTriangles = batch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
-
-					const float *verts = _clipper->getClippedVertices().buffer();
-					const float *uvs = _clipper->getClippedUVs().buffer();
-                    V3F_C4B_T2F *vertex = batchedTriangles->getTriangles().verts;
-                    for (int v = 0, vn = batchedTriangles->getTriangles().vertCount, vv = 0; v < vn; ++v, vv += 2, ++vertex) {
-                        vertex->vertices.x = verts[vv];
-                        vertex->vertices.y = verts[vv + 1];
+                    const float* verts  = _clipper->getClippedVertices().buffer();
+                    const float* uvs    = _clipper->getClippedUVs().buffer();
+                    V3F_C4B_T2F* vertex = triangles.verts;
+                    for (int v = 0, vn = triangles.vertCount, vv = 0; v < vn;
+                         ++v, vv += 2, ++vertex)
+                    {
+                        vertex->vertices.x  = verts[vv];
+                        vertex->vertices.y  = verts[vv + 1];
                         vertex->texCoords.u = uvs[vv];
                         vertex->texCoords.v = uvs[vv + 1];
-                        vertex->colors = color4B;
+                        vertex->colors      = color4B;
                     }
+					batch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
 				} else {
 					// Not clipping.
-					axmol::TrianglesCommand *batchedTriangles = batch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
-                    V3F_C4B_T2F *vertex = batchedTriangles->getTriangles().verts;
-                    for (int v = 0, vn = batchedTriangles->getTriangles().vertCount; v < vn; ++v, ++vertex) {
+                    V3F_C4B_T2F* vertex = triangles.verts;
+                    for (int v = 0, vn = triangles.vertCount; v < vn;
+                         ++v, ++vertex)
+                    {
                         vertex->colors = color4B;
                     }
+					batch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
 				}
 			} else {
 				// Two color tinting.
@@ -444,28 +447,30 @@ namespace spine {
 					trianglesTwoColor.indices = twoColorBatch->allocateIndices(trianglesTwoColor.indexCount);
 					memcpy(trianglesTwoColor.indices, _clipper->getClippedTriangles().buffer(), sizeof(unsigned short) * _clipper->getClippedTriangles().size());
 
-					TwoColorTrianglesCommand *batchedTriangles = lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
+                    const float* verts = _clipper->getClippedVertices().buffer();
+                    const float* uvs   = _clipper->getClippedUVs().buffer();
 
-					const float *verts = _clipper->getClippedVertices().buffer();
-					const float *uvs = _clipper->getClippedUVs().buffer();
-
-                    V3F_C4B_C4B_T2F *vertex = batchedTriangles->getTriangles().verts;
-                    for (int v = 0, vn = batchedTriangles->getTriangles().vertCount, vv = 0; v < vn; ++v, vv += 2, ++vertex) {
-                        vertex->position.x = verts[vv];
-                        vertex->position.y = verts[vv + 1];
+                    V3F_C4B_C4B_T2F* vertex = trianglesTwoColor.verts;
+                    for (int v = 0, vn = trianglesTwoColor.vertCount, vv = 0; v < vn;
+                         ++v, vv += 2, ++vertex)
+                    {
+                        vertex->position.x  = verts[vv];
+                        vertex->position.y  = verts[vv + 1];
                         vertex->texCoords.u = uvs[vv];
                         vertex->texCoords.v = uvs[vv + 1];
-                        vertex->color = color4B;
-                        vertex->color2 = darkColor4B;
+                        vertex->color       = color4B;
+                        vertex->color2      = darkColor4B;
                     }
+					lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
 				} else {
-					TwoColorTrianglesCommand *batchedTriangles = lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
-
-                    V3F_C4B_C4B_T2F *vertex = batchedTriangles->getTriangles().verts;
-                    for (int v = 0, vn = batchedTriangles->getTriangles().vertCount; v < vn; ++v, ++vertex) {
-                        vertex->color = color4B;
+                    V3F_C4B_C4B_T2F* vertex = trianglesTwoColor.verts;
+                    for (int v = 0, vn = trianglesTwoColor.vertCount; v < vn;
+                         ++v, ++vertex)
+                    {
+                        vertex->color  = color4B;
                         vertex->color2 = darkColor4B;
                     }
+					lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
 				}
 			}
 			_clipper->clipEnd(*slot);


### PR DESCRIPTION

## Describe your changes

The two color tint vertex data was being updated after a new render command (`TwoColorTrianglesCommand`) is added, but the issue is that the `addCommand` method would have already updated the back-end buffer with the passed in data.  This meant that the vertex data in the back-end buffer did not contain the updated values.

It's primarily an issue with `TwoColorTrianglesCommand`, because of how it works.  The non-two color tint code uses `TrianglesCommand`, and does not seem to copy the data on `addCommand`, but rather hold a reference to the vertex data to be used later in the rendering process (if I understand it correctly).  Regardless of that, the section for non-two color tint has also been changed to update the data before the `Renderer::addCommand` is called.

## Issue ticket number and link
#1824 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
