### PR TITLE
[FairyGUI] Use content scale factor to correctly set up a scale 9 sprite

### DIFF
--- a/extensions/fairygui/src/fairygui/GImage.cpp
+++ b/extensions/fairygui/src/fairygui/GImage.cpp
@@ -1,3 +1,27 @@
+/****************************************************************************
+ Copyright (c) 2015 fairygui.com
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
 #include "GImage.h"
 #include "PackageItem.h"
 #include "display/FUISprite.h"

--- a/extensions/fairygui/src/fairygui/GImage.cpp
+++ b/extensions/fairygui/src/fairygui/GImage.cpp
@@ -126,16 +126,28 @@ void GImage::setProp(ObjectPropID propId, const ax::Value& value)
 void GImage::constructFromResource()
 {
     PackageItem* contentItem = _packageItem->getBranch();
-    sourceSize.width = contentItem->width;
-    sourceSize.height = contentItem->height;
-    initSize = sourceSize;
+    sourceSize.width         = contentItem->width;
+    sourceSize.height        = contentItem->height;
+    initSize                 = sourceSize;
 
     contentItem = contentItem->getHighResolution();
     contentItem->load();
 
     _content->setSpriteFrame(contentItem->spriteFrame);
     if (contentItem->scale9Grid)
-        ((FUISprite*)_content)->setScale9Grid(contentItem->scale9Grid);
+    {
+        const auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
+
+        const auto leftInset = contentItem->scale9Grid->origin.x;
+        const auto topInset  = contentItem->scale9Grid->origin.y;
+        const auto bottomInset =
+            sourceSize.height - contentItem->scale9Grid->size.y - contentItem->scale9Grid->origin.y;
+        const auto rightInset = sourceSize.width - contentItem->scale9Grid->size.x - contentItem->scale9Grid->origin.x;
+
+        auto insets = Rect(leftInset, topInset, (sourceSize.width / contentScaleFactor) - rightInset - leftInset,
+                           (sourceSize.height / contentScaleFactor) - bottomInset - topInset);
+        ((FUISprite*)_content)->setScale9Grid(&insets);
+    }
     else if (contentItem->scaleByTile)
         ((FUISprite*)_content)->setScaleByTile(true);
 

--- a/extensions/fairygui/src/fairygui/GImage.cpp
+++ b/extensions/fairygui/src/fairygui/GImage.cpp
@@ -138,15 +138,12 @@ void GImage::constructFromResource()
     {
         const auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
 
-        const auto leftInset = contentItem->scale9Grid->origin.x;
-        const auto topInset  = contentItem->scale9Grid->origin.y;
-        const auto bottomInset =
-            sourceSize.height - contentItem->scale9Grid->size.y - contentItem->scale9Grid->origin.y;
-        const auto rightInset = sourceSize.width - contentItem->scale9Grid->size.x - contentItem->scale9Grid->origin.x;
+        auto scaledInsets = *contentItem->scale9Grid;
 
-        auto insets = Rect(leftInset, topInset, (sourceSize.width / contentScaleFactor) - rightInset - leftInset,
-                           (sourceSize.height / contentScaleFactor) - bottomInset - topInset);
-        ((FUISprite*)_content)->setScale9Grid(&insets);
+        scaledInsets.setRect(scaledInsets.origin.x / contentScaleFactor, scaledInsets.origin.y / contentScaleFactor,
+                             scaledInsets.size.x / contentScaleFactor, scaledInsets.size.y / contentScaleFactor);
+
+        ((FUISprite*)_content)->setScale9Grid(&scaledInsets);
     }
     else if (contentItem->scaleByTile)
         ((FUISprite*)_content)->setScaleByTile(true);


### PR DESCRIPTION

## Describe your changes
This patch ensures that the scale 9 sprite is set up correctly when content scaling factor is a value other than 1.

## Issue ticket number and link
#1865 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
