### PR TITLE
Retain _debugDrawNode in Label

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -510,6 +510,8 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
 
 #if AX_LABEL_DEBUG_DRAW
     _debugDrawNode = DrawNode::create();
+    AX_SAFE_RETAIN(_debugDrawNode);
+    
     addChild(_debugDrawNode);
 #endif
 
@@ -567,6 +569,10 @@ Label::~Label()
 
     AX_SAFE_RELEASE_NULL(_textSprite);
     AX_SAFE_RELEASE_NULL(_shadowNode);
+    
+#if AX_LABEL_DEBUG_DRAW
+    AX_SAFE_RELEASE_NULL(_debugDrawNode);
+#endif
 }
 
 void Label::reset()

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -2,6 +2,7 @@
  Copyright (c) 2013      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -512,8 +512,6 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
 #if AX_LABEL_DEBUG_DRAW
     _debugDrawNode = DrawNode::create();
     AX_SAFE_RETAIN(_debugDrawNode);
-    
-    addChild(_debugDrawNode);
 #endif
 
     _purgeTextureListener = EventListenerCustom::create(FontAtlas::CMD_PURGE_FONTATLAS, [this](EventCustom* event) {
@@ -2103,6 +2101,10 @@ void Label::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t pare
         this->drawSelf(visibleByCamera, renderer, flags);
     }
 
+#if AX_LABEL_DEBUG_DRAW
+    _debugDrawNode->visit(renderer, _modelViewTransform, parentFlags | FLAGS_TRANSFORM_DIRTY);
+#endif
+    
     _director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
 }
 


### PR DESCRIPTION
## Describe your changes
This fixes the memory corruption bug and resulting crash I outlined in the TextFieldTTF (and likely other TextField classes) where the _debugDrawNode wasn't being retained, and the label isn't added to the scene for a TextField, but is maintained by the TextField. This caused _debugDrawNode in the Label class to get cleaned up, even though Label still thought it had a valid reference to a DrawNode.

## Issue ticket number and link
#1889

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.