### PR TITLE
Add support for ensuring sprite content size does not change on new texture

### DIFF
--- a/core/2d/Sprite.cpp
+++ b/core/2d/Sprite.cpp
@@ -415,7 +415,10 @@ void Sprite::setTextureRect(const Rect& rect, bool rotated, const Vec2& untrimme
 {
     _rectRotated = rotated;
 
-    Node::setContentSize(untrimmedSize);
+    if (_contentSizeDynamic || _contentSize == Vec2::ZERO)
+    {
+        Node::setContentSize(untrimmedSize);
+    }
     _originalContentSize = untrimmedSize;
 
     setVertexRect(rect);

--- a/core/2d/Sprite.cpp
+++ b/core/2d/Sprite.cpp
@@ -415,7 +415,7 @@ void Sprite::setTextureRect(const Rect& rect, bool rotated, const Vec2& untrimme
 {
     _rectRotated = rotated;
 
-    if (_contentSizeDynamic || _contentSize == Vec2::ZERO)
+    if (_autoSizeEnabled || _contentSize == Vec2::ZERO)
     {
         Node::setContentSize(untrimmedSize);
     }

--- a/core/2d/Sprite.h
+++ b/core/2d/Sprite.h
@@ -629,9 +629,9 @@ public:
      * Indicate if the sprite content size can change if new textures are applied to
      * the sprite.
      *
-     * @param dynamic True if the sprite can change size on new frames/textures
+     * @param enabled True if the sprite can change size on new frames/textures
      */
-    void setContentSizeDynamic(bool dynamic) { _contentSizeDynamic = dynamic; }
+    void setAutoSize(bool enabled) { _autoSizeEnabled = enabled; }
 
 protected:
     virtual void updateColor() override;
@@ -711,7 +711,7 @@ protected:
     bool _stretchEnabled = true;
     bool _autoUpdatePS   = true;
 
-    bool _contentSizeDynamic = true;
+    bool _autoSizeEnabled = true;
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(Sprite);

--- a/core/2d/Sprite.h
+++ b/core/2d/Sprite.h
@@ -625,6 +625,14 @@ public:
 
     void setAutoUpdatePS(bool bVal) { _autoUpdatePS = bVal; }
 
+    /**
+     * Indicate if the sprite content size can change if new textures are applied to
+     * the sprite.
+     *
+     * @param dynamic True if the sprite can change size on new frames/textures
+     */
+    void setContentSizeDynamic(bool dynamic) { _contentSizeDynamic = dynamic; }
+
 protected:
     virtual void updateColor() override;
     virtual void setTextureCoords(const Rect& rect);
@@ -702,6 +710,8 @@ protected:
 
     bool _stretchEnabled = true;
     bool _autoUpdatePS   = true;
+
+    bool _contentSizeDynamic = true;
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(Sprite);


### PR DESCRIPTION
## Describe your changes
If a sprite is to be used for animations (such as the `Animate` action), and a specific sprite content size is set (usually with stretch mode enabled), then this adds support for ensuring that the content size of the sprite is not modified during the animation.

An explicit call to `setContentSize` will still work, but setting new textures on the sprite will not affect the content size due to this change:

```
void Sprite::setTextureRect(const Rect& rect, bool rotated, const Vec2& untrimmedSize)
{
    _rectRotated = rotated;

    if (_contentSizeDynamic || _contentSize == Vec2::ZERO)
    {
        Node::setContentSize(untrimmedSize);
    }
    _originalContentSize = untrimmedSize;

    setVertexRect(rect);
    updateStretchFactor();
    updatePoly();
}
```

The added method is:
```
void setContentSizeDynamic(bool dynamic) { _contentSizeDynamic = dynamic; }
```

I'm not completely sure about the naming of that method, `setContentSizeDynamic`, so if anyone has any alternate suggestions, then please put them forward.  It should be something that indicates the sprite content size is not affected by new content (being a new texture etc.).

Also note that existing behaviour does not change, since the default is `_contentSizeDynamic = true`.

## Issue ticket number and link
#1896

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
