### PR TITLE
[BUG] Fix system font blurring

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1597,6 +1597,8 @@ void Label::createSpriteForSystemFont(const FontDefinition& fontDef)
     _textSprite->setCameraMask(getCameraMask());
     _textSprite->setGlobalZOrder(getGlobalZOrder());
     _textSprite->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
+    auto& s = _textSprite->getContentSize();
+    _textSprite->setPosition(Vec2((int)s.x % 2 == 0 ? 0 : 0.5, (int)s.y % 2 == 0 ? 0 : 0.5));
     this->setContentSize(_textSprite->getContentSize());
     texture->release();
     if (_blendFuncDirty)

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1599,7 +1599,7 @@ void Label::createSpriteForSystemFont(const FontDefinition& fontDef)
     _textSprite->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
     auto& s = _textSprite->getContentSize();
     _textSprite->setPosition(Vec2((int)s.x % 2 == 0 ? 0 : 0.5, (int)s.y % 2 == 0 ? 0 : 0.5));
-    this->setContentSize(_textSprite->getContentSize());
+    this->setContentSize(s);
     texture->release();
     if (_blendFuncDirty)
     {


### PR DESCRIPTION
## Describe your changes
This PR fixes a blurring issue in system fonts caused by odd content size of text sprites

![image](https://github.com/axmolengine/axmol/assets/45469625/b1cfad5f-ee19-404b-ab13-c79a03a45aff)

the top text is what system fonts are expected to look like

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
