### PR TITLE
Fix shaders not copying to final build on macOS for non Xcode builds (2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,6 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(axmol)
 
 if(XCODE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,9 @@
 cmake_minimum_required(VERSION 3.22)
 
 if(APPLE)
-    enable_language(OBJC OBJCXX)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
 endif()
 
 project(axmol)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@
 
 cmake_minimum_required(VERSION 3.22)
 
+if(APPLE)
+    enable_language(OBJC OBJCXX)
+endif()
+
 project(axmol)
 
 if(XCODE)

--- a/cmake/Modules/AXConfigDefine.cmake
+++ b/cmake/Modules/AXConfigDefine.cmake
@@ -208,6 +208,12 @@ endif()
 # apply axmol spec compile options
 add_compile_options(${_ax_compile_options})
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 # Try enable asm & nasm compiler support
 set(can_use_assembler TRUE)
 enable_language(ASM)

--- a/templates/cpp/CMakeLists.txt
+++ b/templates/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME Dummy)
 
@@ -176,6 +176,10 @@ else()
     config_android_shared_libs("org.axmol.lib" "${CMAKE_CURRENT_SOURCE_DIR}/proj.android/app/src")
 endif()
 
+if (NOT _AX_USE_PREBUILT)
+    target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
+endif()
+
 # The optional thirdparties(not dependent by engine)
 if (AX_WITH_YAML_CPP)
     list(APPEND GAME_INC_DIRS "${_AX_ROOT}/3rdparty/yaml-cpp/include")
@@ -186,9 +190,6 @@ target_include_directories(${APP_NAME} PRIVATE ${GAME_INC_DIRS})
 
 # mark app resources, resource will be copy auto after mark
 ax_setup_app_config(${APP_NAME})
-if (NOT _AX_USE_PREBUILT)
-    target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
-endif()
 
 if(APPLE)
     set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")

--- a/templates/cpp/CMakeLists.txt
+++ b/templates/cpp/CMakeLists.txt
@@ -27,6 +27,12 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME Dummy)
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(XCODE)

--- a/templates/cpp/CMakeLists.txt
+++ b/templates/cpp/CMakeLists.txt
@@ -27,12 +27,6 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME Dummy)
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(XCODE)

--- a/templates/lua/CMakeLists.txt
+++ b/templates/lua/CMakeLists.txt
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME Dummy)
 

--- a/templates/lua/CMakeLists.txt
+++ b/templates/lua/CMakeLists.txt
@@ -27,6 +27,12 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME Dummy)
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(XCODE)

--- a/templates/lua/CMakeLists.txt
+++ b/templates/lua/CMakeLists.txt
@@ -27,12 +27,6 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME Dummy)
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(XCODE)

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME cpp-tests)
 
@@ -563,6 +563,8 @@ else()
     config_android_shared_libs("org.axmol.lib" "${CMAKE_CURRENT_SOURCE_DIR}/proj.android/app/src")
 endif()
 
+target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
+
 target_include_directories(${APP_NAME} PRIVATE ${GAME_INC_DIRS})
 
 if (AX_ENABLE_EXT_EFFEKSEER)
@@ -575,7 +577,6 @@ endif()
 
 # mark app resources
 ax_setup_app_config(${APP_NAME})
-target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
 
 if(APPLE)
     set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -11,12 +11,6 @@ if (MSVC)
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -11,6 +11,12 @@ if (MSVC)
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/fairygui-tests/CMakeLists.txt
+++ b/tests/fairygui-tests/CMakeLists.txt
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME fairygui-tests)
 
@@ -165,11 +165,12 @@ else()
     config_android_shared_libs("org.axmol.lib" "${CMAKE_CURRENT_SOURCE_DIR}/proj.android/app/src")
 endif()
 
+target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
+
 target_include_directories(${APP_NAME} PRIVATE ${GAME_INC_DIRS})
 
 # mark app resources
 ax_setup_app_config(${APP_NAME})
-target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
 
 if(APPLE)
     set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")
@@ -204,7 +205,7 @@ endif()
 
 if((NOT IOS) AND (NOT WINRT))
     message("CMake ${APP_NAME} target_precompile_headers")
-    target_precompile_headers(${APP_NAME} PRIVATE 
+    target_precompile_headers(${APP_NAME} PRIVATE
       "$<$<COMPILE_LANGUAGE:CXX>:axmol.h>"
     )
 endif()

--- a/tests/fairygui-tests/CMakeLists.txt
+++ b/tests/fairygui-tests/CMakeLists.txt
@@ -27,6 +27,12 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME fairygui-tests)
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/fairygui-tests/CMakeLists.txt
+++ b/tests/fairygui-tests/CMakeLists.txt
@@ -27,12 +27,6 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME fairygui-tests)
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/live2d-tests/CMakeLists.txt
+++ b/tests/live2d-tests/CMakeLists.txt
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME live2d-tests)
 
@@ -166,11 +166,12 @@ else()
     config_android_shared_libs("org.axmol.lib" "${CMAKE_CURRENT_SOURCE_DIR}/proj.android/app/src")
 endif()
 
+target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
+
 target_include_directories(${APP_NAME} PRIVATE ${GAME_INC_DIRS})
 
 # mark app resources
 ax_setup_app_config(${APP_NAME})
-target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
 
 if(APPLE)
     set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")
@@ -205,7 +206,7 @@ endif()
 
 if((NOT IOS) AND (NOT WINRT))
     message("CMake ${APP_NAME} target_precompile_headers")
-    target_precompile_headers(${APP_NAME} PRIVATE 
+    target_precompile_headers(${APP_NAME} PRIVATE
       "$<$<COMPILE_LANGUAGE:CXX>:axmol.h>"
     )
 endif()

--- a/tests/live2d-tests/CMakeLists.txt
+++ b/tests/live2d-tests/CMakeLists.txt
@@ -27,12 +27,6 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME live2d-tests)
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/live2d-tests/CMakeLists.txt
+++ b/tests/live2d-tests/CMakeLists.txt
@@ -27,6 +27,12 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME live2d-tests)
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/lua-tests/CMakeLists.txt
+++ b/tests/lua-tests/CMakeLists.txt
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME lua-tests)
 
@@ -183,6 +183,10 @@ else()
     config_android_shared_libs("org.axmol.lib" "${CMAKE_CURRENT_SOURCE_DIR}/proj.android/app/src")
 endif()
 
+if(NOT _AX_USE_PREBUILT)
+    target_link_libraries(${APP_NAME} ${_AX_LUA_LIB})
+endif()
+
 # The optional thirdparties(not dependent by engine)
 if (AX_WITH_YAML_CPP)
     list(APPEND GAME_INC_DIRS "${_AX_ROOT}/3rdparty/yaml-cpp/include")
@@ -191,9 +195,6 @@ endif()
 target_include_directories(${APP_NAME} PRIVATE ${GAME_INC_DIRS})
 
 # mark app resources, resource will be copy auto after mark
-if(NOT _AX_USE_PREBUILT)
-    target_link_libraries(${APP_NAME} ${_AX_LUA_LIB})
-endif()
 ax_setup_app_config(${APP_NAME} CONSOLE)
 
 if(APPLE)

--- a/tests/lua-tests/CMakeLists.txt
+++ b/tests/lua-tests/CMakeLists.txt
@@ -27,6 +27,12 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME lua-tests)
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/lua-tests/CMakeLists.txt
+++ b/tests/lua-tests/CMakeLists.txt
@@ -27,12 +27,6 @@ cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME lua-tests)
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 set(APP_NAME unit-tests)
 
@@ -161,6 +161,8 @@ else()
     config_android_shared_libs("org.axmol.lib" "${CMAKE_CURRENT_SOURCE_DIR}/proj.android/app/src")
 endif()
 
+target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
+
 target_include_directories(${APP_NAME} PRIVATE ${GAME_INC_DIRS})
 
 if (AX_ENABLE_EXT_EFFEKSEER)
@@ -173,7 +175,6 @@ endif()
 
 # mark app resources
 ax_setup_app_config(${APP_NAME} CONSOLE)
-target_link_libraries(${APP_NAME} ${_AX_CORE_LIB})
 
 if(APPLE)
     set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -15,12 +15,6 @@ if (MSVC)
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
 
-if(APPLE)
-    enable_language(C CXX OBJC OBJCXX)
-else()
-    enable_language(C CXX)
-endif()
-
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -15,6 +15,12 @@ if (MSVC)
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
 
+if(APPLE)
+    enable_language(C CXX OBJC OBJCXX)
+else()
+    enable_language(C CXX)
+endif()
+
 project(${APP_NAME})
 
 if(NOT DEFINED BUILD_ENGINE_DONE)


### PR DESCRIPTION
## Describe your changes

I attempted to fix this in #1631, but it works only if the shaders were already built (since it scans the `runtime/axslc` dir for files), so you have to rerun CMake again to pick them up. This PR fixes that.

How it works: when `ax_target_compile_shaders()` is called on an app or library target to compile the shaders, it sets `AX_COMPILED_SHADERS` variable on the target. The variable contains a list of compiled shaders. When `ax_setup_app_config()` is called on the app target, it recursively iterates all targets being linked, extracts the list of all shaders from them, and adds them as resources.