### PR TITLE
Allow video media controls to be rotated left or right by 90 degrees

### DIFF
--- a/core/ui/UIMediaPlayer.h
+++ b/core/ui/UIMediaPlayer.h
@@ -54,14 +54,25 @@ class MediaPlayer;
 class AX_GUI_DLL MediaController : public ax::ui::Widget
 {
 public:
+    enum class Orientation
+    {
+        Default,
+        RotatedLeft,
+        RotatedRight,
+    };
+
     explicit MediaController(MediaPlayer* player) : _mediaPlayer(player) {}
     ~MediaController() override = 0;
 
     virtual void updateControllerState() = 0;
     virtual void setTimelineBarHeight(float height) = 0;
 
+    void setOrientation(Orientation orientation);
+    Orientation getOrientation() const { return _orientation; }
+
 protected:
     MediaPlayer* _mediaPlayer = nullptr;
+    Orientation _orientation  = Orientation::Default;
 };
 inline MediaController::~MediaController() = default;  // Required since the destructor is pure virtual
 


### PR DESCRIPTION
## Describe your changes

If a video is played that has content which is rotated by 90 degrees, then it would be nice to be able to rotate the media controls to match that orientation.  There is no way for the code to detect rotated content, since the video is rendered in that way, and not actually rotated, so this PR introduced the ability for the developer to set the rotation.  The 3 options would be Default, RotatedLeft (90°) and RotatedRight (90°).

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
