### PR TITLE
Set AX_USE_METAL and AX_USE_GL to 1 if defined

### DIFF
--- a/core/platform/PlatformConfig.h
+++ b/core/platform/PlatformConfig.h
@@ -155,11 +155,11 @@ Linux: Desktop GL/Vulkan
 
 #if defined(__APPLE__)
 #    if !defined(AX_USE_GL)
-#        define AX_USE_METAL
+#        define AX_USE_METAL 1
 #    endif
 #else  // win32,linux,winuwp,android
 #    if !defined(AX_USE_GL)
-#        define AX_USE_GL
+#        define AX_USE_GL 1
 #    endif
 #endif
 


### PR DESCRIPTION
## Describe your changes

This PR sets `AX_USE_METAL` and `AX_USE_GL` to 1 if defined, to make it more consistent with other `AX_USE_*` macros and to enable writing `#if AX_USE_GL` like expressions.