### PR TITLE
[Android] Update the CMake minimum version requirement to 3.23.0+

### DIFF
--- a/core/platform/android/libaxmol/axutils.gradle
+++ b/core/platform/android/libaxmol/axutils.gradle
@@ -97,7 +97,7 @@ class axutils {
 //    }
 
     @SuppressWarnings('unused')
-    static String[] findNativeBuildTools(project, cmakeVer = "3.22.1+", ndkVer = "23.2.8568313") {
+    static String[] findNativeBuildTools(project, cmakeVer = "3.23.0+", ndkVer = "23.2.8568313") {
         // cmakeVer should overwrite by command line
         if (project.properties.__1K_CMAKE_VERSION != null)
             cmakeVer = project.properties.__1K_CMAKE_VERSION


### PR DESCRIPTION
## Describe your changes

Fix the mismatching minimum version of cmake required in `fetch.cmake` versus what is set as the minimum in `axutils.gradle`

## Issue ticket number and link
#1917

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
