### PR TITLE
[Android] Fix ImGui usage crash due to invalid pointer

### DIFF
--- a/extensions/ImGui/src/ImGui/imgui_impl_ax_android.cpp
+++ b/extensions/ImGui/src/ImGui/imgui_impl_ax_android.cpp
@@ -245,6 +245,7 @@ void ImGui_ImplAndroid_Shutdown()
 
     io.BackendPlatformName = NULL;
     io.BackendPlatformUserData = NULL;
+    io.BackendRendererUserData = NULL;
 
     IM_DELETE(bd);
 }


### PR DESCRIPTION
## Describe your changes

This will fix the crash due to the assert statement in `ImGui::Shutdown`:
`IM_ASSERT_USER_ERROR(g.IO.BackendRendererUserData == NULL, "Forgot to shutdown Renderer backend?");`

The `IO.BackendRendererUserData` either contains the same value as `IO.BackendPlatformUserData` or `NULL`.

## Issue ticket number and link
#1915 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
