### PR TITLE
Fix passing non null terminated strings for null terminated params

### DIFF
--- a/core/media/AvfMediaEngine.mm
+++ b/core/media/AvfMediaEngine.mm
@@ -194,14 +194,14 @@ bool AvfMediaEngine::open(std::string_view sourceUri)
         // Media Framework doesn't percent encode the URL, so the path portion is just a native file path.
         // Extract it and then use it create a proper URL.
         Path             = sourceUri.substr(7);
-        NSString* nsPath = [NSString stringWithUTF8String:std::string(Path).c_str()];
+        NSString* nsPath = [[NSString alloc] initWithBytes:Path.data() length:Path.size() encoding:NSUTF8StringEncoding];
         nsMediaUrl       = [NSURL fileURLWithPath:nsPath isDirectory:NO];
     }
     else
     {
         // Assume that this has been percent encoded for now - when we support HTTP Live Streaming we will need to check
         // for that.
-        NSString* nsUri = [NSString stringWithUTF8String:std::string(sourceUri).c_str()];
+        NSString* nsUri = [[NSString alloc] initWithBytes:sourceUri.data() length:sourceUri.size() encoding:NSUTF8StringEncoding];
         nsMediaUrl      = [NSURL URLWithString:nsUri];
     }
 

--- a/core/media/AvfMediaEngine.mm
+++ b/core/media/AvfMediaEngine.mm
@@ -194,14 +194,14 @@ bool AvfMediaEngine::open(std::string_view sourceUri)
         // Media Framework doesn't percent encode the URL, so the path portion is just a native file path.
         // Extract it and then use it create a proper URL.
         Path             = sourceUri.substr(7);
-        NSString* nsPath = [NSString stringWithUTF8String:Path.data()];
+        NSString* nsPath = [NSString stringWithUTF8String:std::string(Path).c_str()];
         nsMediaUrl       = [NSURL fileURLWithPath:nsPath isDirectory:NO];
     }
     else
     {
         // Assume that this has been percent encoded for now - when we support HTTP Live Streaming we will need to check
         // for that.
-        NSString* nsUri = [NSString stringWithUTF8String:sourceUri.data()];
+        NSString* nsUri = [NSString stringWithUTF8String:std::string(sourceUri).c_str()];
         nsMediaUrl      = [NSURL URLWithString:nsUri];
     }
 

--- a/core/platform/apple/FileUtils-apple.mm
+++ b/core/platform/apple/FileUtils-apple.mm
@@ -159,7 +159,7 @@ bool FileUtilsApple::isFileExistInternal(std::string_view filePath) const
     {
         // Search path is an absolute path.
         BOOL isDir = NO;
-        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:std::string(filePath).c_str()] isDirectory:&isDir] && !isDir)
+        if ([s_fileManager fileExistsAtPath:[[NSString alloc] initWithBytes:filePath.data() length:filePath.size() encoding:NSUTF8StringEncoding] isDirectory:&isDir] && !isDir)
         {
             ret = true;
         }
@@ -207,7 +207,7 @@ std::string FileUtilsApple::getPathForDirectory(std::string_view dir,
     if (path[0] == '/')
     {
         BOOL isDir = NO;
-        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:path.c_str()] isDirectory:&isDir])
+        if ([s_fileManager fileExistsAtPath:[[NSString alloc] initWithBytes:path.data() length:path.size() encoding:NSUTF8StringEncoding] isDirectory:&isDir])
         {
             return appendTrailingSlashToDir(isDir ? path : "");
         }
@@ -232,9 +232,9 @@ std::string FileUtilsApple::getFullPathForFilenameWithinDirectory(std::string_vi
     // Build full path for the file
     if (directory[0] != '/')
     {
-        NSString* path = [pimpl_->getBundle() pathForResource:[NSString stringWithUTF8String:std::string(filename).c_str()]
+        NSString* path = [pimpl_->getBundle() pathForResource:[[NSString alloc] initWithBytes:filename.data() length:filename.size() encoding:NSUTF8StringEncoding]
                                                        ofType:nil
-                                                  inDirectory:[NSString stringWithUTF8String:std::string(directory).c_str()]];
+                                                  inDirectory:[[NSString alloc] initWithBytes:directory.data() length:directory.size() encoding:NSUTF8StringEncoding]];
         if (path != nil)
         {
             fullPath = [path UTF8String];
@@ -265,7 +265,7 @@ bool FileUtilsApple::createDirectory(std::string_view path) const
 
     NSError* error;
 
-    bool result = [s_fileManager createDirectoryAtPath:[NSString stringWithUTF8String:std::string(path).c_str()]
+    bool result = [s_fileManager createDirectoryAtPath:[[NSString alloc] initWithBytes:path.data() length:path.size() encoding:NSUTF8StringEncoding]
                            withIntermediateDirectories:YES
                                             attributes:nil
                                                  error:&error];

--- a/core/platform/apple/FileUtils-apple.mm
+++ b/core/platform/apple/FileUtils-apple.mm
@@ -159,7 +159,7 @@ bool FileUtilsApple::isFileExistInternal(std::string_view filePath) const
     {
         // Search path is an absolute path.
         BOOL isDir = NO;
-        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:filePath.data()] isDirectory:&isDir] && !isDir)
+        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:std::string(filePath).c_str()] isDirectory:&isDir] && !isDir)
         {
             ret = true;
         }
@@ -207,7 +207,7 @@ std::string FileUtilsApple::getPathForDirectory(std::string_view dir,
     if (path[0] == '/')
     {
         BOOL isDir = NO;
-        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:path.data()] isDirectory:&isDir])
+        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:path.c_str()] isDirectory:&isDir])
         {
             return appendTrailingSlashToDir(isDir ? path : "");
         }
@@ -232,9 +232,9 @@ std::string FileUtilsApple::getFullPathForFilenameWithinDirectory(std::string_vi
     // Build full path for the file
     if (directory[0] != '/')
     {
-        NSString* path = [pimpl_->getBundle() pathForResource:[NSString stringWithUTF8String:filename.data()]
+        NSString* path = [pimpl_->getBundle() pathForResource:[NSString stringWithUTF8String:std::string(filename).c_str()]
                                                        ofType:nil
-                                                  inDirectory:[NSString stringWithUTF8String:directory.data()]];
+                                                  inDirectory:[NSString stringWithUTF8String:std::string(directory).c_str()]];
         if (path != nil)
         {
             fullPath = [path UTF8String];
@@ -265,14 +265,14 @@ bool FileUtilsApple::createDirectory(std::string_view path) const
 
     NSError* error;
 
-    bool result = [s_fileManager createDirectoryAtPath:[NSString stringWithUTF8String:path.data()]
+    bool result = [s_fileManager createDirectoryAtPath:[NSString stringWithUTF8String:std::string(path).c_str()]
                            withIntermediateDirectories:YES
                                             attributes:nil
                                                  error:&error];
 
     if (!result && error != nil)
     {
-        AXLOGERROR("Fail to create directory \"%s\": %s", path.data(), [error.localizedDescription UTF8String]);
+        AXLOGERROR("Fail to create directory \"%s\": %s", std::string(path).c_str(), [error.localizedDescription UTF8String]);
     }
 
     return result;

--- a/core/platform/ios/Device-ios.mm
+++ b/core/platform/ios/Device-ios.mm
@@ -463,7 +463,7 @@ static bool _initWithString(std::string_view text,
 
         AX_BREAK_IF(!font);
 
-        NSString* str = [NSString stringWithUTF8String:text.data()];
+        NSString* str = [NSString stringWithUTF8String:std::string(text).c_str()];
         AX_BREAK_IF(!str);
 
         CGSize dimensions;

--- a/core/platform/ios/Device-ios.mm
+++ b/core/platform/ios/Device-ios.mm
@@ -463,7 +463,7 @@ static bool _initWithString(std::string_view text,
 
         AX_BREAK_IF(!font);
 
-        NSString* str = [NSString stringWithUTF8String:std::string(text).c_str()];
+        NSString* str = [[NSString alloc] initWithBytes:text.data() length:text.size() encoding:NSUTF8StringEncoding];
         AX_BREAK_IF(!str);
 
         CGSize dimensions;

--- a/core/platform/mac/Device-mac.mm
+++ b/core/platform/mac/Device-mac.mm
@@ -295,7 +295,7 @@ static bool _initWithString(std::string_view text,
 
     do
     {
-        NSString* string = [NSString stringWithUTF8String:text.data()];
+        NSString* string = [NSString stringWithUTF8String:std::string(text).c_str()];
         AX_BREAK_IF(!string);
 
         id font = _createSystemFont(fontName, size);

--- a/core/platform/mac/Device-mac.mm
+++ b/core/platform/mac/Device-mac.mm
@@ -295,7 +295,7 @@ static bool _initWithString(std::string_view text,
 
     do
     {
-        NSString* string = [NSString stringWithUTF8String:std::string(text).c_str()];
+        NSString* string = [[NSString alloc] initWithBytes:text.data() length:text.size() encoding:NSUTF8StringEncoding];
         AX_BREAK_IF(!string);
 
         id font = _createSystemFont(fontName, size);


### PR DESCRIPTION
Fixes some cases where `std::string_view` is passed to `[NSString stringWithUTF8String:]`. `stringWithUTF8String` expects a zero terminated string.