### PR TITLE
Do image processing to reverse premultiplied alpha in separate thread

### DIFF
--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -382,20 +382,20 @@ bool RenderTexture::saveToFileAsNonPMA(std::string_view filename, bool isRGBA, S
 
     if (basename.find(".png") != std::string::npos)
     {
-        return saveToFileAsNonPMA(filename, Image::Format::PNG, isRGBA, callback);
+        return saveToFileAsNonPMA(filename, Image::Format::PNG, isRGBA, std::move(callback));
     }
     else if (basename.find(".jpg") != std::string::npos)
     {
         if (isRGBA)
             AXLOG("RGBA is not supported for JPG format.");
-        return saveToFileAsNonPMA(filename, Image::Format::JPG, false, callback);
+        return saveToFileAsNonPMA(filename, Image::Format::JPG, false, std::move(callback));
     }
     else
     {
         AXLOG("Only PNG and JPG format are supported now!");
     }
 
-    return saveToFileAsNonPMA(filename, Image::Format::JPG, false, callback);
+    return saveToFileAsNonPMA(filename, Image::Format::JPG, false, std::move(callback));
 }
 
 bool RenderTexture::saveToFile(std::string_view filename, bool isRGBA, SaveFileCallbackType callback)
@@ -405,20 +405,20 @@ bool RenderTexture::saveToFile(std::string_view filename, bool isRGBA, SaveFileC
 
     if (basename.find(".png") != std::string::npos)
     {
-        return saveToFile(filename, Image::Format::PNG, isRGBA, callback);
+        return saveToFile(filename, Image::Format::PNG, isRGBA, std::move(callback));
     }
     else if (basename.find(".jpg") != std::string::npos)
     {
         if (isRGBA)
             AXLOG("RGBA is not supported for JPG format.");
-        return saveToFile(filename, Image::Format::JPG, false, callback);
+        return saveToFile(filename, Image::Format::JPG, false, std::move(callback));
     }
     else
     {
         AXLOG("Only PNG and JPG format are supported now!");
     }
 
-    return saveToFile(filename, Image::Format::JPG, false, callback);
+    return saveToFile(filename, Image::Format::JPG, false, std::move(callback));
 }
 
 bool RenderTexture::saveToFileAsNonPMA(std::string_view fileName,
@@ -431,7 +431,7 @@ bool RenderTexture::saveToFileAsNonPMA(std::string_view fileName,
     if (isRGBA && format == Image::Format::JPG)
         AXLOG("RGBA is not supported for JPG format");
 
-    _saveFileCallback = callback;
+    _saveFileCallback = std::move(callback);
 
     std::string fullpath = FileUtils::getInstance()->getWritablePath().append(fileName);
 
@@ -454,7 +454,7 @@ bool RenderTexture::saveToFile(std::string_view fileName,
     if (isRGBA && format == Image::Format::JPG)
         AXLOG("RGBA is not supported for JPG format");
 
-    _saveFileCallback = callback;
+    _saveFileCallback = std::move(callback);
 
     std::string fullpath = FileUtils::getInstance()->getWritablePath().append(fileName);
 
@@ -472,15 +472,28 @@ void RenderTexture::onSaveToFile(std::string filename, bool isRGBA, bool forceNo
     auto callbackFunc = [this, _filename = std::move(filename), isRGBA, forceNonPMA](RefPtr<Image> image) {
         if (image)
         {
-            if (forceNonPMA && image->hasPremultipliedAlpha())
-            {
-                image->reversePremultipliedAlpha();
-            }
-            image->saveToFile(_filename, !isRGBA);
+            std::thread([this, image, _filename, isRGBA, forceNonPMA]() {
+                if (forceNonPMA && image->hasPremultipliedAlpha())
+                {
+                    image->reversePremultipliedAlpha();
+                }
+
+                image->saveToFile(_filename, !isRGBA);
+
+                Director::getInstance()->getScheduler()->runOnAxmolThread([this, _filename] {
+                    if (_saveFileCallback)
+                    {
+                        _saveFileCallback(this, _filename);
+                    }
+                });
+            }).detach();
         }
-        if (_saveFileCallback)
+        else
         {
-            _saveFileCallback(this, _filename);
+            if (_saveFileCallback)
+            {
+                _saveFileCallback(this, _filename);
+            }          
         }
     };
     newImage(callbackFunc);

--- a/core/2d/RenderTexture.h
+++ b/core/2d/RenderTexture.h
@@ -176,7 +176,7 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
-    bool saveToFileAsNonPMA(std::string_view filename, bool isRGBA = true, SaveFileCallbackType = nullptr);
+    bool saveToFileAsNonPMA(std::string_view filename, bool isRGBA = true, SaveFileCallbackType callback = nullptr);
 
     /** Saves the texture into a file using JPEG format. The file will be saved in the Documents folder.
      * Returns true if the operation is successful.
@@ -186,7 +186,7 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
-    bool saveToFile(std::string_view filename, bool isRGBA = true, SaveFileCallbackType = nullptr);
+    bool saveToFile(std::string_view filename, bool isRGBA = true, SaveFileCallbackType callback = nullptr);
 
     /** saves the texture into a file in non-PMA. The format could be JPG or PNG. The file will be saved in the
       Documents folder. Returns true if the operation is successful.


### PR DESCRIPTION
## Describe your changes
The speed of reversing pre-multiplied alpha in an image that is to be saved to disk is dependent on the size of the image, so the larger the image, the slower the process is.  Moving this task to a separate thread helps in reducing any lag/stutter on the main thread.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
