### PR TITLE
Add support for necessary events to be sent regardless of event dispatcher enabled state

### DIFF
--- a/core/base/EventDispatcher.cpp
+++ b/core/base/EventDispatcher.cpp
@@ -959,9 +959,9 @@ void EventDispatcher::dispatchTouchEventToListeners(EventListenerVector* listene
     }
 }
 
-void EventDispatcher::dispatchEvent(Event* event)
+void EventDispatcher::dispatchEvent(Event* event, bool forced)
 {
-    if (!_isEnabled)
+    if (!_isEnabled && !forced)
         return;
 
     updateDirtyFlagForSceneGraph();
@@ -1000,11 +1000,11 @@ void EventDispatcher::dispatchEvent(Event* event)
     updateListeners(event);
 }
 
-void EventDispatcher::dispatchCustomEvent(std::string_view eventName, void* optionalUserData)
+void EventDispatcher::dispatchCustomEvent(std::string_view eventName, void* optionalUserData, bool forced)
 {
     EventCustom ev(eventName);
     ev.setUserData(optionalUserData);
-    dispatchEvent(&ev);
+    dispatchEvent(&ev, forced);
 }
 
 bool EventDispatcher::hasEventListener(std::string_view listenerID) const

--- a/core/base/EventDispatcher.h
+++ b/core/base/EventDispatcher.h
@@ -169,15 +169,17 @@ public:
      *  event dispatcher list.
      *
      * @param event The event needs to be dispatched.
+     * @param forced If the event should be sent out regardless of enabled state
      */
-    void dispatchEvent(Event* event);
+    void dispatchEvent(Event* event, bool forced = false);
 
     /** Dispatches a Custom Event with a event name an optional user data.
      *
      * @param eventName The name of the event which needs to be dispatched.
      * @param optionalUserData The optional user data, it's a void*, the default value is nullptr.
+     * @param forced If the event should be sent out regardless of enabled state
      */
-    void dispatchCustomEvent(std::string_view eventName, void* optionalUserData = nullptr);
+    void dispatchCustomEvent(std::string_view eventName, void* optionalUserData = nullptr, bool forced = false);
 
     /** Query whether the specified event listener id has been added.
      *

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -301,7 +301,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
         // AxmolGLSurfaceView
         this.mGLSurfaceView = this.onCreateView();
-        this.mGLSurfaceView.setPreserveEGLContextOnPause(true);
+        this.mGLSurfaceView.setPreserveEGLContextOnPause(false);
 
         // ...add to FrameLayout
         mFrameLayout.addView(this.mGLSurfaceView);

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -301,7 +301,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
         // AxmolGLSurfaceView
         this.mGLSurfaceView = this.onCreateView();
-        this.mGLSurfaceView.setPreserveEGLContextOnPause(false);
+        this.mGLSurfaceView.setPreserveEGLContextOnPause(true);
 
         // ...add to FrameLayout
         mFrameLayout.addView(this.mGLSurfaceView);

--- a/core/platform/android/javaactivity-android.cpp
+++ b/core/platform/android/javaactivity-android.cpp
@@ -99,7 +99,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeInit(JNIEnv*, jcla
         backend::DriverBase::getInstance()->resetState();
         ax::Director::getInstance()->resetMatrixStack();
         ax::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
-        director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
+        director->getEventDispatcher()->dispatchEvent(&recreatedEvent, true);
         director->setGLDefaultValues();
 #if AX_ENABLE_CACHE_TEXTURE_DATA
         ax::VolatileTextureMgr::reloadAllTextures();
@@ -112,7 +112,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeOnContextLost(JNIE
 #if AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST
     auto director = ax::Director::getInstance();
     ax::EventCustom recreatedEvent(EVENT_APP_RESTARTING);
-    director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
+    director->getEventDispatcher()->dispatchEvent(&recreatedEvent, true);
 
     //  Pop to root scene, replace with an empty scene, and clear all cached data before restarting
     director->popToRootScene();

--- a/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
+++ b/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
@@ -49,7 +49,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeOnPause(JNIEnv*, j
     {
         Application::getInstance()->applicationDidEnterBackground();
         ax::EventCustom backgroundEvent(EVENT_COME_TO_BACKGROUND);
-        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&backgroundEvent);
+        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&backgroundEvent, true);
     }
 }
 
@@ -64,7 +64,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeOnResume(JNIEnv*, 
             Application::getInstance()->applicationWillEnterForeground();
 
         ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
-        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent);
+        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent, true);
 
         firstTime = false;
     }

--- a/core/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/core/platform/winrt/xaml/AxmolRenderer.cpp
@@ -71,7 +71,7 @@ void AxmolRenderer::Resume()
     {
         Application::getInstance()->applicationWillEnterForeground();
         ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
-        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent);
+        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent, true);
     }
 }
 
@@ -81,7 +81,7 @@ void AxmolRenderer::Pause()
     {
         Application::getInstance()->applicationDidEnterBackground();
         ax::EventCustom backgroundEvent(EVENT_COME_TO_BACKGROUND);
-        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&backgroundEvent);
+        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&backgroundEvent, true);
     }
 }
 
@@ -104,12 +104,12 @@ void AxmolRenderer::DeviceLost()
         // ax::VolatileTextureMgr::reloadAllTextures();
 
         ax::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
-        director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
+        director->getEventDispatcher()->dispatchEvent(&recreatedEvent, true);
         director->setGLDefaultValues();
 
         Application::getInstance()->applicationWillEnterForeground();
         ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
-        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent);
+        ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent, true);
     }
 }
 

--- a/tests/cpp-tests/Source/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Source/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -1447,7 +1447,7 @@ Issue4129::Issue4129() : _bugFixed(false)
         this->addChild(menu2);
 
         // Simulate to dispatch 'come to background' event
-        _eventDispatcher->dispatchCustomEvent(EVENT_COME_TO_BACKGROUND);
+        _eventDispatcher->dispatchCustomEvent(EVENT_COME_TO_BACKGROUND, nullptr, true);
     });
 
     removeAllTouchItem->setFontSizeObj(16);


### PR DESCRIPTION
## Describe your changes

If the event dispatcher is disabled, then necessary events such as `EVENT_RENDERER_RECREATED`, `EVENT_APP_RESTARTING`, `EVENT_COME_TO_FOREGROUND`,  and `EVENT_COME_TO_BACKGROUND` will not be sent, which in certain instances will result in application crashes.

An example case:

1 - event dispatcher is disabled (such as on entering a scene transition)
2 - the app is moved to the background for any reason
3 - the app is then moved back to the foreground
4 - if the EGL context is lost, then it will attempt to recover/restart depending on the configuration (AX_ENABLE_CACHE_TEXTURE_DATA == 1 or AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST == 1)
5 - since the event dispatcher is still disabled, EVENT_RENDERER_RECREATED (or EVENT_APP_RESTARTING) would never be sent out

## Issue ticket number and link

Related issue: #1211

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
