### PR TITLE
Only pause GLSurfaceView if activity is moved to the background, and not if it just loses focus

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -72,6 +72,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     private boolean hasFocus = false;
     private boolean showVirtualButton = false;
     private boolean paused = true;
+    private boolean rendererPaused = true;
 
     public AxmolGLSurfaceView getGLSurfaceView(){
         return  mGLSurfaceView;
@@ -223,7 +224,11 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     private void resume() {
         this.hideVirtualButton();
         AxmolEngine.onResume();
-        mGLSurfaceView.onResume();
+        if (rendererPaused) {
+            mGLSurfaceView.onResume();
+            rendererPaused = false;
+        }
+        mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
     }
 
     private void resumeIfHasFocus() {
@@ -242,6 +247,13 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
         paused = true;
         super.onPause();
         AxmolEngine.onPause();
+        mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        rendererPaused = true;
         mGLSurfaceView.onPause();
     }
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -1,6 +1,7 @@
 /****************************************************************************
 Copyright (c) 2010-2013 cocos2d-x.org
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmolengine.github.io/
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -1,27 +1,27 @@
 /****************************************************************************
-Copyright (c) 2010-2013 cocos2d-x.org
-Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
-Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+ Copyright (c) 2010-2013 cocos2d-x.org
+ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
-https://axmolengine.github.io/
+ https://axmolengine.github.io/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
  ****************************************************************************/
 package org.axmol.lib;
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -186,7 +186,6 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
     @Override
     public void onResume() {
         super.onResume();
-        this.setRenderMode(RENDERMODE_CONTINUOUSLY);
         this.queueEvent(new Runnable() {
             @Override
             public void run() {
@@ -203,7 +202,6 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
                 AxmolGLSurfaceView.this.mRenderer.handleOnPause();
             }
         });
-        this.setRenderMode(RENDERMODE_WHEN_DIRTY);
         super.onPause();
     }
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -1,26 +1,27 @@
 /****************************************************************************
-Copyright (c) 2010-2011 cocos2d-x.org
-Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2010-2011 cocos2d-x.org
+ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
-https://axmolengine.github.io/
+ https://axmolengine.github.io/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
  ****************************************************************************/
 package org.axmol.lib;
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -47,6 +47,7 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
     private int mScreenWidth;
     private int mScreenHeight;
     private boolean mNativeInitCompleted = false;
+    private boolean mIsPaused = false;
 
     // ===========================================================
     // Constructors
@@ -97,7 +98,7 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
         } else {
             final long now = System.nanoTime();
             final long interval = now - this.mLastTickInNanoSeconds;
-            
+
             /*
              * Render time MUST be counted in, or the FPS will slower than appointed.
             */
@@ -164,10 +165,14 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
             return;
 
         AxmolRenderer.nativeOnPause();
+        mIsPaused = true;
     }
 
     public void handleOnResume() {
-        AxmolRenderer.nativeOnResume();
+        if (mIsPaused) {
+            AxmolRenderer.nativeOnResume();
+            mIsPaused = false;
+        }
     }
 
     private static native void nativeInsertText(final String text);

--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -1,26 +1,26 @@
 /****************************************************************************
-Copyright (c) 2010-2011 cocos2d-x.org
-Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2010-2011 cocos2d-x.org
+ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+ https://axmolengine.github.io/
 
-https://axmolengine.github.io/
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
  ****************************************************************************/
 package org.axmol.lib;
 

--- a/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
+++ b/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
@@ -55,18 +55,11 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeOnPause(JNIEnv*, j
 
 JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeOnResume(JNIEnv*, jclass)
 {
-    static bool firstTime = true;
     if (Director::getInstance()->getGLView())
     {
-        // don't invoke at first to keep the same logic as iOS
-        // can refer to https://github.com/cocos2d/cocos2d-x/issues/14206
-        if (!firstTime)
-            Application::getInstance()->applicationWillEnterForeground();
-
+        Application::getInstance()->applicationWillEnterForeground();
         ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
         ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent, true);
-
-        firstTime = false;
     }
 }
 

--- a/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
+++ b/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 


### PR DESCRIPTION
## Describe your changes

At the moment, there are several issues on Android:

1 - There are instances where `applicationWillEnterForeground()` is called twice.  This should also not be called on initial app start-up, since the behaviour would be different to other platforms.

2 - The `GLSurfaceView` should not be paused if the activity has simply lost focus, but still visible to the user.  According to the Android [documentation](https://developer.android.com/reference/android/opengl/GLSurfaceView#onPause()), the recommendation is that it only be paused if the application enters the background, meaning in `Activity.onStop`.  

3 - If the `GLSurfaceView` is paused, there is a possibility that Android will discard the EGL context under certain conditions.  If the application has simply lost focus and is still visible to the user, the view should remain valid.

4 - `Application::applicationDidEnterBackground()` is also called from `GLSurfaceView.onPause()`, but this should not occur if the application simply lost focus and is still visible.

3 - `Activity.onPause()` should not take too much time complete, and the current implementation which calls `GLSurfaceView.onPause()` from `Activity.onPause()`, and queues a call to `Application::applicationDidEnterBackground()` on the GL thread.  There is no guarantee that the game state can be saved before the application goes into the background if this is a time-intensive process.

The changes in this PR should resolve all the issues listed above. 

1 - `applicationWillEnterForeground()` should not be called on initial app start-up.
2 - If the application activity loses focus, then the `GLSurfaceView` should not be paused, but simply put into a more efficient rendering mode, using `RENDERMODE_WHEN_DIRTY` instead of `RENDERMODE_CONTINUOUSLY`.
3 - Android will not detect the `GLSurfaceView` as being paused if it is not yet in the background, which means there is no reason for the EGL context to be discarded.
4 - Now that `GLSurfaceView.onPause()` is called from `Activity.onStop()`, then there are no longer any issues with time-intensive processing of saving game state in `Application::applicationDidEnterBackground()`.

## Issue ticket number and link
Related to #1211 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
