### PR TITLE
Fix Callback and store Renderer Image type

### DIFF
--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -64,7 +64,6 @@ RenderTexture::~RenderTexture()
     AX_SAFE_RELEASE(_renderTarget);
     AX_SAFE_RELEASE(_sprite);
     AX_SAFE_RELEASE(_depthStencilTexture);
-    AX_SAFE_RELEASE(_UITextureImage);
 }
 
 void RenderTexture::listenToBackground(EventCustom* /*event*/)
@@ -73,12 +72,10 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
     // So we disable this pair of message handler at present.
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     // to get the rendered texture data
-    auto func = [&](Image* uiTextureImage) {
+    auto func = [&](RefPtr<Image> uiTextureImage) {
         if (uiTextureImage)
         {
-            AX_SAFE_RELEASE(_UITextureImage);
             _UITextureImage = uiTextureImage;
-            AX_SAFE_RETAIN(_UITextureImage);
             const Vec2& s = _texture2D->getContentSizeInPixels();
             VolatileTextureMgr::addDataTexture(_texture2D, uiTextureImage->getData(), s.width * s.height * 4,
                                                backend::PixelFormat::RGBA8, s);
@@ -87,7 +84,6 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
         {
             AXLOG("Cache rendertexture failed!");
         }
-        AX_SAFE_RELEASE(uiTextureImage);
     };
     auto callback = std::bind(func, std::placeholders::_1);
     newImage(callback, false);

--- a/core/2d/RenderTexture.h
+++ b/core/2d/RenderTexture.h
@@ -398,7 +398,7 @@ protected:
     backend::RenderTarget* _oldRenderTarget = nullptr;
     RenderTargetFlag _renderTargetFlags{};
 
-    Image* _UITextureImage            = nullptr;
+    RefPtr<Image> _UITextureImage            = nullptr;
     backend::PixelFormat _pixelFormat = backend::PixelFormat::RGBA8;
 
     Color4F _clearColor;


### PR DESCRIPTION
## Describe your changes

The `RenderTexture::listenToBackground(EventCustom* /*event*/)` method is using the `newImage` method but the callback has still the old type, leading to a crash.
We expect a `RefPtr<Image>` and not an `Image*`. I changed the memory management and member type in consequence.
