### PR TITLE
Apply child stencils correctly to the clipping node

### DIFF
--- a/core/2d/ClippingNode.h
+++ b/core/2d/ClippingNode.h
@@ -71,8 +71,11 @@ public:
     /** Set the Node to use as a stencil to do the clipping.
      *
      * @param stencil The Node to use as a stencil to do the clipping.
+     * @param uniqueChildStencils Set a different ProgramState per child stencil if enabled. Only
+     *                            set to true if the child stencils are different in some way, as in
+     *                            different shapes, images etc..
      */
-    void setStencil(Node* stencil);
+    void setStencil(Node* stencil, bool uniqueChildStencils = false);
 
     /** If stencil has no children it will not be drawn.
      * If you have custom stencil-based node with stencil drawing mechanics other then children-based,
@@ -159,6 +162,7 @@ protected:
     void setProgramStateRecursively(Node* node, backend::ProgramState* programState);
     void restoreAllProgramStates();
 
+    bool _uniqueChildStencils                 = false;
     Node* _stencil                            = nullptr;
     StencilStateManager* _stencilStateManager = nullptr;
 

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
@@ -1104,7 +1104,7 @@ void UniqueChildStencilTest::addChildStencils()
     sprite->setPosition(Vec2(50, contentSize.height - 50));
     _parentStencil->addChild(sprite);
 
-    // Child stencil 3
+    // Child stencil 4
     sprite = Sprite::create("Images/elephant1_Diffuse.png");
     sprite->setStretchEnabled(true);
     sprite->setContentSize(spriteSize);

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 
@@ -65,6 +66,7 @@ ClippingNodeTests::ClippingNodeTests()
     ADD_TEST_CASE(ClippingToRenderTextureTest);
     ADD_TEST_CASE(ClippingRectangleNodeTest);
     ADD_TEST_CASE(ClippingNodePerformanceTest);
+    ADD_TEST_CASE(UniqueChildStencilTest);
 }
 
 //// Demo examples start here
@@ -1017,4 +1019,97 @@ void ClippingNodePerformanceTest::setup()
     auto menu = Menu::create(increase, nullptr);
     menu->setPosition(Vec2(s.width / 2, s.height - 80));
     addChild(menu, 1);
+}
+
+// UniqueChildStencilTest
+
+UniqueChildStencilTest::~UniqueChildStencilTest()
+{
+    AX_SAFE_RELEASE(_outerClipper);
+    AX_SAFE_RELEASE(_parentStencil);
+}
+
+std::string UniqueChildStencilTest::title() const
+{
+    return "Unique Child Stencil Demo";
+}
+
+std::string UniqueChildStencilTest::subtitle() const
+{
+    return "";
+}
+
+void UniqueChildStencilTest::setup()
+{
+    auto target = Sprite::create(s_pathBlock);
+    target->setAnchorPoint(Vec2::ZERO);
+    target->setStretchEnabled(true);
+    target->setContentSize(target->getContentSize() * 3);
+
+    _outerClipper = ClippingNode::create();
+    _outerClipper->retain();
+    AffineTransform transform = AffineTransform::IDENTITY;
+    transform                 = AffineTransformScale(transform, target->getScale(), target->getScale());
+
+    _outerClipper->setContentSize(SizeApplyAffineTransform(target->getContentSize(), transform));
+    _outerClipper->setAnchorPoint(Vec2(0.5f, 0.5f));
+    _outerClipper->setPosition(Vec2(this->getContentSize()) * 0.5f);
+    _outerClipper->runAction(RepeatForever::create(RotateBy::create(1, 45)));
+
+    _outerClipper->setStencil(target);
+
+    auto clipper = ClippingNode::create();
+    clipper->setInverted(true);
+    clipper->setAlphaThreshold(0.05f);
+
+    clipper->addChild(target);
+
+    _parentStencil = Node::create();
+    _parentStencil->setContentSize(target->getContentSize());
+    _parentStencil->retain();
+
+    clipper->setStencil(_parentStencil, true);
+
+    _outerClipper->addChild(clipper);
+
+    this->addChild(_outerClipper);
+
+    addChildStencils();
+}
+
+void UniqueChildStencilTest::addChildStencils()
+{
+    auto&& contentSize = _parentStencil->getContentSize();
+
+    // Child stencil 1
+    constexpr auto radius = 30.f;
+    auto* drawNode        = DrawNode::create(2);
+    drawNode->drawSolidCircle(Vec2(50, 50), radius, 360, 180, 1, 1, Color4B::MAGENTA);
+
+    _parentStencil->addChild(drawNode);
+
+    // Child stencil 2
+    drawNode = DrawNode::create(2);
+    drawNode->drawSolidRect(Vec2(contentSize.width - 75, contentSize.height - 75),
+                            Vec2(contentSize.width - 25, contentSize.height - 25), Color4B::MAGENTA);
+    _parentStencil->addChild(drawNode);
+
+    // Child stencil 3
+    auto spriteSize = Vec2(80, 80);
+    auto sprite     = Sprite::create("Images/grossini.png");
+    sprite->setStretchEnabled(true);
+    sprite->setContentSize(spriteSize);
+    sprite->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+    // position the sprite on the center of the screen
+    sprite->setPosition(Vec2(50, contentSize.height - 50));
+    _parentStencil->addChild(sprite);
+
+    // Child stencil 3
+    sprite = Sprite::create("Images/elephant1_Diffuse.png");
+    sprite->setStretchEnabled(true);
+    sprite->setContentSize(spriteSize);
+    sprite->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+    // position the sprite on the center of the screen
+    sprite->setPosition(Vec2(contentSize.width - 50, 50));
+    _parentStencil->addChild(sprite);
 }

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.h
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmolengine.github.io/
 
@@ -151,6 +152,7 @@ private:
     ax::Node* _holesStencil;
 };
 
+
 class ScrollViewDemo : public BaseClippingNodeTest
 {
 public:
@@ -297,4 +299,20 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
     virtual void setup() override;
+};
+
+class UniqueChildStencilTest : public BaseClippingNodeTest
+{
+public:
+    CREATE_FUNC(UniqueChildStencilTest);
+
+    ~UniqueChildStencilTest();
+    virtual void setup() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    void addChildStencils();
+
+private:
+    ax::ClippingNode* _outerClipper;
+    ax::Node* _parentStencil;
 };


### PR DESCRIPTION
Fix incorrect reference count for original program states stored in collection

## Describe your changes
When using different child stencils in a `ClippingNode`, the `ProgramState` applied to each child was exactly the same, resulting in incorrect output.

With this change, it now allows the developer to set whether the `ClippingNode` uses the same unique `ProgramState` per child stencil.

An existing issue is also fixed, due to the `_originalStencilProgramState` collection not retaining the `ProgramState` instances saved in it.  These instances were being released by the parent node after being added to the `_originalStencilProgramState`, which meant that they may have been freed if their reference count became 0.  The change in this PR ensures that they are correctly retained prior to being added to the collection.

This change will not affect existing usage, as the new functionality is optional.

## Issue ticket number and link
#1956 

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
