### PR TITLE
Change cmake version from 3.23 to 3.22

### DIFF
--- a/1k/dm/CMakeLists.txt
+++ b/1k/dm/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.22)
 
 project(dm)
 

--- a/1k/fetch.cmake
+++ b/1k/fetch.cmake
@@ -4,7 +4,7 @@
 #   _1kfetch_cache_dir
 #   _1kfetch_manifest
 # 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.22)
 
 ### 1kdist url
 find_program(PWSH_PROG NAMES pwsh powershell NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH)


### PR DESCRIPTION
## Describe your changes
Change cmake version from 3.23 to 3.22
android sdk has only 3.22. Using anythin higher then 3.22 enforces to use non android sdk cmake
```
 % ./sdkmanager --list | grep cmake
  cmake;3.22.1         | 3.22.1        | CMake 3.22.1                            | cmake/3.22.1        
  cmake;3.10.2.4988404                                                                     | 3.10.2            | CMake 3.10.2.4988404                                                 
  cmake;3.18.1                                                                             | 3.18.1            | CMake 3.18.1                                                         
  cmake;3.22.1                                                                             | 3.22.1            | CMake 3.22.1                                                         
  cmake;3.6.4111459                                                                        | 3.6.4111459       | CMake 3.6.4111459       
```
## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
