### PR TITLE
Renderer recreated fixes

### DIFF
--- a/core/renderer/TextureCache.cpp
+++ b/core/renderer/TextureCache.cpp
@@ -581,7 +581,7 @@ Texture2D* TextureCache::addImage(const Data& imageData, std::string_view key)
         {
             if (texture->initWithImage(image))
             {
-                
+
 #if CC_ENABLE_CACHE_TEXTURE_DATA
                 VolatileTextureMgr::addImage(texture, image);
 #endif
@@ -598,7 +598,7 @@ Texture2D* TextureCache::addImage(const Data& imageData, std::string_view key)
         {
             AXLOG("axmol: Allocating memory for Texture2D failed!");
         }
-        
+
         AX_SAFE_RELEASE(image);
 
     } while (0);
@@ -978,13 +978,10 @@ void VolatileTextureMgr::reloadTexture(Texture2D* texture, std::string_view file
     if (!texture)
         return;
 
-    Image* image = new Image();
-    Data data    = FileUtils::getInstance()->getDataFromFile(filename);
+    Image image;
 
-    if (image->initWithImageData(data.getBytes(), data.getSize()))
-        texture->initWithImage(image, pixelFormat);
-
-    AX_SAFE_DELETE(image);
+    if (image.initWithImageFile(filename))
+        texture->initWithImage(&image, pixelFormat);
 }
 
 #endif  // AX_ENABLE_CACHE_TEXTURE_DATA

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -200,8 +200,8 @@ void Texture2DGL::updateData(uint8_t* data, std::size_t width, std::size_t heigh
         return;
 
     // Set the row align only when mipmapsNum == 1 and the data is uncompressed
-    auto mipmapEnalbed = isMipmapEnabled(_textureInfo.minFilterGL) || isMipmapEnabled(_textureInfo.magFilterGL);
-    if (!mipmapEnalbed)
+    auto mipmapEnabled = isMipmapEnabled(_textureInfo.minFilterGL) || isMipmapEnabled(_textureInfo.magFilterGL);
+    if (!mipmapEnabled)
     {
         unsigned int bytesPerRow = width * _bitsPerPixel / 8;
 
@@ -232,6 +232,14 @@ void Texture2DGL::updateData(uint8_t* data, std::size_t width, std::size_t heigh
                  _textureInfo.format, _textureInfo.type, data);
 
     CHECK_GL_ERROR_DEBUG();
+
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    if (_generateMipmaps)
+    {
+        _hasMipmaps = false;
+        generateMipmaps();
+    }
+#endif
 
     if (!_hasMipmaps && level > 0)
         _hasMipmaps = true;
@@ -304,6 +312,9 @@ void Texture2DGL::generateMipmaps()
 
     if (!_hasMipmaps)
     {
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+        _generateMipmaps = true;
+#endif
         _hasMipmaps = true;
         __gl->bindTexture(GL_TEXTURE_2D, (GLuint)this->getHandler());
         glGenerateMipmap(GL_TEXTURE_2D);

--- a/core/renderer/backend/opengl/TextureGL.h
+++ b/core/renderer/backend/opengl/TextureGL.h
@@ -207,6 +207,10 @@ private:
 
     TextureInfoGL _textureInfo;
     EventListener* _rendererRecreatedListener = nullptr;
+
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    bool _generateMipmaps = false;
+#endif
 };
 
 /**


### PR DESCRIPTION
Couple fixes for issues after GL context loss on Android:

* Fixes `Texture2D::getPath()` returning empty string.
* Fixes missing mipmaps for textures that had `Texture2D::generateMipmap()` called.