### PR TITLE
Renderer fixes

### DIFF
--- a/core/2d/Grid.cpp
+++ b/core/2d/Grid.cpp
@@ -219,7 +219,7 @@ void GridBase::beforeDraw()
         _oldRenderTarget = renderer->getRenderTarget();
         AX_SAFE_RELEASE(_renderTarget);
         _renderTarget =
-            backend::DriverBase::getInstance()->newRenderTarget(TargetBufferFlags::COLOR, _texture->getBackendTexture());
+            backend::DriverBase::getInstance()->newRenderTarget(_texture->getBackendTexture());
         renderer->setRenderTarget(_renderTarget);
     };
     renderer->addCallbackCommand(beforeDrawCommandFunc);

--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -187,11 +187,9 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         descriptor.textureFormat = PixelFormat::RGBA8;
         _texture2D               = new Texture2D();
         _texture2D->updateTextureDescriptor(descriptor, !!AX_ENABLE_PREMULTIPLIED_ALPHA);
-        _renderTargetFlags = RenderTargetFlag::COLOR;
 
         if (PixelFormat::D24S8 == depthStencilFormat || sharedRenderTarget)
         {
-            _renderTargetFlags       = RenderTargetFlag::ALL;
             descriptor.textureFormat = PixelFormat::D24S8;
 
             AX_SAFE_RELEASE(_depthStencilTexture);
@@ -210,7 +208,7 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         else
         {
              _renderTarget = backend::DriverBase::getInstance()->newRenderTarget(
-                 _renderTargetFlags, _texture2D ? _texture2D->getBackendTexture() : nullptr,
+                 _texture2D ? _texture2D->getBackendTexture() : nullptr,
                  _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr,
                  _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr);	        
         }

--- a/core/2d/RenderTexture.h
+++ b/core/2d/RenderTexture.h
@@ -396,7 +396,6 @@ protected:
 
     backend::RenderTarget* _renderTarget    = nullptr;
     backend::RenderTarget* _oldRenderTarget = nullptr;
-    RenderTargetFlag _renderTargetFlags{};
 
     RefPtr<Image> _UITextureImage            = nullptr;
     backend::PixelFormat _pixelFormat = backend::PixelFormat::RGBA8;

--- a/core/base/Types.h
+++ b/core/base/Types.h
@@ -469,7 +469,6 @@ using PixelFormat  = backend::PixelFormat;
 
 using TargetBufferFlags = backend::TargetBufferFlags;
 using DepthStencilFlags = backend::DepthStencilFlags;
-using RenderTargetFlag  = backend::RenderTargetFlag;
 using ClearFlag         = backend::ClearFlag;
 
 typedef void (*AsyncOperation)(void* param);

--- a/core/renderer/Renderer.cpp
+++ b/core/renderer/Renderer.cpp
@@ -282,13 +282,7 @@ void Renderer::processGroupCommand(GroupCommand* command)
 
     int renderQueueID = ((GroupCommand*)command)->getRenderQueueID();
 
-    pushStateBlock();
-    // apply default state for all render queues
-    setDepthTest(false);
-    setDepthWrite(false);
-    setCullMode(backend::CullMode::NONE);
     visitRenderQueue(_renderGroups[renderQueueID]);
-    popStateBlock();
 }
 
 void Renderer::processRenderCommand(RenderCommand* command)
@@ -357,6 +351,13 @@ void Renderer::processRenderCommand(RenderCommand* command)
 
 void Renderer::visitRenderQueue(RenderQueue& queue)
 {
+    pushStateBlock();
+
+    // Apply default state for all render queues
+    setDepthTest(false);
+    setDepthWrite(false);
+    setCullMode(backend::CullMode::NONE);
+
     //
     // Process Global-Z < 0 Objects
     //
@@ -387,6 +388,8 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     // Process Global-Z > 0 Queue
     //
     doVisitRenderQueue(queue.getSubQueue(RenderQueue::QUEUE_GROUP::GLOBALZ_POS));
+
+    popStateBlock();
 }
 
 void Renderer::doVisitRenderQueue(const std::vector<RenderCommand*>& renderCommands)

--- a/core/renderer/Renderer.cpp
+++ b/core/renderer/Renderer.cpp
@@ -204,9 +204,8 @@ void Renderer::init()
 
     auto driver    = backend::DriverBase::getInstance();
     _commandBuffer = driver->newCommandBuffer();
-    // @MTL: the depth stencil flags must same render target and _dsDesc
     _dsDesc.flags = DepthStencilFlags::ALL;
-    _defaultRT    = driver->newDefaultRenderTarget(TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH_AND_STENCIL);
+    _defaultRT    = driver->newDefaultRenderTarget();
 
     _currentRT      = _defaultRT;
     _renderPipeline = driver->newRenderPipeline();
@@ -218,7 +217,7 @@ void Renderer::init()
 
 backend::RenderTarget* Renderer::getOffscreenRenderTarget() {
     if (_offscreenRT != nullptr) return _offscreenRT;
-    return (_offscreenRT = backend::DriverBase::getInstance()->newRenderTarget(TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH_AND_STENCIL));
+    return (_offscreenRT = backend::DriverBase::getInstance()->newRenderTarget());
 }
 
 void Renderer::addCallbackCommand(std::function<void()> func, float globalZOrder)
@@ -455,29 +454,17 @@ void Renderer::clean()
 void Renderer::setDepthTest(bool value)
 {
     if (value)
-    {
-        _currentRT->addFlag(TargetBufferFlags::DEPTH);
         _dsDesc.addFlag(DepthStencilFlags::DEPTH_TEST);
-    }
     else
-    {
-        _currentRT->removeFlag(TargetBufferFlags::DEPTH);
         _dsDesc.removeFlag(DepthStencilFlags::DEPTH_TEST);
-    }
 }
 
 void Renderer::setStencilTest(bool value)
 {
     if (value)
-    {
-        _currentRT->addFlag(TargetBufferFlags::STENCIL);
         _dsDesc.addFlag(DepthStencilFlags::STENCIL_TEST);
-    }
     else
-    {
-        _currentRT->removeFlag(TargetBufferFlags::STENCIL);
         _dsDesc.removeFlag(DepthStencilFlags::STENCIL_TEST);
-    }
 }
 
 void Renderer::setDepthWrite(bool value)
@@ -849,7 +836,18 @@ void Renderer::readPixels(backend::RenderTarget* rt,
 void Renderer::beginRenderPass()
 {
     _commandBuffer->beginRenderPass(_currentRT, _renderPassDesc);
-    _commandBuffer->updateDepthStencilState(_dsDesc);
+
+    // Disable depth/stencil access if render target has no relevant attachments.
+    auto depthStencil = _dsDesc;
+    if (!_currentRT->isDefaultRenderTarget())
+    {
+        if (!_currentRT->_depth)
+            depthStencil.removeFlag(DepthStencilFlags::DEPTH_TEST | DepthStencilFlags::DEPTH_WRITE);
+        if (!_currentRT->_stencil)
+            depthStencil.removeFlag(DepthStencilFlags::STENCIL_TEST);
+    }
+
+    _commandBuffer->updateDepthStencilState(depthStencil);
     _commandBuffer->setStencilReferenceValue(_stencilRef);
 
     _commandBuffer->setViewport(_viewport.x, _viewport.y, _viewport.width, _viewport.height);
@@ -927,11 +925,6 @@ unsigned int Renderer::getClearStencil() const
 ClearFlag Renderer::getClearFlag() const
 {
     return _clearFlag;
-}
-
-RenderTargetFlag Renderer::getRenderTargetFlag() const
-{
-    return _currentRT->getTargetFlags();
 }
 
 void Renderer::setScissorTest(bool enabled)

--- a/core/renderer/Renderer.h
+++ b/core/renderer/Renderer.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-  
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -233,12 +233,6 @@ public:
      * @return The clear flag.
      */
     ClearFlag getClearFlag() const;
-
-    /**
-     * Get the render target flag.
-     * @return The render target flag.
-     */
-    RenderTargetFlag getRenderTargetFlag() const;
 
     // depth/stencil state.
 

--- a/core/renderer/backend/DepthStencilState.h
+++ b/core/renderer/backend/DepthStencilState.h
@@ -62,7 +62,6 @@ struct DepthStencilDescriptor
     StencilDescriptor frontFaceStencil;
     void addFlag(DepthStencilFlags flag) { this->flags |= flag; }
     void removeFlag(DepthStencilFlags flag) { this->flags &= ~flag; }
-    // must match current render target
     DepthStencilFlags flags = DepthStencilFlags::ALL;
 };
 

--- a/core/renderer/backend/DriverBase.h
+++ b/core/renderer/backend/DriverBase.h
@@ -110,10 +110,9 @@ public:
      */
     virtual TextureBackend* newTexture(const TextureDescriptor& descriptor) = 0;
 
-    virtual RenderTarget* newDefaultRenderTarget(TargetBufferFlags rtf) = 0;
+    virtual RenderTarget* newDefaultRenderTarget() = 0;
 
-    virtual RenderTarget* newRenderTarget(TargetBufferFlags rtf,
-                                          TextureBackend* colorAttachment    = nullptr,
+    virtual RenderTarget* newRenderTarget(TextureBackend* colorAttachment    = nullptr,
                                           TextureBackend* depthAttachment    = nullptr,
                                           TextureBackend* stencilAttachhment = nullptr) = 0;
 

--- a/core/renderer/backend/RenderTarget.h
+++ b/core/renderer/backend/RenderTarget.h
@@ -28,18 +28,6 @@ public:
 
     bool isDefaultRenderTarget() const { return _defaultRenderTarget; }
 
-    void addFlag(TargetBufferFlags flag) {
-        setTargetFlags(_flags |= flag);
-    }
-    void removeFlag(TargetBufferFlags flag) { 
-        setTargetFlags(_flags & ~flag);
-    }
-
-    TargetBufferFlags getTargetFlags() const { return _flags; }
-    void setTargetFlags(TargetBufferFlags flags) { 
-        _flags = flags; 
-    }
-
     void setColorAttachment(ColorAttachment attachment)
     {
         for (auto colorItem : _color)
@@ -83,12 +71,10 @@ public:
     ColorAttachment _color{};
     RenderBuffer _depth{};
     RenderBuffer _stencil{};
-    TargetBufferFlags _flags{};
 
 protected:
     bool _defaultRenderTarget = false;
     mutable bool _dirty = false;
-    // uint8_t samples = 1;
 };
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/RenderTarget.h
+++ b/core/renderer/backend/RenderTarget.h
@@ -30,43 +30,54 @@ public:
 
     void setColorAttachment(ColorAttachment attachment)
     {
-        for (auto colorItem : _color)
+        for (int i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
+        {
+            auto colorItem = _color[i];
+            if (colorItem.texture != attachment[i].texture || colorItem.level != attachment[i].level)
+                _dirtyFlags |= getMRTColorFlag(i);
             AX_SAFE_RELEASE(colorItem.texture);
+        }
         memcpy(_color, attachment, sizeof(ColorAttachment));
         for (auto colorItem : _color)
             AX_SAFE_RETAIN(colorItem.texture);
-
-        _dirty = true;
     };
 
-    void setColorAttachment(TextureBackend* attachment, int level = 0, int index = 0) { 
-        AX_SAFE_RELEASE(_color[index].texture);
-        _color[index].texture = attachment;
-        _color[index].level   = level;
-        AX_SAFE_RETAIN(_color[index].texture);
-        _dirty = true;
+    void setColorAttachment(TextureBackend* attachment, int level = 0, int index = 0)
+    {
+        if (_color[index].texture != attachment || _color[index].level != level)
+        {
+            _dirtyFlags |= getMRTColorFlag(index);
+            AX_SAFE_RELEASE(_color[index].texture);
+            _color[index].texture = attachment;
+            _color[index].level   = level;
+            AX_SAFE_RETAIN(_color[index].texture);
+        }
     }
 
     void setDepthAttachment(TextureBackend* attachment, int level = 0)
     {
-        AX_SAFE_RELEASE(_depth.texture);
-        _depth.texture = attachment;
-        _depth.level   = level;
-        AX_SAFE_RETAIN(_depth.texture);
-
-        _dirty = true;
+        if (_depth.texture != attachment || _depth.level != level)
+        {
+            _dirtyFlags |= TargetBufferFlags::DEPTH;
+            AX_SAFE_RELEASE(_depth.texture);
+            _depth.texture = attachment;
+            _depth.level   = level;
+            AX_SAFE_RETAIN(_depth.texture);
+        }
     };
     void setStencilAttachment(TextureBackend* attachment, int level = 0)
     {
-        AX_SAFE_RELEASE(_stencil.texture);
-        _stencil.texture = attachment;
-        _stencil.level   = level;
-        AX_SAFE_RETAIN(_stencil.texture);
-
-        _dirty = true;
+        if (_stencil.texture != attachment || _depth.level != level)
+        {
+            _dirtyFlags |= TargetBufferFlags::STENCIL;
+            AX_SAFE_RELEASE(_stencil.texture);
+            _stencil.texture = attachment;
+            _stencil.level   = level;
+            AX_SAFE_RETAIN(_stencil.texture);
+        }
     };
-    
-    bool isDirty() const { return _dirty; }
+
+    bool isDirty() const { return !!_dirtyFlags; }
 
     ColorAttachment _color{};
     RenderBuffer _depth{};
@@ -74,7 +85,7 @@ public:
 
 protected:
     bool _defaultRenderTarget = false;
-    mutable bool _dirty = false;
+    mutable TargetBufferFlags _dirtyFlags{};
 };
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -45,7 +45,6 @@ inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept
 }
 
 typedef TargetBufferFlags ClearFlag;
-typedef TargetBufferFlags RenderTargetFlag;
 
 struct SamplerDescriptor
 {

--- a/core/renderer/backend/metal/CommandBufferMTL.h
+++ b/core/renderer/backend/metal/CommandBufferMTL.h
@@ -255,7 +255,6 @@ private:
     dispatch_semaphore_t _frameBoundarySemaphore;
     const RenderTarget* _currentRenderTarget = nil;  // weak ref
     RenderPassDescriptor _currentRenderPassDesc;
-    TargetBufferFlags _currentRenderTargetFlags = TargetBufferFlags::NONE;
     NSAutoreleasePool* _autoReleasePool         = nil;
 
     std::vector<std::pair<TextureBackend*, std::function<void(const PixelBufferDescriptor&)>>> _captureCallbacks;

--- a/core/renderer/backend/metal/CommandBufferMTL.mm
+++ b/core/renderer/backend/metal/CommandBufferMTL.mm
@@ -204,7 +204,6 @@ void CommandBufferMTL::updateRenderCommandEncoder(const RenderTarget* renderTarg
                                                   const RenderPassDescriptor& renderPassDesc)
 {
     if (_mtlRenderEncoder != nil && _currentRenderPassDesc == renderPassDesc && _currentRenderTarget == renderTarget &&
-        _currentRenderTargetFlags == renderTarget->getTargetFlags() &&
         !renderTarget->isDirty())
     {
         return;
@@ -212,7 +211,6 @@ void CommandBufferMTL::updateRenderCommandEncoder(const RenderTarget* renderTarg
 
     _currentRenderTarget      = renderTarget;
     _currentRenderPassDesc    = renderPassDesc;
-    _currentRenderTargetFlags = renderTarget->getTargetFlags();
 
     if (_mtlRenderEncoder != nil)
     {

--- a/core/renderer/backend/metal/DepthStencilStateMTL.h
+++ b/core/renderer/backend/metal/DepthStencilStateMTL.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -62,6 +63,8 @@ private:
 
     // the current depth stencil state
     id<MTLDepthStencilState> _mtlDepthStencilState = nil;
+    // static state for disabled depth and stencil
+    id<MTLDepthStencilState> _mtlDepthStencilDisabledState = nil;
 
     tsl::robin_map<uint32_t, id<MTLDepthStencilState>> _mtlStateCache;
 };

--- a/core/renderer/backend/metal/DepthStencilStateMTL.mm
+++ b/core/renderer/backend/metal/DepthStencilStateMTL.mm
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -107,7 +108,13 @@ void setMTLStencilDescriptor(MTLStencilDescriptor* stencilDescriptor, const Sten
 }
 }
 
-DepthStencilStateMTL::DepthStencilStateMTL(id<MTLDevice> mtlDevice) : _mtlDevice(mtlDevice) {}
+DepthStencilStateMTL::DepthStencilStateMTL(id<MTLDevice> mtlDevice) : _mtlDevice(mtlDevice)
+{
+    // By default MTLDepthStencilDescriptor disables depth and stencil access
+    MTLDepthStencilDescriptor* mtlDescriptor = [MTLDepthStencilDescriptor new];
+    _mtlDepthStencilDisabledState = [mtlDevice newDepthStencilStateWithDescriptor:mtlDescriptor];
+    [mtlDescriptor release];
+}
 
 void DepthStencilStateMTL::update(const DepthStencilDescriptor& dsDesc)
 {
@@ -115,7 +122,7 @@ void DepthStencilStateMTL::update(const DepthStencilDescriptor& dsDesc)
 
     if (!isEnabled())
     {
-        _mtlDepthStencilState = nil;
+        _mtlDepthStencilState = _mtlDepthStencilDisabledState;
         return;
     }
 
@@ -159,6 +166,7 @@ void DepthStencilStateMTL::update(const DepthStencilDescriptor& dsDesc)
 DepthStencilStateMTL::~DepthStencilStateMTL()
 {
     _mtlDepthStencilState = nullptr;
+    [_mtlDepthStencilDisabledState release];
     for (auto& stateItem : _mtlStateCache)
         [stateItem.second release];
     _mtlStateCache.clear();

--- a/core/renderer/backend/metal/DriverMTL.h
+++ b/core/renderer/backend/metal/DriverMTL.h
@@ -149,9 +149,8 @@ public:
      */
     TextureBackend* newTexture(const TextureDescriptor& descriptor) override;
 
-    RenderTarget* newDefaultRenderTarget(TargetBufferFlags rtf) override;
-    RenderTarget* newRenderTarget(TargetBufferFlags rtf,
-                                  TextureBackend* colorAttachment,
+    RenderTarget* newDefaultRenderTarget() override;
+    RenderTarget* newRenderTarget(TextureBackend* colorAttachment,
                                   TextureBackend* depthAttachment,
                                   TextureBackend* stencilAttachhment) override;
 

--- a/core/renderer/backend/metal/DriverMTL.mm
+++ b/core/renderer/backend/metal/DriverMTL.mm
@@ -482,20 +482,17 @@ TextureBackend* DriverMTL::newTexture(const TextureDescriptor& descriptor)
     }
 }
 
-RenderTarget* DriverMTL::newDefaultRenderTarget(TargetBufferFlags rtf)
+RenderTarget* DriverMTL::newDefaultRenderTarget()
 {
     auto rtGL = new RenderTargetMTL(true);
-    rtGL->setTargetFlags(rtf);
     return rtGL;
 }
 
-RenderTarget* DriverMTL::newRenderTarget(TargetBufferFlags rtf,
-                                         TextureBackend* colorAttachment,
+RenderTarget* DriverMTL::newRenderTarget(TextureBackend* colorAttachment,
                                          TextureBackend* depthAttachment,
                                          TextureBackend* stencilAttachhment)
 {
     auto rtMTL = new RenderTargetMTL(false);
-    rtMTL->setTargetFlags(rtf);
     RenderTarget::ColorAttachment colors{{colorAttachment, 0}};
     rtMTL->setColorAttachment(colors);
     rtMTL->setDepthAttachment(depthAttachment);

--- a/core/renderer/backend/metal/RenderPipelineMTL.mm
+++ b/core/renderer/backend/metal/RenderPipelineMTL.mm
@@ -308,22 +308,11 @@ void RenderPipelineMTL::chooseAttachmentFormat(const RenderTarget* renderTarget,
 {
     // Choose color attachment format
     auto rtMTL   = static_cast<const RenderTargetMTL*>(renderTarget);
-    auto rtflags = rtMTL->getTargetFlags();
     for (auto i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
-    {
-        colorAttachmentsFormat[i] =
-            bitmask::any(rtflags, getMRTColorFlag(i)) ? rtMTL->getColorAttachmentPixelFormat(i) : PixelFormat::NONE;
-    }
+        colorAttachmentsFormat[i] = rtMTL->getColorAttachmentPixelFormat(i);
 
-    if (bitmask::any(rtflags, RenderTargetFlag::DEPTH_AND_STENCIL))
-    {
-        depthFormat   = rtMTL->getDepthAttachmentPixelFormat();
-        stencilFormat = rtMTL->getStencilAttachmentPixelFormat();
-    }
-    else
-    {
-        depthFormat = stencilFormat = PixelFormat::NONE;
-    }
+    depthFormat   = rtMTL->getDepthAttachmentPixelFormat();
+    stencilFormat = rtMTL->getStencilAttachmentPixelFormat();
 }
 
 void RenderPipelineMTL::setBlendStateAndFormat(const BlendDescriptor& blendDescriptor)

--- a/core/renderer/backend/metal/RenderTargetMTL.mm
+++ b/core/renderer/backend/metal/RenderTargetMTL.mm
@@ -122,7 +122,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassDescriptor& par
     }
 #endif
     
-    _dirty = false;
+    _dirtyFlags = TargetBufferFlags::NONE;
 }
 
 RenderTargetMTL::Attachment RenderTargetMTL::getColorAttachment(int index) const

--- a/core/renderer/backend/metal/RenderTargetMTL.mm
+++ b/core/renderer/backend/metal/RenderTargetMTL.mm
@@ -77,7 +77,6 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassDescriptor& par
     }
 
     // Sets descriptor depth and stencil params, should match RenderTargetMTL::chooseAttachmentFormat
-    if (bitmask::any(this->_flags, RenderTargetFlag::DEPTH_AND_STENCIL))
     {
         auto depthAttachment = getDepthAttachment();
         if (depthAttachment)
@@ -163,23 +162,19 @@ PixelFormat RenderTargetMTL::getColorAttachmentPixelFormat(int index) const
 
 PixelFormat RenderTargetMTL::getDepthAttachmentPixelFormat() const
 {  // FIXME: axmol only support D24S8
-    if (bitmask::any(_flags, TargetBufferFlags::DEPTH_AND_STENCIL))
-    {
-        if (isDefaultRenderTarget() || !_depth)
-            return PixelFormat::D24S8;
+    if (isDefaultRenderTarget())
+        return PixelFormat::D24S8;
+    if (_depth)
         return _depth.texture->getTextureFormat();
-    }
     return PixelFormat::NONE;
 }
 
 PixelFormat RenderTargetMTL::getStencilAttachmentPixelFormat() const
 {  // FIXME: axmol only support D24S8
-    if (bitmask::any(_flags, TargetBufferFlags::DEPTH_AND_STENCIL))
-    {
-        if (isDefaultRenderTarget() || !_stencil)
-            return PixelFormat::D24S8;
+    if (isDefaultRenderTarget())
+        return PixelFormat::D24S8;
+    if (_stencil)
         return _stencil.texture->getTextureFormat();
-    }
     return PixelFormat::NONE;
 }
 

--- a/core/renderer/backend/opengl/DriverGL.cpp
+++ b/core/renderer/backend/opengl/DriverGL.cpp
@@ -221,20 +221,17 @@ TextureBackend* DriverGL::newTexture(const TextureDescriptor& descriptor)
     }
 }
 
-RenderTarget* DriverGL::newDefaultRenderTarget(TargetBufferFlags rtf)
+RenderTarget* DriverGL::newDefaultRenderTarget()
 {
     auto rtGL = new RenderTargetGL(true, this);
-    rtGL->setTargetFlags(rtf);
     return rtGL;
 }
 
-RenderTarget* DriverGL::newRenderTarget(TargetBufferFlags rtf,
-                                        TextureBackend* colorAttachment,
+RenderTarget* DriverGL::newRenderTarget(TextureBackend* colorAttachment,
                                         TextureBackend* depthAttachment,
                                         TextureBackend* stencilAttachhment)
 {
     auto rtGL = new RenderTargetGL(false, this);
-    rtGL->setTargetFlags(rtf);
     rtGL->bindFrameBuffer();
     RenderTarget::ColorAttachment colors{{colorAttachment, 0}};
     rtGL->setColorAttachment(colors);

--- a/core/renderer/backend/opengl/DriverGL.h
+++ b/core/renderer/backend/opengl/DriverGL.h
@@ -70,9 +70,8 @@ public:
      */
     TextureBackend* newTexture(const TextureDescriptor& descriptor) override;
 
-    RenderTarget* newDefaultRenderTarget(TargetBufferFlags rtf) override;
-    RenderTarget* newRenderTarget(TargetBufferFlags rtf,
-                                  TextureBackend* colorAttachment,
+    RenderTarget* newDefaultRenderTarget() override;
+    RenderTarget* newRenderTarget(TextureBackend* colorAttachment,
                                   TextureBackend* depthAttachment,
                                   TextureBackend* stencilAttachhment) override;
 

--- a/core/renderer/backend/opengl/RenderTargetGL.cpp
+++ b/core/renderer/backend/opengl/RenderTargetGL.cpp
@@ -50,14 +50,15 @@ void RenderTargetGL::update() const {
             GLenum bufs[MAX_COLOR_ATTCHMENT] = {GL_NONE};
             for (size_t i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
             {
+                GLuint texture = 0;
+                GLint level = 0;
                 if (_color[i])
                 {
-                    auto textureInfo    = _color[i];
-                    auto textureHandler = static_cast<GLuint>(textureInfo.texture != nullptr ? textureInfo.texture->getHandler() : 0);
-                    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D, textureHandler,
-                                        textureInfo.level);
+                    texture = static_cast<GLuint>(_color[i].texture->getHandler());
+                    level = _color[i].level;
                     bufs[i] = GL_COLOR_ATTACHMENT0 + i;
                 }
+                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D, texture, level);
             }
     #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32 || AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
             glDrawBuffers(MAX_COLOR_ATTCHMENT, bufs);

--- a/core/renderer/backend/opengl/RenderTargetGL.cpp
+++ b/core/renderer/backend/opengl/RenderTargetGL.cpp
@@ -43,41 +43,50 @@ void RenderTargetGL::unbindFrameBuffer() const
     __gl->bindFrameBuffer(0);
 }
 
-void RenderTargetGL::update() const {
-    if (!_dirty) return;
-    if(!_defaultRenderTarget) {
-        { // color attachments
+void RenderTargetGL::update() const
+{
+    if (!_dirtyFlags)
+        return;
+    if (!_defaultRenderTarget)
+    {
+        if (bitmask::any(_dirtyFlags, TargetBufferFlags::COLOR_ALL))
+        {  // color attachments
             GLenum bufs[MAX_COLOR_ATTCHMENT] = {GL_NONE};
             for (size_t i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
             {
-                GLuint texture = 0;
-                GLint level = 0;
-                if (_color[i])
-                {
-                    texture = static_cast<GLuint>(_color[i].texture->getHandler());
-                    level = _color[i].level;
+                auto textureInfo = _color[i];
+                if (textureInfo.texture)
                     bufs[i] = GL_COLOR_ATTACHMENT0 + i;
-                }
-                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D, texture, level);
+                if (bitmask::any(_dirtyFlags, getMRTColorFlag(i)))
+                    glFramebufferTexture2D(
+                        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D,
+                        static_cast<GLuint>(textureInfo.texture ? textureInfo.texture->getHandler() : 0),
+                        textureInfo.level);
             }
-    #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32 || AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
+#if AX_GLES_PROFILE != 200
             glDrawBuffers(MAX_COLOR_ATTCHMENT, bufs);
-    #endif
+#endif
             CHECK_GL_ERROR_DEBUG();
         }
 
-        // depth attacmhemt
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
-                               _depth.texture != nullptr ? _depth.texture->getHandler() : 0, _depth.level);
-        CHECK_GL_ERROR_DEBUG();
+        if (bitmask::any(_dirtyFlags, TargetBufferFlags::DEPTH))
+        {
+            // depth attacmhemt
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                                   _depth.texture != nullptr ? _depth.texture->getHandler() : 0, _depth.level);
+            CHECK_GL_ERROR_DEBUG();
+        }
 
-        // stencil attachment
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
-                               _stencil.texture != nullptr ? _stencil.texture->getHandler() : 0, _stencil.level);
-        CHECK_GL_ERROR_DEBUG();
+        if (bitmask::any(_dirtyFlags, TargetBufferFlags::STENCIL))
+        {
+            // stencil attachment
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                                   _stencil.texture != nullptr ? _stencil.texture->getHandler() : 0, _stencil.level);
+            CHECK_GL_ERROR_DEBUG();
+        }
     }
 
-    _dirty = false;
+    _dirtyFlags = TargetBufferFlags::NONE;
 }
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/opengl/RenderTargetGL.cpp
+++ b/core/renderer/backend/opengl/RenderTargetGL.cpp
@@ -46,12 +46,11 @@ void RenderTargetGL::unbindFrameBuffer() const
 void RenderTargetGL::update() const {
     if (!_dirty) return;
     if(!_defaultRenderTarget) {
-        if(bitmask::any(_flags, TargetBufferFlags::COLOR_ALL))
         { // color attachments
             GLenum bufs[MAX_COLOR_ATTCHMENT] = {GL_NONE};
             for (size_t i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
             {
-                if (bitmask::any(_flags, getMRTColorFlag(i)))
+                if (_color[i])
                 {
                     auto textureInfo    = _color[i];
                     auto textureHandler = static_cast<GLuint>(textureInfo.texture != nullptr ? textureInfo.texture->getHandler() : 0);
@@ -74,7 +73,7 @@ void RenderTargetGL::update() const {
         // stencil attachment
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
                                _stencil.texture != nullptr ? _stencil.texture->getHandler() : 0, _stencil.level);
-        CHECK_GL_ERROR_DEBUG();        
+        CHECK_GL_ERROR_DEBUG();
     }
 
     _dirty = false;

--- a/extensions/scripting/lua-bindings/auto/axlua_backend_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_backend_auto.cpp
@@ -2677,21 +2677,18 @@ int lua_ax_backend_DriverBase_newDefaultRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 0) 
     {
-        ax::backend::TargetBufferFlags arg0;
-
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axb.DriverBase:newDefaultRenderTarget");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_backend_DriverBase_newDefaultRenderTarget'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->newDefaultRenderTarget(arg0);
+        auto&& ret = cobj->newDefaultRenderTarget();
         object_to_luaval<ax::backend::RenderTarget>(tolua_S, "axb.RenderTarget",(ax::backend::RenderTarget*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axb.DriverBase:newDefaultRenderTarget",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axb.DriverBase:newDefaultRenderTarget",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -2727,11 +2724,22 @@ int lua_ax_backend_DriverBase_newRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_backend_DriverBase_newRenderTarget'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->newRenderTarget();
+        object_to_luaval<ax::backend::RenderTarget>(tolua_S, "axb.RenderTarget",(ax::backend::RenderTarget*)ret);
+        return 1;
+    }
     if (argc == 1) 
     {
-        ax::backend::TargetBufferFlags arg0;
+        ax::backend::TextureBackend* arg0;
 
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axb.DriverBase:newRenderTarget");
+        ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 2, "axb.TextureBackend",&arg0, "axb.DriverBase:newRenderTarget");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_backend_DriverBase_newRenderTarget'", nullptr);
@@ -2743,10 +2751,10 @@ int lua_ax_backend_DriverBase_newRenderTarget(lua_State* tolua_S)
     }
     if (argc == 2) 
     {
-        ax::backend::TargetBufferFlags arg0;
+        ax::backend::TextureBackend* arg0;
         ax::backend::TextureBackend* arg1;
 
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axb.DriverBase:newRenderTarget");
+        ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 2, "axb.TextureBackend",&arg0, "axb.DriverBase:newRenderTarget");
 
         ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 3, "axb.TextureBackend",&arg1, "axb.DriverBase:newRenderTarget");
         if(!ok)
@@ -2760,11 +2768,11 @@ int lua_ax_backend_DriverBase_newRenderTarget(lua_State* tolua_S)
     }
     if (argc == 3) 
     {
-        ax::backend::TargetBufferFlags arg0;
+        ax::backend::TextureBackend* arg0;
         ax::backend::TextureBackend* arg1;
         ax::backend::TextureBackend* arg2;
 
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axb.DriverBase:newRenderTarget");
+        ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 2, "axb.TextureBackend",&arg0, "axb.DriverBase:newRenderTarget");
 
         ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 3, "axb.TextureBackend",&arg1, "axb.DriverBase:newRenderTarget");
 
@@ -2778,30 +2786,7 @@ int lua_ax_backend_DriverBase_newRenderTarget(lua_State* tolua_S)
         object_to_luaval<ax::backend::RenderTarget>(tolua_S, "axb.RenderTarget",(ax::backend::RenderTarget*)ret);
         return 1;
     }
-    if (argc == 4) 
-    {
-        ax::backend::TargetBufferFlags arg0;
-        ax::backend::TextureBackend* arg1;
-        ax::backend::TextureBackend* arg2;
-        ax::backend::TextureBackend* arg3;
-
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axb.DriverBase:newRenderTarget");
-
-        ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 3, "axb.TextureBackend",&arg1, "axb.DriverBase:newRenderTarget");
-
-        ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 4, "axb.TextureBackend",&arg2, "axb.DriverBase:newRenderTarget");
-
-        ok &= luaval_to_object<ax::backend::TextureBackend>(tolua_S, 5, "axb.TextureBackend",&arg3, "axb.DriverBase:newRenderTarget");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_backend_DriverBase_newRenderTarget'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->newRenderTarget(arg0, arg1, arg2, arg3);
-        object_to_luaval<ax::backend::RenderTarget>(tolua_S, "axb.RenderTarget",(ax::backend::RenderTarget*)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axb.DriverBase:newRenderTarget",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axb.DriverBase:newRenderTarget",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -99230,53 +99230,6 @@ int lua_ax_base_Renderer_getClearFlag(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Renderer_getRenderTargetFlag(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Renderer* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Renderer",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Renderer*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Renderer_getRenderTargetFlag'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Renderer_getRenderTargetFlag'", nullptr);
-            return 0;
-        }
-        int ret = (int)cobj->getRenderTargetFlag();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Renderer:getRenderTargetFlag",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Renderer_getRenderTargetFlag'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_base_Renderer_setDepthTest(lua_State* tolua_S)
 {
     int argc = 0;
@@ -101079,7 +101032,6 @@ int lua_register_ax_base_Renderer(lua_State* tolua_S)
         tolua_function(tolua_S,"getClearDepth",lua_ax_base_Renderer_getClearDepth);
         tolua_function(tolua_S,"getClearStencil",lua_ax_base_Renderer_getClearStencil);
         tolua_function(tolua_S,"getClearFlag",lua_ax_base_Renderer_getClearFlag);
-        tolua_function(tolua_S,"getRenderTargetFlag",lua_ax_base_Renderer_getRenderTargetFlag);
         tolua_function(tolua_S,"setDepthTest",lua_ax_base_Renderer_setDepthTest);
         tolua_function(tolua_S,"setDepthWrite",lua_ax_base_Renderer_setDepthWrite);
         tolua_function(tolua_S,"setDepthCompareFunction",lua_ax_base_Renderer_setDepthCompareFunction);


### PR DESCRIPTION
Fixed #1981 PR. First two commits are same as in last PR. New commit fixes the issue of GL render target attachments not being cleared: https://github.com/axmolengine/axmol/commit/fb1ae45e213e2230e9bd9d8ceaf663e6248cd9d8 . @solan-solan please check if this fixes the issue in your project.