### PR TITLE
Mark AXLOG, AXLOGINFO, AXLOGWARN, AXLOGERROR deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Mark as deprecated
 
 - `AsyncTaskPool`, use `JobSystem` instead.
+- `AXLOG`, `AXLOGINFO`, `AXLOGWARN`, `AXLOGERROR`, use `AXLOGD`, `AXLOGI`, `AXLOGE` instead.
 
 ### Bug Fixes
 

--- a/core/2d/Action.cpp
+++ b/core/2d/Action.cpp
@@ -42,7 +42,7 @@ Action::Action() : _originalTarget(nullptr), _target(nullptr), _tag(Action::INVA
 
 Action::~Action()
 {
-    AXLOGINFO("deallocing Action: %p - tag: %i", this, _tag);
+    AXLOGV("deallocing Action: {} - tag: {}", fmt::ptr(this), _tag);
 }
 
 std::string Action::description() const
@@ -67,12 +67,12 @@ bool Action::isDone() const
 
 void Action::step(float /*dt*/)
 {
-    AXLOG("[Action step]. override me");
+    AXLOGD("[Action step]. override me");
 }
 
 void Action::update(float /*time*/)
 {
-    AXLOG("[Action update]. override me");
+    AXLOGD("[Action update]. override me");
 }
 
 //

--- a/core/2d/ActionCatmullRom.cpp
+++ b/core/2d/ActionCatmullRom.cpp
@@ -79,7 +79,7 @@ PointArray* PointArray::clone() const
 
 PointArray::~PointArray()
 {
-    AXLOGINFO("deallocing PointArray: %p", this);
+    AXLOGV("deallocing PointArray: {}", fmt::ptr(this));
 }
 
 PointArray::PointArray() {}

--- a/core/2d/ActionGrid3D.cpp
+++ b/core/2d/ActionGrid3D.cpp
@@ -74,7 +74,7 @@ void Waves3D::update(float time)
             Vec2 pos((float)i, (float)j);
             Vec3 v = getOriginalVertex(pos);
             v.z += (sinf((float)M_PI * time * _waves * 2 + (v.y + v.x) * 0.01f) * _amplitude * _amplitudeRate);
-            // AXLOG("v.z offset is %f\n", (sinf((float)M_PI * time * _waves * 2 + (v.y+v.x) * .01f) * _amplitude *
+            // AXLOGD("v.z offset is {}\n", (sinf((float)M_PI * time * _waves * 2 + (v.y+v.x) * .01f) * _amplitude *
             // _amplitudeRate));
             setVertex(pos, v);
         }

--- a/core/2d/ActionManager.cpp
+++ b/core/2d/ActionManager.cpp
@@ -42,7 +42,7 @@ ActionManager::ActionManager() : _currentTarget(nullptr), _currentTargetSalvaged
 
 ActionManager::~ActionManager()
 {
-    AXLOGINFO("deallocing ActionManager: %p", this);
+    AXLOGV("deallocing ActionManager: {}", fmt::ptr(this));
 
     removeAllActions();
 }

--- a/core/2d/Animation.cpp
+++ b/core/2d/Animation.cpp
@@ -59,7 +59,7 @@ bool AnimationFrame::initWithSpriteFrame(SpriteFrame* spriteFrame, float delayUn
 
 AnimationFrame::~AnimationFrame()
 {
-    AXLOGINFO("deallocing AnimationFrame: %p", this);
+    AXLOGD("deallocing AnimationFrame: {}", fmt::ptr(this));
 
     AX_SAFE_RELEASE(_spriteFrame);
 }
@@ -153,7 +153,7 @@ Animation::Animation()
 
 Animation::~Animation()
 {
-    AXLOGINFO("deallocing Animation: %p", this);
+    AXLOGV("deallocing Animation: {}", fmt::ptr(this));
 }
 
 void Animation::addSpriteFrame(SpriteFrame* spriteFrame)

--- a/core/2d/AnimationCache.cpp
+++ b/core/2d/AnimationCache.cpp
@@ -61,7 +61,7 @@ AnimationCache::AnimationCache() {}
 
 AnimationCache::~AnimationCache()
 {
-    AXLOGINFO("deallocing AnimationCache: %p", this);
+    AXLOGV("deallocing AnimationCache: {}", fmt::ptr(this));
 }
 
 void AnimationCache::addAnimation(Animation* animation, std::string_view name)
@@ -95,10 +95,10 @@ void AnimationCache::parseVersion1(const ValueMap& animations)
 
         if (frameNames.empty())
         {
-            AXLOG(
-                "axmol: AnimationCache: Animation '%s' found in dictionary without any frames - cannot add to "
+            AXLOGW(
+                "axmol: AnimationCache: Animation '{}' found in dictionary without any frames - cannot add to "
                 "animation cache.",
-                anim.first.c_str());
+                anim.first);
             continue;
         }
 
@@ -111,10 +111,10 @@ void AnimationCache::parseVersion1(const ValueMap& animations)
 
             if (!spriteFrame)
             {
-                AXLOG(
-                    "axmol:AnimationCache: Animation '%s' refers to frame '%s' which is not currently in the "
+                AXLOGW(
+                    "axmol:AnimationCache: Animation '{}' refers to frame '{}' which is not currently in the "
                     "SpriteFrameCache. This frame will not be added to the animation.",
-                    anim.first.c_str(), frameName.asString().c_str());
+                    anim.first, frameName.asString());
 
                 continue;
             }
@@ -125,18 +125,18 @@ void AnimationCache::parseVersion1(const ValueMap& animations)
 
         if (frames.empty())
         {
-            AXLOG(
-                "axmol:AnimationCache: None of the frames for animation '%s' were found in the SpriteFrameCache. "
+            AXLOGW(
+                "axmol:AnimationCache: None of the frames for animation '{}' were found in the SpriteFrameCache. "
                 "Animation is not being added to the Animation Cache.",
-                anim.first.c_str());
+                anim.first);
             continue;
         }
         else if (frames.size() != frameNameSize)
         {
-            AXLOG(
+            AXLOGW(
                 "axmol:AnimationCache: An animation in your dictionary refers to a frame which is not in the "
-                "SpriteFrameCache. Some or all of the frames for the animation '%s' may be missing.",
-                anim.first.c_str());
+                "SpriteFrameCache. Some or all of the frames for the animation '{}' may be missing.",
+                anim.first);
         }
 
         animation = Animation::create(frames, delay, 1);
@@ -161,10 +161,10 @@ void AnimationCache::parseVersion2(const ValueMap& animations)
 
         if (frameArray.empty())
         {
-            AXLOG(
-                "axmol:AnimationCache: Animation '%s' found in dictionary without any frames - cannot add to "
+            AXLOGW(
+                "axmol:AnimationCache: Animation '{}' found in dictionary without any frames - cannot add to "
                 "animation cache.",
-                name.c_str());
+                name);
             continue;
         }
 
@@ -179,10 +179,10 @@ void AnimationCache::parseVersion2(const ValueMap& animations)
 
             if (!spriteFrame)
             {
-                AXLOG(
-                    "axmol:AnimationCache: Animation '%s' refers to frame '%s' which is not currently in the "
+                AXLOGW(
+                    "axmol:AnimationCache: Animation '{}' refers to frame '{}' which is not currently in the "
                     "SpriteFrameCache. This frame will not be added to the animation.",
-                    name.c_str(), spriteFrameName.c_str());
+                    name, spriteFrameName);
 
                 continue;
             }
@@ -211,7 +211,7 @@ void AnimationCache::addAnimationsWithDictionary(const ValueMap& dictionary, std
     auto anisItr = dictionary.find("animations");
     if (anisItr == dictionary.end())
     {
-        AXLOG("axmol: AnimationCache: No animations were found in provided dictionary.");
+        AXLOGW("axmol: AnimationCache: No animations were found in provided dictionary.");
         return;
     }
 

--- a/core/2d/AutoPolygon.cpp
+++ b/core/2d/AutoPolygon.cpp
@@ -388,7 +388,7 @@ std::vector<ax::Vec2> AutoPolygon::marchSquare(const Rect& rect, const Vec2& sta
             }
             break;
         default:
-            AXLOG("this shouldn't happen.");
+            AXLOGD("this shouldn't happen.");
         }
         // little optimization
         //  if previous direction is same as current direction,
@@ -577,7 +577,7 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const ax:
         }
         else
         {
-            AXLOG("Clipper2 detect a hole!");
+            AXLOGW("Clipper2 detect a hole!");
         }
     }
 

--- a/core/2d/Camera.cpp
+++ b/core/2d/Camera.cpp
@@ -307,7 +307,7 @@ Vec2 Camera::projectGL(const Vec3& src) const
     getViewProjectionMatrix().transformVector(Vec4(src.x, src.y, src.z, 1.0f), &clipPos);
 
     if (clipPos.w == 0.0f)
-        AXLOG("WARNING: Camera's clip position w is 0.0! a black screen should be expected.");
+        AXLOGW("WARNING: Camera's clip position w is 0.0! a black screen should be expected.");
 
     float ndcX = clipPos.x / clipPos.w;
     float ndcY = clipPos.y / clipPos.w;

--- a/core/2d/ClippingNode.cpp
+++ b/core/2d/ClippingNode.cpp
@@ -103,7 +103,7 @@ void ClippingNode::onEnter()
     }
     else
     {
-        AXLOG("ClippingNode warning: _stencil is nil.");
+        AXLOGW("ClippingNode warning: _stencil is nil.");
     }
 }
 

--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -324,7 +324,7 @@ void FastTMXLayer::setupTiles()
         break;
     case FAST_TMX_ORIENTATION_HEX:
     default:
-        AXLOGERROR("FastTMX does not support type %d", _layerOrientation);
+        AXLOGE("FastTMX does not support type {}", _layerOrientation);
         break;
     }
 

--- a/core/2d/FastTMXTiledMap.cpp
+++ b/core/2d/FastTMXTiledMap.cpp
@@ -151,7 +151,7 @@ TMXTilesetInfo* FastTMXTiledMap::tilesetForLayer(TMXLayerInfo* layerInfo, TMXMap
     }
 
     // If all the tiles are 0, return empty tileset
-    AXLOG("axmol: Warning: TMX Layer '%s' has no tiles", layerInfo->_name.c_str());
+    AXLOGW("axmol: Warning: TMX Layer '{}' has no tiles", layerInfo->_name);
     return nullptr;
 }
 

--- a/core/2d/FontFNT.cpp
+++ b/core/2d/FontFNT.cpp
@@ -117,7 +117,7 @@ BMFontConfiguration::BMFontConfiguration() : _commonHeight(0), _characterSet(nul
 
 BMFontConfiguration::~BMFontConfiguration()
 {
-    AXLOGINFO("deallocing BMFontConfiguration: %p", this);
+    AXLOGV("deallocing BMFontConfiguration: {}", fmt::ptr(this));
     this->purgeFontDefDictionary();
     this->purgeKerningDictionary();
     _atlasName.clear();
@@ -156,7 +156,7 @@ std::set<unsigned int>* BMFontConfiguration::parseConfigFile(std::string_view co
     }
     if (data[0] == 0)
     {
-        AXLOG("axmol: Error parsing FNTfile %s", controlFile.data());
+        AXLOGW("axmol: Error parsing FNTfile {}", controlFile);
         return nullptr;
     }
     auto contents = data.c_str();
@@ -429,7 +429,7 @@ void BMFontConfiguration::parseInfoArguments(const char* line)
     // padding
     sscanf(strstr(line, "padding=") + 8, "%d,%d,%d,%d", &_padding.top, &_padding.right, &_padding.bottom,
            &_padding.left);
-    // AXLOG("axmol: padding: %d,%d,%d,%d", _padding.left, _padding.top, _padding.right, _padding.bottom);
+    // AXLOGD("axmol: padding: {},{},{},{}", _padding.left, _padding.top, _padding.right, _padding.bottom);
 }
 
 void BMFontConfiguration::parseCommonArguments(const char* line)
@@ -738,7 +738,7 @@ FontAtlas* FontFNT::newFontAtlas()
         // add the new definition
         if (65535 < fontDef.charID)
         {
-            AXLOGWARN("Warning: 65535 < fontDef.charID (%u), ignored", fontDef.charID);
+            AXLOGW("Warning: 65535 < fontDef.charID ({}), ignored", fontDef.charID);
         }
         else
         {

--- a/core/2d/Grid.cpp
+++ b/core/2d/Grid.cpp
@@ -150,7 +150,7 @@ void GridBase::updateBlendState()
 
 GridBase::~GridBase()
 {
-    AXLOGINFO("deallocing GridBase: %p", this);
+    AXLOGV("deallocing GridBase: {}", fmt::ptr(this));
 
     AX_SAFE_RELEASE(_renderTarget);
 

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -2258,7 +2258,7 @@ void Label::setAdditionalKerning(float space)
         }
     }
     else
-        AXLOG("Label::setAdditionalKerning not supported on LabelType::STRING_TEXTURE");
+        AXLOGW("Label::setAdditionalKerning not supported on LabelType::STRING_TEXTURE");
 }
 
 float Label::getAdditionalKerning() const
@@ -2525,7 +2525,7 @@ FontDefinition Label::_getFontDefinition() const
 #if (AX_TARGET_PLATFORM != AX_PLATFORM_ANDROID) && (AX_TARGET_PLATFORM != AX_PLATFORM_IOS)
     if (systemFontDef._stroke._strokeEnabled)
     {
-        AXLOGERROR("Stroke Currently only supported on iOS and Android!");
+        AXLOGE("Stroke Currently only supported on iOS and Android!");
     }
     systemFontDef._stroke._strokeEnabled = false;
 #endif
@@ -2835,8 +2835,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             if (!getFontLetterDef(character, letterDef))
             {
                 recordPlaceholderInfo(letterIndex, character);
-                AXLOG("LabelTextFormatter error: can't find letter definition in font file for letter: 0x%x",
-                      character);
+                AXLOGW("LabelTextFormatter error: can't find letter definition in font file for letter: 0x{:x}",
+                      static_cast<uint32_t>(character));
                 continue;
             }
 

--- a/core/2d/Menu.cpp
+++ b/core/2d/Menu.cpp
@@ -50,7 +50,7 @@ enum
 
 Menu::~Menu()
 {
-    AXLOGINFO("In the destructor of Menu. %p", this);
+    AXLOGV("In the destructor of Menu. {}", fmt::ptr(this));
 }
 
 Menu* Menu::create()

--- a/core/2d/MenuItem.cpp
+++ b/core/2d/MenuItem.cpp
@@ -347,7 +347,7 @@ MenuItemFont::MenuItemFont() : _fontSize(0), _fontName("") {}
 
 MenuItemFont::~MenuItemFont()
 {
-    AXLOGINFO("In the destructor of MenuItemFont (%p).", this);
+    AXLOGV("In the destructor of MenuItemFont ({}).", fmt::ptr(this));
 }
 
 bool MenuItemFont::initWithString(std::string_view value, const ccMenuCallback& callback)

--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -156,7 +156,7 @@ Node* Node::create()
 
 Node::~Node()
 {
-    AXLOGINFO("deallocing Node: %p - tag: %i", this, _tag);
+    AXLOGV("deallocing Node: {} - tag: {}", fmt::ptr(this), _tag);
 
     AX_SAFE_DELETE(_childrenIndexer);
 
@@ -1096,7 +1096,7 @@ void Node::removeChildByTag(int tag, bool cleanup /* = true */)
 
     if (child == nullptr)
     {
-        AXLOG("axmol: removeChildByTag(tag = %d): child not found!", tag);
+        AXLOGD("axmol: removeChildByTag(tag = {}): child not found!", tag);
     }
     else
     {
@@ -1112,7 +1112,7 @@ void Node::removeChildByName(std::string_view name, bool cleanup)
 
     if (child == nullptr)
     {
-        AXLOG("axmol: removeChildByName(name = %s): child not found!", name.data());
+        AXLOGD("axmol: removeChildByName(name = {}): child not found!", name);
     }
     else
     {

--- a/core/2d/ParticleBatchNode.cpp
+++ b/core/2d/ParticleBatchNode.cpp
@@ -459,13 +459,13 @@ void ParticleBatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t
 
 void ParticleBatchNode::increaseAtlasCapacityTo(ssize_t quantity)
 {
-    AXLOG("axmol: ParticleBatchNode: resizing TextureAtlas capacity from [%d] to [%d].",
+    AXLOGD("axmol: ParticleBatchNode: resizing TextureAtlas capacity from [{}] to [{}].",
           (int)_textureAtlas->getCapacity(), (int)quantity);
 
     if (!_textureAtlas->resizeCapacity(quantity))
     {
         // serious problems
-        AXLOGWARN("axmol: WARNING: Not enough memory to resize the atlas");
+        AXLOGW("axmol: WARNING: Not enough memory to resize the atlas");
         AXASSERT(false, "XXX: ParticleBatchNode #increaseAtlasCapacity SHALL handle this assert");
     }
 }

--- a/core/2d/ParticleSystem.cpp
+++ b/core/2d/ParticleSystem.cpp
@@ -659,7 +659,7 @@ bool ParticleSystem::initWithDictionary(const ValueMap& dictionary, std::string_
                 _yCoordFlipped = optValue(dictionary, "yCoordFlipped").asInt(1);
 
                 if (!this->_texture)
-                    AXLOGWARN("axmol: Warning: ParticleSystemQuad system without a texture");
+                    AXLOGW("axmol: Warning: ParticleSystemQuad system without a texture");
             }
             ret = true;
         }
@@ -675,7 +675,7 @@ bool ParticleSystem::initWithTotalParticles(int numberOfParticles)
 
     if (!_particleData.init(_totalParticles))
     {
-        AXLOG("Particle system: not enough memory");
+        AXLOGW("Particle system: not enough memory");
         this->release();
         return false;
     }
@@ -2337,7 +2337,7 @@ void ParticleEmissionMaskCache::bakeEmissionMask(std::string_view maskId,
 
     iter->second = desc;
 
-    AXLOG("Particle emission mask '%u' baked (%dx%d), %zu samples generated taking %.2fmb of memory.",
+    AXLOGD("Particle emission mask '{}' baked ({}x{}), {} samples generated taking {:.2f}mb of memory.",
           (unsigned int)htonl(fourccId), w, h, desc.points.size(), desc.points.size() * 8 / 1e+6);
 }
 

--- a/core/2d/ParticleSystemQuad.cpp
+++ b/core/2d/ParticleSystemQuad.cpp
@@ -694,7 +694,7 @@ void ParticleSystemQuad::setTotalParticles(int tp)
         _particleData.release();
         if (!_particleData.init(tp))
         {
-            AXLOG("Particle system: not enough memory");
+            AXLOGW("Particle system: not enough memory");
             return;
         }
         V3F_C4B_T2F_Quad* quadsNew = (V3F_C4B_T2F_Quad*)realloc(_quads, quadsSize);
@@ -720,7 +720,7 @@ void ParticleSystemQuad::setTotalParticles(int tp)
             if (indicesNew)
                 _indices = indicesNew;
 
-            AXLOG("Particle system: out of memory");
+            AXLOGW("Particle system: out of memory");
             return;
         }
 
@@ -782,7 +782,7 @@ bool ParticleSystemQuad::allocMemory()
 
     if (!_quads || !_indices)
     {
-        AXLOG("axmol: Particle system: not enough memory");
+        AXLOGW("axmol: Particle system: not enough memory");
         AX_SAFE_FREE(_quads);
         AX_SAFE_FREE(_indices);
 

--- a/core/2d/PlistSpriteSheetLoader.cpp
+++ b/core/2d/PlistSpriteSheetLoader.cpp
@@ -26,7 +26,7 @@ void PlistSpriteSheetLoader::load(std::string_view filePath, SpriteFrameCache& c
     if (fullPath.empty())
     {
         // return if plist file doesn't exist
-        AXLOG("axmol: SpriteFrameCache: can not find %s", filePath.data());
+        AXLOGW("SpriteFrameCache: can not find {}", filePath);
         return;
     }
 
@@ -61,7 +61,7 @@ void PlistSpriteSheetLoader::load(std::string_view filePath, SpriteFrameCache& c
         // append .png
         texturePath = texturePath.append(".png");
 
-        AXLOG("axmol: SpriteFrameCache: Trying to use file %s as texture", texturePath.c_str());
+        AXLOGD("SpriteFrameCache: Trying to use file {} as texture", texturePath);
     }
     addSpriteFramesWithDictionary(dict, texturePath, filePath, cache);
 }
@@ -143,7 +143,7 @@ void PlistSpriteSheetLoader::reload(std::string_view filePath, SpriteFrameCache&
     }
     else
     {
-        AXLOG("axmol: SpriteFrameCache: Couldn't load texture");
+        AXLOGD("SpriteFrameCache: Couldn't load texture");
     }
 }
 
@@ -219,8 +219,8 @@ void PlistSpriteSheetLoader::addSpriteFramesWithDictionary(ValueMap& dictionary,
             // check ow/oh
             if (!ow || !oh)
             {
-                AXLOGWARN(
-                    "axmol: WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as "
+                AXLOGW(
+                    "WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as "
                     "expected. Regenerate the .plist");
             }
             // abs ow/oh
@@ -268,7 +268,7 @@ void PlistSpriteSheetLoader::addSpriteFramesWithDictionary(ValueMap& dictionary,
                 }
                 else
                 {
-                    AXLOGWARN("axmol: WARNING: an alias with name %s already exists", oneAlias.c_str());
+                    AXLOGW("WARNING: an alias with name {} already exists", oneAlias);
                 }
             }
 
@@ -364,7 +364,7 @@ void PlistSpriteSheetLoader::addSpriteFramesWithDictionary(ValueMap& dict,
     }
     else
     {
-        AXLOG("axmol: SpriteFrameCache: Couldn't load texture");
+        AXLOGD("SpriteFrameCache: Couldn't load texture");
     }
 }
 
@@ -414,8 +414,8 @@ void PlistSpriteSheetLoader::reloadSpriteFramesWithDictionary(ValueMap& dict,
             // check ow/oh
             if (!ow || !oh)
             {
-                AXLOGWARN(
-                    "axmol:WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as "
+                AXLOGW(
+                    "WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as "
                     "expected. Regenerate the .plist");
             }
             // abs ow/oh
@@ -463,7 +463,7 @@ void PlistSpriteSheetLoader::reloadSpriteFramesWithDictionary(ValueMap& dict,
                 }
                 else
                 {
-                    AXLOGWARN("axmol: WARNING: an alias with name %s already exists", oneAlias.c_str());
+                    AXLOGW("WARNING: an alias with name {} already exists", oneAlias);
                 }
             }
 

--- a/core/2d/ProtectedNode.cpp
+++ b/core/2d/ProtectedNode.cpp
@@ -38,7 +38,7 @@ ProtectedNode::ProtectedNode() : _reorderProtectedChildDirty(false) {}
 
 ProtectedNode::~ProtectedNode()
 {
-    AXLOGINFO("deallocing ProtectedNode: %p - tag: %i", this, _tag);
+    AXLOGV("deallocing ProtectedNode: {} - tag: {}", fmt::ptr(this), _tag);
     removeAllProtectedChildren();
 }
 
@@ -230,7 +230,7 @@ void ProtectedNode::removeProtectedChildByTag(int tag, bool cleanup)
 
     if (child == nullptr)
     {
-        AXLOG("axmol: removeChildByTag(tag = %d): child not found!", tag);
+        AXLOGD("axmol: removeChildByTag(tag = {}): child not found!", tag);
     }
     else
     {

--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -82,7 +82,7 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
         }
         else
         {
-            AXLOG("Cache rendertexture failed!");
+            AXLOGW("Cache rendertexture failed!");
         }
     };
     auto callback = std::bind(func, std::placeholders::_1);
@@ -381,12 +381,12 @@ bool RenderTexture::saveToFileAsNonPMA(std::string_view filename, bool isRGBA, S
     else if (basename.find(".jpg") != std::string::npos)
     {
         if (isRGBA)
-            AXLOG("RGBA is not supported for JPG format.");
+            AXLOGD("RGBA is not supported for JPG format.");
         return saveToFileAsNonPMA(filename, Image::Format::JPG, false, std::move(callback));
     }
     else
     {
-        AXLOG("Only PNG and JPG format are supported now!");
+        AXLOGD("Only PNG and JPG format are supported now!");
     }
 
     return saveToFileAsNonPMA(filename, Image::Format::JPG, false, std::move(callback));
@@ -404,12 +404,12 @@ bool RenderTexture::saveToFile(std::string_view filename, bool isRGBA, SaveFileC
     else if (basename.find(".jpg") != std::string::npos)
     {
         if (isRGBA)
-            AXLOG("RGBA is not supported for JPG format.");
+            AXLOGD("RGBA is not supported for JPG format.");
         return saveToFile(filename, Image::Format::JPG, false, std::move(callback));
     }
     else
     {
-        AXLOG("Only PNG and JPG format are supported now!");
+        AXLOGD("Only PNG and JPG format are supported now!");
     }
 
     return saveToFile(filename, Image::Format::JPG, false, std::move(callback));
@@ -423,7 +423,7 @@ bool RenderTexture::saveToFileAsNonPMA(std::string_view fileName,
     AXASSERT(format == Image::Format::JPG || format == Image::Format::PNG,
              "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG)
-        AXLOG("RGBA is not supported for JPG format");
+        AXLOGD("RGBA is not supported for JPG format");
 
     _saveFileCallback = std::move(callback);
 
@@ -446,7 +446,7 @@ bool RenderTexture::saveToFile(std::string_view fileName,
     AXASSERT(format == Image::Format::JPG || format == Image::Format::PNG,
              "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG)
-        AXLOG("RGBA is not supported for JPG format");
+        AXLOGD("RGBA is not supported for JPG format");
 
     _saveFileCallback = std::move(callback);
 

--- a/core/2d/Sprite.cpp
+++ b/core/2d/Sprite.cpp
@@ -193,7 +193,7 @@ bool Sprite::initWithFile(std::string_view filename, PixelFormat format)
 {
     if (filename.empty())
     {
-        AXLOG("Call Sprite::initWithFile with blank resource filename.");
+        AXLOGD("Call Sprite::initWithFile with blank resource filename.");
         return false;
     }
 
@@ -320,7 +320,7 @@ bool Sprite::initWithImageData(const Data& imageData, std::string_view key)
 {
     if (imageData.isNull() || key.empty())
     {
-        AXLOG("Call Sprite::initWithImageData empty data or blank key.");
+        AXLOGD("Call Sprite::initWithImageData empty data or blank key.");
         return false;
     }
 
@@ -706,7 +706,7 @@ void Sprite::setCenterRectNormalized(const ax::Rect& rectTopLeft)
 {
     if (_renderMode != RenderMode::QUAD && _renderMode != RenderMode::SLICE9)
     {
-        AXLOGWARN("Warning: Sprite::setCenterRectNormalized() only works with QUAD and SLICE9 render modes");
+        AXLOGW("Warning: Sprite::setCenterRectNormalized() only works with QUAD and SLICE9 render modes");
         return;
     }
 
@@ -762,7 +762,7 @@ void Sprite::setCenterRect(const ax::Rect& rectInPoints)
 {
     if (_renderMode != RenderMode::QUAD && _renderMode != RenderMode::SLICE9)
     {
-        AXLOGWARN("Warning: Sprite::setCenterRect() only works with QUAD and SLICE9 render modes");
+        AXLOGW("Warning: Sprite::setCenterRect() only works with QUAD and SLICE9 render modes");
         return;
     }
 
@@ -1360,7 +1360,7 @@ void Sprite::setVisible(bool bVisible)
 void Sprite::setContentSize(const Vec2& size)
 {
     if (_renderMode == RenderMode::QUAD_BATCHNODE || _renderMode == RenderMode::POLYGON)
-        AXLOGWARN(
+        AXLOGW(
             "Sprite::setContentSize() doesn't stretch the sprite when using QUAD_BATCHNODE or POLYGON render modes");
 
     Node::setContentSize(size);

--- a/core/2d/SpriteBatchNode.cpp
+++ b/core/2d/SpriteBatchNode.cpp
@@ -443,13 +443,13 @@ void SpriteBatchNode::increaseAtlasCapacity()
     // this is likely computationally expensive
     ssize_t quantity = (_textureAtlas->getCapacity() + 1) * 4 / 3;
 
-    AXLOG("axmol: SpriteBatchNode: resizing TextureAtlas capacity from [%d] to [%d].",
+    AXLOGD("SpriteBatchNode: resizing TextureAtlas capacity from [{}] to [{}].",
           static_cast<int>(_textureAtlas->getCapacity()), static_cast<int>(quantity));
 
     if (!_textureAtlas->resizeCapacity(quantity))
     {
         // serious problems
-        AXLOGWARN("axmol: WARNING: Not enough memory to resize the atlas");
+        AXLOGW("WARNING: Not enough memory to resize the atlas");
         AXASSERT(false, "Not enough memory to resize the atlas");
     }
 }
@@ -462,7 +462,7 @@ void SpriteBatchNode::reserveCapacity(ssize_t newCapacity)
     if (!_textureAtlas->resizeCapacity(newCapacity))
     {
         // serious problems
-        AXLOGWARN("axmol: WARNING: Not enough memory to resize the atlas");
+        AXLOGW("WARNING: Not enough memory to resize the atlas");
         AXASSERT(false, "Not enough memory to resize the atlas");
     }
 }

--- a/core/2d/SpriteFrame.cpp
+++ b/core/2d/SpriteFrame.cpp
@@ -152,7 +152,7 @@ bool SpriteFrame::initWithTextureFilename(std::string_view filename,
 
 SpriteFrame::~SpriteFrame()
 {
-    AXLOGINFO("deallocing SpriteFrame: %p", this);
+    AXLOGV("deallocing SpriteFrame: {}", fmt::ptr(this));
     AX_SAFE_RELEASE(_texture);
 }
 

--- a/core/2d/SpriteFrameCache.cpp
+++ b/core/2d/SpriteFrameCache.cpp
@@ -159,7 +159,7 @@ void SpriteFrameCache::removeUnusedSpriteFrames()
         {
             toRemoveFrames.emplace_back(iter.first);
             spriteFrame->getTexture()->removeSpriteFrameCapInset(spriteFrame);
-            AXLOG("axmol: SpriteFrameCache: removing unused frame: %s", iter.first.c_str());
+            AXLOGD("SpriteFrameCache: removing unused frame: {}", iter.first);
             removed = true;
         }
     }
@@ -192,7 +192,7 @@ void SpriteFrameCache::removeUnusedSpriteSheets()
 
     for (auto& spriteSheetFileName : willRemoveSpriteSheetFileNames)
     {
-        AXLOG("axmol: SpriteFrameCache: removing unused sprite sheet file : %s", spriteSheetFileName.data());
+        AXLOGD("SpriteFrameCache: removing unused sprite sheet file : {}", spriteSheetFileName);
         removeSpriteSheet(spriteSheetFileName);
     }
 }
@@ -212,7 +212,7 @@ void SpriteFrameCache::removeSpriteFramesFromFile(std::string_view atlasPath)
     // auto dict = FileUtils::getInstance()->getValueMapFromFile(fullPath);
     // if (dict.empty())
     //{
-    //     AXLOG("axmol:SpriteFrameCache:removeSpriteFramesFromFile: create dict by %s fail.",plist.c_str());
+    //     AXLOGD("axmol:SpriteFrameCache:removeSpriteFramesFromFile: create dict by {} fail.",plist);
     //     return;
     // }
     // removeSpriteFramesFromDictionary(dict);
@@ -227,7 +227,7 @@ void SpriteFrameCache::removeSpriteFramesFromFileContent(std::string_view plist_
         FileUtils::getInstance()->getValueMapFromData(plist_content.data(), static_cast<int>(plist_content.size()));
     if (dict.empty())
     {
-        AXLOG("axmol:SpriteFrameCache:removeSpriteFramesFromFileContent: create dict by fail.");
+        AXLOGD("SpriteFrameCache:removeSpriteFramesFromFileContent: create dict by fail.");
         return;
     }
     removeSpriteFramesFromDictionary(dict);
@@ -274,7 +274,7 @@ SpriteFrame* SpriteFrameCache::getSpriteFrameByName(std::string_view name)
     auto* frame = findFrame(name);
     if (!frame)
     {
-        AXLOG("axmol: SpriteFrameCache: Frame '%s' isn't found", name.data());
+        AXLOGD("axmol: SpriteFrameCache: Frame '{}' isn't found", name);
     }
     return frame;
 }

--- a/core/2d/TMXObjectGroup.cpp
+++ b/core/2d/TMXObjectGroup.cpp
@@ -37,7 +37,7 @@ TMXObjectGroup::TMXObjectGroup() : _groupName("") {}
 
 TMXObjectGroup::~TMXObjectGroup()
 {
-    AXLOGINFO("deallocing TMXObjectGroup: %p", this);
+    AXLOGV("deallocing TMXObjectGroup: {}", fmt::ptr(this));
 }
 
 ValueMap TMXObjectGroup::getObject(std::string_view objectName) const

--- a/core/2d/TMXXMLParser.cpp
+++ b/core/2d/TMXXMLParser.cpp
@@ -46,7 +46,7 @@ TMXLayerInfo::TMXLayerInfo() : _name(""), _tiles(nullptr), _ownTiles(true) {}
 
 TMXLayerInfo::~TMXLayerInfo()
 {
-    AXLOGINFO("deallocing TMXLayerInfo: %p", this);
+    AXLOGV("deallocing TMXLayerInfo: {}", fmt::ptr(this));
     if (_ownTiles && _tiles)
     {
         free(_tiles);
@@ -70,7 +70,7 @@ TMXTilesetInfo::TMXTilesetInfo() : _firstGid(0), _tileSize(Vec2::ZERO), _spacing
 
 TMXTilesetInfo::~TMXTilesetInfo()
 {
-    AXLOGINFO("deallocing TMXTilesetInfo: %p", this);
+    AXLOGV("deallocing TMXTilesetInfo: {}", fmt::ptr(this));
 }
 
 Rect TMXTilesetInfo::getRectForGID(uint32_t gid)
@@ -169,7 +169,7 @@ TMXMapInfo::TMXMapInfo()
 
 TMXMapInfo::~TMXMapInfo()
 {
-    AXLOGINFO("deallocing TMXMapInfo: %p", this);
+    AXLOGV("deallocing TMXMapInfo: {}", fmt::ptr(this));
 }
 
 bool TMXMapInfo::parseXMLString(std::string_view xmlString)
@@ -222,7 +222,7 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char* name, const char** atts
     if (elementName == "map")
     {
         std::string version = attributeDict["version"].asString();
-        AXLOG("axmol: TMXFormat: TMX version: %s", version.c_str());
+        AXLOGD("TMXFormat: TMX version: {}", version);
 
         std::string orientationStr = attributeDict["orientation"].asString();
         if (orientationStr == "orthogonal")
@@ -243,7 +243,7 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char* name, const char** atts
         }
         else
         {
-            AXLOG("axmol: TMXFomat: Unsupported orientation: %d", tmxMapInfo->getOrientation());
+            AXLOGD("TMXFomat: Unsupported orientation: {}", tmxMapInfo->getOrientation());
         }
 
         std::string staggerAxisStr = attributeDict["staggeraxis"].asString();
@@ -525,8 +525,8 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char* name, const char** atts
         tmxMapInfo->setStoringCharacters(true);
         if (tmxMapInfo->getParentElement() == TMXPropertyNone)
         {
-            AXLOG("TMX tile map: Parent element is unsupported. Cannot add property named '%s' with value '%s'",
-                  attributeDict["name"].asString().c_str(), attributeDict["value"].asString().c_str());
+            AXLOGD("TMX tile map: Parent element is unsupported. Cannot add property named '{}' with value '{}'",
+                  attributeDict["name"].asString(), attributeDict["value"].asString());
             tmxMapInfo->setStoringCharacters(false);
         }
         else if (tmxMapInfo->getParentElement() == TMXPropertyMap)
@@ -698,7 +698,7 @@ void TMXMapInfo::endElement(void* /*ctx*/, const char* name)
             auto buffer = utils::base64Decode(currentString);
             if (buffer.empty())
             {
-                AXLOG("axmol: TiledMap: decode data error");
+                AXLOGW("TiledMap: decode data error");
                 return;
             }
 
@@ -713,7 +713,7 @@ void TMXMapInfo::endElement(void* /*ctx*/, const char* name)
 
                 if (buffer.empty())
                 {
-                    AXLOG("axmol: TiledMap: inflate data error");
+                    AXLOGW("TiledMap: inflate data error");
                     return;
                 }
 

--- a/core/2d/TileMapAtlas.cpp
+++ b/core/2d/TileMapAtlas.cpp
@@ -130,7 +130,7 @@ void TileMapAtlas::setTile(const Color3B& tile, const Vec2& position)
     Color3B value = ptr[(unsigned int)(position.x + position.y * _TGAInfo->width)];
     if (value.r == 0)
     {
-        AXLOG("axmol: Value.r must be non 0.");
+        AXLOGD("Value.r must be non 0.");
     }
     else
     {

--- a/core/3d/Animate3D.cpp
+++ b/core/3d/Animate3D.cpp
@@ -224,7 +224,7 @@ void Animate3D::startWithTarget(Node* target)
 
         if (!hasCurve)
         {
-            AXLOG("warning: no animation found for the skeleton");
+            AXLOGW("warning: no animation found for the skeleton");
         }
     }
 

--- a/core/3d/Bundle3D.cpp
+++ b/core/3d/Bundle3D.cpp
@@ -193,7 +193,7 @@ bool Bundle3D::load(std::string_view path)
     }
     else
     {
-        AXLOG("warning: %s is invalid file formate", path.data());
+        AXLOGW("warning: {} is invalid file format", path.data());
     }
 
     ret ? (_path = path) : (_path = "");
@@ -329,7 +329,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas,
 
         return true;
     }
-    AXLOG("warning: load %s file error: %s", fullPath.data(), ret.c_str());
+    AXLOGW("warning: load {} file error: {}", fullPath, ret);
     return false;
 }
 
@@ -396,7 +396,7 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
     unsigned int meshSize = 0;
     if (_binaryReader.read(&meshSize, 4, 1) != 1)
     {
-        AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
         return false;
     }
     MeshData* meshData = nullptr;
@@ -406,7 +406,7 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
         // read mesh data
         if (_binaryReader.read(&attribSize, 4, 1) != 1 || attribSize < 1)
         {
-            AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
             goto FAILED;
         }
         meshData              = new MeshData();
@@ -418,7 +418,7 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
             unsigned int vSize;
             if (_binaryReader.read(&vSize, 4, 1) != 1)
             {
-                AXLOG("warning: Failed to read meshdata: usage or size '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read meshdata: usage or size '{}'.", _path);
                 goto FAILED;
             }
             std::string type                  = _binaryReader.readString();
@@ -430,14 +430,14 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
         // Read vertex data
         if (_binaryReader.read(&vertexSizeInFloat, 4, 1) != 1 || vertexSizeInFloat == 0)
         {
-            AXLOG("warning: Failed to read meshdata: vertexSizeInFloat '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: vertexSizeInFloat '{}'.", _path);
             goto FAILED;
         }
 
         meshData->vertex.resize(vertexSizeInFloat);
         if (_binaryReader.read(&meshData->vertex[0], 4, vertexSizeInFloat) != vertexSizeInFloat)
         {
-            AXLOG("warning: Failed to read meshdata: vertex element '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: vertex element '{}'.", _path);
             goto FAILED;
         }
 
@@ -453,13 +453,13 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
             unsigned int nIndexCount;
             if (_binaryReader.read(&nIndexCount, 4, 1) != 1)
             {
-                AXLOG("warning: Failed to read meshdata: nIndexCount '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read meshdata: nIndexCount '{}'.", _path);
                 goto FAILED;
             }
             indexArray.resize(nIndexCount);
             if (_binaryReader.read(indexArray.data(), 2, nIndexCount) != nIndexCount)
             {
-                AXLOG("warning: Failed to read meshdata: indices '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read meshdata: indices '{}'.", _path);
                 goto FAILED;
             }
             auto& storedIndices = meshData->subMeshIndices.emplace_back(std::move(indexArray));
@@ -472,7 +472,7 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
                 float aabb[6];
                 if (_binaryReader.read(aabb, 4, 6) != 6)
                 {
-                    AXLOG("warning: Failed to read meshdata: aabb '%s'.", _path.c_str());
+                    AXLOGW("warning: Failed to read meshdata: aabb '{}'.", _path);
                     goto FAILED;
                 } 
                 meshData->subMeshAABB.emplace_back(AABB(Vec3(aabb[0], aabb[1], aabb[2]), Vec3(aabb[3], aabb[4], aabb[5])));
@@ -511,7 +511,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
     unsigned int attribSize = 0;
     if (_binaryReader.read(&attribSize, 4, 1) != 1 || attribSize < 1)
     {
-        AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -535,7 +535,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
         shaderinfos::VertexKey usage;
         if (_binaryReader.read(&vUsage, 4, 1) != 1 || _binaryReader.read(&vSize, 4, 1) != 1)
         {
-            AXLOG("warning: Failed to read meshdata: usage or size '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: usage or size '{}'.", _path);
             AX_SAFE_DELETE(meshdata);
             return false;
         }
@@ -574,7 +574,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
     // Read vertex data
     if (_binaryReader.read(&meshdata->vertexSizeInFloat, 4, 1) != 1 || meshdata->vertexSizeInFloat == 0)
     {
-        AXLOG("warning: Failed to read meshdata: vertexSizeInFloat '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: vertexSizeInFloat '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -582,7 +582,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
     meshdata->vertex.resize(meshdata->vertexSizeInFloat);
     if (_binaryReader.read(&meshdata->vertex[0], 4, meshdata->vertexSizeInFloat) != meshdata->vertexSizeInFloat)
     {
-        AXLOG("warning: Failed to read meshdata: vertex element '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: vertex element '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -594,7 +594,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
         unsigned int nIndexCount;
         if (_binaryReader.read(&nIndexCount, 4, 1) != 1)
         {
-            AXLOG("warning: Failed to read meshdata: nIndexCount '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: nIndexCount '{}'.", _path);
             AX_SAFE_DELETE(meshdata);
             return false;
         }
@@ -603,7 +603,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
         indices.resize(nIndexCount);
         if (_binaryReader.read(indices.data(), 2, nIndexCount) != nIndexCount)
         {
-            AXLOG("warning: Failed to read meshdata: indices '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: indices '{}'.", _path);
             AX_SAFE_DELETE(meshdata);
             return false;
         }
@@ -629,7 +629,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
     unsigned int attribSize = 0;
     if (_binaryReader.read(&attribSize, 4, 1) != 1 || attribSize < 1)
     {
-        AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -653,7 +653,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
         shaderinfos::VertexKey usage = shaderinfos::VertexKey::VERTEX_ATTRIB_ERROR;
         if (_binaryReader.read(&vUsage, 4, 1) != 1 || _binaryReader.read(&vSize, 4, 1) != 1)
         {
-            AXLOG("warning: Failed to read meshdata: usage or size '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: usage or size '{}'.", _path);
             AX_SAFE_DELETE(meshdata);
             return false;
         }
@@ -688,7 +688,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
     // Read vertex data
     if (_binaryReader.read(&meshdata->vertexSizeInFloat, 4, 1) != 1 || meshdata->vertexSizeInFloat == 0)
     {
-        AXLOG("warning: Failed to read meshdata: vertexSizeInFloat '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: vertexSizeInFloat '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -696,7 +696,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
     meshdata->vertex.resize(meshdata->vertexSizeInFloat);
     if (_binaryReader.read(&meshdata->vertex[0], 4, meshdata->vertexSizeInFloat) != meshdata->vertexSizeInFloat)
     {
-        AXLOG("warning: Failed to read meshdata: vertex element '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: vertex element '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -705,7 +705,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
     unsigned int submeshCount;
     if (_binaryReader.read(&submeshCount, 4, 1) != 1)
     {
-        AXLOG("warning: Failed to read meshdata: submeshCount '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: submeshCount '{}'.", _path);
         AX_SAFE_DELETE(meshdata);
         return false;
     }
@@ -715,7 +715,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
         unsigned int nIndexCount;
         if (_binaryReader.read(&nIndexCount, 4, 1) != 1)
         {
-            AXLOG("warning: Failed to read meshdata: nIndexCount '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: nIndexCount '{}'.", _path);
             AX_SAFE_DELETE(meshdata);
             return false;
         }
@@ -724,7 +724,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
         indices.resize(nIndexCount);
         if (_binaryReader.read(indices.data(), 2, nIndexCount) != nIndexCount)
         {
-            AXLOG("warning: Failed to read meshdata: indices '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read meshdata: indices '{}'.", _path);
             AX_SAFE_DELETE(meshdata);
             return false;
         }
@@ -943,13 +943,13 @@ bool Bundle3D::loadMaterialsBinary(MaterialDatas& materialdatas)
             textureData.id = _binaryReader.readString();
             if (textureData.id.empty())
             {
-                AXLOG("warning: Failed to read Materialdata: texturePath is empty '%s'.", textureData.id.c_str());
+                AXLOGW("warning: Failed to read Materialdata: texturePath is empty '{}'.", textureData.id);
                 return false;
             }
             std::string texturePath = _binaryReader.readString();
             if (texturePath.empty())
             {
-                AXLOG("warning: Failed to read Materialdata: texturePath is empty '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read Materialdata: texturePath is empty '{}'.", _path);
                 return false;
             }
 
@@ -975,7 +975,7 @@ bool Bundle3D::loadMaterialsBinary_0_1(MaterialDatas& materialdatas)
     std::string texturePath = _binaryReader.readString();
     if (texturePath.empty())
     {
-        AXLOG("warning: Failed to read Materialdata: texturePath is empty '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read Materialdata: texturePath is empty '{}'.", _path);
         return false;
     }
 
@@ -1003,7 +1003,7 @@ bool Bundle3D::loadMaterialsBinary_0_2(MaterialDatas& materialdatas)
         std::string texturePath = _binaryReader.readString();
         if (texturePath.empty())
         {
-            AXLOG("warning: Failed to read Materialdata: texturePath is empty '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read Materialdata: texturePath is empty '{}'.", _path);
             return true;
         }
 
@@ -1070,7 +1070,7 @@ bool Bundle3D::loadJson(std::string_view path)
     if (_jsonReader.ParseInsitu<0>((char*)_jsonBuffer.c_str()).HasParseError())
     {
         clear();
-        AXLOG("Parse json failed in Bundle3D::loadJson function");
+        AXLOGW("Parse json failed in Bundle3D::loadJson function");
         return false;
     }
 
@@ -1093,7 +1093,7 @@ bool Bundle3D::loadBinary(std::string_view path)
     if (_binaryBuffer.isNull())
     {
         clear();
-        AXLOG("warning: Failed to read file: %s", path.data());
+        AXLOGW("warning: Failed to read file: {}", path);
         return false;
     }
 
@@ -1106,7 +1106,7 @@ bool Bundle3D::loadBinary(std::string_view path)
     if (_binaryReader.read(sig, 1, 4) != 4 || memcmp(sig, identifier, 4) != 0)
     {
         clear();
-        AXLOG("warning: Invalid identifier: %s", path.data());
+        AXLOGW("warning: Invalid identifier: {}", path);
         return false;
     }
 
@@ -1114,7 +1114,7 @@ bool Bundle3D::loadBinary(std::string_view path)
     unsigned char ver[2];
     if (_binaryReader.read(ver, 1, 2) != 2)
     {
-        AXLOG("warning: Failed to read version:");
+        AXLOGW("warning: Failed to read version:");
         return false;
     }
 
@@ -1126,7 +1126,7 @@ bool Bundle3D::loadBinary(std::string_view path)
     if (_binaryReader.read(&_referenceCount, 4, 1) != 1)
     {
         clear();
-        AXLOG("warning: Failed to read ref table size '%s'.", path.data());
+        AXLOGW("warning: Failed to read ref table size '{}'.", path);
         return false;
     }
 
@@ -1140,7 +1140,7 @@ bool Bundle3D::loadBinary(std::string_view path)
             _binaryReader.read(&_references[i].offset, 4, 1) != 1)
         {
             clear();
-            AXLOG("warning: Failed to read ref number %u for bundle '%s'.", i, path.data());
+            AXLOGW("warning: Failed to read ref number {} for bundle '{}'.", i, path);
             AX_SAFE_DELETE_ARRAY(_references);
             return false;
         }
@@ -1301,7 +1301,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
     float bindShape[16];
     if (!_binaryReader.readMatrix(bindShape))
     {
-        AXLOG("warning: Failed to read SkinData: bindShape matrix  '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read SkinData: bindShape matrix  '{}'.", _path);
         return false;
     }
 
@@ -1309,7 +1309,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
     unsigned int boneNum;
     if (!_binaryReader.read(&boneNum))
     {
-        AXLOG("warning: Failed to read SkinData: boneNum  '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read SkinData: boneNum  '{}'.", _path);
         return false;
     }
 
@@ -1325,7 +1325,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
         skindata->skinBoneNames.emplace_back(skinBoneName);
         if (!_binaryReader.readMatrix(bindpos))
         {
-            AXLOG("warning: Failed to load SkinData: bindpos '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to load SkinData: bindpos '{}'.", _path);
             return false;
         }
         skindata->inverseBindPoseMatrices.emplace_back(bindpos);
@@ -1365,7 +1365,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
 
         if (!_binaryReader.readMatrix(transform))
         {
-            AXLOG("warning: Failed to load SkinData: transform '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to load SkinData: transform '{}'.", _path);
             return false;
         }
 
@@ -1572,7 +1572,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
     {
         if (!_binaryReader.read(&animNum))
         {
-            AXLOG("warning: Failed to read AnimationData: animNum '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read AnimationData: animNum '{}'.", _path);
             return false;
         }
     }
@@ -1585,14 +1585,14 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
 
         if (!_binaryReader.read(&animationdata->_totalTime))
         {
-            AXLOG("warning: Failed to read AnimationData: totalTime '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read AnimationData: totalTime '{}'.", _path);
             return false;
         }
 
         unsigned int nodeAnimationNum;
         if (!_binaryReader.read(&nodeAnimationNum))
         {
-            AXLOG("warning: Failed to read AnimationData: animNum '%s'.", _path.c_str());
+            AXLOGW("warning: Failed to read AnimationData: animNum '{}'.", _path);
             return false;
         }
         for (unsigned int i = 0; i < nodeAnimationNum; ++i)
@@ -1601,7 +1601,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
             unsigned int keyframeNum;
             if (!_binaryReader.read(&keyframeNum))
             {
-                AXLOG("warning: Failed to read AnimationData: keyframeNum '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read AnimationData: keyframeNum '{}'.", _path);
                 return false;
             }
 
@@ -1614,7 +1614,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
                 float keytime;
                 if (!_binaryReader.read(&keytime))
                 {
-                    AXLOG("warning: Failed to read AnimationData: keytime '%s'.", _path.c_str());
+                    AXLOGW("warning: Failed to read AnimationData: keytime '{}'.", _path);
                     return false;
                 }
 
@@ -1624,7 +1624,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
                 {
                     if (!_binaryReader.read(&transformFlag))
                     {
-                        AXLOG("warning: Failed to read AnimationData: transformFlag '%s'.", _path.c_str());
+                        AXLOGW("warning: Failed to read AnimationData: transformFlag '{}'.", _path);
                         return false;
                     }
                 }
@@ -1639,7 +1639,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
                     Quaternion rotate;
                     if (_binaryReader.read(&rotate, 4, 4) != 4)
                     {
-                        AXLOG("warning: Failed to read AnimationData: rotate '%s'.", _path.c_str());
+                        AXLOGW("warning: Failed to read AnimationData: rotate '{}'.", _path);
                         return false;
                     }
                     animationdata->_rotationKeys[boneName].emplace_back(Animation3DData::QuatKey(keytime, rotate));
@@ -1655,7 +1655,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
                     Vec3 scale;
                     if (_binaryReader.read(&scale, 4, 3) != 3)
                     {
-                        AXLOG("warning: Failed to read AnimationData: scale '%s'.", _path.c_str());
+                        AXLOGW("warning: Failed to read AnimationData: scale '{}'.", _path);
                         return false;
                     }
                     animationdata->_scaleKeys[boneName].emplace_back(Animation3DData::Vec3Key(keytime, scale));
@@ -1671,7 +1671,7 @@ bool Bundle3D::loadAnimationDataBinary(std::string_view id, Animation3DData* ani
                     Vec3 position;
                     if (_binaryReader.read(&position, 4, 3) != 3)
                     {
-                        AXLOG("warning: Failed to read AnimationData: position '%s'.", _path.c_str());
+                        AXLOGW("warning: Failed to read AnimationData: position '{}'.", _path);
                         return false;
                     }
                     animationdata->_translationKeys[boneName].emplace_back(Animation3DData::Vec3Key(keytime, position));
@@ -1748,7 +1748,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
 
             if (modelnodedata->subMeshId == "" || modelnodedata->materialId == "")
             {
-                AXLOG("warning: Node %s part is missing meshPartId or materialId", nodedata->id.c_str());
+                AXLOGW("warning: Node {} part is missing meshPartId or materialId", nodedata->id);
                 AX_SAFE_DELETE(modelnodedata);
                 AX_SAFE_DELETE(nodedata);
                 return nullptr;
@@ -1765,7 +1765,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
                     // node
                     if (!bone.HasMember(NODE))
                     {
-                        AXLOG("warning: Bone node ID missing");
+                        AXLOGW("warning: Bone node ID missing");
                         AX_SAFE_DELETE(modelnodedata);
                         AX_SAFE_DELETE(nodedata);
                         return nullptr;
@@ -1832,7 +1832,7 @@ bool Bundle3D::loadNodesBinary(NodeDatas& nodedatas)
     unsigned int nodeSize = 0;
     if (_binaryReader.read(&nodeSize, 4, 1) != 1)
     {
-        AXLOG("warning: Failed to read nodes");
+        AXLOGW("warning: Failed to read nodes");
         return false;
     }
 
@@ -1857,7 +1857,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
     bool skeleton_;
     if (_binaryReader.read(&skeleton_, 1, 1) != 1)
     {
-        AXLOG("warning: Failed to read is skeleton");
+        AXLOGW("warning: Failed to read is skeleton");
         return nullptr;
     }
     if (skeleton_)
@@ -1867,14 +1867,14 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
     Mat4 transform;
     if (!_binaryReader.readMatrix(transform.m))
     {
-        AXLOG("warning: Failed to read transform matrix");
+        AXLOGW("warning: Failed to read transform matrix");
         return nullptr;
     }
     // parts
     unsigned int partsSize = 0;
     if (_binaryReader.read(&partsSize, 4, 1) != 1)
     {
-        AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
         return nullptr;
     }
 
@@ -1893,7 +1893,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
 
             if (modelnodedata->subMeshId.empty() || modelnodedata->materialId.empty())
             {
-                AXLOG("Node %s part is missing meshPartId or materialId", nodedata->id.c_str());
+                AXLOGW("Node {} part is missing meshPartId or materialId", nodedata->id);
                 AX_SAFE_DELETE(modelnodedata);
                 AX_SAFE_DELETE(nodedata);
                 return nullptr;
@@ -1903,7 +1903,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
             unsigned int bonesSize = 0;
             if (_binaryReader.read(&bonesSize, 4, 1) != 1)
             {
-                AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
                 AX_SAFE_DELETE(modelnodedata);
                 AX_SAFE_DELETE(nodedata);
                 return nullptr;
@@ -1931,7 +1931,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
             unsigned int uvMapping = 0;
             if (_binaryReader.read(&uvMapping, 4, 1) != 1)
             {
-                AXLOG("warning: Failed to read nodedata: uvMapping '%s'.", _path.c_str());
+                AXLOGW("warning: Failed to read nodedata: uvMapping '{}'.", _path);
                 AX_SAFE_DELETE(modelnodedata);
                 AX_SAFE_DELETE(nodedata);
                 return nullptr;
@@ -1941,7 +1941,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
                 unsigned int textureIndexSize = 0;
                 if (_binaryReader.read(&textureIndexSize, 4, 1) != 1)
                 {
-                    AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+                    AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
                     AX_SAFE_DELETE(modelnodedata);
                     AX_SAFE_DELETE(nodedata);
                     return nullptr;
@@ -1982,7 +1982,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
     unsigned int childrenSize = 0;
     if (_binaryReader.read(&childrenSize, 4, 1) != 1)
     {
-        AXLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
+        AXLOGW("warning: Failed to read meshdata: attribCount '{}'.", _path);
         AX_SAFE_DELETE(nodedata);
         return nullptr;
     }
@@ -2007,7 +2007,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::UBYTE4;
         default:
-            AXLOGERROR("parseVertexType GL_BYTE x %d error", size);
+            AXLOGE("parseVertexType GL_BYTE x {} error", size);
         }
     }
     else if (str == "GL_UNSIGNED_BYTE")
@@ -2017,7 +2017,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::UBYTE4;
         default:
-            AXLOGERROR("parseVertexType GL_UNSIGNED_BYTE x %d error", size);
+            AXLOGE("parseVertexType GL_UNSIGNED_BYTE x {} error", size);
         }
     }
     else if (str == "GL_SHORT")
@@ -2029,7 +2029,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::USHORT4;
         default:
-            AXLOGERROR("parseVertexType GL_SHORT x %d error", size);
+            AXLOGE("parseVertexType GL_SHORT x {} error", size);
         }
     }
     else if (str == "GL_UNSIGNED_SHORT")
@@ -2041,7 +2041,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::USHORT4;
         default:
-            AXLOGERROR("parseVertexType GL_UNSIGNED_SHORT x %d error", size);
+            AXLOGE("parseVertexType GL_UNSIGNED_SHORT x {} error", size);
         }
     }
     else if (str == "GL_INT")
@@ -2057,7 +2057,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::INT4;
         default:
-            AXLOGERROR("parseVertexType GL_INT x %d error", size);
+            AXLOGE("parseVertexType GL_INT x {} error", size);
         }
     }
     else if (str == "GL_UNSIGNED_INT")
@@ -2073,7 +2073,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::INT4;
         default:
-            AXLOGERROR("parseVertexType GL_UNSIGNED_INT x %d error", size);
+            AXLOGE("parseVertexType GL_UNSIGNED_INT x {} error", size);
         }
     }
     else if (str == "GL_FLOAT")
@@ -2089,7 +2089,7 @@ backend::VertexFormat Bundle3D::parseGLDataType(std::string_view str, int size)
         case 4:
             return backend::VertexFormat::FLOAT4;
         default:
-            AXLOGERROR("parseVertexType GL_UNSIGNED_INT x %d error", size);
+            AXLOGE("parseVertexType GL_UNSIGNED_INT x {} error", size);
         }
     }
     AXASSERT(false, "parseVertexType failed!");
@@ -2256,7 +2256,7 @@ Reference* Bundle3D::seekToFirstType(unsigned int type, std::string_view id)
             // Found a match
             if (_binaryReader.seek(ref->offset, SEEK_SET) == false)
             {
-                AXLOG("warning: Failed to seek to object '%s' in bundle '%s'.", ref->id.c_str(), _path.c_str());
+                AXLOGW("warning: Failed to seek to object '{}' in bundle '{}'.", ref->id, _path);
                 return nullptr;
             }
             return ref;

--- a/core/3d/BundleReader.cpp
+++ b/core/3d/BundleReader.cpp
@@ -50,7 +50,7 @@ ssize_t BundleReader::read(void* ptr, ssize_t size, ssize_t count)
 {
     if (!_buffer || eof())
     {
-        AXLOG("warning: bundle reader out of range");
+        AXLOGW("warning: bundle reader out of range");
         return 0;
     }
 
@@ -72,7 +72,7 @@ ssize_t BundleReader::read(void* ptr, ssize_t size, ssize_t count)
             _position += readLength;
             validCount += 1;
         }
-        AXLOG("warning: bundle reader out of range");
+        AXLOGW("warning: bundle reader out of range");
     }
     else
     {

--- a/core/3d/BundleReader.h
+++ b/core/3d/BundleReader.h
@@ -188,7 +188,7 @@ inline bool BundleReader::read<char>(char* ptr)
 template <>
 inline bool BundleReader::read<std::string>(std::string* /*ptr*/)
 {
-    AXLOG("can not read std::string, use readString() instead");
+    AXLOGW("can not read std::string, use readString() instead");
     return false;
 }
 

--- a/core/3d/MeshMaterial.cpp
+++ b/core/3d/MeshMaterial.cpp
@@ -391,7 +391,7 @@ void MeshMaterialCache::removeUnusedMeshMaterial()
         auto value = it->second;
         if (value->getReferenceCount() == 1)
         {
-            AXLOG("axmol: MeshMaterialCache: removing unused mesh renderer materials.");
+            AXLOGD("MeshMaterialCache: removing unused mesh renderer materials.");
 
             value->release();
             it = _materials.erase(it);

--- a/core/3d/MeshRenderer.cpp
+++ b/core/3d/MeshRenderer.cpp
@@ -170,7 +170,7 @@ void MeshRenderer::afterAsyncLoad(void* param)
         }
         else
         {
-            AXLOG("file load failed: %s\n", asyncParam->modelPath.c_str());
+            AXLOGW("file load failed: {}\n", asyncParam->modelPath);
         }
         asyncParam->afterLoadCallback(this, asyncParam->callbackParam);
     }

--- a/core/3d/Terrain.cpp
+++ b/core/3d/Terrain.cpp
@@ -246,7 +246,7 @@ bool Terrain::initHeightMap(std::string_view heightMap)
     }
     else
     {
-        AXLOG("warning: the height map size is not POT or POT + 1");
+        AXLOGW("warning: the height map size is not POT or POT + 1");
         return false;
     }
 }
@@ -683,7 +683,7 @@ void Terrain::setDetailMap(unsigned int index, DetailMap detailMap)
 {
     if (index > 4)
     {
-        AXLOG("invalid DetailMap index %d\n", index);
+        AXLOGW("invalid DetailMap index {}\n", index);
     }
     _terrainData._detailMaps[index] = detailMap;
     if (_detailMapTextures[index])

--- a/core/3d/VertexAttribBinding.cpp
+++ b/core/3d/VertexAttribBinding.cpp
@@ -145,13 +145,13 @@ void VertexAttribBinding::setVertexAttribPointer(VertexLayout* vertexLayout,
     auto v = getVertexAttribValue(name);
     if (v)
     {
-        // AXLOG("axmol: set attribute '%s' location: %d, offset: %d", name.c_str(), v->location, offset);
+        // AXLOGD("set attribute '{}' location: {}, offset: {}", name, v->location, offset);
         vertexLayout->setAttrib(name, v->location, type, offset, normalized);
         _vertexAttribsFlags |= flag;
     }
     else
     {
-        // AXLOG("axmol: warning: Attribute not found: %s", name.c_str());
+        // AXLOGD("warning: Attribute not found: {}", name);
     }
 }
 

--- a/core/base/AutoreleasePool.cpp
+++ b/core/base/AutoreleasePool.cpp
@@ -50,7 +50,7 @@ AutoreleasePool::AutoreleasePool(std::string_view name)
 
 AutoreleasePool::~AutoreleasePool()
 {
-    AXLOGINFO("deallocing AutoreleasePool: %p", this);
+    AXLOGV("deallocing AutoreleasePool: {}", fmt::ptr(this));
     clear();
 
     PoolManager::getInstance()->pop();
@@ -89,12 +89,12 @@ bool AutoreleasePool::contains(Object* object) const
 
 void AutoreleasePool::dump()
 {
-    AXLOG("autorelease pool: %s, number of managed object %d\n", _name.c_str(),
+    AXLOGD("autorelease pool: {}, number of managed object {}\n", _name,
           static_cast<int>(_managedObjectArray.size()));
-    AXLOG("%20s%20s%20s", "Object pointer", "Object id", "reference count");
+    AXLOGD("{}\t{}\t{}", "Object pointer", "Object id", "reference count");
     for (const auto& obj : _managedObjectArray)
     {
-        AXLOG("%20p%20u\n", obj, obj->getReferenceCount());
+        AXLOGD("{}\t{}\n", fmt::ptr(obj), obj->getReferenceCount());
     }
 }
 
@@ -130,7 +130,7 @@ PoolManager::PoolManager()
 
 PoolManager::~PoolManager()
 {
-    AXLOGINFO("deallocing PoolManager: %p", this);
+    AXLOGI("deallocing PoolManager: {}", fmt::ptr(this));
 
     while (!_releasePoolStack.empty())
     {

--- a/core/base/Configuration.cpp
+++ b/core/base/Configuration.cpp
@@ -98,13 +98,13 @@ std::string Configuration::getInfo() const
 {
     // And Dump some warnings as well
 #if AX_ENABLE_PROFILERS
-    AXLOG(
+    AXLOGD(
         "axmol: **** WARNING **** AX_ENABLE_PROFILERS is defined. Disable it when you finish profiling (from "
         "ccConfig.h)\n");
 #endif
 
 #if AX_ENABLE_GL_STATE_CACHE == 0
-    AXLOG(
+    AXLOGD(
         "axmol: **** WARNING **** AX_ENABLE_GL_STATE_CACHE is disabled. To improve performance, enable it (from "
         "ccConfig.h)\n");
 #endif
@@ -351,14 +351,14 @@ void Configuration::loadConfigFile(std::string_view filename)
 
     if (!validMetadata)
     {
-        AXLOG("Invalid config format for file: %s", filename.data());
+        AXLOGW("Invalid config format for file: {}", filename);
         return;
     }
 
     auto dataIter = dict.find("data");
     if (dataIter == dict.cend() || dataIter->second.getType() != Value::Type::MAP)
     {
-        AXLOG("Expected 'data' dict, but not found. Config file: %s", filename.data());
+        AXLOGW("Expected 'data' dict, but not found. Config file: {}", filename);
         return;
     }
 
@@ -370,7 +370,7 @@ void Configuration::loadConfigFile(std::string_view filename)
         if (_valueDict.find(dataMapIter.first) == _valueDict.cend())
             _valueDict[dataMapIter.first] = dataMapIter.second;
         else
-            AXLOG("Key already present. Ignoring '%s'", dataMapIter.first.c_str());
+            AXLOGD("Key already present. Ignoring '{}'", dataMapIter.first);
     }
 
     // light info

--- a/core/base/Controller-android.cpp
+++ b/core/base/Controller-android.cpp
@@ -53,7 +53,7 @@ public:
     static void onConnected(std::string_view deviceName, int deviceId)
     {
         // Check whether the controller is already connected.
-        AXLOG("onConnected %s,%d", deviceName.data(), deviceId);
+        AXLOGD("onConnected {},{}", deviceName, deviceId);
 
         auto iter = findController(deviceName, deviceId);
         if (iter != Controller::s_allController.end())
@@ -70,12 +70,12 @@ public:
 
     static void onDisconnected(std::string_view deviceName, int deviceId)
     {
-        AXLOG("onDisconnected %s,%d", deviceName.data(), deviceId);
+        AXLOGD("onDisconnected {},{}", deviceName, deviceId);
 
         auto iter = findController(deviceName, deviceId);
         if (iter == Controller::s_allController.end())
         {
-            AXLOGERROR("Could not find the controller!");
+            AXLOGE("Could not find the controller!");
             return;
         }
 
@@ -93,7 +93,7 @@ public:
         auto iter = findController(deviceName, deviceId);
         if (iter == Controller::s_allController.end())
         {
-            AXLOG("onButtonEvent:connect new controller.");
+            AXLOGD("onButtonEvent:connect new controller.");
             onConnected(deviceName, deviceId);
             iter = findController(deviceName, deviceId);
         }
@@ -106,7 +106,7 @@ public:
         auto iter = findController(deviceName, deviceId);
         if (iter == Controller::s_allController.end())
         {
-            AXLOG("onAxisEvent:connect new controller.");
+            AXLOGD("onAxisEvent:connect new controller.");
             onConnected(deviceName, deviceId);
             iter = findController(deviceName, deviceId);
         }
@@ -172,7 +172,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_GameControllerAdapter_nativeController
                                                                                              jstring deviceName,
                                                                                              jint controllerID)
 {
-    AXLOG("controller id: %d connected!", controllerID);
+    AXLOGD("controller id: {} connected!", controllerID);
     ax::ControllerImpl::onConnected(ax::JniHelper::jstring2string(deviceName), controllerID);
 }
 
@@ -181,7 +181,7 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_GameControllerAdapter_nativeController
                                                                                                 jstring deviceName,
                                                                                                 jint controllerID)
 {
-    AXLOG("controller id: %d disconnected!", controllerID);
+    AXLOGD("controller id: {} disconnected!", controllerID);
     ax::ControllerImpl::onDisconnected(ax::JniHelper::jstring2string(deviceName), controllerID);
 }
 

--- a/core/base/Controller-linux-win32.cpp
+++ b/core/base/Controller-linux-win32.cpp
@@ -4222,7 +4222,7 @@ public:
             if (deviceName.compare(it.first) == 0)
             {
                 // Found controller profile. Attach it to the controller:
-                AXLOG("ControllerImpl: Found input profile for controller: %s", deviceName.data());
+                AXLOGD("ControllerImpl: Found input profile for controller: {}", deviceName);
                 controller->_buttonInputMap = it.second.first;
                 controller->_axisInputMap   = it.second.second;
 
@@ -4238,10 +4238,10 @@ public:
                     const auto& it = controller->_buttonInputMap.find(i);
                     if (it == controller->_buttonInputMap.end())
                     {
-                        AXLOG(
-                            "ControllerImpl: Could not find a button input mapping for controller \"%s\", and keyCode "
-                            "\"%d\". This keyCode will not match any from Controller::Key",
-                            controller->getDeviceName().data(), i);
+                        AXLOGD(
+                            "ControllerImpl: Could not find a button input mapping for controller \"{}\", and keyCode "
+                            "\"{}\". This keyCode will not match any from Controller::Key",
+                            controller->getDeviceName(), i);
                     }
                 }
 
@@ -4252,10 +4252,10 @@ public:
                     const auto& it = controller->_axisInputMap.find(i);
                     if (it == controller->_axisInputMap.end())
                     {
-                        AXLOG(
-                            "ControllerImpl: Could not find an axis input mapping for controller \"%s\", and keyCode "
-                            "\"%d\". This keyCode will not match any from Controller::Key",
-                            controller->getDeviceName().data(), i);
+                        AXLOGD(
+                            "ControllerImpl: Could not find an axis input mapping for controller \"{}\", and keyCode "
+                            "\"{}\". This keyCode will not match any from Controller::Key",
+                            controller->getDeviceName(), i);
                     }
                 }
 #    endif
@@ -4268,12 +4268,12 @@ public:
 #    ifdef _AX_DEBUG
         if (controller->_buttonInputMap.empty())
         {
-            AXLOG("ControllerImpl: Could not find a button input map for controller: %s", deviceName.data());
+            AXLOGD("ControllerImpl: Could not find a button input map for controller: {}", deviceName);
         }
 
         if (controller->_axisInputMap.empty())
         {
-            AXLOG("ControllerImpl: Could not find an axis input map for controller: %s", deviceName.data());
+            AXLOGD("ControllerImpl: Could not find an axis input map for controller: {}", deviceName);
         }
 #    endif
 
@@ -4286,7 +4286,7 @@ public:
         auto iter = findController(deviceId);
         if (iter == Controller::s_allController.end())
         {
-            AXLOGERROR("ControllerImpl Error: Could not find the controller!");
+            AXLOGE("ControllerImpl Error: Could not find the controller!");
             return;
         }
 
@@ -4299,7 +4299,7 @@ public:
         auto iter = findController(deviceId);
         if (iter == Controller::s_allController.end())
         {
-            AXLOG("ControllerImpl::onButtonEvent: new controller detected. Registering...");
+            AXLOGD("ControllerImpl::onButtonEvent: new controller detected. Registering...");
             onConnected(glfwGetJoystickName(deviceId), deviceId);
             iter = findController(deviceId);
         }
@@ -4312,7 +4312,7 @@ public:
         auto iter = findController(deviceId);
         if (iter == Controller::s_allController.end())
         {
-            AXLOG("ControllerImpl::onAxisEvent: new controller detected. Registering...");
+            AXLOGD("ControllerImpl::onAxisEvent: new controller detected. Registering...");
             onConnected(glfwGetJoystickName(deviceId), deviceId);
             iter = findController(deviceId);
         }
@@ -4335,7 +4335,7 @@ public:
 #    ifdef _AX_DEBUG
         else
         {
-            AXLOG("ControllerImpl: Unhandled GLFW joystick event: %d", event);
+            AXLOGD("ControllerImpl: Unhandled GLFW joystick event: {}", event);
         }
 #    endif
     }

--- a/core/base/Data.cpp
+++ b/core/base/Data.cpp
@@ -33,22 +33,22 @@ const Data Data::Null;
 
 Data::Data()
 {
-    AXLOGINFO("In the empty constructor of Data.");
+    AXLOGV("In the empty constructor of Data.");
 }
 
 Data::Data(Data&& other) : _impl(std::move(other._impl))
 {
-    AXLOGINFO("In the move constructor of Data.");
+    AXLOGV("In the move constructor of Data.");
 }
 
 Data::Data(const Data& other) : _impl(other._impl)
 {
-    AXLOGINFO("In the copy constructor of Data.");
+    AXLOGV("In the copy constructor of Data.");
 }
 
 Data::~Data()
 {
-    AXLOGINFO("deallocing Data: %p", this);
+    AXLOGV("deallocing Data: {}", fmt::ptr(this));
     clear();
 }
 
@@ -56,7 +56,7 @@ Data& Data::operator=(const Data& other)
 {
     if (this != &other)
     {
-        AXLOGINFO("In the copy assignment of Data.");
+        AXLOGV("In the copy assignment of Data.");
         _impl = other._impl;
     }
     return *this;
@@ -66,7 +66,7 @@ Data& Data::operator=(Data&& other)
 {
     if (this != &other)
     {
-        AXLOGINFO("In the move assignment of Data.");
+        AXLOGV("In the move assignment of Data.");
         this->_impl = std::move(other._impl);
     }
     return *this;

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -167,7 +167,7 @@ bool Director::init()
 
 Director::~Director()
 {
-    AXLOGINFO("deallocing Director: %p", this);
+    AXLOGI("deallocing Director: {}", fmt::ptr(this));
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     _eventDispatcher->removeEventListener(_rendererRecreatedListener);
@@ -617,7 +617,7 @@ void Director::setProjection(Projection projection)
 
     if (size.width == 0 || size.height == 0)
     {
-        AXLOGERROR("axmol: warning, Director::setProjection() failed because size is 0");
+        AXLOGE("warning, Director::setProjection() failed because size is 0");
         return;
     }
 
@@ -659,7 +659,7 @@ void Director::setProjection(Projection projection)
         break;
 
     default:
-        AXLOG("axmol: Director: unrecognized projection");
+        AXLOGD("Director: unrecognized projection");
         break;
     }
 
@@ -1320,7 +1320,7 @@ void Director::createStatsLabel()
     {
         if (image)
             delete image;
-        AXLOGERROR("%s", "Fails: init fps_images");
+        AXLOGE("{}", "Fails: init fps_images");
         return;
     }
 

--- a/core/base/EventListener.cpp
+++ b/core/base/EventListener.cpp
@@ -32,7 +32,7 @@ EventListener::EventListener() {}
 
 EventListener::~EventListener()
 {
-    AXLOGINFO("In the destructor of EventListener. %p", this);
+    AXLOGV("In the destructor of EventListener. {}", fmt::ptr(this));
 }
 
 bool EventListener::init(Type t, std::string_view listenerID, const std::function<void(Event*)>& callback)

--- a/core/base/EventListenerAcceleration.cpp
+++ b/core/base/EventListenerAcceleration.cpp
@@ -35,7 +35,7 @@ EventListenerAcceleration::EventListenerAcceleration() {}
 
 EventListenerAcceleration::~EventListenerAcceleration()
 {
-    AXLOGINFO("In the destructor of AccelerationEventListener. %p", this);
+    AXLOGV("In the destructor of AccelerationEventListener. {}", fmt::ptr(this));
 }
 
 EventListenerAcceleration* EventListenerAcceleration::create(const std::function<void(Acceleration*, Event*)>& callback)

--- a/core/base/EventListenerFocus.cpp
+++ b/core/base/EventListenerFocus.cpp
@@ -36,7 +36,7 @@ EventListenerFocus::EventListenerFocus() : onFocusChanged(nullptr) {}
 
 EventListenerFocus::~EventListenerFocus()
 {
-    AXLOGINFO("In the destructor of EventListenerFocus, %p", this);
+    AXLOGV("In the destructor of EventListenerFocus, {}", fmt::ptr(this));
 }
 
 EventListenerFocus* EventListenerFocus::create()

--- a/core/base/EventListenerTouch.cpp
+++ b/core/base/EventListenerTouch.cpp
@@ -44,7 +44,7 @@ EventListenerTouchOneByOne::EventListenerTouchOneByOne()
 
 EventListenerTouchOneByOne::~EventListenerTouchOneByOne()
 {
-    AXLOGINFO("In the destructor of EventListenerTouchOneByOne, %p", this);
+    AXLOGV("In the destructor of EventListenerTouchOneByOne, {}", fmt::ptr(this));
 }
 
 bool EventListenerTouchOneByOne::init()
@@ -126,7 +126,7 @@ EventListenerTouchAllAtOnce::EventListenerTouchAllAtOnce()
 
 EventListenerTouchAllAtOnce::~EventListenerTouchAllAtOnce()
 {
-    AXLOGINFO("In the destructor of EventListenerTouchAllAtOnce, %p", this);
+    AXLOGV("In the destructor of EventListenerTouchAllAtOnce, {}", fmt::ptr(this));
 }
 
 bool EventListenerTouchAllAtOnce::init()

--- a/core/base/Map.h
+++ b/core/base/Map.h
@@ -90,14 +90,14 @@ public:
     Map() : _data()
     {
         static_assert(std::is_convertible<V, Object*>::value, "Invalid Type for ax::Map<K, V>!");
-        AXLOGINFO("In the default constructor of Map!");
+        AXLOGV("In the default constructor of Map!");
     }
 
     /** Constructor with capacity. */
     explicit Map(ssize_t capacity) : _data()
     {
         static_assert(std::is_convertible<V, Object*>::value, "Invalid Type for ax::Map<K, V>!");
-        AXLOGINFO("In the constructor with capacity of Map!");
+        AXLOGV("In the constructor with capacity of Map!");
         _data.reserve(capacity);
     }
 
@@ -105,7 +105,7 @@ public:
     Map(const Map& other)
     {
         static_assert(std::is_convertible<V, Object*>::value, "Invalid Type for ax::Map<K, V>!");
-        AXLOGINFO("In the copy constructor of Map!");
+        AXLOGV("In the copy constructor of Map!");
         _data = other._data;
         addRefForAllObjects();
     }
@@ -114,7 +114,7 @@ public:
     Map(Map&& other)
     {
         static_assert(std::is_convertible<V, Object*>::value, "Invalid Type for ax::Map<K, V>!");
-        AXLOGINFO("In the move constructor of Map!");
+        AXLOGV("In the move constructor of Map!");
         _data = std::move(other._data);
     }
 
@@ -124,7 +124,7 @@ public:
      */
     ~Map()
     {
-        AXLOGINFO("In the destructor of Map!");
+        AXLOGV("In the destructor of Map!");
         clear();
     }
 
@@ -379,25 +379,25 @@ public:
     // Don't uses operator since we could not decide whether it needs 'retain'/'release'.
     //    V& operator[] ( const K& key )
     //    {
-    //        AXLOG("copy: [] ref");
+    //        AXLOGD("copy: [] ref");
     //        return _data[key];
     //    }
     //
     //    V& operator[] ( K&& key )
     //    {
-    //        AXLOG("move [] ref");
+    //        AXLOGD("move [] ref");
     //        return _data[key];
     //    }
 
     //    const V& operator[] ( const K& key ) const
     //    {
-    //        AXLOG("const copy []");
+    //        AXLOGD("const copy []");
     //        return _data.at(key);
     //    }
     //
     //    const V& operator[] ( K&& key ) const
     //    {
-    //        AXLOG("const move []");
+    //        AXLOGD("const move []");
     //        return _data.at(key);
     //    }
 
@@ -406,7 +406,7 @@ public:
     {
         if (this != &other)
         {
-            AXLOGINFO("In the copy assignment operator of Map!");
+            AXLOGV("In the copy assignment operator of Map!");
             clear();
             _data = other._data;
             addRefForAllObjects();
@@ -419,7 +419,7 @@ public:
     {
         if (this != &other)
         {
-            AXLOGINFO("In the move assignment operator of Map!");
+            AXLOGV("In the move assignment operator of Map!");
             clear();
             _data = std::move(other._data);
         }

--- a/core/base/Properties.cpp
+++ b/core/base/Properties.cpp
@@ -101,7 +101,7 @@ Properties* Properties::createNonRefCounted(std::string_view url)
 {
     if (url.empty())
     {
-        AXLOGERROR("Attempting to create a Properties object from an empty URL!");
+        AXLOGE("Attempting to create a Properties object from an empty URL!");
         return nullptr;
     }
 
@@ -122,7 +122,7 @@ Properties* Properties::createNonRefCounted(std::string_view url)
     Properties* p = getPropertiesFromNamespacePath(properties, namespacePath);
     if (!p)
     {
-        AXLOGWARN("Failed to load properties from url '%s'.", url.data());
+        AXLOGW("Failed to load properties from url '{}'.", url);
         AX_SAFE_DELETE(properties);
         return nullptr;
     }
@@ -185,7 +185,7 @@ void Properties::readProperties()
         rc = readLine(line, 2048);
         if (rc == NULL)
         {
-            AXLOGERROR("Error reading line from file.");
+            AXLOGE("Error reading line from file.");
             return;
         }
 
@@ -219,7 +219,7 @@ void Properties::readProperties()
                 name = strtok(line, "=");
                 if (name == NULL)
                 {
-                    AXLOGERROR("Error parsing properties file: attribute without name.");
+                    AXLOGE("Error parsing properties file: attribute without name.");
                     return;
                 }
 
@@ -230,7 +230,7 @@ void Properties::readProperties()
                 value = strtok(NULL, "");
                 if (value == NULL)
                 {
-                    AXLOGERROR("Error parsing properties file: attribute with name ('%s') but no value.", name);
+                    AXLOGE("Error parsing properties file: attribute with name ('{}') but no value.", name);
                     return;
                 }
 
@@ -272,7 +272,7 @@ void Properties::readProperties()
                 name = trimWhiteSpace(name);
                 if (name == NULL)
                 {
-                    AXLOGERROR("Error parsing properties file: failed to determine a valid token for line '%s'.", line);
+                    AXLOGE("Error parsing properties file: failed to determine a valid token for line '{}'.", line);
                     return;
                 }
                 else if (name[0] == '}')
@@ -299,20 +299,20 @@ void Properties::readProperties()
                     {
                         if (seekFromCurrent(-1) == false)
                         {
-                            AXLOGERROR("Failed to seek back to before a '}' character in properties file.");
+                            AXLOGE("Failed to seek back to before a '}}' character in properties file.");
                             return;
                         }
                         while (readChar() != '}')
                         {
                             if (seekFromCurrent(-2) == false)
                             {
-                                AXLOGERROR("Failed to seek back to before a '}' character in properties file.");
+                                AXLOGE("Failed to seek back to before a '}}' character in properties file.");
                                 return;
                             }
                         }
                         if (seekFromCurrent(-1) == false)
                         {
-                            AXLOGERROR("Failed to seek back to before a '}' character in properties file.");
+                            AXLOGE("Failed to seek back to before a '}}' character in properties file.");
                             return;
                         }
                     }
@@ -326,7 +326,7 @@ void Properties::readProperties()
                     {
                         if (seekFromCurrent(1) == false)
                         {
-                            AXLOGERROR("Failed to seek to immediately after a '}' character in properties file.");
+                            AXLOGE("Failed to seek to immediately after a '}}' character in properties file.");
                             return;
                         }
                     }
@@ -341,20 +341,20 @@ void Properties::readProperties()
                         {
                             if (seekFromCurrent(-1) == false)
                             {
-                                AXLOGERROR("Failed to seek back to before a '}' character in properties file.");
+                                AXLOGE("Failed to seek back to before a '}}' character in properties file.");
                                 return;
                             }
                             while (readChar() != '}')
                             {
                                 if (seekFromCurrent(-2) == false)
                                 {
-                                    AXLOGERROR("Failed to seek back to before a '}' character in properties file.");
+                                    AXLOGE("Failed to seek back to before a '}}' character in properties file.");
                                     return;
                                 }
                             }
                             if (seekFromCurrent(-1) == false)
                             {
-                                AXLOGERROR("Failed to seek back to before a '}' character in properties file.");
+                                AXLOGE("Failed to seek back to before a '}}' character in properties file.");
                                 return;
                             }
                         }
@@ -368,7 +368,7 @@ void Properties::readProperties()
                         {
                             if (seekFromCurrent(1) == false)
                             {
-                                AXLOGERROR("Failed to seek to immediately after a '}' character in properties file.");
+                                AXLOGE("Failed to seek to immediately after a '}}' character in properties file.");
                                 return;
                             }
                         }
@@ -388,9 +388,9 @@ void Properties::readProperties()
                         {
                             // Back up from fgetc()
                             if (seekFromCurrent(-1) == false)
-                                AXLOGERROR(
+                                AXLOGE(
                                     "Failed to seek backwards a single character after testing if the next line starts "
-                                    "with '{'.");
+                                    "with '{{'.");
 
                             // Store "name value" as a name/value pair, or even just "name".
                             if (value != NULL)
@@ -481,7 +481,7 @@ void Properties::skipWhiteSpace()
     {
         if (seekFromCurrent(-1) == false)
         {
-            AXLOGERROR("Failed to seek backwards one character after skipping whitespace.");
+            AXLOGE("Failed to seek backwards one character after skipping whitespace.");
         }
     }
 }
@@ -879,7 +879,7 @@ int Properties::getInt(const char* name) const
         scanned = sscanf(valueString, "%d", &value);
         if (scanned != 1)
         {
-            AXLOGERROR("Error attempting to parse property '%s' as an integer.", name);
+            AXLOGE("Error attempting to parse property '{}' as an integer.", name);
             return 0;
         }
         return value;
@@ -898,7 +898,7 @@ float Properties::getFloat(const char* name) const
         scanned = sscanf(valueString, "%f", &value);
         if (scanned != 1)
         {
-            AXLOGERROR("Error attempting to parse property '%s' as a float.", name);
+            AXLOGE("Error attempting to parse property '{}' as a float.", name);
             return 0.0f;
         }
         return value;
@@ -921,7 +921,7 @@ bool Properties::getMat4(const char* name, Mat4* out) const
 
         if (scanned != 16)
         {
-            AXLOGERROR("Error attempting to parse property '%s' as a matrix.", name);
+            AXLOGE("Error attempting to parse property '{}' as a matrix.", name);
             out->setIdentity();
             return false;
         }
@@ -1144,7 +1144,7 @@ Properties* getPropertiesFromNamespacePath(Properties* properties, const std::ve
             {
                 if (iter == NULL)
                 {
-                    AXLOGWARN("Failed to load properties object from url.");
+                    AXLOGW("Failed to load properties object from url.");
                     return nullptr;
                 }
 
@@ -1185,7 +1185,7 @@ bool Properties::parseVec2(const char* str, Vec2* out)
         }
         else
         {
-            AXLOGWARN("Error attempting to parse property as a two-dimensional vector: %s", str);
+            AXLOGW("Error attempting to parse property as a two-dimensional vector: {}", str);
         }
     }
 
@@ -1207,7 +1207,7 @@ bool Properties::parseVec3(const char* str, Vec3* out)
         }
         else
         {
-            AXLOGWARN("Error attempting to parse property as a three-dimensional vector: %s", str);
+            AXLOGW("Error attempting to parse property as a three-dimensional vector: {}", str);
         }
     }
 
@@ -1229,7 +1229,7 @@ bool Properties::parseVec4(const char* str, Vec4* out)
         }
         else
         {
-            AXLOGWARN("Error attempting to parse property as a four-dimensional vector: %s", str);
+            AXLOGW("Error attempting to parse property as a four-dimensional vector: {}", str);
         }
     }
 
@@ -1251,7 +1251,7 @@ bool Properties::parseAxisAngle(const char* str, Quaternion* out)
         }
         else
         {
-            AXLOGWARN("Error attempting to parse property as an axis-angle rotation: %s", str);
+            AXLOGW("Error attempting to parse property as an axis-angle rotation: {}", str);
         }
     }
 
@@ -1277,13 +1277,13 @@ bool Properties::parseColor(const char* str, Vec3* out)
             else
             {
                 // Invalid format
-                AXLOGWARN("Error attempting to parse property as an RGB color: %s", str);
+                AXLOGW("Error attempting to parse property as an RGB color: {}", str);
             }
         }
         else
         {
             // Not a color string.
-            AXLOGWARN("Error attempting to parse property as an RGB color (not specified as a color string): %s", str);
+            AXLOGW("Error attempting to parse property as an RGB color (not specified as a color string): {}", str);
         }
     }
 
@@ -1309,13 +1309,13 @@ bool Properties::parseColor(const char* str, Vec4* out)
             else
             {
                 // Invalid format
-                AXLOGWARN("Error attempting to parse property as an RGBA color: %s", str);
+                AXLOGW("Error attempting to parse property as an RGBA color: {}", str);
             }
         }
         else
         {
             // Not a color string.
-            AXLOGWARN("Error attempting to parse property as an RGBA color (not specified as a color string): %s", str);
+            AXLOGW("Error attempting to parse property as an RGBA color (not specified as a color string): {}", str);
         }
     }
 

--- a/core/base/Scheduler.cpp
+++ b/core/base/Scheduler.cpp
@@ -279,7 +279,7 @@ void Scheduler::schedule(const ccSchedulerFunc& callback,
         });
         if (timerIt != timers.end())
         {
-            AXLOG("Scheduler#schedule. Reiniting timer with interval %.4f, repeat %u, delay %.4f", interval, repeat,
+            AXLOGD("Scheduler#schedule. Reiniting timer with interval {:.4f}, repeat {}, delay {:.4f}", interval, repeat,
                   delay);
             (*timerIt)->setupTimerWithInterval(interval, repeat, delay);
             return;
@@ -903,7 +903,7 @@ void Scheduler::schedule(SEL_SCHEDULE selector,
         });
         if (timerIt != timers.end())
         {
-            AXLOG("Scheduler#schedule. Reiniting timer with interval %.4f, repeat %u, delay %.4f", interval, repeat,
+            AXLOGD("Scheduler#schedule. Reiniting timer with interval {:.4}, repeat {}, delay {:.4f}", interval, repeat,
                   delay);
             (*timerIt)->setupTimerWithInterval(interval, repeat, delay);
             return;

--- a/core/base/UTF8.cpp
+++ b/core/base/UTF8.cpp
@@ -478,7 +478,7 @@ void StringUTF8::replace(std::string_view newStr)
 
         if (lengthString == 0)
         {
-            AXLOG("Bad utf-8 set string: %s", newStr.data());
+            AXLOGD("Bad utf-8 set string: {}", newStr);
             return;
         }
 

--- a/core/base/Utils.cpp
+++ b/core/base/Utils.cpp
@@ -94,7 +94,7 @@ void captureScreen(std::function<void(RefPtr<Image>)> imageCallback)
 {
     if (s_captureScreenListener)
     {
-        AXLOG("Warning: CaptureScreen has been called already, don't call more than once in one frame.");
+        AXLOGW("Warning: CaptureScreen has been called already, don't call more than once in one frame.");
         return;
     }
 
@@ -131,7 +131,7 @@ void captureNode(Node* startNode, std::function<void(RefPtr<Image>)> imageCallba
 {
     if (s_captureNodeListener.find(startNode) != s_captureNodeListener.end())
     {
-        AXLOG("Warning: current node has been captured already");
+        AXLOGW("Warning: current node has been captured already");
         return;
     }
 
@@ -718,7 +718,7 @@ std::vector<int> parseIntegerList(std::string_view intsString)
             if (errno == ERANGE)
             {
                 errno = 0;
-                AXLOGWARN("%s contains out of range integers", intsString.data());
+                AXLOGW("{} contains out of range integers", intsString);
             }
             result.emplace_back(static_cast<int>(i));
             cStr = endptr;

--- a/core/base/Vector.h
+++ b/core/base/Vector.h
@@ -120,7 +120,7 @@ public:
     explicit Vector(ssize_t capacity) : _data()
     {
         static_assert(std::is_convertible<T, Object*>::value, "Invalid Type for ax::Vector!");
-        AXLOGINFO("In the default constructor with capacity of Vector.");
+        AXLOGV("In the default constructor with capacity of Vector.");
         reserve(capacity);
     }
 
@@ -136,7 +136,7 @@ public:
     /** Destructor. */
     ~Vector()
     {
-        AXLOGINFO("In the destructor of Vector.");
+        AXLOGV("In the destructor of Vector.");
         clear();
     }
 
@@ -144,7 +144,7 @@ public:
     Vector(const Vector& other)
     {
         static_assert(std::is_convertible<T, Object*>::value, "Invalid Type for ax::Vector!");
-        AXLOGINFO("In the copy constructor!");
+        AXLOGV("In the copy constructor!");
         _data = other._data;
         addRefForAllObjects();
     }
@@ -153,7 +153,7 @@ public:
     Vector(Vector&& other)
     {
         static_assert(std::is_convertible<T, Object*>::value, "Invalid Type for ax::Vector!");
-        AXLOGINFO("In the move constructor of Vector!");
+        AXLOGV("In the move constructor of Vector!");
         _data = std::move(other._data);
     }
 
@@ -162,7 +162,7 @@ public:
     {
         if (this != &other)
         {
-            AXLOGINFO("In the copy assignment operator!");
+            AXLOGV("In the copy assignment operator!");
             clear();
             _data = other._data;
             addRefForAllObjects();
@@ -175,7 +175,7 @@ public:
     {
         if (this != &other)
         {
-            AXLOGINFO("In the move assignment operator!");
+            AXLOGV("In the move assignment operator!");
             clear();
             _data = std::move(other._data);
         }

--- a/core/base/ZipUtils.cpp
+++ b/core/base/ZipUtils.cpp
@@ -178,16 +178,16 @@ _L_end:
         switch (err)
         {
         case Z_MEM_ERROR:
-            AXLOG("axmol: ZipUtils: Out of memory while decompressing map data!");
+            AXLOGW("ZipUtils: Out of memory while decompressing map data!");
             break;
         case Z_VERSION_ERROR:
-            AXLOG("axmol: ZipUtils: Incompatible zlib version!");
+            AXLOGW("ZipUtils: Incompatible zlib version!");
             break;
         case Z_DATA_ERROR:
-            AXLOG("axmol: ZipUtils: Incorrect zlib compressed data!");
+            AXLOGW("ZipUtils: Incorrect zlib compressed data!");
             break;
         default:
-            AXLOG("axmol: ZipUtils: Unknown error while decompressing map data!");
+            AXLOGW("ZipUtils: Unknown error while decompressing map data!");
         }
         output.clear();
         output.shrink_to_fit();
@@ -314,7 +314,7 @@ int ZipUtils::inflateGZipFile(const char* path, unsigned char** out)
     gzFile inFile = gzopen(path, "rb");
     if (inFile == nullptr)
     {
-        AXLOG("axmol: ZipUtils: error open gzip file: %s", path);
+        AXLOGW("ZipUtils: error open gzip file: %s", path);
         return -1;
     }
 
@@ -329,7 +329,7 @@ int ZipUtils::inflateGZipFile(const char* path, unsigned char** out)
         len = gzread(inFile, readBuffer, sizeof(readBuffer));
         if (len < 0)
         {
-            AXLOG("axmol: ZipUtils: error in gzread");
+            AXLOGW("ZipUtils: error in gzread");
             return -1;
         }
         if (len == 0)
@@ -342,7 +342,7 @@ int ZipUtils::inflateGZipFile(const char* path, unsigned char** out)
 
     if (gzclose(inFile) != Z_OK)
     {
-        AXLOG("axmol: ZipUtils: gzclose failed");
+        AXLOGW("ZipUtils: gzclose failed");
     }
 
 
@@ -359,7 +359,7 @@ bool ZipUtils::isCCZFile(const char* path)
 
     if (compressedData.isNull())
     {
-        AXLOG("axmol: ZipUtils: loading file failed");
+        AXLOGW("ZipUtils: loading file failed");
         return false;
     }
 
@@ -385,7 +385,7 @@ bool ZipUtils::isGZipFile(const char* path)
 
     if (compressedData.isNull())
     {
-        AXLOG("axmol: ZipUtils: loading file failed");
+        AXLOGW("ZipUtils: loading file failed");
         return false;
     }
 
@@ -413,14 +413,14 @@ int ZipUtils::inflateCCZBuffer(const unsigned char* buffer, ssize_t bufferLen, u
         unsigned int version = AX_SWAP_INT16_BIG_TO_HOST(header->version);
         if (version > 2)
         {
-            AXLOG("axmol: Unsupported CCZ header format");
+            AXLOGW("Unsupported CCZ header format");
             return -1;
         }
 
         // verify compression format
         if (AX_SWAP_INT16_BIG_TO_HOST(header->compression_type) != CCZ_COMPRESSION_ZLIB)
         {
-            AXLOG("axmol: CCZ Unsupported compression method");
+            AXLOGW("CCZ Unsupported compression method");
             return -1;
         }
     }
@@ -433,14 +433,14 @@ int ZipUtils::inflateCCZBuffer(const unsigned char* buffer, ssize_t bufferLen, u
         unsigned int version = AX_SWAP_INT16_BIG_TO_HOST(header->version);
         if (version > 0)
         {
-            AXLOG("axmol: Unsupported CCZ header format");
+            AXLOGW("Unsupported CCZ header format");
             return -1;
         }
 
         // verify compression format
         if (AX_SWAP_INT16_BIG_TO_HOST(header->compression_type) != CCZ_COMPRESSION_ZLIB)
         {
-            AXLOG("axmol: CCZ Unsupported compression method");
+            AXLOGW("CCZ Unsupported compression method");
             return -1;
         }
 
@@ -457,21 +457,21 @@ int ZipUtils::inflateCCZBuffer(const unsigned char* buffer, ssize_t bufferLen, u
 
         if (calculated != required)
         {
-            AXLOG("axmol: Can't decrypt image file. Is the decryption key valid?");
+            AXLOGW("Can't decrypt image file. Is the decryption key valid?");
             return -1;
         }
 #endif
     }
     else
     {
-        AXLOG("axmol: Invalid CCZ file");
+        AXLOGW("Invalid CCZ file");
         return -1;
     }
 
     unsigned int len = AX_SWAP_INT32_BIG_TO_HOST(header->len);
     if (!len)
     {
-        AXLOG("axmol: CCZ: Failed to allocate memory for texture");
+        AXLOGW("CCZ: Failed to allocate memory for texture");
         return -1;
     }
 
@@ -483,7 +483,7 @@ int ZipUtils::inflateCCZBuffer(const unsigned char* buffer, ssize_t bufferLen, u
 
     if (ret != Z_OK)
     {
-        AXLOG("axmol: CCZ: Failed to uncompress data");
+        AXLOGW("CCZ: Failed to uncompress data");
         return -1;
     }
     *out = outBuffer.release_pointer();
@@ -499,7 +499,7 @@ int ZipUtils::inflateCCZFile(const char* path, unsigned char** out)
 
     if (compressedData.isNull())
     {
-        AXLOG("axmol: Error loading CCZ compressed file");
+        AXLOGW("Error loading CCZ compressed file");
         return -1;
     }
 

--- a/core/math/Mat4.cpp
+++ b/core/math/Mat4.cpp
@@ -131,7 +131,7 @@ void Mat4::createPerspective(float fieldOfView, float aspectRatio, float zNearPl
     float theta = MATH_DEG_TO_RAD(fieldOfView) * 0.5f;
     if (std::abs(std::fmod(theta, MATH_PIOVER2)) < MATH_EPSILON)
     {
-        AXLOGERROR("Invalid field of view value (%f) causes attempted calculation tan(%f), which is undefined.",
+        AXLOGE("Invalid field of view value ({}) causes attempted calculation tan({}), which is undefined.",
                    fieldOfView, theta);
         return;
     }

--- a/core/media/MediaEngine.h
+++ b/core/media/MediaEngine.h
@@ -27,7 +27,7 @@
 #if !defined(AXME_NO_AXMOL)
 #    include "base/Logging.h"
 #    include "platform/PlatformMacros.h"
-#    define AXME_TRACE AXLOG
+#    define AXME_TRACE AXLOGD
 #else
 #    define AXME_TRACE printf
 #    define NS_AX_BEGIN \

--- a/core/media/VlcMediaEngine.cpp
+++ b/core/media/VlcMediaEngine.cpp
@@ -185,7 +185,7 @@ void VlcMediaEngine::libvlc_handle_event(const libvlc_event_t* event, void* user
 
 VlcMediaEngine::VlcMediaEngine()
 {
-    AXLOG("libvlc-version: %s", libvlc_get_version());
+    AXLOGD("libvlc-version: {}", libvlc_get_version());
 
     // too late set vlc plugins path at hete, vlc maybe read it at DllMain
     //_putenv_s("VLC_PLUGIN_PATH", R"(D:\dev\axmol\3rdparty\vlc\win\lib)");

--- a/core/network/HttpClient-wasm.cpp
+++ b/core/network/HttpClient-wasm.cpp
@@ -69,20 +69,20 @@ namespace network
     , _clearRequestPredicate(nullptr)
     , _clearResponsePredicate(nullptr)
     {
-        AXLOG("In the constructor of HttpClient!");
+        AXLOGD("In the constructor of HttpClient!");
         increaseThreadCount();
     }
 
     HttpClient::~HttpClient()
     {
-        AXLOG("HttpClient destructor");
+        AXLOGD("HttpClient destructor");
     }
 
     void HttpClient::destroyInstance()
     {
         if (nullptr == _httpClient)
         {
-            AXLOG("HttpClient singleton is nullptr");
+            AXLOGD("HttpClient singleton is nullptr");
         }
 
         auto thiz = _httpClient;
@@ -109,7 +109,7 @@ namespace network
 
     void HttpClient::setSSLVerification(std::string_view caFile)
     {
-        AXLOG("HttpClient::setSSLVerification not required on Emscripten");
+        AXLOGD("HttpClient::setSSLVerification not required on Emscripten");
         // _sslCaFilename = caFile;
     }
 
@@ -205,7 +205,7 @@ namespace network
             if (pos != std::string::npos)
             {
                 if (cxx20::ic::starts_with(header, "user-agent")) {
-                    AXLOGWARN("Ignore user-agent for wasm to avoid cause error: Refused to set unsafe header \"User-Agent\"");
+                    AXLOGW("Ignore user-agent for wasm to avoid cause error: Refused to set unsafe header \"User-Agent\"");
                     continue;
                 }
                 auto key = header.substr(0, pos);

--- a/core/network/HttpClient.cpp
+++ b/core/network/HttpClient.cpp
@@ -76,15 +76,15 @@ void HttpClient::destroyInstance()
 {
     if (nullptr == _httpClient)
     {
-        AXLOG("HttpClient singleton is nullptr");
+        AXLOGD("HttpClient singleton is nullptr");
         return;
     }
 
-    AXLOG("HttpClient::destroyInstance begin");
+    AXLOGD("HttpClient::destroyInstance begin");
     delete _httpClient;
     _httpClient = nullptr;
 
-    AXLOG("HttpClient::destroyInstance() finished!");
+    AXLOGD("HttpClient::destroyInstance() finished!");
 }
 
 void HttpClient::enableCookies(const char* cookieFile)
@@ -120,7 +120,7 @@ HttpClient::HttpClient()
     , _cookie(nullptr)
     , _clearResponsePredicate(nullptr)
 {
-    AXLOG("In the constructor of HttpClient!");
+    AXLOGD("In the constructor of HttpClient!");
     _scheduler = Director::getInstance()->getScheduler();
 
     _service = new yasio::io_service(HttpClient::MAX_CHANNELS);
@@ -150,7 +150,7 @@ HttpClient::~HttpClient()
         delete _cookie;
     }
 
-    AXLOG("HttpClient destructor");
+    AXLOGD("HttpClient destructor");
 }
 
 void HttpClient::setDispatchOnWorkThread(bool bVal)

--- a/core/network/HttpResponse.h
+++ b/core/network/HttpResponse.h
@@ -162,7 +162,7 @@ private:
                 auto redirectUrl = iter->second;
                 if (_responseCode == 302)
                     getHttpRequest()->setRequestType(HttpRequest::Type::GET);
-                AXLOG("Process url redirect (%d): %s", _responseCode, redirectUrl.c_str());
+                AXLOGD("Process url redirect ({}): {}", _responseCode, redirectUrl);
                 return setLocation(redirectUrl, true);
             }
         }

--- a/core/network/Uri.cpp
+++ b/core/network/Uri.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "network/Uri.h"
-#include "base/Logging.h"  // For AXLOGERROR macro
+#include "base/Logging.h"
 
 #include <regex>
 #include <sstream>
@@ -169,7 +169,7 @@ bool Uri::doParse(std::string_view str)
 
     if (str.empty())
     {
-        AXLOGERROR("%s", "Empty URI is invalid!");
+        AXLOGE("{}", "Empty URI is invalid!");
         return false;
     }
 
@@ -185,7 +185,7 @@ bool Uri::doParse(std::string_view str)
     std::smatch match;
     if (UNLIKELY(!std::regex_match(copied.cbegin(), copied.cend(), match, uriRegex)))
     {
-        AXLOGERROR("Invalid URI: %s", str.data());
+        AXLOGE("Invalid URI: {}", str);
         return false;
     }
 
@@ -211,7 +211,7 @@ bool Uri::doParse(std::string_view str)
         if (!std::regex_match(authority.first, authority.second, authorityMatch, authorityRegex))
         {
             std::string invalidAuthority(authority.first, authority.second);
-            AXLOGERROR("Invalid URI authority: %s", invalidAuthority.c_str());
+            AXLOGE("Invalid URI authority: {}", invalidAuthority);
             return false;
         }
 

--- a/core/network/WebSocket-wasm.cpp
+++ b/core/network/WebSocket-wasm.cpp
@@ -58,7 +58,7 @@ bool WebSocket::open(Delegate* delegate, std::string_view url, std::string_view 
 {
     if (url.empty())
     {
-        AXLOG("ws open fail, url is empty!");
+        AXLOGW("ws open fail, url is empty!");
         return false;
     }
 
@@ -70,7 +70,7 @@ bool WebSocket::open(Delegate* delegate, std::string_view url, std::string_view 
     EmscriptenWebSocketCreateAttributes ws_attrs = {_url.c_str(),
                                                     _subProtocols.empty() ? nullptr : _subProtocols.c_str(), EM_TRUE};
 
-    AXLOG("ws open url: %s, protocols: %s", ws_attrs.url, ws_attrs.protocols);
+    AXLOGD("ws open url: {}, protocols: {}", ws_attrs.url, ws_attrs.protocols);
 
     _state = WebSocket::State::CONNECTING;
     _wsfd = emscripten_websocket_new(&ws_attrs);
@@ -95,7 +95,7 @@ void WebSocket::send(std::string_view message)
 {
     auto error = emscripten_websocket_send_utf8_text(_wsfd, message.data());
     if (error)
-        AXLOG("Failed to emscripten_websocket_send_binary(): %d", error);
+        AXLOGW("Failed to emscripten_websocket_send_binary(): {}", error);
 }
 
 /**
@@ -109,7 +109,7 @@ void WebSocket::send(const void* data, unsigned int len)
 {
     auto error = emscripten_websocket_send_binary(_wsfd, const_cast<void*>(data), len);
     if (error)
-        AXLOG("Failed to emscripten_websocket_send_binary(): %d", error);
+        AXLOGW("Failed to emscripten_websocket_send_binary(): {}", error);
 }
 
 /**
@@ -136,7 +136,7 @@ void WebSocket::closeAsync()
     if (!error)
         _state = WebSocket::State::CLOSING;
     else
-        AXLOG("Failed to emscripten_websocket_close(): %d", error);
+        AXLOGW("Failed to emscripten_websocket_close(): {}", error);
 }
 
 }  // namespace network

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -386,17 +386,17 @@ int WebSocket::on_frame_end(websocket_parser* parser)
             ws->_eventQueue.emplace_back(new MessageEvent{std::move(ws->_receivedData), ws->_opcode == WS_OP_BINARY});
             break;
         case WS_OP_CLOSE:
-            AXLOG("WS: control frame: CLOSE");
+            AXLOGD("WS: control frame: CLOSE");
             break;
         case WS_OP_PING:
-            AXLOG("WS: control frame: PING");
+            AXLOGD("WS: control frame: PING");
             WebSocketProtocol::sendFrame(*ws, ws->_receivedData.data(), ws->_receivedData.size(),
                                          ws::detail::opcode::pong);
             break;
         case WS_OP_PONG:
-            AXLOG("WS: control frame: PONG");
+            AXLOGD("WS: control frame: PONG");
             if (ws->_receivedData.size() != 4 || 0 != memcmp(ws->_receivedData.data(), "WSWS", 4))
-                AXLOG("WS: Unsolicited PONG frame from server (possible keep-alive)\n\n");
+                AXLOGD("WS: Unsolicited PONG frame from server (possible keep-alive)\n\n");
             break;
         }
     }
@@ -449,13 +449,13 @@ void WebSocket::close()
                 _syncCloseState = std::make_shared<std::promise<int>>();
                 int status      = _syncCloseState->get_future().get();
                 _syncCloseState.reset();
-                AXLOG("WebSocket close with status: %d", status);
+                AXLOGD("WebSocket close with status: {}", status);
             }
             else
             {
                 _service->stop();  // stop internal service for sync close
                 _state = State::CLOSED;
-                AXLOG("WebSocket::close: connection not ready!");
+                AXLOGW("WebSocket::close: connection not ready!");
             }
         }
         else

--- a/core/physics/PhysicsBody.cpp
+++ b/core/physics/PhysicsBody.cpp
@@ -603,7 +603,7 @@ void PhysicsBody::setVelocity(const Vec2& velocity)
 {
     if (cpBodyGetType(_cpBody) == CP_BODY_TYPE_STATIC)
     {
-        AXLOG("physics warning: you can't set velocity for a static body.");
+        AXLOGD("physics warning: you can't set velocity for a static body.");
         return;
     }
 
@@ -629,7 +629,7 @@ void PhysicsBody::setAngularVelocity(float velocity)
 {
     if (cpBodyGetType(_cpBody) == CP_BODY_TYPE_STATIC)
     {
-        AXLOG("physics warning: you can't set angular velocity for a static body.");
+        AXLOGD("physics warning: you can't set angular velocity for a static body.");
         return;
     }
 

--- a/core/physics/PhysicsShape.cpp
+++ b/core/physics/PhysicsShape.cpp
@@ -118,7 +118,7 @@ void PhysicsShape::setScale(float scaleX, float scaleY)
     {
         if (_type == Type::CIRCLE && scaleX != scaleY)
         {
-            AXLOG("PhysicsShapeCircle WARNING: CANNOT support setScale with different x and y");
+            AXLOGD("PhysicsShapeCircle WARNING: CANNOT support setScale with different x and y");
             return;
         }
         _newScaleX = scaleX;

--- a/core/physics/PhysicsWorld.cpp
+++ b/core/physics/PhysicsWorld.cpp
@@ -635,7 +635,7 @@ void PhysicsWorld::removeBody(PhysicsBody* body)
 {
     if (body->getWorld() != this)
     {
-        AXLOG("Physics Warning: this body doesn't belong to this world");
+        AXLOGD("Physics Warning: this body doesn't belong to this world");
         return;
     }
 
@@ -679,7 +679,7 @@ void PhysicsWorld::removeJoint(PhysicsJoint* joint, bool destroy)
     {
         if (joint->getWorld() != this && destroy)
         {
-            AXLOG(
+            AXLOGD(
                 "physics warning: the joint is not in this world, it won't be destroyed until the body it connects is "
                 "destroyed");
             return;
@@ -909,7 +909,7 @@ void PhysicsWorld::step(float delta)
 {
     if (_autoStep)
     {
-        AXLOG("Physics Warning: You need to close auto step( setAutoStep(false) ) first");
+        AXLOGD("Physics Warning: You need to close auto step( setAutoStep(false) ) first");
     }
     else
     {

--- a/core/physics3d/Physics3DDebugDrawer.cpp
+++ b/core/physics3d/Physics3DDebugDrawer.cpp
@@ -68,7 +68,7 @@ void Physics3DDebugDrawer::drawContactPoint(const btVector3& PointOnB,
 
 void Physics3DDebugDrawer::reportErrorWarning(const char* warningString)
 {
-    AXLOG("%s", warningString);
+    AXLOGD("{}", warningString);
 }
 
 void Physics3DDebugDrawer::draw3dText(const btVector3& /*location*/, const char* /*textString*/) {}

--- a/core/platform/FileUtils.cpp
+++ b/core/platform/FileUtils.cpp
@@ -704,7 +704,7 @@ std::string FileUtils::fullPathForFilename(std::string_view filename) const
 
     if (isPopupNotify())
     {
-        AXLOG("axmol: fullPathForFilename: No file found at %s. Possible missing file.", filename.data());
+        AXLOGD("fullPathForFilename: No file found at {}. Possible missing file.", filename);
     }
 
     // The file wasn't found, return empty string.
@@ -756,7 +756,7 @@ std::string FileUtils::fullPathForDirectory(std::string_view dir) const
 
             if (result.empty() && isPopupNotify())
             {
-                AXLOG("axmol: fullPathForDirectory: No directory found at %s. Possible missing directory.", dir.data());
+                AXLOGD("fullPathForDirectory: No directory found at {}. Possible missing directory.", dir);
             }
         }
     }
@@ -849,7 +849,7 @@ void FileUtils::setSearchPaths(const std::vector<std::string>& searchPaths)
 
     if (!existDefaultRootPath)
     {
-        // AXLOG("Default root path doesn't exist, adding it.");
+        // AXLOGD("Default root path doesn't exist, adding it.");
         _searchPathArray.emplace_back(_defaultResRootPath);
     }
 }
@@ -1313,7 +1313,7 @@ bool FileUtils::renameFile(std::string_view oldfullpath, std::string_view newful
 
     if (0 != errorCode)
     {
-        AXLOGERROR("Fail to rename file %s to %s !Error code is %d", oldfullpath.data(), newfullpath.data(), errorCode);
+        AXLOGE("Fail to rename file {} to {} !Error code is {}", oldfullpath, newfullpath, errorCode);
         return false;
     }
     return true;

--- a/core/platform/GLView.cpp
+++ b/core/platform/GLView.cpp
@@ -314,7 +314,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
             // The touches is more than MAX_TOUCHES ?
             if (unusedIndex == -1)
             {
-                AXLOG("The touches is more than MAX_TOUCHES, unusedIndex = %d", unusedIndex);
+                AXLOGD("The touches is more than MAX_TOUCHES, unusedIndex = {}", unusedIndex);
                 continue;
             }
 
@@ -322,7 +322,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
             touch->setTouchInfo(unusedIndex, (x - _viewPortRect.origin.x) / _scaleX,
                                 (y - _viewPortRect.origin.y) / _scaleY);
 
-            AXLOGINFO("x = %f y = %f", touch->getLocationInView().x, touch->getLocationInView().y);
+            AXLOGI("x = {} y = {}", touch->getLocationInView().x, touch->getLocationInView().y);
 
             g_touchIdReorderMap.emplace(id, unusedIndex);
             touchEvent._touches.emplace_back(touch);
@@ -331,7 +331,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
 
     if (touchEvent._touches.empty())
     {
-        AXLOG("touchesBegan: size = 0");
+        AXLOGD("touchesBegan: size = 0");
         return;
     }
 
@@ -365,11 +365,11 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], 
         auto iter = g_touchIdReorderMap.find(id);
         if (iter == g_touchIdReorderMap.end())
         {
-            AXLOG("if the index doesn't exist, it is an error");
+            AXLOGD("if the index doesn't exist, it is an error");
             continue;
         }
 
-        AXLOGINFO("Moving touches with id: %d, x=%f, y=%f, force=%f, maxFource=%f", (int)id, x, y, force, maxForce);
+        AXLOGI("Moving touches with id: {}, x={}, y={}, force={}, maxFource={}", (int)id, x, y, force, maxForce);
         Touch* touch = g_touches[iter->second];
         if (touch)
         {
@@ -381,14 +381,14 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], 
         else
         {
             // It is error, should return.
-            AXLOG("Moving touches with id: %d error", static_cast<int32_t>(id));
+            AXLOGD("Moving touches with id: {} error", static_cast<int32_t>(id));
             return;
         }
     }
 
     if (touchEvent._touches.empty())
     {
-        AXLOG("touchesMoved: size = 0");
+        AXLOGD("touchesMoved: size = 0");
         return;
     }
 
@@ -417,7 +417,7 @@ void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
         auto iter = g_touchIdReorderMap.find(id);
         if (iter == g_touchIdReorderMap.end())
         {
-            AXLOG("if the index doesn't exist, it is an error");
+            AXLOGD("if the index doesn't exist, it is an error");
             continue;
         }
 
@@ -425,7 +425,7 @@ void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
         Touch* touch = g_touches[iter->second];
         if (touch)
         {
-            AXLOGINFO("Ending touches with id: %d, x=%f, y=%f", (int)id, x, y);
+            AXLOGI("Ending touches with id: {}, x={}, y={}", (int)id, x, y);
             touch->setTouchInfo(iter->second, (x - _viewPortRect.origin.x) / _scaleX,
                                 (y - _viewPortRect.origin.y) / _scaleY);
 
@@ -438,14 +438,14 @@ void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
         }
         else
         {
-            AXLOG("Ending touches with id: %d error", static_cast<int32_t>(id));
+            AXLOGD("Ending touches with id: {} error", static_cast<int32_t>(id));
             return;
         }
     }
 
     if (touchEvent._touches.empty())
     {
-        AXLOG("touchesEnded or touchesCancel: size = 0");
+        AXLOGD("touchesEnded or touchesCancel: size = 0");
         return;
     }
 

--- a/core/platform/GLViewImpl.cpp
+++ b/core/platform/GLViewImpl.cpp
@@ -546,7 +546,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
     id<MTLDevice> device = MTLCreateSystemDefaultDevice();
     if (!device)
     {
-        AXLOG("Doesn't support metal.");
+        AXLOGD("Doesn't support metal.");
         return false;
     }
 

--- a/core/platform/Image.cpp
+++ b/core/platform/Image.cpp
@@ -701,7 +701,7 @@ bool Image::initWithImageData(uint8_t* data, ssize_t dataLen, bool ownData)
             }
             else
             {
-                AXLOG("axmol: unsupported image format!");
+                AXLOGW("unsupported image format!");
             }
 
             free(tgaData);
@@ -1054,7 +1054,7 @@ myErrorExit(j_common_ptr cinfo)
     //(*cinfo->err->output_message) (cinfo);
     char buffer[JMSG_LENGTH_MAX];
     (*cinfo->err->format_message)(cinfo, buffer);
-    AXLOG("jpeg error: %s", buffer);
+    AXLOGW("jpeg error: {}", buffer);
 
     /* Return control to the setjmp point */
     longjmp(myerr->setjmp_buffer, 1);
@@ -1153,7 +1153,7 @@ bool Image::initWithJpgData(uint8_t* data, ssize_t dataLen)
 
     return ret;
 #else
-    AXLOG("jpeg is not enabled, please enable it in ccConfig.h");
+    AXLOGW("jpeg is not enabled, please enable it in Config.h");
     return false;
 #endif  // AX_USE_JPEG
 }
@@ -1206,7 +1206,7 @@ bool Image::initWithPngData(uint8_t* data, ssize_t dataLen)
         png_byte bit_depth     = png_get_bit_depth(png_ptr, info_ptr);
         png_uint_32 color_type = png_get_color_type(png_ptr, info_ptr);
 
-        // AXLOG("color type %u", color_type);
+        // AXLOGD("color type {}", color_type);
 
         // force palette images to be expanded to 24-bit RGB
         // it may include alpha channel
@@ -1312,7 +1312,7 @@ bool Image::initWithPngData(uint8_t* data, ssize_t dataLen)
     }
     return ret;
 #else
-    AXLOG("png is not enabled, please enable it in ccConfig.h");
+    AXLOGW("png is not enabled, please enable it in Config.h");
     return false;
 #endif  // AX_USE_PNG
 }
@@ -1373,7 +1373,7 @@ bool Image::initWithWebpData(uint8_t* data, ssize_t dataLen)
     } while (0);
     return ret;
 #else
-    AXLOG("webp is not enabled, please enable it in ccConfig.h");
+    AXLOGW("webp is not enabled, please enable it in Config.h");
     return false;
 #endif  // AX_USE_WEBP
 }
@@ -1405,7 +1405,7 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
             }
             else
             {
-                AXLOG("Image WARNING: unsupported true color tga data pixel format. FILE: %s", _filePath.c_str());
+                AXLOGW("Image WARNING: unsupported true color tga data pixel format. FILE: {}", _filePath);
                 break;
             }
         }
@@ -1419,7 +1419,7 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
             else
             {
                 // actually this won't happen, if it happens, maybe the image file is not a tga
-                AXLOG("Image WARNING: unsupported gray tga data pixel format. FILE: %s", _filePath.c_str());
+                AXLOGW("Image WARNING: unsupported gray tga data pixel format. FILE: {}", _filePath);
                 break;
             }
         }
@@ -1438,8 +1438,8 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
     {
         if (FileUtils::getInstance()->getFileExtension(_filePath) != ".tga")
         {
-            AXLOG("Image WARNING: the image file suffix is not tga, but parsed as a tga image file. FILE: %s",
-                  _filePath.c_str());
+            AXLOGW("Image WARNING: the image file suffix is not tga, but parsed as a tga image file. FILE: {}",
+                  _filePath);
         }
     }
     else
@@ -1478,27 +1478,27 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
     bool flipped                       = (flags & (unsigned int)PVR2TextureFlag::VerticalFlip) ? true : false;
     if (flipped)
     {
-        AXLOG("axmol: WARNING: Image is flipped. Regenerate it using PVRTexTool");
+        AXLOGD("WARNING: Image is flipped. Regenerate it using PVRTexTool");
     }
 
     if (!configuration->supportsNPOT() && (static_cast<int>(header->width) != utils::nextPOT(header->width) ||
                                            static_cast<int>(header->height) != utils::nextPOT(header->height)))
     {
-        AXLOG("axmol: ERROR: Loading an NPOT texture (%dx%d) but is not supported on this device", header->width,
+        AXLOGD("ERROR: Loading an NPOT texture ({}x{}) but is not supported on this device", header->width,
               header->height);
         return false;
     }
 
     if (!testFormatForPvr2TCSupport(formatFlags))
     {
-        AXLOG("axmol: WARNING: Unsupported PVR Pixel Format: 0x%02X. Re-encode it with a OpenGL pixel format variant",
+        AXLOGD("WARNING: Unsupported PVR Pixel Format: {:02X}. Re-encode it with a OpenGL pixel format variant",
               (int)formatFlags);
         return false;
     }
 
     if (v2_pixel_formathash.find(formatFlags) == v2_pixel_formathash.end())
     {
-        AXLOG("axmol: WARNING: Unsupported PVR Pixel Format: 0x%02X. Re-encode it with a OpenGL pixel format variant",
+        AXLOGD("WARNING: Unsupported PVR Pixel Format: {:02X}. Re-encode it with a OpenGL pixel format variant",
               (int)formatFlags);
         return false;
     }
@@ -1508,7 +1508,7 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
     int bpp          = info.bpp;
     if (!bpp)
     {
-        AXLOG("axmol: WARNING: Unsupported PVR Pixel Format: 0x%02X. Re-encode it with a OpenGL pixel format variant",
+        AXLOGD("WARNING: Unsupported PVR Pixel Format: {:02X}. Re-encode it with a OpenGL pixel format variant",
               (int)formatFlags);
         return false;
     }
@@ -1538,7 +1538,7 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR2TexturePixelFormat::PVRTC2BPP_RGBA:
             if (!Configuration::getInstance()->supportsPVRTC())
             {
-                AXLOG("axmol: Hardware PVR decoder not present. Using software decoder");
+                AXLOGD("Hardware PVR decoder not present. Using software decoder");
                 _unpack                            = true;
                 _mipmaps[_numberOfMipmaps].len     = width * height * 4;
                 _mipmaps[_numberOfMipmaps].address = (uint8_t*)malloc(width * height * 4);
@@ -1552,7 +1552,7 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR2TexturePixelFormat::PVRTC4BPP_RGBA:
             if (!Configuration::getInstance()->supportsPVRTC())
             {
-                AXLOG("axmol: Hardware PVR decoder not present. Using software decoder");
+                AXLOGD("Hardware PVR decoder not present. Using software decoder");
                 _unpack                            = true;
                 _mipmaps[_numberOfMipmaps].len     = width * height * 4;
                 _mipmaps[_numberOfMipmaps].address = (uint8_t*)malloc(width * height * 4);
@@ -1566,7 +1566,7 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR2TexturePixelFormat::BGRA8888:
             if (!Configuration::getInstance()->supportsBGRA8888())
             {
-                AXLOG("axmol: Image. BGRA8888 not supported on this device");
+                AXLOGD("Image. BGRA8888 not supported on this device");
                 return false;
             }
         default:
@@ -1630,7 +1630,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
     // validate version
     if (AX_SWAP_INT32_BIG_TO_HOST(header->version) != 0x50565203)
     {
-        AXLOG("axmol: WARNING: pvr file version mismatch");
+        AXLOGW("axmol: WARNING: pvr file version mismatch");
         return false;
     }
 
@@ -1639,8 +1639,8 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
 
     if (!testFormatForPvr3TCSupport(pixelFormat))
     {
-        AXLOG(
-            "axmol:WARNING: Unsupported PVR Pixel Format: 0x%016llX. Re-encode it with a OpenGL pixel format "
+        AXLOGW(
+            "axmol:WARNING: Unsupported PVR Pixel Format: 0x{:016X}. Re-encode it with a OpenGL pixel format "
             "variant",
             static_cast<unsigned long long>(pixelFormat));
         return false;
@@ -1648,8 +1648,8 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
 
     if (v3_pixel_formathash.find(pixelFormat) == v3_pixel_formathash.end())
     {
-        AXLOG(
-            "axmol:WARNING: Unsupported PVR Pixel Format: 0x%016llX. Re-encode it with a OpenGL pixel format "
+        AXLOGW(
+            "axmol:WARNING: Unsupported PVR Pixel Format: 0x{:016X}. Re-encode it with a OpenGL pixel format "
             "variant",
             static_cast<unsigned long long>(pixelFormat));
         return false;
@@ -1660,8 +1660,8 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
     int bpp               = info.bpp;
     if (!info.bpp)
     {
-        AXLOG(
-            "axmol:WARNING: Unsupported PVR Pixel Format: 0x%016llX. Re-encode it with a OpenGL pixel format "
+        AXLOGW(
+            "axmol:WARNING: Unsupported PVR Pixel Format: 0x{:016X}. Re-encode it with a OpenGL pixel format "
             "variant",
             static_cast<unsigned long long>(pixelFormat));
         return false;
@@ -1703,7 +1703,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR3TexturePixelFormat::PVRTC2BPP_RGBA:
             if (!Configuration::getInstance()->supportsPVRTC())
             {
-                AXLOG("axmol: Hardware PVR decoder not present. Using software decoder");
+                AXLOGW("Hardware PVR decoder not present. Using software decoder");
                 _unpack             = true;
                 _mipmaps[i].len     = width * height * 4;
                 _mipmaps[i].address = (uint8_t*)malloc(width * height * 4);
@@ -1718,7 +1718,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR3TexturePixelFormat::PVRTC4BPP_RGBA:
             if (!Configuration::getInstance()->supportsPVRTC())
             {
-                AXLOG("axmol: Hardware PVR decoder not present. Using software decoder");
+                AXLOGW("Hardware PVR decoder not present. Using software decoder");
                 _unpack             = true;
                 _mipmaps[i].len     = width * height * 4;
                 _mipmaps[i].address = (uint8_t*)malloc(width * height * 4);
@@ -1732,7 +1732,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR3TexturePixelFormat::ETC1:
             if (!Configuration::getInstance()->supportsETC1())
             {
-                AXLOG("axmol: Hardware ETC1 decoder not present. Using software decoder");
+                AXLOGW("Hardware ETC1 decoder not present. Using software decoder");
                 const int bytePerPixel = 4;
                 _unpack                = true;
                 _mipmaps[i].len        = width * height * bytePerPixel;
@@ -1750,7 +1750,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
         case PVR3TexturePixelFormat::BGRA8888:
             if (!Configuration::getInstance()->supportsBGRA8888())
             {
-                AXLOG("axmol: Image. BGRA8888 not supported on this device");
+                AXLOGW("Image. BGRA8888 not supported on this device");
                 return false;
             }
         default:
@@ -1843,7 +1843,7 @@ bool Image::initWithETCData(uint8_t* data, ssize_t dataLen, bool ownData)
     }
     else
     {
-        AXLOG("axmol: Hardware ETC1 decoder not present. Using software decoder");
+        AXLOGW("Hardware ETC1 decoder not present. Using software decoder");
 
         _dataLen = _width * _height * 4;
         _data    = static_cast<uint8_t*>(malloc(_dataLen));
@@ -1908,7 +1908,7 @@ bool Image::initWithETC2Data(uint8_t* data, ssize_t dataLen, bool ownData)
         }
         else
         {
-            AXLOG("axmol: Hardware ETC2 decoder not present. Using software decoder");
+            AXLOGW("Hardware ETC2 decoder not present. Using software decoder");
 
             // if device do not support ETC2, decode texture by software
             // etc2_decode_image always decode to RGBA8888
@@ -1956,7 +1956,7 @@ bool Image::initWithASTCData(uint8_t* data, ssize_t dataLen, bool ownData)
 
         if (block_x < 4 || block_y < 4)
         {
-            AXLOG("axmol: The ASTC block with and height should be >= 4");
+            AXLOGW("The ASTC block with and height should be >= 4");
             break;
         }
 
@@ -1995,7 +1995,7 @@ bool Image::initWithASTCData(uint8_t* data, ssize_t dataLen, bool ownData)
         }
         else
         {
-            AXLOG("axmol: Hardware ASTC decoder not present. Using software decoder");
+            AXLOGW("Hardware ASTC decoder not present. Using software decoder");
 
             _dataLen = _width * _height * 4;
             _data    = static_cast<uint8_t*>(malloc(_dataLen));
@@ -2106,7 +2106,7 @@ bool Image::initWithS3TCData(uint8_t* data, ssize_t dataLen, bool ownData)
         else
         {  // if it is not gles or device do not support S3TC, decode texture by software
 
-            AXLOG("axmol: Hardware S3TC decoder not present. Using software decoder");
+            AXLOGW("Hardware S3TC decoder not present. Using software decoder");
 
             int bytePerPixel    = 4;
             unsigned int stride = width * bytePerPixel;
@@ -2181,7 +2181,7 @@ bool Image::initWithATITCData(uint8_t* data, ssize_t dataLen, bool ownData)
     bool hardware = Configuration::getInstance()->supportsATITC();
     if (hardware)  // compressed data length
     {
-        AXLOG("this is atitc H decode");
+        AXLOGD("this is atitc H decode");
 
         switch (header->glInternalFormat)
         {
@@ -2201,7 +2201,7 @@ bool Image::initWithATITCData(uint8_t* data, ssize_t dataLen, bool ownData)
     else  // decompressed data length
     {     /* if it is not gles or device do not support ATITC, decode texture by software */
 
-        AXLOG("axmol: Hardware ATITC decoder not present. Using software decoder");
+        AXLOGW("Hardware ATITC decoder not present. Using software decoder");
 
         _pixelFormat = backend::PixelFormat::RGBA8;
 
@@ -2311,8 +2311,8 @@ bool Image::saveToFile(std::string_view filename, bool isToRGB)
     // only support for backend::PixelFormat::RGB8 or backend::PixelFormat::RGBA8 uncompressed data
     if (isCompressed() || (_pixelFormat != backend::PixelFormat::RGB8 && _pixelFormat != backend::PixelFormat::RGBA8))
     {
-        AXLOG(
-            "axmol:Image: saveToFile is only support for backend::PixelFormat::RGB8 or backend::PixelFormat::RGBA8 "
+        AXLOGW(
+            "Image: saveToFile is only support for backend::PixelFormat::RGB8 or backend::PixelFormat::RGBA8 "
             "uncompressed data for now");
         return false;
     }
@@ -2329,7 +2329,7 @@ bool Image::saveToFile(std::string_view filename, bool isToRGB)
     }
     else
     {
-        AXLOG("axmol: Image: saveToFile no support file extension(only .png or .jpg) for file: %s", filename.data());
+        AXLOGW("Image: saveToFile no support file extension(only .png or .jpg) for file: {}", filename);
         return false;
     }
 }
@@ -2475,7 +2475,7 @@ bool Image::saveImageToPNG(std::string_view filePath, bool isToRGB)
     } while (0);
     return ret;
 #else
-    AXLOG("png is not enabled, please enable it in ccConfig.h");
+    AXLOGW("png is not enabled, please enable it in Config.h");
     return false;
 #endif  // AX_USE_PNG
 }
@@ -2579,7 +2579,7 @@ bool Image::saveImageToJPG(std::string_view filePath)
     } while (0);
     return ret;
 #else
-    AXLOG("jpeg is not enabled, please enable it in ccConfig.h");
+    AXLOGW("jpeg is not enabled, please enable it in Config.h");
     return false;
 #endif  // AX_USE_JPEG
 }

--- a/core/platform/PlatformMacros.h
+++ b/core/platform/PlatformMacros.h
@@ -297,7 +297,7 @@ public:                                                             \
 #define __AXLOGWITHFUNCTION(s, ...) \
     ax::print("%s : %s", __FUNCTION__, ax::StringUtils::format(s, ##__VA_ARGS__).c_str())
 
-/// @name Cocos2d debug
+/// @name Cocos2d debug, deprecated since axmol 2.1.4, use AXLOGD, AXLOGI, AXLOGW, ... instead
 /// @{
 #if !defined(_AX_DEBUG) || _AX_DEBUG == 0
 #    define AXLOG(...) \

--- a/core/platform/SAXParser.cpp
+++ b/core/platform/SAXParser.cpp
@@ -150,7 +150,7 @@ bool SAXParser::parseIntrusive(char* xmlData, size_t dataLength, ParseOption opt
     }
     catch (xsxml::parse_error& e)
     {
-        AXLOG("axmol: SAXParser: Error parsing xml: %s at %s", e.what(), e.where<char>());
+        AXLOGE("SAXParser: Error parsing xml: {} at {}", e.what(), e.where<char>());
         return false;
     }
 

--- a/core/platform/android/Device-android.cpp
+++ b/core/platform/android/Device-android.cpp
@@ -88,7 +88,7 @@ public:
                                             "createTextBitmapShadowStroke",
                                             "([BLjava/lang/String;IIIIIIIIZFFFFZIIIIFZI)Z"))
         {
-            AXLOG("%s %d: error to get methodInfo", __FILE__, __LINE__);
+            AXLOGE("{} {}: error to get methodInfo", __FILE__, __LINE__);
             return false;
         }
 

--- a/core/platform/android/FileUtils-android.cpp
+++ b/core/platform/android/FileUtils-android.cpp
@@ -38,7 +38,7 @@ THE SOFTWARE.
 
 #include "yasio/string_view.hpp"
 
-#define LOG_TAG "CCFileUtils-android.cpp"
+#define LOG_TAG "FileUtils-android.cpp"
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 
 #define ASSETS_FOLDER_NAME "assets/"
@@ -73,7 +73,7 @@ FileUtils* FileUtils::getInstance()
         {
             delete s_sharedFileUtils;
             s_sharedFileUtils = nullptr;
-            AXLOG("ERROR: Could not init CCFileUtilsAndroid");
+            AXLOGE("ERROR: Could not init FileUtilsAndroid");
         }
     }
     return s_sharedFileUtils;
@@ -140,7 +140,7 @@ bool FileUtilsAndroid::isFileExistInternal(std::string_view strFilePath) const
             }
             else
             {
-                // AXLOG("[AssetManager] ... in APK %s, found = false!", strFilePath.c_str());
+                // AXLOGD("[AssetManager] ... in APK {}, found = false!", strFilePath);
             }
         }
     }
@@ -175,7 +175,7 @@ bool FileUtilsAndroid::isDirectoryExistInternal(std::string_view dirPath) const
     // find absolute path in flash memory
     if (s[0] == '/')
     {
-        AXLOG("find in flash memory dirPath(%s)", s);
+        AXLOGD("find in flash memory dirPath({})", s);
         struct stat st;
         if (stat(s, &st) == 0)
         {
@@ -187,7 +187,7 @@ bool FileUtilsAndroid::isDirectoryExistInternal(std::string_view dirPath) const
 
         // find it in apk's assets dir
         // Found "assets/" at the beginning of the path and we don't want it
-        AXLOG("find in apk dirPath(%s)", s);
+        AXLOGD("find in apk dirPath({})", s);
         if (dirPath.find(ASSETS_FOLDER_NAME) == 0)
         {
             s += ASSETS_FOLDER_NAME_LENGTH;

--- a/core/platform/apple/FileUtils-apple.mm
+++ b/core/platform/apple/FileUtils-apple.mm
@@ -91,7 +91,7 @@ FileUtils* FileUtils::getInstance()
         {
             delete s_sharedFileUtils;
             s_sharedFileUtils = nullptr;
-            AXLOG("ERROR: Could not init CCFileUtilsApple");
+            AXLOGE("ERROR: Could not init FileUtilsApple");
         }
     }
     return s_sharedFileUtils;
@@ -183,7 +183,7 @@ bool FileUtilsApple::removeDirectory(std::string_view path) const
 {
     if (path.empty())
     {
-        AXLOGERROR("Fail to remove directory, path is empty!");
+        AXLOGE("Fail to remove directory, path is empty!");
         return false;
     }
 
@@ -272,7 +272,7 @@ bool FileUtilsApple::createDirectory(std::string_view path) const
 
     if (!result && error != nil)
     {
-        AXLOGERROR("Fail to create directory \"%s\": %s", std::string(path).c_str(), [error.localizedDescription UTF8String]);
+        AXLOGE("Fail to create directory \"{}\": {}", path, [error.localizedDescription UTF8String]);
     }
 
     return result;

--- a/core/platform/ios/EAGLView-ios.mm
+++ b/core/platform/ios/EAGLView-ios.mm
@@ -194,7 +194,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         id<MTLDevice> device = MTLCreateSystemDefaultDevice();
         if (!device)
         {
-            AXLOG("Doesn't support metal.");
+            AXLOGE("Doesn't support metal.");
             return nil;
         }
         CAMetalLayer* metalLayer   = (CAMetalLayer*)[self layer];
@@ -385,7 +385,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
     if (![context_ presentRenderbuffer:GL_RENDERBUFFER])
     {
-        //         AXLOG(@"cocos2d: Failed to swap renderbuffer in %s\n", __FUNCTION__);
+        //         AXLOGD(@"Failed to swap renderbuffer in {}\n", __FUNCTION__);
     }
 
 #    if _AX_DEBUG
@@ -454,7 +454,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     {
         if (i >= IOS_MAX_TOUCHES_COUNT)
         {
-            AXLOG("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
+            AXLOGW("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
             break;
         }
 
@@ -481,7 +481,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     {
         if (i >= IOS_MAX_TOUCHES_COUNT)
         {
-            AXLOG("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
+            AXLOGW("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
             break;
         }
 
@@ -514,7 +514,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     {
         if (i >= IOS_MAX_TOUCHES_COUNT)
         {
-            AXLOG("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
+            AXLOGW("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
             break;
         }
 
@@ -539,7 +539,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     {
         if (i >= IOS_MAX_TOUCHES_COUNT)
         {
-            AXLOG("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
+            AXLOGW("warning: touches more than 10, should adjust IOS_MAX_TOUCHES_COUNT");
             break;
         }
 

--- a/core/platform/ios/ES3Renderer-ios.m
+++ b/core/platform/ios/ES3Renderer-ios.m
@@ -212,7 +212,7 @@
 
 - (void)dealloc
 {
-//    AXLOGINFO("deallocing ES3Renderer: %p", self);
+//    AXLOGV("deallocing ES3Renderer: {}", fmt::ptr(self));
 
     // Tear down GL
     if (defaultFramebuffer_) {

--- a/core/platform/ios/Image-ios.mm
+++ b/core/platform/ios/Image-ios.mm
@@ -40,7 +40,7 @@ bool ax::Image::saveToFile(std::string_view filename, bool isToRGB)
     // only support for backend::PixelFormat::RGB8 or backend::PixelFormat::RGBA8 uncompressed data
     if (isCompressed() || (_pixelFormat != backend::PixelFormat::RGB8 && _pixelFormat != backend::PixelFormat::RGBA8))
     {
-        AXLOG("cocos2d: Image: saveToFile is only support for backend::PixelFormat::RGB8 or "
+        AXLOGW("Image: saveToFile is only support for backend::PixelFormat::RGB8 or "
               "backend::PixelFormat::RGBA8 uncompressed data for now");
         return false;
     }

--- a/core/platform/ios/InputView-ios.mm
+++ b/core/platform/ios/InputView-ios.mm
@@ -83,7 +83,7 @@ THE SOFTWARE.
 
 - (void)setSelectedTextRange:(UITextRange*)aSelectedTextRange
 {
-    AXLOG("UITextRange:setSelectedTextRange");
+    AXLOGD("UITextRange:setSelectedTextRange");
 }
 
 - (UITextRange*)selectedTextRange
@@ -115,56 +115,56 @@ THE SOFTWARE.
 - (NSWritingDirection)baseWritingDirectionForPosition:(nonnull UITextPosition*)position
                                           inDirection:(UITextStorageDirection)direction
 {
-    AXLOG("baseWritingDirectionForPosition");
+    AXLOGD("baseWritingDirectionForPosition");
     return NSWritingDirectionLeftToRight;
 }
 
 - (CGRect)caretRectForPosition:(nonnull UITextPosition*)position
 {
-    AXLOG("caretRectForPosition");
+    AXLOGD("caretRectForPosition");
     return CGRectZero;
 }
 
 - (nullable UITextRange*)characterRangeAtPoint:(CGPoint)point
 {
-    AXLOG("characterRangeAtPoint");
+    AXLOGD("characterRangeAtPoint");
     return nil;
 }
 
 - (nullable UITextRange*)characterRangeByExtendingPosition:(nonnull UITextPosition*)position
                                                inDirection:(UITextLayoutDirection)direction
 {
-    AXLOG("characterRangeByExtendingPosition");
+    AXLOGD("characterRangeByExtendingPosition");
     return nil;
 }
 
 - (nullable UITextPosition*)closestPositionToPoint:(CGPoint)point
 {
-    AXLOG("closestPositionToPoint");
+    AXLOGD("closestPositionToPoint");
     return nil;
 }
 
 - (nullable UITextPosition*)closestPositionToPoint:(CGPoint)point withinRange:(nonnull UITextRange*)range
 {
-    AXLOG("closestPositionToPoint");
+    AXLOGD("closestPositionToPoint");
     return nil;
 }
 
 - (NSComparisonResult)comparePosition:(nonnull UITextPosition*)position toPosition:(nonnull UITextPosition*)other
 {
-    AXLOG("comparePosition");
+    AXLOGD("comparePosition");
     return (NSComparisonResult)0;
 }
 
 - (CGRect)firstRectForRange:(nonnull UITextRange*)range
 {
-    AXLOG("firstRectForRange");
+    AXLOGD("firstRectForRange");
     return CGRectNull;
 }
 
 - (NSInteger)offsetFromPosition:(nonnull UITextPosition*)from toPosition:(nonnull UITextPosition*)toPosition
 {
-    AXLOG("offsetFromPosition");
+    AXLOGD("offsetFromPosition");
     return 0;
 }
 
@@ -172,20 +172,20 @@ THE SOFTWARE.
                                      inDirection:(UITextLayoutDirection)direction
                                           offset:(NSInteger)offset
 {
-    AXLOG("positionFromPosition");
+    AXLOGD("positionFromPosition");
     return nil;
 }
 
 - (nullable UITextPosition*)positionFromPosition:(nonnull UITextPosition*)position offset:(NSInteger)offset
 {
-    AXLOG("positionFromPosition");
+    AXLOGD("positionFromPosition");
     return nil;
 }
 
 - (nullable UITextPosition*)positionWithinRange:(nonnull UITextRange*)range
                             farthestInDirection:(UITextLayoutDirection)direction
 {
-    AXLOG("positionWithinRange");
+    AXLOGD("positionWithinRange");
     return nil;
 }
 
@@ -194,7 +194,7 @@ THE SOFTWARE.
 
 - (nonnull NSArray<UITextSelectionRect*>*)selectionRectsForRange:(nonnull UITextRange*)range
 {
-    AXLOG("selectionRectsForRange");
+    AXLOGD("selectionRectsForRange");
     return nil;
 }
 
@@ -203,7 +203,7 @@ THE SOFTWARE.
 
 - (void)setMarkedText:(nullable NSString*)markedText selectedRange:(NSRange)selectedRange
 {
-    AXLOG("setMarkedText");
+    AXLOGD("setMarkedText");
     if (markedText == self.myMarkedText)
     {
         return;
@@ -218,7 +218,7 @@ THE SOFTWARE.
 
 - (UITextRange*)markedTextRange
 {
-    AXLOG("markedTextRange");
+    AXLOGD("markedTextRange");
     if (nil != self.myMarkedText)
     {
         return [[[UITextRange alloc] init] autorelease];
@@ -228,7 +228,7 @@ THE SOFTWARE.
 
 - (nullable NSString*)textInRange:(nonnull UITextRange*)range
 {
-    AXLOG("textInRange");
+    AXLOGD("textInRange");
     if (nil != self.myMarkedText)
     {
         return self.myMarkedText;
@@ -239,13 +239,13 @@ THE SOFTWARE.
 - (nullable UITextRange*)textRangeFromPosition:(nonnull UITextPosition*)fromPosition
                                     toPosition:(nonnull UITextPosition*)toPosition
 {
-    AXLOG("textRangeFromPosition");
+    AXLOGD("textRangeFromPosition");
     return nil;
 }
 
 - (void)unmarkText
 {
-    AXLOG("unmarkText");
+    AXLOGD("unmarkText");
     if (nil == self.myMarkedText)
     {
         return;

--- a/core/platform/linux/FileUtils-linux.cpp
+++ b/core/platform/linux/FileUtils-linux.cpp
@@ -62,7 +62,7 @@ FileUtils* FileUtils::getInstance()
         {
             delete s_sharedFileUtils;
             s_sharedFileUtils = nullptr;
-            AXLOG("ERROR: Could not init CCFileUtilsLinux");
+            AXLOGE("ERROR: Could not init FileUtilsLinux");
         }
     }
     return s_sharedFileUtils;

--- a/core/platform/wasm/FileUtils-wasm.cpp
+++ b/core/platform/wasm/FileUtils-wasm.cpp
@@ -50,7 +50,7 @@ FileUtils* FileUtils::getInstance()
         {
           delete s_sharedFileUtils;
           s_sharedFileUtils = nullptr;
-          AXLOG("ERROR: Could not init CCFileUtilsEmscripten");
+          AXLOGE("ERROR: Could not init FileUtilsEmscripten");
         }
     }
     return s_sharedFileUtils;

--- a/core/platform/win32/FileUtils-win32.cpp
+++ b/core/platform/win32/FileUtils-win32.cpp
@@ -87,7 +87,7 @@ FileUtils* FileUtils::getInstance()
         {
             delete s_sharedFileUtils;
             s_sharedFileUtils = nullptr;
-            AXLOG("ERROR: Could not init CCFileUtilsWin32");
+            AXLOGE("ERROR: Could not init FileUtilsWin32");
         }
     }
     return s_sharedFileUtils;
@@ -234,7 +234,7 @@ bool FileUtilsWin32::renameFile(std::string_view oldfullpath, std::string_view n
     {
         if (!DeleteFile(_wNew.c_str()))
         {
-            AXLOGERROR("Fail to delete file %s !Error code is 0x%x", newfullpath.data(), GetLastError());
+            AXLOGE("Fail to delete file {} !Error code is 0x{:x}", newfullpath, GetLastError());
         }
     }
 
@@ -244,7 +244,7 @@ bool FileUtilsWin32::renameFile(std::string_view oldfullpath, std::string_view n
     }
     else
     {
-        AXLOGERROR("Fail to rename file %s to %s !Error code is 0x%x", oldfullpath.data(), newfullpath.data(),
+        AXLOGE("Fail to rename file {} to {} !Error code is 0x{:x}", oldfullpath, newfullpath,
                    GetLastError());
         return false;
     }
@@ -313,7 +313,7 @@ bool FileUtilsWin32::createDirectory(std::string_view dirPath) const
                 BOOL ret = CreateDirectoryW(subpath.c_str(), NULL);
                 if (!ret && ERROR_ALREADY_EXISTS != GetLastError())
                 {
-                    AXLOGERROR("Fail create directory %s !Error code is 0x%x", utf8Path.c_str(), GetLastError());
+                    AXLOGE("Fail create directory {} !Error code is 0x{:x}", utf8Path, GetLastError());
                     return false;
                 }
             }
@@ -332,7 +332,7 @@ bool FileUtilsWin32::removeFile(std::string_view filepath) const
     }
     else
     {
-        AXLOGERROR("Fail remove file %s !Error code is 0x%x", filepath.data(), GetLastError());
+        AXLOGE("Fail remove file {} !Error code is 0x{:x}", filepath, GetLastError());
         return false;
     }
 }

--- a/core/platform/winrt/Device-winrt.cpp
+++ b/core/platform/winrt/Device-winrt.cpp
@@ -496,12 +496,12 @@ void Device::setAccelerometerInterval(float interval)
         }
         catch (winrt::hresult_error const& /*ex*/)
         {
-            AXLOG("Device::setAccelerometerInterval not supported on this device");
+            AXLOGW("Device::setAccelerometerInterval not supported on this device");
         }
     }
     else
     {
-        AXLOG("Device::setAccelerometerInterval: accelerometer not enabled.");
+        AXLOGW("Device::setAccelerometerInterval: accelerometer not enabled.");
     }
 }
 

--- a/core/platform/winrt/FileUtilsWinRT.cpp
+++ b/core/platform/winrt/FileUtilsWinRT.cpp
@@ -73,7 +73,7 @@ FileUtils* FileUtils::getInstance()
         {
           delete s_sharedFileUtils;
           s_sharedFileUtils = nullptr;
-          AXLOG("ERROR: Could not init FileUtilsWinRT");
+          AXLOGE("ERROR: Could not init FileUtilsWinRT");
         }
     }
     return s_sharedFileUtils;
@@ -262,7 +262,7 @@ bool FileUtilsWinRT::removeFile(std::string_view path) const
     }
     else
     {
-        AXLOG("Remove file failed with error: %d", GetLastError());
+        AXLOGW("Remove file failed with error: {}", GetLastError());
         return false;
     }
 }
@@ -284,7 +284,7 @@ bool FileUtilsWinRT::renameFile(std::string_view oldfullpath, std::string_view n
     {
         if (!DeleteFile(_wNewfullpath.c_str()))
         {
-            AXLOGERROR("Fail to delete file %s !Error code is 0x%x", newfullpath.data(), GetLastError());
+            AXLOGE("Fail to delete file {} !Error code is 0x{:x}", newfullpath, GetLastError());
         }
     }
 
@@ -295,7 +295,7 @@ bool FileUtilsWinRT::renameFile(std::string_view oldfullpath, std::string_view n
     }
     else
     {
-        AXLOGERROR("Fail to rename file %s to %s !Error code is 0x%x", oldfullpath.data(), newfullpath.data(), GetLastError());
+        AXLOGE("Fail to rename file {} to {} !Error code is 0x{:x}", oldfullpath, newfullpath, GetLastError());
         return false;
     }
 }

--- a/core/platform/winrt/GLViewImpl-winrt.cpp
+++ b/core/platform/winrt/GLViewImpl-winrt.cpp
@@ -222,15 +222,15 @@ void GLViewImpl::BackButtonListener(EventKeyboard::KeyCode keyCode, Event* event
         AXLOGD("getEventDispatcher()->addEventListenerWithFixedPriority(listener, 1);");
         AXLOGD("");
         AXLOGD("void HelloWorld::onKeyReleased(EventKeyboard::KeyCode keyCode, Event* event)");
-        AXLOGD("{");
+        AXLOGD("{{");
         AXLOGD("     if (keyCode == EventKeyboard::KeyCode::KEY_ESCAPE)");
-        AXLOGD("     {");
+        AXLOGD("     {{");
         AXLOGD("         if (myAppShouldNotQuit) // or whatever logic you want...");
-        AXLOGD("         {");
+        AXLOGD("         {{");
         AXLOGD("             event->stopPropagation();");
-        AXLOGD("         }");
-        AXLOGD("     }");
-        AXLOGD("}");
+        AXLOGD("         }}");
+        AXLOGD("     }}");
+        AXLOGD("}}");
         AXLOGD("");
         AXLOGD("You MUST call event->stopPropagation() if you don't want your app to quit!");
         AXLOGD("*********************************************************************");
@@ -418,7 +418,7 @@ void ax::GLViewImpl::OnMouseWheelChanged(Windows::UI::Core::PointerEventArgs con
     // Because OpenGL and axmol uses different Y axis, we need to convert the coordinate here
     float cursorX = (mousePosition.x - _viewPortRect.origin.x) / _scaleX;
     float cursorY = (_viewPortRect.origin.y + _viewPortRect.size.height - mousePosition.y) / _scaleY;
-    float delta   = args.CurrentPoint().Properties().MouseWheelDelta();
+    float delta   = static_cast<float>(args.CurrentPoint().Properties().MouseWheelDelta());
     if (args.CurrentPoint().Properties().IsHorizontalMouseWheel())
     {
         event.setScrollData(delta / WHEEL_DELTA, 0.0f);

--- a/core/platform/winrt/GLViewImpl-winrt.cpp
+++ b/core/platform/winrt/GLViewImpl-winrt.cpp
@@ -208,32 +208,32 @@ void GLViewImpl::BackButtonListener(EventKeyboard::KeyCode keyCode, Event* event
 {
     if (keyCode == EventKeyboard::KeyCode::KEY_ESCAPE)
     {
-        AXLOG("*********************************************************************");
-        AXLOG("GLViewImpl::BackButtonListener: Exiting application!");
-        AXLOG("");
-        AXLOG("If you want to listen for Windows Phone back button events,");
-        AXLOG("add a listener for EventKeyboard::KeyCode::KEY_ESCAPE");
-        AXLOG("Make sure you call stopPropagation() on the Event if you don't");
-        AXLOG("want your app to exit when the back button is pressed.");
-        AXLOG("");
-        AXLOG("For example, add the following to your scene...");
-        AXLOG("auto listener = EventListenerKeyboard::create();");
-        AXLOG("listener->onKeyReleased = AX_CALLBACK_2(HelloWorld::onKeyReleased, this);");
-        AXLOG("getEventDispatcher()->addEventListenerWithFixedPriority(listener, 1);");
-        AXLOG("");
-        AXLOG("void HelloWorld::onKeyReleased(EventKeyboard::KeyCode keyCode, Event* event)");
-        AXLOG("{");
-        AXLOG("     if (keyCode == EventKeyboard::KeyCode::KEY_ESCAPE)");
-        AXLOG("     {");
-        AXLOG("         if (myAppShouldNotQuit) // or whatever logic you want...");
-        AXLOG("         {");
-        AXLOG("             event->stopPropagation();");
-        AXLOG("         }");
-        AXLOG("     }");
-        AXLOG("}");
-        AXLOG("");
-        AXLOG("You MUST call event->stopPropagation() if you don't want your app to quit!");
-        AXLOG("*********************************************************************");
+        AXLOGD("*********************************************************************");
+        AXLOGD("GLViewImpl::BackButtonListener: Exiting application!");
+        AXLOGD("");
+        AXLOGD("If you want to listen for Windows Phone back button events,");
+        AXLOGD("add a listener for EventKeyboard::KeyCode::KEY_ESCAPE");
+        AXLOGD("Make sure you call stopPropagation() on the Event if you don't");
+        AXLOGD("want your app to exit when the back button is pressed.");
+        AXLOGD("");
+        AXLOGD("For example, add the following to your scene...");
+        AXLOGD("auto listener = EventListenerKeyboard::create();");
+        AXLOGD("listener->onKeyReleased = AX_CALLBACK_2(HelloWorld::onKeyReleased, this);");
+        AXLOGD("getEventDispatcher()->addEventListenerWithFixedPriority(listener, 1);");
+        AXLOGD("");
+        AXLOGD("void HelloWorld::onKeyReleased(EventKeyboard::KeyCode keyCode, Event* event)");
+        AXLOGD("{");
+        AXLOGD("     if (keyCode == EventKeyboard::KeyCode::KEY_ESCAPE)");
+        AXLOGD("     {");
+        AXLOGD("         if (myAppShouldNotQuit) // or whatever logic you want...");
+        AXLOGD("         {");
+        AXLOGD("             event->stopPropagation();");
+        AXLOGD("         }");
+        AXLOGD("     }");
+        AXLOGD("}");
+        AXLOGD("");
+        AXLOGD("You MUST call event->stopPropagation() if you don't want your app to quit!");
+        AXLOGD("*********************************************************************");
 
         Director::getInstance()->end();
     }
@@ -538,7 +538,7 @@ ax::Vec2 GLViewImpl::TransformToOrientation(Windows::Foundation::Point const& p)
         returnValue.y /= zoomFactor;
     }
 
-    // AXLOG("%.2f %.2f : %.2f %.2f", p.X, p.Y,returnValue.x, returnValue.y);
+    // AXLOGD("{:.2f} {:.2f} : {:.2f} {:.2f}", p.X, p.Y,returnValue.x, returnValue.y);
 
     return returnValue;
 }

--- a/core/renderer/Material.cpp
+++ b/core/renderer/Material.cpp
@@ -68,7 +68,7 @@ static bool isValidUniform(const char* name);
 
 Material* Material::createWithFilename(std::string_view filepath)
 {
-    AXLOG("Loading material: %s", filepath.data());
+    AXLOGD("Loading material: {}", filepath);
     auto validfilename = FileUtils::getInstance()->fullPathForFilename(filepath);
     if (!validfilename.empty())
     {
@@ -265,7 +265,7 @@ bool Material::parseSampler(backend::ProgramState* programState, Properties* sam
     auto texture = Director::getInstance()->getTextureCache()->addImage(filename);
     if (!texture)
     {
-        AXLOG("Invalid filepath");
+        AXLOGW("Invalid filepath");
         return false;
     }
 
@@ -289,7 +289,7 @@ bool Material::parseSampler(backend::ProgramState* programState, Properties* sam
         else if (strcasecmp(wrapS, "CLAMP_TO_EDGE") == 0)
             texParams.sAddressMode = backend::SamplerAddressMode::CLAMP_TO_EDGE;
         else
-            AXLOG("Invalid wrapS: %s", wrapS);
+            AXLOGW("Invalid wrapS: {}", wrapS);
 
         // valid options: REPEAT, CLAMP
         const char* wrapT = getOptionalString(samplerProperties, "wrapT", "CLAMP_TO_EDGE");
@@ -298,7 +298,7 @@ bool Material::parseSampler(backend::ProgramState* programState, Properties* sam
         else if (strcasecmp(wrapT, "CLAMP_TO_EDGE") == 0)
             texParams.tAddressMode = backend::SamplerAddressMode::CLAMP_TO_EDGE;
         else
-            AXLOG("Invalid wrapT: %s", wrapT);
+            AXLOGW("Invalid wrapT: {}", wrapT);
 
         // valid options: NEAREST, LINEAR, NEAREST_MIPMAP_NEAREST, LINEAR_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR,
         // LINEAR_MIPMAP_LINEAR
@@ -317,7 +317,7 @@ bool Material::parseSampler(backend::ProgramState* programState, Properties* sam
         else if (strcasecmp(minFilter, "LINEAR_MIPMAP_LINEAR") == 0)
             texParams.minFilter = backend::SamplerFilter::LINEAR;
         else
-            AXLOG("Invalid minFilter: %s", minFilter);
+            AXLOGW("Invalid minFilter: {}", minFilter);
 
         // valid options: NEAREST, LINEAR
         const char* magFilter = getOptionalString(samplerProperties, "magFilter", "LINEAR");
@@ -326,7 +326,7 @@ bool Material::parseSampler(backend::ProgramState* programState, Properties* sam
         else if (strcasecmp(magFilter, "LINEAR") == 0)
             texParams.magFilter = backend::SamplerFilter::LINEAR;
         else
-            AXLOG("Invalid magFilter: %s", magFilter);
+            AXLOGW("Invalid magFilter: {}", magFilter);
 
         texture->setTexParameters(texParams);
     }
@@ -336,7 +336,7 @@ bool Material::parseSampler(backend::ProgramState* programState, Properties* sam
 
     if (!location)
     {
-        AXLOG("warning: failed to find texture uniform location %s when parsing material", textureName.data());
+        AXLOGW("warning: failed to find texture uniform location {} when parsing material", textureName);
         return false;
     }
 

--- a/core/renderer/QuadCommand.cpp
+++ b/core/renderer/QuadCommand.cpp
@@ -68,7 +68,7 @@ void QuadCommand::reIndex(int indicesCount)
         indicesCount *= 1.25;
         indicesCount = std::min(indicesCount, 65536);
 
-        AXLOG("axmol: QuadCommand: resizing index size from [%d] to [%d]", __indexCapacity, indicesCount);
+        AXLOGD("QuadCommand: resizing index size from [{}] to [{}]", __indexCapacity, indicesCount);
 
         _ownedIndices.emplace_back(__indices);
         __indices       = new uint16_t[indicesCount];

--- a/core/renderer/RenderCommandPool.h
+++ b/core/renderer/RenderCommandPool.h
@@ -42,7 +42,7 @@ public:
     {
         //        if( 0 != _usedPool.size())
         //        {
-        //            AXLOG("All RenderCommand should not be used when Pool is released!");
+        //            AXLOGD("All RenderCommand should not be used when Pool is released!");
         //        }
         _freePool.clear();
         for (auto&& allocatedPoolBlock : _allocatedPoolBlocks)
@@ -70,7 +70,7 @@ public:
     {
         //        if(_usedPool.find(ptr) == _usedPool.end())
         //        {
-        //            AXLOG("push Back Wrong command!");
+        //            AXLOGD("push Back Wrong command!");
         //            return;
         //        }
 

--- a/core/renderer/RenderState.cpp
+++ b/core/renderer/RenderState.cpp
@@ -221,8 +221,8 @@ static backend::BlendFactor parseBlend(std::string_view value)
         return backend::BlendFactor::SRC_ALPHA_SATURATE;
     else
     {
-        AXLOG("Unsupported blend value (%s). (Will default to BLEND_ONE if errors are treated as warnings)",
-              value.data());
+        AXLOGW("Unsupported blend value ({}). (Will default to BLEND_ONE if errors are treated as warnings)",
+              value);
         return backend::BlendFactor::ONE;
     }
 }
@@ -250,8 +250,8 @@ static DepthFunction parseDepthFunc(std::string_view value)
         return DepthFunction::ALWAYS;
     else
     {
-        AXLOG("Unsupported depth function value (%s). Will default to DEPTH_LESS if errors are treated as warnings)",
-              value.data());
+        AXLOGW("Unsupported depth function value ({}). Will default to DEPTH_LESS if errors are treated as warnings)",
+              value);
         return DepthFunction::LESS;
     }
 }
@@ -270,8 +270,8 @@ static CullFaceSide parseCullFaceSide(std::string_view value)
     //        return RenderState::CULL_FACE_SIDE_FRONT_AND_BACK;
     else
     {
-        AXLOG("Unsupported cull face side value (%s). Will default to BACK if errors are treated as warnings.",
-              value.data());
+        AXLOGW("Unsupported cull face side value ({}). Will default to BACK if errors are treated as warnings.",
+              value);
         return CullFaceSide::BACK;
     }
 }
@@ -287,8 +287,8 @@ static FrontFace parseFrontFace(std::string_view value)
         return FrontFace::CLOCK_WISE;
     else
     {
-        AXLOG("Unsupported front face side value (%s). Will default to CCW if errors are treated as warnings.",
-              value.data());
+        AXLOGW("Unsupported front face side value ({}). Will default to CCW if errors are treated as warnings.",
+              value);
         return FrontFace::COUNTER_CLOCK_WISE;
     }
 }
@@ -333,7 +333,7 @@ void RenderState::StateBlock::setState(std::string_view name, std::string_view v
     }
     else
     {
-        AXLOG("Unsupported render state string '%s'.", name.data());
+        AXLOGW("Unsupported render state string '{}'.", name);
     }
 }
 

--- a/core/renderer/Texture2D.cpp
+++ b/core/renderer/Texture2D.cpp
@@ -191,7 +191,7 @@ bool Texture2D::updateWithImage(Image* image, backend::PixelFormat format, int i
 {
     if (image == nullptr)
     {
-        AXLOG("axmol: Texture2D. Can't create Texture. UIImage is nil");
+        __AXLOGWITHFUNCTION("axmol: Texture2D. Can't create Texture. UIImage is nil");
         return false;
     }
 
@@ -206,7 +206,7 @@ bool Texture2D::updateWithImage(Image* image, backend::PixelFormat format, int i
     int maxTextureSize = conf->getMaxTextureSize();
     if (imageWidth > maxTextureSize || imageHeight > maxTextureSize)
     {
-        AXLOG("axmol: WARNING: Image (%u x %u) is bigger than the supported %u x %u", imageWidth, imageHeight,
+        AXLOGW("axmol: WARNING: Image ({} x {}) is bigger than the supported {} x {}", imageWidth, imageHeight,
               maxTextureSize, maxTextureSize);
         return false;
     }
@@ -252,7 +252,7 @@ bool Texture2D::updateWithImage(Image* image, backend::PixelFormat format, int i
     {
         if (renderFormat != image->getPixelFormat())
         {
-            AXLOG("axmol: WARNING: This image has more than 1 mipmaps and we will not convert the data format");
+            AXLOGW("WARNING: This image has more than 1 mipmaps and we will not convert the data format");
         }
 
         // pixel format of data is not converted, renderFormat can be different from pixelFormat
@@ -308,14 +308,14 @@ bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
 
     if (mipmapsNum <= 0)
     {
-        AXLOG("axmol: WARNING: mipmap number is less than 1");
+        AXLOGW("WARNING: mipmap number is less than 1");
         return false;
     }
 
     auto& pfd = backend::PixelFormatUtils::getFormatDescriptor(pixelFormat);
     if (!pfd.bpp)
     {
-        AXLOG("axmol: WARNING: unsupported pixelformat: %x", (uint32_t)pixelFormat);
+        AXLOGW("WARNING: unsupported pixelformat: {:x}", (uint32_t)pixelFormat);
 #ifdef AX_USE_METAL
         AXASSERT(false, "pixeformat not found in _pixelFormatInfoTables, register required!");
 #endif
@@ -328,7 +328,7 @@ bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
         !Configuration::getInstance()->supportsETC2() && !Configuration::getInstance()->supportsS3TC() &&
         !Configuration::getInstance()->supportsASTC() && !Configuration::getInstance()->supportsATITC())
     {
-        AXLOG("axmol: WARNING: PVRTC/ETC images are not supported");
+        AXLOGW("WARNING: PVRTC/ETC images are not supported");
         return false;
     }
 
@@ -400,9 +400,9 @@ bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
 
         if (i > 0 && (width != height || utils::nextPOT(width) != width))
         {
-            AXLOG(
-                "axmol: Texture2D. WARNING. Mipmap level %u is not squared. Texture won't render correctly. width=%d "
-                "!= height=%d",
+            AXLOGW(
+                "Texture2D. WARNING. Mipmap level {} is not squared. Texture won't render correctly. width={} "
+                "!= height={}",
                 i, width, height);
         }
 
@@ -454,7 +454,7 @@ bool Texture2D::initWithImage(Image* image, backend::PixelFormat format)
 {
     if (image == nullptr)
     {
-        AXLOG("axmol: Texture2D. Can't create Texture. UIImage is nil");
+        AXLOGW("Texture2D. Can't create Texture. UIImage is nil");
         return false;
     }
 

--- a/core/renderer/TextureAtlas.cpp
+++ b/core/renderer/TextureAtlas.cpp
@@ -51,7 +51,7 @@ TextureAtlas::TextureAtlas() {}
 
 TextureAtlas::~TextureAtlas()
 {
-    AXLOGINFO("deallocing TextureAtlas: %p", this);
+    AXLOGV("deallocing TextureAtlas: {}", fmt::ptr(this));
 
     AX_SAFE_FREE(_quads);
     AX_SAFE_FREE(_indices);
@@ -134,7 +134,7 @@ bool TextureAtlas::initWithFile(std::string_view file, ssize_t capacity)
     }
     else
     {
-        AXLOG("axmol: Could not open file: %s", file.data());
+        AXLOGD("Could not open file: {}", file);
         return false;
     }
 }
@@ -159,7 +159,7 @@ bool TextureAtlas::initWithTexture(Texture2D* texture, ssize_t capacity)
 
     if (!(_quads && _indices) && _capacity > 0)
     {
-        // AXLOG("axmol: TextureAtlas: not enough memory");
+        // AXLOGD("TextureAtlas: not enough memory");
         AX_SAFE_FREE(_quads);
         AX_SAFE_FREE(_indices);
 
@@ -398,7 +398,7 @@ bool TextureAtlas::resizeCapacity(ssize_t newCapacity)
 
     if (!(tmpQuads && tmpIndices))
     {
-        AXLOG("axmol: TextureAtlas: not enough memory");
+        AXLOGD("TextureAtlas: not enough memory");
         AX_SAFE_FREE(tmpQuads);
         AX_SAFE_FREE(tmpIndices);
         AX_SAFE_FREE(_quads);

--- a/core/renderer/TextureCache.cpp
+++ b/core/renderer/TextureCache.cpp
@@ -66,7 +66,7 @@ TextureCache::TextureCache() : _loadingThread(nullptr), _needQuit(false), _async
 
 TextureCache::~TextureCache()
 {
-    AXLOGINFO("deallocing TextureCache: %p", this);
+    AXLOGI("deallocing TextureCache: {}", fmt::ptr(this));
 
     for (auto&& texture : _textures)
         texture.second->release();
@@ -361,7 +361,7 @@ void TextureCache::addImageAsyncCallBack(float /*dt*/)
             else
             {
                 texture = nullptr;
-                AXLOG("axmol: failed to call TextureCache::addImageAsync(%s)", asyncStruct->filename.c_str());
+                AXLOGW("axmol: failed to call TextureCache::addImageAsync({})", asyncStruct->filename);
             }
         }
 
@@ -491,7 +491,7 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat format)
             }
             else
             {
-                AXLOG("axmol: Couldn't create texture for file:%s in TextureCache", path.data());
+                AXLOGW("Couldn't create texture for file:{} in TextureCache", path);
                 AX_SAFE_RELEASE(texture);
                 texture = nullptr;
             }
@@ -543,7 +543,7 @@ Texture2D* TextureCache::addImage(Image* image, std::string_view key, PixelForma
         {
             AX_SAFE_RELEASE(texture);
             texture = nullptr;
-            AXLOG("axmol: initWithImage failed!");
+            AXLOGD("initWithImage failed!");
         }
 
     } while (0);
@@ -591,12 +591,12 @@ Texture2D* TextureCache::addImage(const Data& imageData, std::string_view key)
             {
                 AX_SAFE_RELEASE(texture);
                 texture = nullptr;
-                AXLOG("axmol: initWithImage failed!");
+                AXLOGW("initWithImage failed!");
             }
         }
         else
         {
-            AXLOG("axmol: Allocating memory for Texture2D failed!");
+            AXLOGW("Allocating memory for Texture2D failed!");
         }
 
         AX_SAFE_RELEASE(image);
@@ -663,7 +663,7 @@ void TextureCache::removeUnusedTextures()
         Texture2D* tex = it->second;
         if (tex->getReferenceCount() == 1)
         {
-            AXLOG("axmol: TextureCache: removing unused texture: %s", it->first.c_str());
+            AXLOGD("TextureCache: removing unused texture: {}", it->first);
 
             tex->release();
             it = _textures.erase(it);
@@ -929,7 +929,7 @@ void VolatileTextureMgr::removeTexture(Texture2D* t)
 void VolatileTextureMgr::reloadAllTextures()
 {
     _isReloading = true;
-    AXLOG("reload all texture");
+    AXLOGD("reload all texture");
 
     for (auto&& texture : _textures)
     {

--- a/core/renderer/TextureCache.h
+++ b/core/renderer/TextureCache.h
@@ -193,7 +193,7 @@ public:
     */
     void removeTextureForKey(std::string_view key);
 
-    /** Output to AXLOG the current contents of this TextureCache.
+    /** Output to AXLOGD the current contents of this TextureCache.
      * This will attempt to calculate the size of each texture, and the total texture memory in use.
      *
      * @since v1.0

--- a/core/renderer/TrianglesCommand.cpp
+++ b/core/renderer/TrianglesCommand.cpp
@@ -49,7 +49,7 @@ void TrianglesCommand::init(float globalOrder,
     {
         unsigned int count    = _triangles.indexCount;
         _triangles.indexCount = count / 3 * 3;
-        AXLOGERROR("Resize indexCount from %d to %d, size must be multiple times of 3", count, _triangles.indexCount);
+        AXLOGE("Resize indexCount from {} to {}, size must be multiple times of 3", count, _triangles.indexCount);
     }
     _mv = mv;
 

--- a/core/renderer/backend/PixelFormatUtils.cpp
+++ b/core/renderer/backend/PixelFormatUtils.cpp
@@ -500,8 +500,8 @@ static ax::backend::PixelFormat convertR8ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::R8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::L8 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::L8 to format ID:{}, we will use it's origin format "
                 "PixelFormat::L8",
                 static_cast<int>(format));
         }
@@ -556,8 +556,8 @@ static ax::backend::PixelFormat convertRG8ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::RG8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::LA8 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::LA8 to format ID:{}, we will use it's origin format "
                 "PixelFormat::RG8",
                 static_cast<int>(format));
         }
@@ -612,8 +612,8 @@ static ax::backend::PixelFormat convertRGB8ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::RGB8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::RGB8 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::RGB8 to format ID:{}, we will use it's origin format "
                 "PixelFormat::RGB8",
                 static_cast<int>(format));
         }
@@ -668,8 +668,8 @@ static ax::backend::PixelFormat convertRGBA8ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::RGBA8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::RGBA8 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::RGBA8 to format ID:{}, we will use it's origin format "
                 "PixelFormat::RGBA8",
                 static_cast<int>(format));
         }
@@ -703,8 +703,8 @@ static ax::backend::PixelFormat convertRGB5A1ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::RGBA8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::RGB5A1 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::RGB5A1 to format ID:{}, we will use it's origin format "
                 "PixelFormat::RGB51A",
                 static_cast<int>(format));
         }
@@ -737,8 +737,8 @@ static ax::backend::PixelFormat convertRGB565ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::RGBA8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::RGB565 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::RGB565 to format ID:{}, we will use it's origin format "
                 "PixelFormat::RGB565",
                 static_cast<int>(format));
         }
@@ -771,8 +771,8 @@ static ax::backend::PixelFormat convertRGBA4ToFormat(const unsigned char* data,
         // unsupported conversion or don't need to convert
         if (format != PixelFormat::RGBA8)
         {
-            AXLOG(
-                "Can not convert image format PixelFormat::RGBA444 to format ID:%d, we will use it's origin format "
+            AXLOGW(
+                "Can not convert image format PixelFormat::RGBA444 to format ID:{}, we will use it's origin format "
                 "PixelFormat::RGBA4",
                 static_cast<int>(format));
         }
@@ -854,7 +854,7 @@ ax::backend::PixelFormat convertDataToFormat(const unsigned char* data,
     case PixelFormat::BGRA8:
         return convertBGRA8ToFormat(data, dataLen, format, outData, outDataLen);
     default:
-        AXLOG("unsupported conversion from format %d to format %d", static_cast<int>(originFormat),
+        AXLOGW("unsupported conversion from format {} to format {}", static_cast<int>(originFormat),
               static_cast<int>(format));
         *outData    = (unsigned char*)data;
         *outDataLen = dataLen;

--- a/core/renderer/backend/ProgramManager.cpp
+++ b/core/renderer/backend/ProgramManager.cpp
@@ -68,7 +68,7 @@ ProgramManager::~ProgramManager()
     {
         AX_SAFE_RELEASE(program.second);
     }
-    AXLOGINFO("deallocing ProgramManager: %p", this);
+    AXLOGI("deallocing ProgramManager: {}", fmt::ptr(this));
     backend::ShaderCache::destroyInstance();
 }
 
@@ -284,7 +284,7 @@ void ProgramManager::unloadUnusedPrograms()
         auto program = iter->second;
         if (program->getReferenceCount() == 1)
         {
-            //            AXLOG("axmol: TextureCache: removing unused program");
+            // AXLOGD("TextureCache: removing unused program");
             program->release();
             iter = _cachedPrograms.erase(iter);
         }

--- a/core/renderer/backend/ShaderCache.cpp
+++ b/core/renderer/backend/ShaderCache.cpp
@@ -53,7 +53,7 @@ void ShaderCache::purge()
     {
         AX_SAFE_RELEASE(shaderModule);
     }
-    AXLOGINFO("purging ShaderCache");
+    AXLOGV("purging ShaderCache");
 }
 
 backend::ShaderModule* ShaderCache::newVertexShaderModule(std::string_view shaderSource)
@@ -89,7 +89,7 @@ void ShaderCache::removeUnusedShader()
         auto shaderModule = iter->second;
         if (shaderModule->getReferenceCount() == 1)
         {
-            //            AXLOG("axmol: TextureCache: removing unused program");
+            //            AXLOGD("TextureCache: removing unused program");
             shaderModule->release();
             iter = _cachedShaders.erase(iter);
         }

--- a/core/renderer/backend/VertexLayout.cpp
+++ b/core/renderer/backend/VertexLayout.cpp
@@ -36,7 +36,7 @@ void VertexLayout::setAttrib(std::string_view name,
 {
     if (index == -1)
     {
-        AXLOGWARN("The vertex attribute '%s' vfmt=%d not exist, unused/optimized?", name.data(), static_cast<int>(format));
+        AXLOGW("The vertex attribute '{}' vfmt={} not exist, unused/optimized?", name, static_cast<int>(format));
         return;
     }
 

--- a/core/renderer/backend/opengl/CommandBufferGLES2.cpp
+++ b/core/renderer/backend/opengl/CommandBufferGLES2.cpp
@@ -19,7 +19,7 @@ CommandBufferGLES2::CommandBufferGLES2()
         glVertexAttribDivisor = glVertexAttribDivisorANGLE;
 
     if (!glDrawElementsInstanced)
-        AXLOG("%s", "Device not support instancing draw");
+        AXLOGD("{}", "Device not support instancing draw");
 }
 
 void CommandBufferGLES2::drawElementsInstanced(PrimitiveType primitiveType,

--- a/core/renderer/backend/opengl/UtilsGL.cpp
+++ b/core/renderer/backend/opengl/UtilsGL.cpp
@@ -230,7 +230,7 @@ GLint UtilsGL::toGLMinFilter(SamplerFilter minFilter, bool hasMipmaps, bool isPo
 {
     if (hasMipmaps && !isPow2)
     {
-        AXLOG("Change minification filter to either NEAREST or LINEAR since non-power-of-two texture occur in %s %s %d",
+        AXLOGD("Change minification filter to either NEAREST or LINEAR since non-power-of-two texture occur in {} {} {}",
               __FILE__, __FUNCTION__, __LINE__);
         if (SamplerFilter::LINEAR == minFilter)
             return GL_LINEAR;
@@ -264,7 +264,7 @@ GLint UtilsGL::toGLAddressMode(SamplerAddressMode addressMode, bool isPow2)
     GLint ret = GL_REPEAT;
     if (!isPow2 && (addressMode != SamplerAddressMode::CLAMP_TO_EDGE))
     {
-        AXLOG("Change texture wrap mode to CLAMP_TO_EDGE since non-power-of-two texture occur in %s %s %d", __FILE__,
+        AXLOGD("Change texture wrap mode to CLAMP_TO_EDGE since non-power-of-two texture occur in {} {} {}", __FILE__,
               __FUNCTION__, __LINE__);
         return GL_CLAMP_TO_EDGE;
     }

--- a/core/ui/UIEditBox/Mac/UIEditBoxMac.mm
+++ b/core/ui/UIEditBox/Mac/UIEditBoxMac.mm
@@ -248,19 +248,19 @@
         self.dataInputMode = inputFlag;
         break;
     case ax::ui::EditBox::InputFlag::INITIAL_CAPS_WORD:
-        AXLOG("INITIAL_CAPS_WORD not implemented");
+        AXLOGD("INITIAL_CAPS_WORD not implemented");
         break;
     case ax::ui::EditBox::InputFlag::INITIAL_CAPS_SENTENCE:
-        AXLOG("INITIAL_CAPS_SENTENCE not implemented");
+        AXLOGD("INITIAL_CAPS_SENTENCE not implemented");
         break;
     case ax::ui::EditBox::InputFlag::INITIAL_CAPS_ALL_CHARACTERS:
-        AXLOG("INITIAL_CAPS_ALL_CHARACTERS not implemented");
+        AXLOGD("INITIAL_CAPS_ALL_CHARACTERS not implemented");
         break;
     case ax::ui::EditBox::InputFlag::SENSITIVE:
-        AXLOG("SENSITIVE not implemented");
+        AXLOGD("SENSITIVE not implemented");
         break;
     case ax::ui::EditBox::InputFlag::LOWERCASE_ALL_CHARACTERS:
-        AXLOG("LOWERCASE_ALL_CHARACTERS not implemented");
+        AXLOGD("LOWERCASE_ALL_CHARACTERS not implemented");
         break;
     default:
         break;
@@ -269,7 +269,7 @@
 
 - (void)setReturnType:(ax::ui::EditBox::KeyboardReturnType)returnType
 {
-    AXLOG("setReturnType not implemented");
+    AXLOGD("setReturnType not implemented");
 }
 
 - (void)setTextHorizontalAlignment:(ax::TextHAlignment)alignment

--- a/core/ui/UIEditBox/UIEditBox.cpp
+++ b/core/ui/UIEditBox/UIEditBox.cpp
@@ -834,7 +834,7 @@ static Rect getRect(Node* pNode)
 
 void EditBox::keyboardWillShow(IMEKeyboardNotificationInfo& info)
 {
-    // AXLOG("CCEditBox::keyboardWillShow");
+    // AXLOGD("EditBox::keyboardWillShow");
     Rect rectTracked = getRect(this);
     // some adjustment for margin between the keyboard and the edit box.
     rectTracked.origin.y -= 4;
@@ -842,13 +842,13 @@ void EditBox::keyboardWillShow(IMEKeyboardNotificationInfo& info)
     // if the keyboard area doesn't intersect with the tracking node area, nothing needs to be done.
     if (!rectTracked.intersectsRect(info.end))
     {
-        AXLOG("needn't to adjust view layout.");
+        AXLOGW("needn't to adjust view layout.");
         return;
     }
 
     // assume keyboard at the bottom of screen, calculate the vertical adjustment.
     _adjustHeight = info.end.getMaxY() - rectTracked.getMinY();
-    // AXLOG("CCEditBox:needAdjustVerticalPosition(%f)", _adjustHeight);
+    // AXLOGD("EditBox:needAdjustVerticalPosition({})", _adjustHeight);
 
     if (_editBoxImpl != nullptr)
     {
@@ -860,7 +860,7 @@ void EditBox::keyboardDidShow(IMEKeyboardNotificationInfo& /*info*/) {}
 
 void EditBox::keyboardWillHide(IMEKeyboardNotificationInfo& info)
 {
-    // AXLOG("CCEditBox::keyboardWillHide");
+    // AXLOGD("EditBox::keyboardWillHide");
     if (_editBoxImpl != nullptr)
     {
         _editBoxImpl->doAnimationWhenKeyboardMove(info.duration, -_adjustHeight);

--- a/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -142,7 +142,7 @@ void EditBoxImplAndroid::setNativeFontColor(const Color4B& color)
 
 void EditBoxImplAndroid::setNativePlaceholderFont(const char* pFontName, int fontSize)
 {
-    AXLOG("Warning! You can't change Android Hint fontName and fontSize");
+    AXLOGD("Warning! You can't change Android Hint fontName and fontSize");
 }
 
 void EditBoxImplAndroid::setNativePlaceholderFontColor(const Color4B& color)

--- a/core/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -313,7 +313,7 @@ void EditBoxImplCommon::setVisible(bool visible)
 void EditBoxImplCommon::setContentSize(const Vec2& size)
 {
     _contentSize = applyPadding(size);
-    AXLOG("[Edit text] content size = (%f, %f)", _contentSize.width, _contentSize.height);
+    AXLOGD("[Edit text] content size = ({}, {})", _contentSize.width, _contentSize.height);
     placeInactiveLabels(_contentSize);
 }
 

--- a/core/ui/UIEditBox/UIEditBoxImpl-linux.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-linux.cpp
@@ -282,7 +282,7 @@ static bool LinuxInputBox(std::string& entryLine)
         didChange = true;
         break;
     default:
-        // AXLOG("Undefined. Perhaps dialog was closed");
+        // AXLOGD("Undefined. Perhaps dialog was closed");
         break;
     }
 

--- a/core/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/core/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -117,7 +117,7 @@ void EditBoxImplMac::setNativePlaceholderFont(const char* pFontName, int fontSiz
 
     if (!textFont)
     {
-        AXLOGWARN("Font not found: %s", pFontName);
+        AXLOGW("Font not found: {}", pFontName);
         return;
     }
     [_sysEdit setPlaceholderFont:textFont];

--- a/core/ui/UIEditBox/UIEditBoxImpl-wasm.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-wasm.cpp
@@ -41,7 +41,7 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 void getInputOver(unsigned char* dataPtr, int dataLength)
 {
-    AXLOG("text {} ", dataPtr);
+    AXLOGD("text {} ", dataPtr);
     if (_activeEditBox)
     {
         if (_activeEditBox->isEditingMode())
@@ -56,7 +56,7 @@ EMSCRIPTEN_KEEPALIVE
 
 void getInputChange(unsigned char* dataPtr, int dataLength)
 {
-    AXLOG("text {} ", dataPtr);
+    AXLOGD("text {} ", dataPtr);
     if (_activeEditBox && _activeEditBox->isEditingMode())
     {
         _activeEditBox->editBoxEditingChanged(std::string_view{(char*)dataPtr});

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -376,7 +376,7 @@ std::string EditBoxImplWin::getText() const
     bool conversionResult = ax::StringUtils::UTF16ToUTF8(wstrResult, utf8Result);
     if (!conversionResult)
     {
-        AXLOG("warning, editbox input text conversion error.");
+        AXLOGW("warning, editbox input text conversion error.");
     }
     return std::move(utf8Result);
 }

--- a/core/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
@@ -295,7 +295,7 @@ void EditBoxWinRT::setInputFlag(int inputFlags)
         _password = true;
         break;
     default:
-        AXLOG("Warning: cannot set INITIAL_CAPS_* input flags for WinRT edit boxes");
+        AXLOGD("Warning: cannot set INITIAL_CAPS_* input flags for WinRT edit boxes");
     }
 }
 

--- a/core/ui/UIEditBox/UIEditBoxImpl-winrt.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-winrt.h
@@ -132,14 +132,14 @@ namespace ui {
     virtual void createNativeControl(const Rect& frame) override {  }
     virtual void setNativeFont(const char* pFontName, int fontSize) override;
     virtual void setNativeFontColor(const Color4B& color) override;
-    virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override { AXLOG("Warning! You can't change WinRT placeholder font"); }
-    virtual void setNativePlaceholderFontColor(const Color4B& color) override { AXLOG("Warning! You can't change WinRT placeholder font color"); }
+    virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override { AXLOGD("Warning! You can't change WinRT placeholder font"); }
+    virtual void setNativePlaceholderFontColor(const Color4B& color) override { AXLOGD("Warning! You can't change WinRT placeholder font color"); }
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override;
     virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) override;
-    virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType) override { AXLOG("Warning! You can't change WinRT return type"); }
+    virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType) override { AXLOGD("Warning! You can't change WinRT return type"); }
     virtual void setNativeTextHorizontalAlignment(ax::TextHAlignment alignment);
     virtual void setNativeText(const char* pText) override;
-    virtual void setNativePlaceHolder(const char* pText) override { AXLOG("Warning! You can't change WinRT placeholder text"); }
+    virtual void setNativePlaceHolder(const char* pText) override { AXLOGD("Warning! You can't change WinRT placeholder text"); }
     virtual void setNativeVisible(bool visible) override;
     virtual void updateNativeFrame(const Rect& rect) override; // TODO
     virtual const char* getNativeDefaultFontName() override { return "Segoe UI"; }
@@ -149,7 +149,7 @@ namespace ui {
 
   private:
     ax::Vec2 convertDesignCoordToXamlCoord(const ax::Vec2& designCoord);
-    virtual void doAnimationWhenKeyboardMove(float duration, float distance) override { AXLOG("Warning! doAnimationWhenKeyboardMove not supported on WinRT"); }
+    virtual void doAnimationWhenKeyboardMove(float duration, float distance) override { AXLOGD("Warning! doAnimationWhenKeyboardMove not supported on WinRT"); }
 
     winrt::agile_ref<Windows::Foundation::IInspectable> _system_control_agile;
     winrt::com_ptr<EditBoxWinRT> _system_control{};

--- a/core/ui/UIEditBox/iOS/UIEditBoxIOS.mm
+++ b/core/ui/UIEditBox/iOS/UIEditBoxIOS.mm
@@ -371,7 +371,7 @@
 
 - (BOOL)textViewShouldBeginEditing:(UITextView*)textView
 {
-    AXLOG("textFieldShouldBeginEditing...");
+    AXLOGD("textFieldShouldBeginEditing...");
     _editState     = YES;
     _returnPressed = NO;
 
@@ -389,7 +389,7 @@
 
 - (BOOL)textViewShouldEndEditing:(UITextView*)textView
 {
-    AXLOG("textFieldShouldEndEditing...");
+    AXLOGD("textFieldShouldEndEditing...");
     _editState = NO;
     getEditBoxImplIOS()->refreshInactiveText();
 
@@ -464,7 +464,7 @@
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField*)sender  // return NO to disallow editing.
 {
-    AXLOG("textFieldShouldBeginEditing...");
+    AXLOGD("textFieldShouldBeginEditing...");
     _editState     = YES;
     _returnPressed = NO;
 
@@ -482,7 +482,7 @@
 
 - (BOOL)textFieldShouldEndEditing:(UITextField*)sender
 {
-    AXLOG("textFieldShouldEndEditing...");
+    AXLOGD("textFieldShouldEndEditing...");
     _editState            = NO;
     const char* inputText = [sender.text UTF8String];
 

--- a/core/ui/UIHelper.cpp
+++ b/core/ui/UIHelper.cpp
@@ -123,18 +123,18 @@ std::string Helper::getSubStringOfUTF8String(std::string_view str,
     std::u32string utf32;
     if (!StringUtils::UTF8ToUTF32(str, utf32))
     {
-        AXLOGERROR("Can't convert string to UTF-32: %s", str.data());
+        AXLOGE("Can't convert string to UTF-32: {}", str);
         return "";
     }
     if (utf32.size() < start)
     {
-        AXLOGERROR("'start' is out of range: %d, %s", static_cast<int32_t>(start), str.data());
+        AXLOGE("'start' is out of range: {}, {}", static_cast<int32_t>(start), str);
         return "";
     }
     std::string result;
     if (!StringUtils::UTF32ToUTF8(utf32.substr(start, length), result))
     {
-        AXLOGERROR("Can't convert internal UTF-32 string to UTF-8: %s", str.data());
+        AXLOGE("Can't convert internal UTF-32 string to UTF-8: {}", str);
         return "";
     }
     return result;

--- a/core/ui/UIImageView.cpp
+++ b/core/ui/UIImageView.cpp
@@ -170,7 +170,7 @@ void ImageView::setTextureRect(const Rect& rect)
         }
         else
         {
-            AXLOG("Warning!! you should load texture before set the texture's rect!");
+            AXLOGD("Warning!! you should load texture before set the texture's rect!");
         }
     }
 }

--- a/core/ui/UILayout.cpp
+++ b/core/ui/UILayout.cpp
@@ -1064,7 +1064,7 @@ Vec2 Layout::getWorldCenterPoint(Widget* widget) const
     Layout* layout = dynamic_cast<Layout*>(widget);
     // FIXEDME: we don't need to calculate the content size of layout anymore
     Vec2 widgetSize = layout ? layout->getLayoutAccumulatedSize() : widget->getContentSize();
-    //    AXLOG("content size : width = %f, height = %f", widgetSize.width, widgetSize.height);
+    //    AXLOGD("content size : width = {}, height = {}", widgetSize.width, widgetSize.height);
     return widget->convertToWorldSpace(Vec2(widgetSize.width / 2, widgetSize.height / 2));
 }
 

--- a/core/ui/UIListView.cpp
+++ b/core/ui/UIListView.cpp
@@ -83,7 +83,7 @@ void ListView::setItemModel(Widget* model)
 {
     if (nullptr == model)
     {
-        AXLOG("Can't set a nullptr to item model!");
+        AXLOGD("Can't set a nullptr to item model!");
         return;
     }
     AX_SAFE_RELEASE_NULL(_model);

--- a/core/ui/UIRadioButton.cpp
+++ b/core/ui/UIRadioButton.cpp
@@ -187,7 +187,7 @@ void RadioButtonGroup::removeRadioButton(RadioButton* radioButton)
     ssize_t index = _radioButtons.getIndex(radioButton);
     if (index == AX_INVALID_INDEX)
     {
-        AXLOGERROR("The radio button does not belong to this group!");
+        AXLOGE("The radio button does not belong to this group!");
         return;
     }
 
@@ -224,7 +224,7 @@ RadioButton* RadioButtonGroup::getRadioButtonByIndex(int index) const
 {
     if (index >= _radioButtons.size())
     {
-        AXLOGERROR("Out of array index! length=%d, requestedIndex=%d", (int)_radioButtons.size(), index);
+        AXLOGE("Out of array index! length={}, requestedIndex={}", (int)_radioButtons.size(), index);
         return nullptr;
     }
     return _radioButtons.at(index);
@@ -274,7 +274,7 @@ void RadioButtonGroup::setSelectedButtonWithoutEvent(RadioButton* radioButton)
     }
     if (radioButton != nullptr && !_radioButtons.contains(radioButton))
     {
-        AXLOGERROR("The radio button does not belong to this group!");
+        AXLOGE("The radio button does not belong to this group!");
         return;
     }
 

--- a/core/ui/UIScale9Sprite.cpp
+++ b/core/ui/UIScale9Sprite.cpp
@@ -395,7 +395,7 @@ void Scale9Sprite::setScale9Enabled(bool enabled)
 {
     if (_renderMode == RenderMode::POLYGON)
     {
-        AXLOGWARN("Scale9Sprite::setScale9Enabled() can't be called when using POLYGON render modes");
+        AXLOGW("Scale9Sprite::setScale9Enabled() can't be called when using POLYGON render modes");
         return;
     }
 
@@ -474,7 +474,7 @@ void Scale9Sprite::setRenderingType(Scale9Sprite::RenderingType type)
 {
     if (_renderMode == RenderMode::POLYGON)
     {
-        AXLOGWARN("Scale9Sprite::setRenderingType() can't be called when using POLYGON render modes");
+        AXLOGW("Scale9Sprite::setRenderingType() can't be called when using POLYGON render modes");
         return;
     }
     if (_renderingType != type)

--- a/core/ui/UIScrollView.cpp
+++ b/core/ui/UIScrollView.cpp
@@ -766,7 +766,7 @@ void ScrollView::scrollToTopLeft(float timeInSec, bool attenuated)
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     startAutoScrollToDestination(Vec2(0.0f, _contentSize.height - _innerContainer->getContentSize().height), timeInSec,
@@ -777,7 +777,7 @@ void ScrollView::scrollToTopRight(float timeInSec, bool attenuated)
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     startAutoScrollToDestination(Vec2(_contentSize.width - _innerContainer->getContentSize().width,
@@ -789,7 +789,7 @@ void ScrollView::scrollToBottomLeft(float timeInSec, bool attenuated)
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     startAutoScrollToDestination(Vec2::ZERO, timeInSec, attenuated);
@@ -799,7 +799,7 @@ void ScrollView::scrollToBottomRight(float timeInSec, bool attenuated)
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     startAutoScrollToDestination(Vec2(_contentSize.width - _innerContainer->getContentSize().width, 0.0f), timeInSec,
@@ -874,7 +874,7 @@ void ScrollView::jumpToTopLeft()
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     jumpToDestination(Vec2(0.0f, _contentSize.height - _innerContainer->getContentSize().height));
@@ -884,7 +884,7 @@ void ScrollView::jumpToTopRight()
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     jumpToDestination(Vec2(_contentSize.width - _innerContainer->getContentSize().width,
@@ -895,7 +895,7 @@ void ScrollView::jumpToBottomLeft()
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     jumpToDestination(Vec2::ZERO);
@@ -905,7 +905,7 @@ void ScrollView::jumpToBottomRight()
 {
     if (_direction != Direction::BOTH)
     {
-        AXLOG("Scroll direction is not both!");
+        AXLOGD("Scroll direction is not both!");
         return;
     }
     jumpToDestination(Vec2(_contentSize.width - _innerContainer->getContentSize().width, 0.0f));

--- a/core/ui/UITabControl.cpp
+++ b/core/ui/UITabControl.cpp
@@ -63,7 +63,7 @@ void TabControl::insertTab(int index, TabHeader* header, Layout* container)
     int cellSize = (int)_tabItems.size();
     if (index > cellSize)
     {
-        AXLOG("%s", "insert index error");
+        AXLOGW("{}", "insert index error");
         return;
     }
 
@@ -123,7 +123,7 @@ void TabControl::removeTab(int index)
     int cellSize = (int)_tabItems.size();
     if (cellSize == 0 || index >= cellSize)
     {
-        AXLOG("%s", "no tab or remove index error");
+        AXLOGW("{}", "no tab or remove index error");
         return;
     }
 

--- a/core/ui/UITextAtlas.cpp
+++ b/core/ui/UITextAtlas.cpp
@@ -100,7 +100,7 @@ void TextAtlas::setProperty(std::string_view stringValue,
 
     updateContentSizeWithTextureSize(_labelAtlasRenderer->getContentSize());
     _labelAtlasRendererAdaptDirty = true;
-    //    AXLOG("cs w %f, h %f", _contentSize.width, _contentSize.height);
+    //    AXLOGD("cs w {}, h {}", _contentSize.width, _contentSize.height);
 }
 
 void TextAtlas::setString(std::string_view value)
@@ -113,7 +113,7 @@ void TextAtlas::setString(std::string_view value)
     _labelAtlasRenderer->setString(value);
     updateContentSizeWithTextureSize(_labelAtlasRenderer->getContentSize());
     _labelAtlasRendererAdaptDirty = true;
-    //    AXLOG("cssss w %f, h %f", _contentSize.width, _contentSize.height);
+    //    AXLOGD("cssss w {}, h {}", _contentSize.width, _contentSize.height);
 }
 
 std::string_view TextAtlas::getString() const

--- a/core/ui/UITextFieldEx.cpp
+++ b/core/ui/UITextFieldEx.cpp
@@ -71,7 +71,7 @@ static bool _containsTouchPoint(ax::Node* target, ax::Touch* touch)
 
     bool contains = (rc.containsPoint(pt));
 
-    // AXLOG("check %#x coordinate:(%f, %f), contains:%d", target, pt.x, pt.y, contains);
+    // AXLOGD("check {:#x} coordinate:({}, {}), contains:%d", target, pt.x, pt.y, contains);
     return contains;
 }
 
@@ -85,7 +85,7 @@ static bool engine_inj_containsPoint(ax::Node* target, const ax::Vec2& worldPoin
 
     bool contains = (rc.containsPoint(pt));
 
-    // AXLOG("check %#x coordinate:(%f, %f), contains:%d", target, pt.x, pt.y, contains);
+    // AXLOGD("check {:#x} coordinate:({}, {}), contains:%d", target, pt.x, pt.y, contains);
     return contains;
 }
 
@@ -522,7 +522,7 @@ void TextFieldEx::keyboardDidHide(IMEKeyboardNotificationInfo& /*info*/)
 
 void TextFieldEx::openIME(void)
 {
-    AXLOG("TextFieldEx:: openIME");
+    AXLOGD("TextFieldEx:: openIME");
     this->attachWithIME();
     __updateCursorPosition();
     __showCursor();
@@ -533,7 +533,7 @@ void TextFieldEx::openIME(void)
 
 void TextFieldEx::closeIME(void)
 {
-    AXLOG("TextFieldEx:: closeIME");
+    AXLOGD("TextFieldEx:: closeIME");
     __hideCursor();
     this->detachWithIME();
 

--- a/core/ui/UIWebView/UIWebViewImpl-win32.cpp
+++ b/core/ui/UIWebView/UIWebViewImpl-win32.cpp
@@ -767,7 +767,7 @@ bool Win32WebControl::createWebView(const std::function<bool(std::string_view)>&
 
         if (!embed(m_window, false, cb))
         {
-            AXLOG("Cannot create edge chromium webview");
+            AXLOGD("Cannot create edge chromium webview");
             ret = false;
             break;
         }


### PR DESCRIPTION
## Describe your changes

Remove all old log macro calls from `core` folder, instead use c++20 format style macros: AXLOGD, AXLOGI, AXLOGW, AXLOGE.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
