### PR TITLE
Set several log messages to verbose level

### DIFF
--- a/core/2d/Animation.cpp
+++ b/core/2d/Animation.cpp
@@ -59,7 +59,7 @@ bool AnimationFrame::initWithSpriteFrame(SpriteFrame* spriteFrame, float delayUn
 
 AnimationFrame::~AnimationFrame()
 {
-    AXLOGD("deallocing AnimationFrame: {}", fmt::ptr(this));
+    AXLOGV("deallocing AnimationFrame: {}", fmt::ptr(this));
 
     AX_SAFE_RELEASE(_spriteFrame);
 }

--- a/core/platform/GLView.cpp
+++ b/core/platform/GLView.cpp
@@ -322,7 +322,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
             touch->setTouchInfo(unusedIndex, (x - _viewPortRect.origin.x) / _scaleX,
                                 (y - _viewPortRect.origin.y) / _scaleY);
 
-            AXLOGI("x = {} y = {}", touch->getLocationInView().x, touch->getLocationInView().y);
+            AXLOGV("x = {} y = {}", touch->getLocationInView().x, touch->getLocationInView().y);
 
             g_touchIdReorderMap.emplace(id, unusedIndex);
             touchEvent._touches.emplace_back(touch);
@@ -369,7 +369,7 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], 
             continue;
         }
 
-        AXLOGI("Moving touches with id: {}, x={}, y={}, force={}, maxFource={}", (int)id, x, y, force, maxForce);
+        AXLOGV("Moving touches with id: {}, x={}, y={}, force={}, maxFource={}", (int)id, x, y, force, maxForce);
         Touch* touch = g_touches[iter->second];
         if (touch)
         {
@@ -425,7 +425,7 @@ void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
         Touch* touch = g_touches[iter->second];
         if (touch)
         {
-            AXLOGI("Ending touches with id: {}, x={}, y={}", (int)id, x, y);
+            AXLOGV("Ending touches with id: {}, x={}, y={}", (int)id, x, y);
             touch->setTouchInfo(iter->second, (x - _viewPortRect.origin.x) / _scaleX,
                                 (y - _viewPortRect.origin.y) / _scaleY);
 


### PR DESCRIPTION
## Describe your changes

Several log messages seem to be set to a higher level than is required, which results in the log generating to many messages that are not useful in both release and normal debugging sessions.

This sets those log messages to verbose level, so they are only outputted if required for specific trace level debugging.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
