### PR TITLE
Ensure the RenderTexture reference is valid on threaded saveToFile task completion

### DIFF
--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -468,14 +468,14 @@ void RenderTexture::onSaveToFile(std::string filename, bool isRGBA, bool forceNo
         {
             if (forceNonPMA && image->hasPremultipliedAlpha())
             {
-                _director->getJobSystem()->enqueue([this, image, _filename, isRGBA, forceNonPMA]() {
+                _director->getJobSystem()->enqueue([self = RefPtr(this), image, _filename, isRGBA, forceNonPMA]() {
                     image->reversePremultipliedAlpha();
 
-                    Director::getInstance()->getScheduler()->runOnAxmolThread([this, image, _filename, isRGBA] {
+                    Director::getInstance()->getScheduler()->runOnAxmolThread([self, image, _filename, isRGBA] {
                         image->saveToFile(_filename, !isRGBA);
-                        if (_saveFileCallback)
+                        if (self->_saveFileCallback)
                         {
-                            _saveFileCallback(this, _filename);
+                            self->_saveFileCallback(self, _filename);
                         }
                     });
                 });


### PR DESCRIPTION
## Describe your changes

In certain scenarios, when using `RenderTexture::onSaveToFile` with the `forceNonPMA` as `true`, then the `RenderTexture` may longer exist by the time the the threaded task is completed (such as via `getJobSystem()`), so the program will crash.

The change here ensures that the `RenderTexture` reference is retained and released correctly on completion.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
