### PR TITLE
Change AXLOGI to more appropriate AXLOGD for several log calls

### DIFF
--- a/core/base/AutoreleasePool.cpp
+++ b/core/base/AutoreleasePool.cpp
@@ -131,7 +131,7 @@ PoolManager::PoolManager()
 
 PoolManager::~PoolManager()
 {
-    AXLOGI("deallocing PoolManager: {}", fmt::ptr(this));
+    AXLOGD("deallocing PoolManager: {}", fmt::ptr(this));
 
     while (!_releasePoolStack.empty())
     {

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -167,7 +167,7 @@ bool Director::init()
 
 Director::~Director()
 {
-    AXLOGI("deallocing Director: {}", fmt::ptr(this));
+    AXLOGD("deallocing Director: {}", fmt::ptr(this));
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     _eventDispatcher->removeEventListener(_rendererRecreatedListener);
@@ -680,7 +680,7 @@ void Director::purgeCachedData()
 
         // Note: some tests such as ActionsTest are leaking refcounted textures
         // There should be no test textures left in the cache
-        AXLOGI("{}\n", _textureCache->getCachedTextureInfo());
+        AXLOGD("{}\n", _textureCache->getCachedTextureInfo());
     }
     FileUtils::getInstance()->purgeCachedEntries();
 }

--- a/core/platform/GLViewImpl.cpp
+++ b/core/platform/GLViewImpl.cpp
@@ -368,7 +368,7 @@ GLViewImpl::GLViewImpl(bool initglfw)
 
 GLViewImpl::~GLViewImpl()
 {
-    AXLOGI("deallocing GLViewImpl: {}", fmt::ptr(this));
+    AXLOGD("deallocing GLViewImpl: {}", fmt::ptr(this));
     GLFWEventHandler::setGLViewImpl(nullptr);
     glfwTerminate();
 }

--- a/core/renderer/TextureCache.cpp
+++ b/core/renderer/TextureCache.cpp
@@ -66,7 +66,7 @@ TextureCache::TextureCache() : _loadingThread(nullptr), _needQuit(false), _async
 
 TextureCache::~TextureCache()
 {
-    AXLOGI("deallocing TextureCache: {}", fmt::ptr(this));
+    AXLOGD("deallocing TextureCache: {}", fmt::ptr(this));
 
     for (auto&& texture : _textures)
         texture.second->release();

--- a/core/renderer/backend/ProgramManager.cpp
+++ b/core/renderer/backend/ProgramManager.cpp
@@ -68,7 +68,7 @@ ProgramManager::~ProgramManager()
     {
         AX_SAFE_RELEASE(program.second);
     }
-    AXLOGI("deallocing ProgramManager: {}", fmt::ptr(this));
+    AXLOGD("deallocing ProgramManager: {}", fmt::ptr(this));
     backend::ShaderCache::destroyInstance();
 }
 


### PR DESCRIPTION
## Describe your changes

Prior to PR #2020 several log calls were made using `AXLOGINFO`, which is compiled out of the release executable when `_AX_DEBUG <= 1` .  The changes in this PR bring this same behavior back, using `AXLOGD`, so these log messages are not outputted unless `_AX_DEBUG > 0`.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
