### PR TITLE
Fix FreeType using wrong bit check for USE_TYPO_METRICS in OS/2 table

### DIFF
--- a/3rdparty/freetype/src/sfnt/sfobjs.c
+++ b/3rdparty/freetype/src/sfnt/sfobjs.c
@@ -1362,7 +1362,7 @@
          *    2. Otherwise, use the OS/2 table's usWin* metrics.
          */
 
-        if ( face->os2.version != 0xFFFFU && face->os2.fsSelection & 128 )
+        if ( face->os2.version != 0xFFFFU && face->os2.fsSelection & 64 )
         {
           root->ascender  = face->os2.sTypoAscender;
           root->descender = face->os2.sTypoDescender;


### PR DESCRIPTION
Fixes #2034