### PR TITLE
Use correct starting index of index buffer to fix ImGui graphic glitch

### DIFF
--- a/extensions/ImGui/src/ImGui/imgui_impl_ax.cpp
+++ b/extensions/ImGui/src/ImGui/imgui_impl_ax.cpp
@@ -1840,7 +1840,6 @@ IMGUI_IMPL_API void ImGui_ImplAx_RenderDrawData(ImDrawData* draw_data)
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];
-        size_t ibuffer_offset      = 0;
 
         // Upload vertex/index buffers
         const auto vsize = cmd_list->VtxBuffer.Size * sizeof(ImDrawVert);
@@ -1912,7 +1911,7 @@ IMGUI_IMPL_API void ImGui_ImplAx_RenderDrawData(ImDrawData* draw_data)
                         cmd->setVertexBuffer(vbuffer);
                         cmd->setDrawType(CustomCommand::DrawType::ELEMENT);
                         cmd->setPrimitiveType(PrimitiveType::TRIANGLE);
-                        cmd->setIndexDrawInfo(ibuffer_offset, pcmd->ElemCount);
+                        cmd->setIndexDrawInfo(pcmd->IdxOffset, pcmd->ElemCount);
                         renderer->addCommand(cmd.get());
                     }
                     else
@@ -1928,7 +1927,6 @@ IMGUI_IMPL_API void ImGui_ImplAx_RenderDrawData(ImDrawData* draw_data)
                     }
                 }
             }
-            ibuffer_offset += pcmd->ElemCount;
         }
     }
 

--- a/extensions/ImGui/src/ImGui/imgui_impl_ax_android.cpp
+++ b/extensions/ImGui/src/ImGui/imgui_impl_ax_android.cpp
@@ -609,7 +609,6 @@ IMGUI_IMPL_API void ImGui_ImplAx_RenderDrawData(ImDrawData* draw_data)
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];
-        size_t ibuffer_offset      = 0;
 
         // Upload vertex/index buffers
         const auto vsize = cmd_list->VtxBuffer.Size * sizeof(ImDrawVert);
@@ -681,7 +680,7 @@ IMGUI_IMPL_API void ImGui_ImplAx_RenderDrawData(ImDrawData* draw_data)
                         cmd->setVertexBuffer(vbuffer);
                         cmd->setDrawType(CustomCommand::DrawType::ELEMENT);
                         cmd->setPrimitiveType(PrimitiveType::TRIANGLE);
-                        cmd->setIndexDrawInfo(ibuffer_offset, pcmd->ElemCount);
+                        cmd->setIndexDrawInfo(pcmd->IdxOffset, pcmd->ElemCount);
                         renderer->addCommand(cmd.get());
                     }
                     else
@@ -697,7 +696,6 @@ IMGUI_IMPL_API void ImGui_ImplAx_RenderDrawData(ImDrawData* draw_data)
                     }
                 }
             }
-            ibuffer_offset += pcmd->ElemCount;
         }
     }
 


### PR DESCRIPTION
## Describe your changes
This change ensures that the correct index is used into the index buffer

## Issue ticket number and link
#2051 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
