### PR TITLE
Some pre-built CMake configuration fixes

### DIFF
--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -17,7 +17,7 @@ function(ax_sync_target_res ax_target)
     set(oneValueArgs LINK_TO SYNC_TARGET_ID)
     set(multiValueArgs FOLDERS)
     cmake_parse_arguments(opt "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-   
+
     if (NOT DEFINED opt_SYNC_TARGET_ID)
         set(sync_target_name "SYNC_RESOURCE-${ax_target}")
     else()
@@ -25,7 +25,7 @@ function(ax_sync_target_res ax_target)
     endif()
 
     ax_def_sync_resource_target(${ax_target} ${sync_target_name})
-    
+
     if(NOT TARGET ${sync_target_name})
         message(WARNING "SyncResource targe for ${ax_target} is not defined")
         return()
@@ -291,7 +291,7 @@ function(ax_mark_resources)
             # MakeAppx.exe require deployment location path rule
             #   - must full quailfied windows style path
             #   - can't start with .\xxx.txt, must be xxx.txt
-            # 
+            #
             # Otherwise, will fail with:
             #  MakeAppx : error : 0x8007007b - The filename, directory name, or volume label syntax is incorrect.
             if (opt_RESOURCEBASE STREQUAL ".")
@@ -439,7 +439,7 @@ function(ax_setup_app_config app_name)
         # windows: visual studio/LLVM-clang default is Console app, but we need Windows app
         set(_win32_linker_flags "")
         set(_win32_console_app FALSE)
-        
+
         if (NOT opt_CONSOLE OR WINRT)
             set(_win32_linker_flags "/SUBSYSTEM:WINDOWS")
         else()
@@ -571,8 +571,13 @@ macro (ax_setup_app_props app_name)
         foreach(FOLDER IN LISTS _APP_RES_FOLDER)
             string(APPEND EMSCRIPTEN_LINK_FLAGS " --preload-file ${FOLDER}/@/")
         endforeach()
-        
+
         set_target_properties(${app_name} PROPERTIES LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS}")
+    endif()
+
+    if(MSVC)
+        # explicit set source charset to utf-8 for windows targets
+        target_compile_options(${APP_NAME} PRIVATE "/utf-8")
     endif()
 endmacro()
 
@@ -590,7 +595,7 @@ macro(ax_setup_winrt_sources )
 
     get_target_depends_ext_dlls(3rdparty prebuilt_dlls)
 
-    if (NOT prebuilt_dlls) 
+    if (NOT prebuilt_dlls)
         set(prebuilt_dlls
             ${_AX_ROOT}/${_AX_THIRDPARTY_NAME}/zlib/_x/lib/${PLATFORM_NAME}/${ARCH_ALIAS}/zlib1.dll
             ${_AX_ROOT}/${_AX_THIRDPARTY_NAME}/openssl/_x/lib/${PLATFORM_NAME}/${ARCH_ALIAS}/libssl-3-x64.dll

--- a/cmake/Modules/AXConfigDefine.cmake
+++ b/cmake/Modules/AXConfigDefine.cmake
@@ -35,7 +35,7 @@ if (WINDOWS)
         set(CMAKE_C_STANDARD 11)
     else()
         # windows sdk < 10.0.22000.0, The c11 header stdalign.h was missing, so workaroud fallback C standard to 99
-        # refer to: 
+        # refer to:
         #  - https://github.com/axmolengine/axmol/issues/991
         #  - https://github.com/axmolengine/axmol/issues/1246
         message(WARNING "Forcing set CMAKE_C_STANDARD to 99 when winsdk < 10.0.22000.0")
@@ -132,20 +132,27 @@ function(use_ax_compile_define target)
         if(AX_USE_GL)
             target_compile_definitions(${target}
                 PUBLIC AX_USE_GL=1
-                PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE}
                 PUBLIC GL_SILENCE_DEPRECATION=1
             )
+            if(NOT _AX_USE_PREBUILT)
+                target_compile_definitions(${target} PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE})
+            endif()
         endif()
     elseif(LINUX)
         ax_config_pred(${target} AX_ENABLE_VLC_MEDIA)
         target_compile_definitions(${target} PUBLIC _GNU_SOURCE)
     elseif(ANDROID)
+        if(NOT _AX_USE_PREBUILT)
+            target_compile_definitions(${target} PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE})
+        endif()
         target_compile_definitions(${target} PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE})
         target_compile_definitions(${target} PUBLIC USE_FILE32API)
     elseif(EMSCRIPTEN)
         target_compile_definitions(${target} PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE})
     elseif(WINDOWS)
-        target_compile_definitions(${target} PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE})
+        if(NOT _AX_USE_PREBUILT)
+            target_compile_definitions(${target} PUBLIC AX_GLES_PROFILE=${AX_GLES_PROFILE})
+        endif()
         ax_config_pred(${target} AX_ENABLE_VLC_MEDIA)
         target_compile_definitions(${target}
             PUBLIC WIN32

--- a/cmake/Modules/AXLinkHelpers.cmake
+++ b/cmake/Modules/AXLinkHelpers.cmake
@@ -43,9 +43,9 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
     message(STATUS "AX_ENABLE_EXT_EFFEKSEER=${AX_ENABLE_EXT_EFFEKSEER}")
     message(STATUS "AX_ENABLE_EXT_LUA=${AX_ENABLE_EXT_LUA}")
 	message(STATUS "AX_ENABLE_EXT_DRAWNODEEX=${AX_ENABLE_EXT_DRAWNODEEX}")
-    
+
     # compile defines can't inherit when link prebuits, so need add manually
-    target_compile_definitions(${APP_NAME} 
+    target_compile_definitions(${APP_NAME}
         PRIVATE AX_GLES_PROFILE=${AX_GLES_PROFILE}
         PRIVATE OPENSSL_SUPPRESS_DEPRECATED=1
         PRIVATE NOUNCRYPT=1
@@ -156,8 +156,8 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
         websocket-parser
     )
 
-    ax_link_ext(AX_ENABLE_EXT_DRAGONBONES "DragonBones""${AX_ROOT_DIR}/extensions/DragonBones/src")
-    ax_link_ext(AX_ENABLE_EXT_COCOSTUDIO "cocosstudio" "${AX_ROOT_DIR}/extensions/cocostudio/src")
+    ax_link_ext(AX_ENABLE_EXT_DRAGONBONES "DragonBones" "${AX_ROOT_DIR}/extensions/DragonBones/src")
+    ax_link_ext(AX_ENABLE_EXT_COCOSTUDIO "cocostudio" "${AX_ROOT_DIR}/extensions/cocostudio/src")
     ax_link_ext(AX_ENABLE_EXT_ASSETMANAGER "assets-manager" "${AX_ROOT_DIR}/extensions/assets-manager/src")
     ax_link_ext(AX_ENABLE_EXT_PARTICLE3D "particle3d" "${AX_ROOT_DIR}/extensions/Particle3D/src")
     ax_link_ext(AX_ENABLE_EXT_INSPECTOR "Inspector" "${AX_ROOT_DIR}/extensions/Inspector/src")
@@ -188,11 +188,11 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
             libssl
             libcurl_imp
         )
-        
+
         if (AX_ENABLE_AUDIO)
             target_link_libraries(${APP_NAME}
                 OpenAL32
-            )   
+            )
         endif()
     else()
         target_link_libraries(${APP_NAME}
@@ -203,12 +203,12 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
             ssl
             crypto
         )
-        
+
         if (AX_ENABLE_AUDIO)
             target_link_libraries(${APP_NAME}
                 openal
-            )        
-        endif()        
+            )
+        endif()
     endif()
 
     target_link_libraries(${APP_NAME} debug fmtd optimized fmt)
@@ -231,7 +231,7 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
             add_custom_command(TARGET ${APP_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${AX_ROOT_DIR}/${AX_PREBUILT_DIR}/bin/${BUILD_CONFIG_DIR}OpenAL32.dll"
-                $<TARGET_FILE_DIR:${APP_NAME}>)        
+                $<TARGET_FILE_DIR:${APP_NAME}>)
         endif()
 
         if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
## Describe your changes
It was looking for `cocosstudio` instead of `cocostudio` when prebuilt engine configuration with extensions enabled is used.
For Windows MSVC compiler `/utf-8` flag wasn't being set for prebuilt engine configuration.
Fixed a redefination warning of `AX_GLES_PROFILE` for some compilers when prebuilt engine configuration is used.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
