### PR TITLE
Fix Curl downloader not observing set task limits

### DIFF
--- a/core/network/Downloader-curl.cpp
+++ b/core/network/Downloader-curl.cpp
@@ -52,7 +52,7 @@
 //   https://curl.se/libcurl/c/curl_easy_getinfo.html
 //   https://curl.se/libcurl/c/curl_easy_setopt.html
 
-#    define AX_CURL_POLL_TIMEOUT_MS 1000  // wait until DNS query done
+#    define AX_CURL_POLL_TIMEOUT_MS 1000
 
 enum
 {

--- a/core/network/Downloader-curl.cpp
+++ b/core/network/Downloader-curl.cpp
@@ -668,9 +668,12 @@ private:
             }
 
             // process tasks in _requestList
-            auto size = coTaskMap.size();
-            while (0 == countOfMaxProcessingTasks || size < countOfMaxProcessingTasks)
+            while (true)
             {
+                // Check for set task limit
+                if (countOfMaxProcessingTasks && coTaskMap.size() >= countOfMaxProcessingTasks)
+                    break;
+
                 // get task wrapper from request queue
                 std::shared_ptr<DownloadTask> task;
                 {

--- a/core/network/Downloader-curl.cpp
+++ b/core/network/Downloader-curl.cpp
@@ -611,7 +611,6 @@ private:
 
                         // remove from multi-handle
                         curl_multi_remove_handle(curlmHandle, curlHandle);
-                        bool reinited = false;
                         do
                         {
                             auto coTask = static_cast<DownloadTaskCURL*>(task->_coTask.get());
@@ -623,7 +622,7 @@ private:
                                     curl_easy_getinfo(curlHandle, CURLINFO_RESPONSE_CODE, &responeCode);
                                     fmt::format_to(std::back_inserter(errorMsg), FMT_COMPILE(": {}"), responeCode);
                                 }
-                                
+
                                 coTask->setErrorDesc(DownloadTask::ERROR_IMPL_INTERNAL, errCode, std::move(errorMsg));
                                 break;
                             }


### PR DESCRIPTION
This fixes an issue where DownloaderCURL doesn't observe `countOfMaxProcessingTasks` and starts all download tasks at once.