### PR TITLE
Improve Vec4Base sub-class functionality and Vec4 directional vector method name change

### DIFF
--- a/core/math/Vec4.cpp
+++ b/core/math/Vec4.cpp
@@ -1,6 +1,7 @@
 /**
  Copyright 2013 BlackBerry Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/core/math/Vec4.cpp
+++ b/core/math/Vec4.cpp
@@ -27,23 +27,15 @@
 
 NS_AX_MATH_BEGIN
 
-Vec4::Vec4() : Vec4Base() {}
+Vec4::Vec4() {}
 
 Vec4::Vec4(float xx, float yy, float zz, float ww) : Vec4Base(xx, yy, zz, ww) {}
 
-Vec4::Vec4(const float* src)
-{
-    set(src);
-}
+Vec4::Vec4(const float* src) : Vec4Base(src) {}
 
 Vec4::Vec4(const Vec4& p1, const Vec4& p2)
 {
-    set(p1, p2);
-}
-
-Vec4::Vec4(const Vec4& copy)
-{
-    set(copy);
+    setDirection(p1, p2);
 }
 
 Vec4 Vec4::fromColor(unsigned int color)
@@ -219,33 +211,7 @@ Vec4 Vec4::getNormalized() const
     return v;
 }
 
-void Vec4::set(float xx, float yy, float zz, float ww)
-{
-    this->x = xx;
-    this->y = yy;
-    this->z = zz;
-    this->w = ww;
-}
-
-void Vec4::set(const float* array)
-{
-    GP_ASSERT(array);
-
-    x = array[0];
-    y = array[1];
-    z = array[2];
-    w = array[3];
-}
-
-void Vec4::set(const Vec4& v)
-{
-    this->x = v.x;
-    this->y = v.y;
-    this->z = v.z;
-    this->w = v.w;
-}
-
-void Vec4::set(const Vec4& p1, const Vec4& p2)
+void Vec4::setDirection(const Vec4& p1, const Vec4& p2)
 {
     x = p2.x - p1.x;
     y = p2.y - p1.y;

--- a/core/math/Vec4.h
+++ b/core/math/Vec4.h
@@ -2,6 +2,7 @@
  Copyright 2013 BlackBerry Inc.
  Copyright (c) 2014-2017 Chukong Technologies
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/core/math/Vec4.h
+++ b/core/math/Vec4.h
@@ -45,6 +45,8 @@ public:
 
     Vec4Base() : x(0.0f), y(0.0f), z(0.0f), w(0.0f) {}
     Vec4Base(float xx, float yy, float zz, float ww) : x(xx), y(yy), z(zz), w(ww) {}
+    explicit Vec4Base(const float* src) { this->set(src); }
+
     union
     {
         struct
@@ -106,6 +108,50 @@ public:
         z *= scalar;
         w *= scalar;
         return *static_cast<impl_type*>(this);
+    }
+
+    /**
+     * Sets the elements of this vector to the specified values.
+     *
+     * @param xx The new x coordinate.
+     * @param yy The new y coordinate.
+     * @param zz The new z coordinate.
+     * @param ww The new w coordinate.
+     */
+    void set(float xx, float yy, float zz, float ww)
+    {
+        this->x = xx;
+        this->y = yy;
+        this->z = zz;
+        this->w = ww;        
+    }
+
+    /**
+     * Sets the elements of this vector from the values in the specified array.
+     *
+     * @param array An array containing the elements of the vector in the order x, y, z, w.
+     */
+    void set(const float* array)
+    {
+        GP_ASSERT(array);
+
+        this->x = array[0];
+        this->y = array[1];
+        this->z = array[2];
+        this->w = array[3];        
+    }
+
+    /**
+     * Sets the elements of this vector to those in the specified vector.
+     *
+     * @param v The vector to copy.
+     */
+    void set(const impl_type& v)
+    {
+        this->x = v.x;
+        this->y = v.y;
+        this->z = v.z;
+        this->w = v.w;        
     }
 
     inline impl_type& operator-() { return impl_type{*static_cast<impl_type*>(this)}.negate(); }
@@ -246,7 +292,7 @@ public:
      *
      * @param array An array containing the elements of the vector in the order x, y, z, w.
      */
-    Vec4(const float* array);
+    explicit Vec4(const float* array);
 
     /**
      * Constructs a vector that describes the direction between the specified points.
@@ -255,15 +301,6 @@ public:
      * @param p2 The second point.
      */
     Vec4(const Vec4& p1, const Vec4& p2);
-
-    /**
-     * Constructor.
-     *
-     * Creates a new vector that is a copy of the specified vector.
-     *
-     * @param copy The vector to copy.
-     */
-    Vec4(const Vec4& copy);
 
     /**
      * Creates a new vector from an integer interpreted as an RGBA value.
@@ -414,36 +451,12 @@ public:
     Vec4 getNormalized() const;
 
     /**
-     * Sets the elements of this vector to the specified values.
-     *
-     * @param xx The new x coordinate.
-     * @param yy The new y coordinate.
-     * @param zz The new z coordinate.
-     * @param ww The new w coordinate.
-     */
-    void set(float xx, float yy, float zz, float ww);
-
-    /**
-     * Sets the elements of this vector from the values in the specified array.
-     *
-     * @param array An array containing the elements of the vector in the order x, y, z, w.
-     */
-    void set(const float* array);
-
-    /**
-     * Sets the elements of this vector to those in the specified vector.
-     *
-     * @param v The vector to copy.
-     */
-    void set(const Vec4& v);
-
-    /**
      * Sets this vector to the directional vector between the specified points.
      *
      * @param p1 The first point.
      * @param p2 The second point.
      */
-    void set(const Vec4& p1, const Vec4& p2);
+    void setDirection(const Vec4& p1, const Vec4& p2);
 
     /**
      * Subtracts the specified vectors and stores the result in dst.


### PR DESCRIPTION
## Describe your changes

Move methods from `Vec4` to `Vec4Base`, specifically `set(x,y,z,w)` and `set(float*)`.  This allows their usage in Color4F and other sub-classes of `Vec4Base`.

Remove trivial copy constructor method, since it does not need to be explicitly implemented.

Rename `Vec4::set(const Vec4& p1, const Vec4& p2)` method to `Vec4::setDirection` to reflect its actual purpose.

If anyone currently uses the `Vec4::set(const Vec4& p1, const Vec4& p2)`, then it is a simple rename to `Vec4::setDirection(const Vec4& p1, const Vec4& p2)`.  The `set` name was a bit misleading, and this change renames it to what the method actually does, which is to calculate the directional vector from point `p1` to point `p2`.  The compiler will throw an error regarding this, so there is no danger that this goes unnoticed.

Note that I did try to add the `AX_DEPRECATED_ATTRIBUTE` specifier to the the `Vec4::set(const Vec4& p1, const Vec4& p2)` method, but the compiler would throw errors when attempting to use the other `set` methods that were moved to `Vec4Base`, since they were being hidden by the `Vec4::set` method.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
