### PR TITLE
Remove couple bad warnings

### DIFF
--- a/core/2d/ClippingNode.cpp
+++ b/core/2d/ClippingNode.cpp
@@ -101,10 +101,6 @@ void ClippingNode::onEnter()
     {
         _stencil->onEnter();
     }
-    else
-    {
-        AXLOGW("ClippingNode warning: _stencil is nil.");
-    }
 }
 
 void ClippingNode::onEnterTransitionDidFinish()
@@ -141,6 +137,8 @@ void ClippingNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32
 {
     if (!_visible || !hasContent())
         return;
+
+    AXASSERT(_stencil, "No stencil set");
 
     uint32_t flags = processParentFlags(parentTransform, parentFlags);
 

--- a/core/ui/UIEditBox/UIEditBox.cpp
+++ b/core/ui/UIEditBox/UIEditBox.cpp
@@ -843,7 +843,6 @@ void EditBox::keyboardWillShow(IMEKeyboardNotificationInfo& info)
     // if the keyboard area doesn't intersect with the tracking node area, nothing needs to be done.
     if (!rectTracked.intersectsRect(info.end))
     {
-        AXLOGW("needn't to adjust view layout.");
         return;
     }
 


### PR DESCRIPTION
Remove couple bad warnings:

* Attaching `ClippingNode` to scene should not trigger missing stencil warning, because there can be situations where the stencil is set after the node is attached.
* `EditBox::keyboardWillShow()` warning looks like a leftover dev stuff.