### PR TITLE
Trim trailing whitespace for files in `core` folder

### DIFF
--- a/core/2d/AutoPolygon.h
+++ b/core/2d/AutoPolygon.h
@@ -256,9 +256,9 @@ public:
      * auto sp = Sprite::create(AutoPolygon::generatePolygon("grossini.png"));
      * @endcode
      */
-    static PolygonInfo generatePolygon(std::string_view filename, 
-                                       const Rect& rect = Rect::ZERO, 
-                                       float epsilon = 2.0f,  
+    static PolygonInfo generatePolygon(std::string_view filename,
+                                       const Rect& rect = Rect::ZERO,
+                                       float epsilon = 2.0f,
                                        float threshold = 0.05f);
 
 protected:

--- a/core/2d/Camera.cpp
+++ b/core/2d/Camera.cpp
@@ -217,7 +217,7 @@ void Camera::initDefault()
     }
 
     setDepth(0);
-	
+
     if (_zoomFactor != 1.0F)
         applyZoom();
 }

--- a/core/2d/Camera.h
+++ b/core/2d/Camera.h
@@ -224,14 +224,14 @@ public:
 
     /**
      * Gets the field of view of the camera if the projection mode is 3D.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     float getFOV() const { return _fieldOfView; }
 
     /**
      * Sets the field of view of the camera if the projection mode is 3D.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     void setFOV(float fov);
@@ -243,7 +243,7 @@ public:
 
     /**
      * Sets the frustum's far plane.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     void setFarPlane(float farPlane);
@@ -255,14 +255,14 @@ public:
 
     /**
      * Gets the frustum's near plane.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     void setNearPlane(float nearPlane);
 
     /**
      * Gets the zoom multiplier of the camera.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     float getZoom() const { return _zoomFactor; }
@@ -270,16 +270,16 @@ public:
     /**
      * Sets the zoom multiplier of the camera.
      * This is designed to be used with 2D views only.
-     * 
+     *
      * @param factor The zoom factor of the camera.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     void setZoom(float factor);
 
     /**
      Apply the zoom factor.
-     * 
+     *
      * @since axmol-1.0.0b8
      */
     void applyZoom();
@@ -332,7 +332,7 @@ public:
      * WP8*/
     void setAdditionalProjection(const Mat4& mat);
 
-    /** Init default camera with director current projection, 
+    /** Init default camera with director current projection,
     !!!Note: Must invoke this function again when director projection or winsize changed */
     void initDefault();
 

--- a/core/2d/ClippingNode.cpp
+++ b/core/2d/ClippingNode.cpp
@@ -235,7 +235,7 @@ void ClippingNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32
 void ClippingNode::setGlobalZOrder(float globalZOrder)
 {
     Node::setGlobalZOrder(globalZOrder);
-    
+
     if (_stencil) {
         // Make sure our stencil stays on the same globalZOrder:
         _stencil->setGlobalZOrder(globalZOrder);

--- a/core/2d/ClippingNode.h
+++ b/core/2d/ClippingNode.h
@@ -138,7 +138,7 @@ public:
     virtual void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     virtual void setGlobalZOrder(float globalZOrder) override;
-    
+
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
 
     ClippingNode();

--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -214,7 +214,7 @@ void DrawNode::setVertexLayout(CustomCommand& cmd)
 }
 
 void DrawNode::freeShaderInternal(CustomCommand& cmd)
-{   
+{
     auto& pipelinePS = cmd.getPipelineDescriptor().programState;
     AX_SAFE_RELEASE_NULL(pipelinePS);
 }

--- a/core/2d/DrawNode.h
+++ b/core/2d/DrawNode.h
@@ -152,7 +152,7 @@ public:
                     float scaleX,
                     float scaleY,
                     const Color4B& color,
-                    float threshold = 500);  // 500 should "simulate/save" the backwards compatibility  
+                    float threshold = 500);  // 500 should "simulate/save" the backwards compatibility
 
     /** Draws a circle given the center, radius and number of segments.
      *
@@ -320,7 +320,7 @@ public:
      * @param scaleX The scale value in x.
      * @param scaleY The scale value in y.
      * @param color The solid circle color.
-     * @param DrawMode The draw mode 
+     * @param DrawMode The draw mode
      * @js NA
      */
     void drawPie(const Vec2& center,

--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -439,7 +439,7 @@ void FastTMXLayer::updatePrimitives()
         {
             auto command = new CustomCommand();
             command->setVertexBuffer(_vertexBuffer);
-  
+
 #ifdef AX_FAST_TILEMAP_32_BIT_INDICES
             CustomCommand::IndexFormat indexFormat = CustomCommand::IndexFormat::U_INT;
 #else
@@ -906,11 +906,11 @@ void FastTMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, uint32_t gid
 {
     auto tempPosAt = getPositionAt(pos);
     auto tempSpriteContentSize = sprite->getContentSize();
-    
+
     sprite->setPositionZ((float)getVertexZForPos(pos));
     sprite->setOpacity(this->getOpacity());
 
-    // fix issue #1283 too;  put the anchor in the middle for ease of rotation. 
+    // fix issue #1283 too;  put the anchor in the middle for ease of rotation.
     sprite->setAnchorPoint(Vec2(0.5f, 0.5f));
     sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2),
                         tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2));

--- a/core/2d/FastTMXTiledMap.cpp
+++ b/core/2d/FastTMXTiledMap.cpp
@@ -5,7 +5,7 @@ Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -568,7 +568,7 @@ Label::~Label()
 
     AX_SAFE_RELEASE_NULL(_textSprite);
     AX_SAFE_RELEASE_NULL(_shadowNode);
-    
+
 #if AX_LABEL_DEBUG_DRAW
     AX_SAFE_RELEASE_NULL(_debugDrawNode);
 #endif
@@ -2106,7 +2106,7 @@ void Label::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t pare
 #if AX_LABEL_DEBUG_DRAW
     _debugDrawNode->visit(renderer, _modelViewTransform, parentFlags | FLAGS_TRANSFORM_DIRTY);
 #endif
-    
+
     _director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
 }
 

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -821,7 +821,7 @@ protected:
     void updateBuffer(TextureAtlas* textureAtlas, CustomCommand& customCommand);
 
     void updateBatchCommand(BatchCommand& batch);
-    
+
     bool _contentDirty;
     bool _useDistanceField;
     bool _useA8Shader;
@@ -881,7 +881,7 @@ protected:
     Color4B _textColor;
 
     BlendFunc _blendFunc;
-   
+
     Vec2 _labelDimensions;
     Vec2 _shadowOffset;
     mutable Vec2 _scaledContentSize;  // !SDF scale
@@ -916,7 +916,7 @@ protected:
 
     std::vector<float> _linesWidth;
     std::vector<float> _linesOffsetX;
-    
+
     QuadCommand _quadCommand;
 
     std::vector<BatchCommand> _batchCommands;

--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -1005,13 +1005,13 @@ void Node::addChildHelper(Node* child, int localZOrder, int tag, std::string_vie
     this->insertChild(child, localZOrder);
 
     child->setParent(this);
-    
+
     if (_childFollowCameraMask)
     {
         child->setCameraMask(this->getCameraMask());
         child->applyMaskOnEnter(true);
     }
-    
+
     if (setTag)
     {
         child->setTag(tag);

--- a/core/2d/Node.h
+++ b/core/2d/Node.h
@@ -1827,7 +1827,7 @@ public:
      * @param applyChildren A boolean value to determine whether the mask bit should apply to its children or not.
      */
     void applyMaskOnEnter(bool applyChildren);
-    
+
     virtual void setProgramState(uint32_t programType) { setProgramStateWithRegistry(programType, nullptr); }
     void setProgramStateWithRegistry(uint32_t programType, Texture2D* texture);
 
@@ -1998,7 +1998,7 @@ protected:
 
     bool _usingNormalizedPosition;
     bool _normalizedPositionDirty;
-    
+
     bool _childFollowCameraMask;
     // camera mask, it is visible only when _cameraMask & current camera' camera flag is true
     unsigned short _cameraMask;

--- a/core/2d/ParticleSystem.h
+++ b/core/2d/ParticleSystem.h
@@ -1214,7 +1214,7 @@ public:
 
     /** Adds an emission shape to the system.
      * The index is automatically incremented on each addition.
-     * 
+     *
      * @param shape Shape descriptor object.
      */
     void addEmissionShape(EmissionShape shape);
@@ -1227,7 +1227,7 @@ public:
 
     /** Adds an emission shape of type mask to the system.
      * The mask should be added using the ParticleEmissionMaskCache class.
-     * 
+     *
      * @param maskId The id of the mask, FOURCC starts with '#', such as "#abcd"
      * @param pos Position of the emission shape in local space.
      * @param overrideSize Size of the emission mask in pixels, leave ZERO to use texture size.
@@ -1240,18 +1240,18 @@ public:
                                          Vec2 scale        = Vec2::ONE,
                                          float angle       = 0.0F);
 
-    /** Adds an emission shape of type point to the system. 
+    /** Adds an emission shape of type point to the system.
      * @param pos Position of the emission shape in local space.
      */
     static EmissionShape createPointShape(Vec2 pos);
 
-    /** Adds an emission shape of type Rectangle to the system. 
+    /** Adds an emission shape of type Rectangle to the system.
      * @param pos Position of the emission shape in local space.
      * @param size Size of the rectangle.
      */
     static EmissionShape createRectShape(Vec2 pos, Size size);
 
-    /** Adds an emission shape of type Rectangular Torus to the system. 
+    /** Adds an emission shape of type Rectangular Torus to the system.
      * @param pos Position of the emission shape in local space.
      * @param innerSize Inner size offset of the rectangle.
      * @param outerSize Outer size of the rectangle.

--- a/core/2d/PlistSpriteSheetLoader.cpp
+++ b/core/2d/PlistSpriteSheetLoader.cpp
@@ -1,6 +1,6 @@
  /****************************************************************************
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,7 +21,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
- 
+
 #include "2d/PlistSpriteSheetLoader.h"
 
 #include "platform/FileUtils.h"

--- a/core/2d/PlistSpriteSheetLoader.h
+++ b/core/2d/PlistSpriteSheetLoader.h
@@ -1,6 +1,6 @@
  /****************************************************************************
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/2d/ProgressTimer.cpp
+++ b/core/2d/ProgressTimer.cpp
@@ -232,15 +232,15 @@ void ProgressTimer::updateDisplayedOpacity(uint8_t parentOpacity)
     Node::updateDisplayedOpacity(parentOpacity);
 
     _displayedOpacity = _realOpacity * parentOpacity / 0xFF;
-    
+
     _sprite->setOpacity(_displayedOpacity);
     updateColor();
     updateProgress();
-    
+
     if (_cascadeOpacityEnabled)
     {
         _sprite->updateDisplayedOpacity(_displayedOpacity);
-        
+
         for(const auto& child : _children)
         {
             child->updateDisplayedOpacity(_displayedOpacity);
@@ -306,10 +306,10 @@ const Color3B& ProgressTimer::getColor() const
 void ProgressTimer::setOpacity(uint8_t opacity)
 {
     _displayedOpacity = _realOpacity = opacity;
-    
+
     _sprite->setOpacity(_displayedOpacity);
     updateColor();
-    
+
     updateCascadeOpacity();
 }
 
@@ -622,7 +622,7 @@ Vec2 ProgressTimer::boundaryTexCoord(char index)
             return Vec2((kProgressTextureCoords >> ((index << 1) + 1)) & 1,
                         (kProgressTextureCoords >> (index << 1)) & 1);
     }
-    
+
     return Vec2::ZERO;
 }
 

--- a/core/2d/ProtectedNode.cpp
+++ b/core/2d/ProtectedNode.cpp
@@ -6,7 +6,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/2d/ProtectedNode.h
+++ b/core/2d/ProtectedNode.h
@@ -6,7 +6,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -210,7 +210,7 @@ bool RenderTexture::initWithWidthAndHeight(int w,
              _renderTarget = backend::DriverBase::getInstance()->newRenderTarget(
                  _texture2D ? _texture2D->getBackendTexture() : nullptr,
                  _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr,
-                 _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr);	        
+                 _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr);
         }
 
         _renderTarget->setColorAttachment(_texture2D ? _texture2D->getBackendTexture() : nullptr);
@@ -494,7 +494,7 @@ void RenderTexture::onSaveToFile(std::string filename, bool isRGBA, bool forceNo
             if (_saveFileCallback)
             {
                 _saveFileCallback(this, _filename);
-            }          
+            }
         }
     };
     newImage(callbackFunc);

--- a/core/2d/Sprite.cpp
+++ b/core/2d/Sprite.cpp
@@ -327,7 +327,7 @@ bool Sprite::initWithImageData(const Data& imageData, std::string_view key)
     //_fileName = filename;
 
     Texture2D *texture = _director->getTextureCache()->addImage(imageData, key);
-    
+
     if (texture)
     {
         Rect rect = Rect::ZERO;

--- a/core/2d/Sprite.h
+++ b/core/2d/Sprite.h
@@ -161,7 +161,7 @@ public:
      * @return  An autoreleased sprite object.
      */
     static Sprite* create(const ax::Data& imageData, std::string_view key);
-    
+
     /**
      * Creates a sprite with a Texture2D object.
      *
@@ -627,7 +627,7 @@ public:
      * @lua     init
      */
     virtual bool initWithFile(std::string_view filename, const Rect& rect);
-    
+
     /**
      * Initializes a sprite with an image data, and a key for the cache.
      *

--- a/core/2d/SpriteBatchNode.h
+++ b/core/2d/SpriteBatchNode.h
@@ -6,7 +6,7 @@ Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/2d/SpriteFrame.cpp
+++ b/core/2d/SpriteFrame.cpp
@@ -5,7 +5,7 @@ Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/2d/TextFieldTTF.h
+++ b/core/2d/TextFieldTTF.h
@@ -39,7 +39,7 @@ NS_AX_BEGIN
 class TextFieldTTF;
 
 /**
- * A input protocol for TextField. 
+ * A input protocol for TextField.
  * !!!DEPRECATED since axmol-2.1.3
  */
 class AX_DLL TextFieldDelegate

--- a/core/2d/Transition.cpp
+++ b/core/2d/Transition.cpp
@@ -135,7 +135,7 @@ void TransitionScene::setWaitForFinishCount(int count)
 void TransitionScene::finish()
 {
     _waitForFinishCount--;
-    
+
     if(_waitForFinishCount == 0)
     {
         // clean up
@@ -144,13 +144,13 @@ void TransitionScene::finish()
         _inScene->setScale(1.0f);
         _inScene->setRotation(0.0f);
         _inScene->setAdditionalTransform(nullptr);
-        
+
         _outScene->setVisible(false);
         _outScene->setPosition(0, 0);
         _outScene->setScale(1.0f);
         _outScene->setRotation(0.0f);
         _outScene->setAdditionalTransform(nullptr);
-        
+
         //[self schedule:@selector(setNewScene:) interval:0];
         this->schedule(AX_SCHEDULE_SELECTOR(TransitionScene::setNewScene), 0);
     }
@@ -186,7 +186,7 @@ void TransitionScene::hideOutShowIn()
 void TransitionScene::onEnter()
 {
     Scene::onEnter();
-    
+
     // disable events while transitions
     _eventDispatcher->setEnabled(false);
 
@@ -278,9 +278,9 @@ void TransitionRotoZoom::onEnter()
 
     _inScene->setAnchorPoint(Vec2(0.5f, 0.5f));
     _outScene->setAnchorPoint(Vec2(0.5f, 0.5f));
-    
+
     setWaitForFinishCount(2);
-    
+
     auto rotozoom = Sequence::create(
         Spawn::create(ScaleBy::create(_duration / 2, 0.001f), RotateBy::create(_duration / 2, 360 * 2), nullptr),
         DelayTime::create(_duration / 2), nullptr);
@@ -320,7 +320,7 @@ void TransitionJumpZoom::onEnter()
     _outScene->setAnchorPoint(Vec2(0.5f, 0.5f));
 
     setWaitForFinishCount(2);
-    
+
     ActionInterval* jump     = JumpBy::create(_duration / 4, Vec2(-s.width, 0.0f), s.width / 4, 2);
     ActionInterval* scaleIn  = ScaleTo::create(_duration / 4, 1.0f);
     ActionInterval* scaleOut = ScaleTo::create(_duration / 4, 0.5f);
@@ -329,7 +329,7 @@ void TransitionJumpZoom::onEnter()
     auto jumpZoomIn  = Sequence::create(jump, scaleIn, nullptr);
 
     ActionInterval* delay = DelayTime::create(_duration / 2);
-    
+
     _outScene->runAction(
         Sequence::create(jumpZoomOut, CallFunc::create(AX_CALLBACK_0(TransitionScene::finish, this)), nullptr));
     _inScene->runAction(
@@ -474,15 +474,15 @@ void TransitionSlideInL::onEnter()
     this->initScenes();
 
     setWaitForFinishCount(2);
-    
+
     ActionInterval* in  = this->action();
     ActionInterval* out = this->action();
-    
+
     ActionInterval* inAction = Sequence::create(easeActionWithAction(in), CallFunc::create(AX_CALLBACK_0(TransitionScene::finish, this)), nullptr);
 
     ActionInterval* outAction = Sequence::create(
         easeActionWithAction(out), CallFunc::create(AX_CALLBACK_0(TransitionScene::finish, this)), nullptr);
-    
+
     _inScene->runAction(inAction);
     _outScene->runAction(outAction);
 }
@@ -655,10 +655,10 @@ void TransitionShrinkGrow::onEnter()
     _outScene->setAnchorPoint(Vec2(1 / 3.0f, 0.5f));
 
     setWaitForFinishCount(2);
-    
+
     ActionInterval* scaleOut = ScaleTo::create(_duration, 0.01f);
     ActionInterval* scaleIn  = ScaleTo::create(_duration, 1.0f);
-    
+
     _inScene->runAction(Sequence::create(this->easeActionWithAction(scaleIn),
                                          CallFunc::create(AX_CALLBACK_0(TransitionScene::finish, this)), nullptr));
     _outScene->runAction(Sequence::create(this->easeActionWithAction(scaleOut),
@@ -683,7 +683,7 @@ void TransitionFlipX::onEnter()
     _inScene->setVisible(false);
 
     setWaitForFinishCount(2);
-    
+
     float inDeltaZ, inAngleZ;
     float outDeltaZ, outAngleZ;
 
@@ -701,7 +701,7 @@ void TransitionFlipX::onEnter()
         outDeltaZ = -90;
         outAngleZ = 0;
     }
-    
+
     auto inA = Sequence::create(DelayTime::create(_duration / 2), Show::create(),
                                 OrbitCamera::create(_duration / 2, 1, 0, inAngleZ, inDeltaZ, 0, 0),
                                 CallFunc::create(AX_CALLBACK_0(TransitionScene::finish, this)), nullptr);
@@ -741,7 +741,7 @@ void TransitionFlipY::onEnter()
     _inScene->setVisible(false);
 
     setWaitForFinishCount(2);
-    
+
     float inDeltaZ, inAngleZ;
     float outDeltaZ, outAngleZ;
 
@@ -799,7 +799,7 @@ void TransitionFlipAngular::onEnter()
     _inScene->setVisible(false);
 
     setWaitForFinishCount(2);
-    
+
     float inDeltaZ, inAngleZ;
     float outDeltaZ, outAngleZ;
 
@@ -856,7 +856,7 @@ void TransitionZoomFlipX::onEnter()
     _inScene->setVisible(false);
 
     setWaitForFinishCount(2);
-    
+
     float inDeltaZ, inAngleZ;
     float outDeltaZ, outAngleZ;
 
@@ -916,7 +916,7 @@ void TransitionZoomFlipY::onEnter()
     _inScene->setVisible(false);
 
     setWaitForFinishCount(2);
-    
+
     float inDeltaZ, inAngleZ;
     float outDeltaZ, outAngleZ;
 
@@ -977,7 +977,7 @@ void TransitionZoomFlipAngular::onEnter()
     _inScene->setVisible(false);
 
     setWaitForFinishCount(2);
-    
+
     float inDeltaZ, inAngleZ;
     float outDeltaZ, outAngleZ;
 

--- a/core/2d/Transition.h
+++ b/core/2d/Transition.h
@@ -122,7 +122,7 @@ public:
 protected:
     virtual void sceneOrder();
     void setNewScene(float dt);
-    
+
     /**  Set the number of actions to be done to finish
      */
     void setWaitForFinishCount(int count);
@@ -132,11 +132,11 @@ protected:
     float _duration;
     bool _isInSceneOnTop;
     bool _isSendCleanupToScene;
-    
-    
+
+
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(TransitionScene);
-    
+
     int _waitForFinishCount = 1;
 };
 

--- a/core/3d/Animate3D.cpp
+++ b/core/3d/Animate3D.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/3d/Animate3D.h
+++ b/core/3d/Animate3D.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/3d/AnimationCurve.inl
+++ b/core/3d/AnimationCurve.inl
@@ -14,15 +14,15 @@ void AnimationCurve<componentSize>::evaluate(float time, float* dst, EvaluateTyp
         memcpy(dst, &_value[(_count - 1) * componentSize], _componentSizeByte);
         return;
     }
-    
+
     unsigned int index = determineIndex(time);
-    
+
     float scale = (_keytime[index + 1] - _keytime[index]);
     float t = (time - _keytime[index]) / scale;
-    
+
     float* fromValue = &_value[index * componentSize];
     float* toValue = fromValue + componentSize;
-    
+
     switch (type) {
         case EvaluateType::INT_LINEAR:
         {
@@ -45,7 +45,7 @@ void AnimationCurve<componentSize>::evaluate(float time, float* dst, EvaluateTyp
                 Quaternion::slerp(Quaternion(fromValue), Quaternion(toValue), t, &quat);
             else
                 Quaternion::slerp(Quaternion(toValue), Quaternion(fromValue), t, &quat);
-            
+
             dst[0] = quat.x;
             dst[1] = quat.y;
             dst[2] = quat.z;
@@ -58,7 +58,7 @@ void AnimationCurve<componentSize>::evaluate(float time, float* dst, EvaluateTyp
                 _evaluateFun(time, dst);
         }
         break;
-            
+
         default:
             break;
     }
@@ -78,15 +78,15 @@ AnimationCurve<componentSize>* AnimationCurve<componentSize>::create(float* keyt
     AnimationCurve* curve = new AnimationCurve();
     curve->_keytime = new float[count];
     memcpy(curve->_keytime, keytime, count * floatSize);
-    
+
     int compoentSizeByte = componentSize * floatSize;
     int totalByte = count * compoentSizeByte;
     curve->_value = new float[totalByte / floatSize];
     memcpy(curve->_value, value, totalByte);
-    
+
     curve->_count = count;
     curve->_componentSizeByte = compoentSizeByte;
-    
+
     curve->autorelease();
     return curve;
 }
@@ -112,7 +112,7 @@ AnimationCurve<componentSize>::AnimationCurve()
 , _componentSizeByte(0)
 , _evaluateFun(nullptr)
 {
-    
+
 }
 template <int componentSize>
 AnimationCurve<componentSize>::~AnimationCurve()
@@ -127,11 +127,11 @@ int AnimationCurve<componentSize>::determineIndex(float time) const
     unsigned int min = 0;
     unsigned int max = _count - 1;
     unsigned int mid = 0;
-    
+
     do
     {
         mid = (min + max) >> 1;
-        
+
         if (time >= _keytime[mid] && time <= _keytime[mid + 1])
             return mid;
         else if (time < _keytime[mid])
@@ -139,7 +139,7 @@ int AnimationCurve<componentSize>::determineIndex(float time) const
         else
             min = mid + 1;
     } while (min <= max);
-    
+
     // We should never hit this!
     return -1;
 }

--- a/core/3d/Bundle3D.cpp
+++ b/core/3d/Bundle3D.cpp
@@ -474,7 +474,7 @@ bool Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
                 {
                     AXLOGW("warning: Failed to read meshdata: aabb '{}'.", _path);
                     goto FAILED;
-                } 
+                }
                 meshData->subMeshAABB.emplace_back(AABB(Vec3(aabb[0], aabb[1], aabb[2]), Vec3(aabb[3], aabb[4], aabb[5])));
             }
             else
@@ -2329,7 +2329,7 @@ ax::AABB Bundle3D::calculateAABB(const std::vector<float>& vertex,
 
     indices.for_each ([&](uint32_t i) {
         Vec3 point(vertex[i * stride], vertex[i * stride + 1], vertex[i * stride + 2]);
-        aabb.updateMinMax(&point, 1); 
+        aabb.updateMinMax(&point, 1);
     });
 
     return aabb;

--- a/core/3d/BundleReader.h
+++ b/core/3d/BundleReader.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/3d/Mesh.cpp
+++ b/core/3d/Mesh.cpp
@@ -199,7 +199,7 @@ Mesh* Mesh::create(const std::vector<float>& positions,
     int perVertexSizeInFloat = 0;
     std::vector<float> vertices;
     std::vector<MeshVertexAttrib> attribs;
-    
+
     MeshVertexAttrib att;
     att.type = backend::VertexFormat::FLOAT3;
 

--- a/core/3d/MeshMaterial.cpp
+++ b/core/3d/MeshMaterial.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/3d/MeshMaterial.h
+++ b/core/3d/MeshMaterial.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/3d/MeshRenderer.h
+++ b/core/3d/MeshRenderer.h
@@ -154,7 +154,7 @@ public:
      * This node becomes the action's target. Refer to Action::getTarget()
      * @warning Actions don't retain their target.
      *
-     * @return a pointer to Action 
+     * @return a pointer to Action
      */
     virtual Action* runAction(Action* action) override;
 
@@ -196,13 +196,13 @@ public:
 
     /** Adds a new material to a particular mesh in this mesh renderer.
      * if meshIndex == -1, then it will be applied to all the meshes that belong to this mesh renderer.
-     * 
+     *
      * @param meshIndex Index of the mesh to apply the material to.
      */
     void setMaterial(Material* material, int meshIndex);
 
     /** Gets the material of a specific mesh in this mesh renderer.
-     * 
+     *
      * @param meshIndex Index of the mesh to get the material from. 0 is the default index.
      */
     Material* getMaterial(int meshIndex = 0) const;

--- a/core/3d/Terrain.cpp
+++ b/core/3d/Terrain.cpp
@@ -2,7 +2,7 @@
 Copyright (c) 2015-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/3d/VertexAttribBinding.cpp
+++ b/core/3d/VertexAttribBinding.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2017 Chukong Technologies
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/core/3d/VertexAttribBinding.h
+++ b/core/3d/VertexAttribBinding.h
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2017 Chukong Technologies
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2014 martell malone
 # Copyright (c) 2015-2017 Chukong Technologies Inc.
 # Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-# 
+#
 # https://axmol.dev/
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -178,7 +178,7 @@ configure_file(
         "${CMAKE_CURRENT_LIST_DIR}/axmolver.h.in"
         "${CMAKE_CURRENT_LIST_DIR}/axmolver.h" @ONLY)
 
-# early experimental features     
+# early experimental features
 # include(CMakeDependentOption)
 # cmake_dependent_option(AX_ENABLE_EARLY_FEATURES
 #   "Build the tests when we are the root project" ON
@@ -359,16 +359,16 @@ if(XCODE OR VS)
 endif()
 
 message("CMake ${_AX_CORE_LIB} target_precompile_headers")
-target_precompile_headers(${_AX_CORE_LIB} PRIVATE 
+target_precompile_headers(${_AX_CORE_LIB} PRIVATE
   "$<$<COMPILE_LANGUAGE:CXX>:axmol.h>"
 )
 
 if(WINDOWS)
     # cppwinrt or webview2 require nuget
     if(WINDOWS_STORE OR AX_ENABLE_MSEDGE_WEBVIEW2)
-        find_program(NUGET_EXE NAMES nuget 
+        find_program(NUGET_EXE NAMES nuget
             PATHS ${_AX_ROOT}/tools/external/nuget)
-            
+
         if(NOT NUGET_EXE)
             message("NUGET.EXE not found.")
             message(FATAL_ERROR "Please run setup.ps1 again to download NUGET.EXE, and run CMake again.")

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -11,7 +11,7 @@ set(_AX_AUDIO_HEADER
     audio/AudioCache.h
     audio/AudioEngineImpl.h
     )
-    
+
 set(_AX_AUDIO_SRC
     audio/AudioEngine.cpp
     audio/AudioDecoderManager.cpp
@@ -24,7 +24,7 @@ set(_AX_AUDIO_SRC
 
 if(APPLE)
     set_source_files_properties(audio/AudioEngineImpl.cpp PROPERTIES LANGUAGE OBJCXX)
-    
+
     set(_AX_AUDIO_HEADER ${_AX_AUDIO_HEADER}
                         audio/AudioDecoderEXT.h)
     set(_AX_AUDIO_SRC ${_AX_AUDIO_SRC}

--- a/core/base/Controller-android.cpp
+++ b/core/base/Controller-android.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/Controller-linux-win32.cpp
+++ b/core/base/Controller-linux-win32.cpp
@@ -4,7 +4,7 @@
   Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
   Copyright (c) 2017 Wilson E. Alvarez <wilson.e.alvarez1@gmail.com>
   Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/Data.cpp
+++ b/core/base/Data.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/Data.h
+++ b/core/base/Data.h
@@ -3,7 +3,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/Event.cpp
+++ b/core/base/Event.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventDispatcher.cpp
+++ b/core/base/EventDispatcher.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListener.h
+++ b/core/base/EventListener.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListenerAcceleration.cpp
+++ b/core/base/EventListenerAcceleration.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListenerAcceleration.h
+++ b/core/base/EventListenerAcceleration.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListenerFocus.cpp
+++ b/core/base/EventListenerFocus.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListenerFocus.h
+++ b/core/base/EventListenerFocus.h
@@ -3,7 +3,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListenerTouch.cpp
+++ b/core/base/EventListenerTouch.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/EventListenerTouch.h
+++ b/core/base/EventListenerTouch.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/JobSystem.cpp
+++ b/core/base/JobSystem.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
 
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/base/Properties.h
+++ b/core/base/Properties.h
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2017 Chukong Technologies
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/core/base/Random.h
+++ b/core/base/Random.h
@@ -42,7 +42,7 @@ NS_AX_BEGIN
 
 /**
  * @class RandomHelper
- * @brief A helper class for creating device dependent random number 
+ * @brief A helper class for creating device dependent random number
  * @remark
  *     Random Generator: std::mt19937 32bit
  */

--- a/core/base/Vector.h
+++ b/core/base/Vector.h
@@ -247,7 +247,7 @@ public:
 
     T operator[](ssize_t index) const
     {
-        return this->at(index); 
+        return this->at(index);
     }
 
     /** Returns the first element in the Vector. */

--- a/core/base/base64.h
+++ b/core/base/base64.h
@@ -43,7 +43,7 @@ decoded_size(std::size_t n)
 /** Encode a series of octets as a padded, base64 string.
 
     The resulting string will not be null terminated.
-      
+
     @par Requires
 
     The memory pointed to by `out` points to valid memory

--- a/core/math/Mat4.h
+++ b/core/math/Mat4.h
@@ -3,7 +3,7 @@
  Copyright (c) 2014-2017 Chukong Technologies
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/core/math/Vec4.h
+++ b/core/math/Vec4.h
@@ -125,7 +125,7 @@ public:
         this->x = xx;
         this->y = yy;
         this->z = zz;
-        this->w = ww;        
+        this->w = ww;
     }
 
     /**
@@ -140,7 +140,7 @@ public:
         this->x = array[0];
         this->y = array[1];
         this->z = array[2];
-        this->w = array[3];        
+        this->w = array[3];
     }
 
     /**
@@ -153,7 +153,7 @@ public:
         this->x = v.x;
         this->y = v.y;
         this->z = v.z;
-        this->w = v.w;        
+        this->w = v.w;
     }
 
     inline impl_type& operator-() { return impl_type{*static_cast<impl_type*>(this)}.negate(); }

--- a/core/media/AvfMediaEngine.mm
+++ b/core/media/AvfMediaEngine.mm
@@ -63,7 +63,7 @@ USING_NS_AX;
 {
 #if TARGET_OS_IPHONE
     auto nc = [NSNotificationCenter defaultCenter];
-    
+
     [nc addObserver:self
            selector:@selector(handleAudioRouteChange:)
                name:AVAudioSessionRouteChangeNotification
@@ -170,7 +170,7 @@ void AvfMediaEngine::onPlayerEnd()
     _playbackEnded = true;
     _state = MEMediaState::Stopped;
     fireMediaEvent(MEMediaEventType::Stopped);
-    
+
     if (_repeatEnabled) {
         this->setCurrentTime(0);
         this->play();
@@ -297,11 +297,11 @@ void AvfMediaEngine::onStatusNotification(void* context)
         NSString* mediaType      = assetTrack.mediaType;
         if ([mediaType isEqualToString:AVMediaTypeVideo])
         {  // we only care about video
-            
+
             auto naturalSize = [assetTrack naturalSize];
             _videoExtent.x = naturalSize.width;
             _videoExtent.y = naturalSize.height;
-            
+
             NSMutableDictionary* outputAttrs = [NSMutableDictionary dictionary];
             CMFormatDescriptionRef DescRef   = (CMFormatDescriptionRef)[assetTrack.formatDescriptions objectAtIndex:0];
             CMVideoCodecType codecType       = CMFormatDescriptionGetMediaSubType(DescRef);
@@ -487,7 +487,7 @@ double AvfMediaEngine::getCurrentTime()
         if (CMTIME_IS_VALID(currTime))
             return CMTimeGetSeconds(currTime);
     }
-        
+
     return 0.0;
 }
 

--- a/core/media/MfMediaEngine.cpp
+++ b/core/media/MfMediaEngine.cpp
@@ -4,7 +4,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 // Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-// 
+//
 // https://axmol.dev/
 //-------------------------------------------------------------------------------------
 

--- a/core/media/MfMediaEngine.h
+++ b/core/media/MfMediaEngine.h
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 // Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-// 
+//
 // https://axmol.dev/
 //-------------------------------------------------------------------------------------
 
@@ -54,7 +54,7 @@ class MfMediaEngine : public IMFNotify, public MediaEngine
 public:
     MfMediaEngine() noexcept;
     ~MfMediaEngine();
-    
+
     MfMediaEngine(const MfMediaEngine&)            = delete;
     MfMediaEngine& operator=(const MfMediaEngine&) = delete;
 
@@ -80,7 +80,7 @@ public:
 
     bool open(std::string_view sourceUri) override;
     bool close() override;
- 
+
     bool setLoop(bool bLoop) override;
     bool setRate(double fRate) override;
 
@@ -133,7 +133,7 @@ struct MfMediaEngineFactory : public MediaEngineFactory {
         engine->Initialize();
         return engine;
     }
-    void destroyMediaEngine(MediaEngine* me) override 
+    void destroyMediaEngine(MediaEngine* me) override
     {
         delete static_cast<MfMediaEngine*>(me);
     }

--- a/core/media/WmfMediaEngine.cpp
+++ b/core/media/WmfMediaEngine.cpp
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 //
 // Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-// 
+//
 // https://axmol.dev/
 //////////////////////////////////////////////////////////////////////////
 

--- a/core/navmesh/NavMeshDebugDraw.cpp
+++ b/core/navmesh/NavMeshDebugDraw.cpp
@@ -45,15 +45,15 @@ NavMeshDebugDraw::NavMeshDebugDraw()
 
     // the POSITION_COLOR default vertex layout is: V3F_C4B, so we need modify it
     auto vertexLayout = _programState->getMutableVertexLayout();
-    vertexLayout->setAttrib("a_position", 
+    vertexLayout->setAttrib("a_position",
                                 _programState->getAttributeLocation(backend::Attribute::POSITION),
                                 backend::VertexFormat::FLOAT3,
-                                offsetof(V3F_C4F, position), 
+                                offsetof(V3F_C4F, position),
                                 false);
-    vertexLayout->setAttrib("a_color", 
-                                _programState->getAttributeLocation(backend::Attribute::COLOR), 
-                                backend::VertexFormat::FLOAT4, 
-                                offsetof(V3F_C4F, color), 
+    vertexLayout->setAttrib("a_color",
+                                _programState->getAttributeLocation(backend::Attribute::COLOR),
+                                backend::VertexFormat::FLOAT4,
+                                offsetof(V3F_C4F, color),
                                 false);
     vertexLayout->setStride(sizeof(V3F_C4F));
 }
@@ -166,7 +166,7 @@ void NavMeshDebugDraw::draw(Renderer* renderer)
     auto& transform = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     auto beforeCommand = renderer->nextCallbackCommand();
     auto afterCommand  = renderer->nextCallbackCommand();
-    
+
     beforeCommand->init(0, Mat4::IDENTITY, Node::FLAGS_RENDER_AS_3D);
     afterCommand->init(0, Mat4::IDENTITY, Node::FLAGS_RENDER_AS_3D);
 

--- a/core/network/CMakeLists.txt
+++ b/core/network/CMakeLists.txt
@@ -15,7 +15,7 @@ if(EMSCRIPTEN)
         network/Downloader-wasm.cpp
         network/Uri.cpp
     )
-    
+
     if (AX_ENABLE_HTTP)
         list(APPEND _AX_NETWORK_HEADER
             network/HttpClient.h
@@ -27,9 +27,9 @@ if(EMSCRIPTEN)
         list(APPEND _AX_NETWORK_SRC
             network/HttpClient-wasm.cpp
             network/HttpCookie.cpp
-        )    
+        )
     endif()
-    
+
     if (AX_ENABLE_WEBSOCKET)
         list(APPEND _AX_NETWORK_HEADER
             network/WebSocket.h
@@ -37,9 +37,9 @@ if(EMSCRIPTEN)
 
         list(APPEND _AX_NETWORK_SRC
             network/WebSocket-wasm.cpp
-        )    
+        )
     endif()
-    
+
 else()
     set(_AX_NETWORK_HEADER
         network/Downloader-curl.h
@@ -53,7 +53,7 @@ else()
         network/Downloader-curl.cpp
         network/Uri.cpp
     )
-    
+
     if (AX_ENABLE_HTTP)
         list(APPEND _AX_NETWORK_HEADER
             network/HttpClient.h
@@ -65,9 +65,9 @@ else()
         list(APPEND _AX_NETWORK_SRC
             network/HttpClient.cpp
             network/HttpCookie.cpp
-        )    
+        )
     endif()
-    
+
     if (AX_ENABLE_WEBSOCKET)
         list(APPEND _AX_NETWORK_HEADER
             network/WebSocket.h
@@ -75,7 +75,7 @@ else()
 
         list(APPEND _AX_NETWORK_SRC
             network/WebSocket.cpp
-        )    
+        )
     endif()
 endif()
 

--- a/core/network/Downloader-wasm.cpp
+++ b/core/network/Downloader-wasm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -90,7 +90,7 @@ namespace ax { namespace network {
 
             DownloadTaskEmscripten *coTask = new DownloadTaskEmscripten(fetch->id);
             coTask->task = task;
-            
+
             AXLOGD("DownloaderEmscripten::createCoTask id: {}", coTask->id);
             _taskMap.insert(make_pair(coTask->id, coTask));
         }
@@ -111,7 +111,7 @@ namespace ax { namespace network {
             std::vector<unsigned char> buf(reinterpret_cast<const uint8_t*>(fetch->data), reinterpret_cast<const uint8_t*>(fetch->data) + size);
             emscripten_fetch_close(fetch);
             coTask->fetch = fetch = NULL;
-            
+
             downloader->_taskMap.erase(iter);
             downloader->onTaskFinish(*coTask->task,
                 DownloadTask::ERROR_NO_ERROR,
@@ -119,7 +119,7 @@ namespace ax { namespace network {
                 "",
                 buf
             );
-            
+
             coTask->task.reset();
         }
 
@@ -138,7 +138,7 @@ namespace ax { namespace network {
             DownloadTaskEmscripten *coTask = iter->second;
             vector<unsigned char> buf;
             downloader->_taskMap.erase(iter);
-            
+
             string storagePath = coTask->task->storagePath;
             int errCode = DownloadTask::ERROR_NO_ERROR;
             int errCodeInternal = 0;

--- a/core/network/Downloader-wasm.h
+++ b/core/network/Downloader-wasm.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
- 
+
  https://axmol.dev
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -50,9 +50,9 @@ namespace ax { namespace network
         int _id;
 
         DownloaderHints hints;
-        
+
         std::unordered_map<unsigned int, DownloadTaskEmscripten*> _taskMap;
-        
+
         static void onError(emscripten_fetch_t *fetch);
 
         static void onProgress(emscripten_fetch_t *fetch);

--- a/core/network/Downloader.h
+++ b/core/network/Downloader.h
@@ -60,7 +60,7 @@ public:
     std::string identifier;
     std::string requestURL;
     std::string storagePath;
-    
+
     std::string cacertPath;
 
     struct

--- a/core/network/HttpClient-wasm.h
+++ b/core/network/HttpClient-wasm.h
@@ -150,7 +150,7 @@ public:
      * If defined, the method uses the ClearRequestPredicate and ClearResponsePredicate
      * to check for each request/response which to delete
      */
-    void clearResponseAndRequestQueue(); 
+    void clearResponseAndRequestQueue();
 
     void clearResponseQueue() { clearResponseAndRequestQueue(); }
 
@@ -158,7 +158,7 @@ public:
     * Sets a predicate function that is going to be called to determine if we proceed
     * each of the pending requests
     *
-    * @param predicate function that will be called 
+    * @param predicate function that will be called
     */
     void setClearRequestPredicate(ClearRequestPredicate predicate) { _clearRequestPredicate = predicate; }
 
@@ -166,15 +166,15 @@ public:
      Sets a predicate function that is going to be called to determine if we proceed
     * each of the pending requests
     *
-    * @param cb predicate function that will be called 
+    * @param cb predicate function that will be called
     */
     void setClearResponsePredicate(ClearResponsePredicate predicate) { _clearResponsePredicate = predicate; }
 
-        
+
 private:
     HttpClient();
     virtual ~HttpClient();
-    
+
     void processResponse(HttpResponse* response, bool isAlone);
     static void onRequestComplete(emscripten_fetch_t *fetch);
     void increaseThreadCount();
@@ -182,17 +182,17 @@ private:
 
 private:
     int _timeoutForConnect;
-    
+
     int _timeoutForRead;
-    
+
     int _threadCount;
-    
+
     Vector<HttpRequest*>  _requestQueue;
-    
+
     std::string _cookieFilename;
-    
+
     std::string _sslCaFilename;
-    
+
     HttpCookie* _cookie;
 
     ClearRequestPredicate _clearRequestPredicate;

--- a/core/network/Uri.cpp
+++ b/core/network/Uri.cpp
@@ -174,7 +174,7 @@ bool Uri::doParse(std::string_view str)
     }
 
     bool hasScheme = true;
-	
+
     std::string copied(str);
     if (copied.find("://") == std::string::npos)
     {

--- a/core/network/WebSocket-wasm.cpp
+++ b/core/network/WebSocket-wasm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,7 +21,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
- 
+
 #include "network/WebSocket-wasm.h"
 #include "yasio/errc.hpp"
 #include "base/Logging.h"

--- a/core/network/WebSocket-wasm.h
+++ b/core/network/WebSocket-wasm.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,7 +21,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
- 
+
 #pragma once
 
 #include "platform/PlatformMacros.h"

--- a/core/physics/PhysicsWorld.cpp
+++ b/core/physics/PhysicsWorld.cpp
@@ -973,7 +973,7 @@ void PhysicsWorld::update(float delta, bool userCall /* = false*/)
                 cpSpaceStep(_cpSpace, dt);
 #    else
                 cpHastySpaceStep(_cpSpace, dt);
-#    endif                
+#    endif
             }
         }
         else

--- a/core/platform/Device.h
+++ b/core/platform/Device.h
@@ -83,7 +83,7 @@ public:
      *  @return The DPI of device.
      */
     static int getDPI();
-    
+
     /**
      * Gets the device pixel ratio
      * @since axmol-2.1.0

--- a/core/platform/FileStream.h
+++ b/core/platform/FileStream.h
@@ -40,7 +40,7 @@ class AX_DLL FileStream : public IFileStream
 {
 public:
     using IFileStream::Mode;
-    
+
     FileStream() = default;
     ~FileStream() override;
 

--- a/core/platform/GLView.h
+++ b/core/platform/GLView.h
@@ -3,7 +3,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/platform/android/ControllerManualAdapter/AndroidManifest.xml
+++ b/core/platform/android/ControllerManualAdapter/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     android:versionCode="1"
     android:versionName="1.0">
-     
+
     <uses-sdk android:minSdkVersion="10"/>
-    
-</manifest> 
+
+</manifest>

--- a/core/platform/android/GLViewImpl-android.cpp
+++ b/core/platform/android/GLViewImpl-android.cpp
@@ -3,7 +3,7 @@ Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/platform/android/java/AndroidManifest.xml
+++ b/core/platform/android/java/AndroidManifest.xml
@@ -5,4 +5,4 @@
 
     <uses-sdk android:minSdkVersion="9"/>
 
-</manifest> 
+</manifest>

--- a/core/platform/android/libaxmol-with-controller/build.gradle
+++ b/core/platform/android/libaxmol-with-controller/build.gradle
@@ -16,7 +16,7 @@ android {
         java.srcDirs = ['../java/src','../ControllerManualAdapter/src']
         manifest.srcFile "AndroidManifest.xml"
     }
-    
+
     buildTypes {
         release {
             minifyEnabled false

--- a/core/platform/ios/Device-ios.mm
+++ b/core/platform/ios/Device-ios.mm
@@ -342,11 +342,11 @@ int Device::getDPI()
         float scale = getDevicePixelRatio(sdpi);
         return static_cast<int>(scale * sdpi);
     }
-    
+
     return dpi;
 }
 
-float Device::getPixelRatio() 
+float Device::getPixelRatio()
 {
     int ignored_sdpi;
     return getDevicePixelRatio(ignored_sdpi);

--- a/core/platform/ios/ES3Renderer-ios.m
+++ b/core/platform/ios/ES3Renderer-ios.m
@@ -63,7 +63,7 @@
             [self release];
             return nil;
         }
-        
+
         depthFormat_ = depthFormat;
         pixelFormat_ = pixelFormat;
         multiSampling_ = multiSampling;
@@ -84,12 +84,12 @@
             GLint maxSamplesAllowed;
             glGetIntegerv(GL_MAX_SAMPLES, &maxSamplesAllowed);
             samplesToUse_ = MIN(maxSamplesAllowed,requestedSamples);
-            
+
             /* Create the MSAA framebuffer (offscreen) */
             glGenFramebuffers(1, &msaaFramebuffer_);
             NSAssert( msaaFramebuffer_, @"Can't create default MSAA frame buffer");
             glBindFramebuffer(GL_FRAMEBUFFER, msaaFramebuffer_);
-            
+
         }
 
         CHECK_GL_ERROR();
@@ -107,7 +107,7 @@
     {
         NSLog(@"failed to call context");
     }
-    
+
     glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &backingWidth_);
     glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &backingHeight_);
 
@@ -119,21 +119,21 @@
             glDeleteRenderbuffers(1, &msaaColorbuffer_);
             msaaColorbuffer_ = 0;
         }
-        
+
         /* Create the offscreen MSAA color buffer.
          After rendering, the contents of this will be blitted into ColorRenderbuffer */
-        
+
         //msaaFrameBuffer needs to be binded
         glBindFramebuffer(GL_FRAMEBUFFER, msaaFramebuffer_);
         glGenRenderbuffers(1, &msaaColorbuffer_);
         NSAssert(msaaFramebuffer_, @"Can't create MSAA color buffer");
-        
+
         glBindRenderbuffer(GL_RENDERBUFFER, msaaColorbuffer_);
-        
+
         glRenderbufferStorageMultisample(GL_RENDERBUFFER, samplesToUse_, pixelFormat_ , backingWidth_, backingHeight_);
-        
+
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, msaaColorbuffer_);
-        
+
         GLenum error;
         if ( (error=glCheckFramebufferStatus(GL_FRAMEBUFFER)) != GL_FRAMEBUFFER_COMPLETE)
         {
@@ -152,20 +152,20 @@
         }
 
         glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer_);
-        
+
         if( multiSampling_ )
             glRenderbufferStorageMultisample(GL_RENDERBUFFER, samplesToUse_, depthFormat_,backingWidth_, backingHeight_);
         else
             glRenderbufferStorage(GL_RENDERBUFFER, depthFormat_, backingWidth_, backingHeight_);
 
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer_);
-        
+
         if (depthFormat_ == GL_DEPTH24_STENCIL8) {
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthBuffer_);
         }
 
         // bind color buffer
-        glBindRenderbuffer(GL_RENDERBUFFER, colorRenderbuffer_);        
+        glBindRenderbuffer(GL_RENDERBUFFER, colorRenderbuffer_);
     }
 
     CHECK_GL_ERROR();
@@ -229,13 +229,13 @@
         glDeleteRenderbuffers(1, &depthBuffer_ );
         depthBuffer_ = 0;
     }
-    
+
     if ( msaaColorbuffer_)
     {
         glDeleteRenderbuffers(1, &msaaColorbuffer_);
         msaaColorbuffer_ = 0;
     }
-    
+
     if ( msaaFramebuffer_)
     {
         glDeleteRenderbuffers(1, &msaaFramebuffer_);

--- a/core/platform/linux/Device-linux.cpp
+++ b/core/platform/linux/Device-linux.cpp
@@ -103,7 +103,7 @@ int Device::getDPI()
     return dpi;
 }
 
-float Device::getPixelRatio() 
+float Device::getPixelRatio()
 {
     return Device::getDPI() / 96.0f;
 }

--- a/core/platform/mac/Device-mac.mm
+++ b/core/platform/mac/Device-mac.mm
@@ -65,7 +65,7 @@ int Device::getDPI()
     return ((displayPixelSize.width / displayPhysicalSize.width) * 25.4f);
 }
 
-float Device::getPixelRatio() 
+float Device::getPixelRatio()
 {
     NSScreen* screen    = [NSScreen mainScreen];
     const auto points = [screen frame];

--- a/core/platform/wasm/Application-wasm.h
+++ b/core/platform/wasm/Application-wasm.h
@@ -71,7 +71,7 @@ public:
 
     /** @deprecated Use getInstance() instead */
     AX_DEPRECATED_ATTRIBUTE static Application* sharedApplication();
-    
+
     /* override functions */
     virtual LanguageType getCurrentLanguage() override;
 
@@ -80,7 +80,7 @@ public:
     @return Current language iso 639-1 code
     */
     virtual const char * getCurrentLanguageCode() override;
-    
+
     /**
     @brief Get application version
     */
@@ -99,13 +99,13 @@ public:
      *  @deprecated Please use FileUtils::getInstance()->setSearchPaths() instead.
      */
     AX_DEPRECATED_ATTRIBUTE void setResourceRootPath(const std::string& rootResDir);
-    
-    /** 
+
+    /**
      *  Gets the Resource root path.
-     *  @deprecated Please use FileUtils::getInstance()->getSearchPaths() instead. 
+     *  @deprecated Please use FileUtils::getInstance()->getSearchPaths() instead.
      */
     AX_DEPRECATED_ATTRIBUTE const std::string& getResourceRootPath();
-    
+
     /**
      @brief Get target platform
      */
@@ -113,7 +113,7 @@ public:
 protected:
     long _animationSpeed;  // micro second
     std::string _resourceRootPath;
-    
+
     static Application * sm_pSharedApplication;
 };
 

--- a/core/platform/wasm/Device-wasm.cpp
+++ b/core/platform/wasm/Device-wasm.cpp
@@ -41,7 +41,7 @@ int Device::getDPI()
     return static_cast<int>(160 * Device::getPixelRatio());
 }
 
-float Device::getPixelRatio() 
+float Device::getPixelRatio()
 {
     return EM_ASM_DOUBLE(return window.devicePixelRatio);
 }
@@ -70,11 +70,11 @@ Data Device::getTextureDataForText(std::string_view text, const FontDefinition& 
         var dimWidth = $4;
         var dimHeight = $5;
         var align = $6;
-        
+
         var canvas = Module.axmolSharedCanvas = Module.axmolSharedCanvas || document.createElement("canvas");
         var context = canvas.getContext("2d");
         context.font = fontSize + "px " + fontName;
-        
+
         var canvasWidth = dimWidth;
         var canvasHeight = dimHeight;
         for (var i = 0; i < lines.length; i++) {
@@ -82,7 +82,7 @@ Data Device::getTextureDataForText(std::string_view text, const FontDefinition& 
             linesWidth[i] = lineWidth;
             if (lineWidth > canvasWidth && dimWidth <= 0) {
                 canvasWidth = lineWidth;
-            }             
+            }
         };
 
         if (dimHeight <= 0) {
@@ -94,11 +94,11 @@ Data Device::getTextureDataForText(std::string_view text, const FontDefinition& 
 
         canvas.width = canvasWidth;
         canvas.height = canvasHeight;
-        
+
         context.clearRect(0, 0, canvasWidth, canvasHeight);
         context.font = fontSize + "px " + fontName;
         context.fillStyle = color;
-        context.textBaseline = "top"; 
+        context.textBaseline = "top";
 
         //Vertical top
         var offsetY = 0;
@@ -122,14 +122,14 @@ Data Device::getTextureDataForText(std::string_view text, const FontDefinition& 
             }
             context.fillText(lines[i], offsetX, offsetY + lineHeight * i);
         }
-        
+
         var data = context.getImageData(0, 0, canvasWidth, canvasHeight).data;
         var ptr = _malloc(data.byteLength); // Cocos Data object free it
         var buffer= new Uint8Array(Module.HEAPU8.buffer, ptr, data.byteLength);
         buffer.set(data);
         return ptr;
     }, text.data(), textDefinition._fontName.c_str(), textDefinition._fontSize, color, textDefinition._dimensions.width, textDefinition._dimensions.height, align);
-    
+
     width = EM_ASM_INT({
         return Module.axmolSharedCanvas.width;
     });
@@ -137,7 +137,7 @@ Data Device::getTextureDataForText(std::string_view text, const FontDefinition& 
         return Module.axmolSharedCanvas.height;
     });
     hasPremultipliedAlpha = false;
-    
+
     Data ret;
     ret.fastSet(ptr, width * height * 4);
     return ret;

--- a/core/platform/wasm/shell_minimal.html
+++ b/core/platform/wasm/shell_minimal.html
@@ -35,7 +35,7 @@
     <div class="emscripten_border">
       <div class="emscripten" id="status">Downloading...</div>
       <div class="emscripten">
-        <progress value="0" max="100" id="progress" hidden=1></progress>  
+        <progress value="0" max="100" id="progress" hidden=1></progress>
       </div>
       <canvas class="emscripten" id="canvas"  oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
     </div>
@@ -43,14 +43,14 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked,
                                                                                 document.getElementById('resize').checked)">
       |
       <input type="button" value="Pause" onclick="Module.ccall('axmol_director_pause')">
       <input type="button" value="Resume" onclick="Module.ccall('axmol_director_resume')">
       <input type="button" value="Step" onclick="Module.ccall('axmol_director_step')">
     </div>
-    
+
     <div class="emscripten">
       <textarea class="emscripten" id="output" rows="8"></textarea>
     </div>
@@ -58,7 +58,7 @@
     <script type='text/javascript'>
       var statusElement = document.getElementById('status');
       var progressElement = document.getElementById('progress');
-      
+
       var hierarchyElement = document.getElementById('hierarchy');
       var nodeProperties = [];
       for(var i = 0; i < 20; i++) {

--- a/core/platform/winrt/Application-winrt.h
+++ b/core/platform/winrt/Application-winrt.h
@@ -100,7 +100,7 @@ protected:
     LARGE_INTEGER m_nFreq;
     LARGE_INTEGER m_nLast;
     LARGE_INTEGER m_nNow;
-    
+
     std::string m_resourceRootPath;
     std::string m_startupScriptFilename;
 

--- a/core/platform/winrt/FileUtilsWinRT.cpp
+++ b/core/platform/winrt/FileUtilsWinRT.cpp
@@ -3,7 +3,7 @@ Copyright (c) 2010 cocos2d-x.org
 Copyright (c) Microsoft Open Technologies, Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/platform/winrt/FileUtilsWinRT.h
+++ b/core/platform/winrt/FileUtilsWinRT.h
@@ -3,7 +3,7 @@
  Copyright (c) Microsoft Open Technologies, Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/platform/winrt/GLViewImpl-winrt.cpp
+++ b/core/platform/winrt/GLViewImpl-winrt.cpp
@@ -3,7 +3,7 @@ Copyright (c) 2013 cocos2d-x.org
 Copyright (c) Microsoft Open Technologies, Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/platform/winrt/InputEventTypes.h
+++ b/core/platform/winrt/InputEventTypes.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 NS_AX_BEGIN
 
 
-enum class AxmolKeyEvent : int 
+enum class AxmolKeyEvent : int
 {
     Text,
     Escape,

--- a/core/platform/winrt/WICImageLoader-winrt.cpp
+++ b/core/platform/winrt/WICImageLoader-winrt.cpp
@@ -37,42 +37,42 @@ IWICImagingFactory* WICImageLoader::_wicFactory = NULL;
 
 namespace {
 
-WICConvert g_WICConvert[] = 
+WICConvert g_WICConvert[] =
 {
 	// Note target GUID in this conversion table must be one of those directly supported by cocos2d-x
 
 	{ GUID_WICPixelFormatBlackWhite,            GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
 
-	{ GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
-	{ GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
-	{ GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
-	{ GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
 
-	{ GUID_WICPixelFormat2bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM 
-	{ GUID_WICPixelFormat4bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM 
+	{ GUID_WICPixelFormat2bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
+	{ GUID_WICPixelFormat4bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
 
-	{ GUID_WICPixelFormat16bppGrayFixedPoint,   GUID_WICPixelFormat16bppGrayHalf }, // DXGI_FORMAT_R16_FLOAT 
-	{ GUID_WICPixelFormat32bppGrayFixedPoint,   GUID_WICPixelFormat32bppGrayFloat }, // DXGI_FORMAT_R32_FLOAT 
+	{ GUID_WICPixelFormat16bppGrayFixedPoint,   GUID_WICPixelFormat16bppGrayHalf }, // DXGI_FORMAT_R16_FLOAT
+	{ GUID_WICPixelFormat32bppGrayFixedPoint,   GUID_WICPixelFormat32bppGrayFloat }, // DXGI_FORMAT_R32_FLOAT
 
 	{ GUID_WICPixelFormat16bppBGR555,           GUID_WICPixelFormat16bppBGRA5551 }, // DXGI_FORMAT_B5G5R5A1_UNORM
 
 	{ GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // DXGI_FORMAT_R10G10B10A2_UNORM
 
-    { GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R8G8B8A8_UNORM 
-    { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R8G8B8A8_UNORM 
-	{ GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
-	{ GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+    { GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R8G8B8A8_UNORM
+    { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
 
     { GUID_WICPixelFormat48bppRGB,              GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R16G16B16A16_UNORM
     { GUID_WICPixelFormat48bppBGR,              GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R16G16B16A16_UNORM
 
-    { GUID_WICPixelFormat48bppRGBFixedPoint,    GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
-    { GUID_WICPixelFormat48bppBGRFixedPoint,    GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+    { GUID_WICPixelFormat48bppRGBFixedPoint,    GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+    { GUID_WICPixelFormat48bppBGRFixedPoint,    GUID_WICPixelFormat24bppRGB }, // DXGI_FORMAT_R16G16B16A16_FLOAT
 
 	//#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
 	//    { GUID_WICPixelFormat32bppRGB,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
 	//    { GUID_WICPixelFormat64bppRGB,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
-	//    { GUID_WICPixelFormat64bppPRGBAHalf,        GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	//    { GUID_WICPixelFormat64bppPRGBAHalf,        GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
 	//#endif
 
 	// We don't support n-channel formats
@@ -283,9 +283,9 @@ bool WICImageLoader::processImage(IWICBitmapDecoder* pDecoder)
 
 	if(SUCCEEDED(hr))
 	{
-		_bpp = getBitsPerPixel(_format); 
+		_bpp = getBitsPerPixel(_format);
 
-		if(NULL != pConv) 
+		if(NULL != pConv)
 		{
 			hr = pConv->GetSize((UINT*)&_width, (UINT*)&_height);
 		}
@@ -534,7 +534,7 @@ IWICImagingFactory* WICImageLoader::getWICFactory()
 		}
 	}
 
-	return _wicFactory;	
+	return _wicFactory;
 }
 
 #endif

--- a/core/platform/winrt/WICImageLoader-winrt.h
+++ b/core/platform/winrt/WICImageLoader-winrt.h
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-Based upon code from the DirectX Tool Kit by Microsoft Corporation, 
+Based upon code from the DirectX Tool Kit by Microsoft Corporation,
 obtained from https://directxtk.codeplex.com
 ****************************************************************************/
 
@@ -65,7 +65,7 @@ public:
 
 protected:
 	bool processImage(IWICBitmapDecoder* decoder);
-	size_t getBitsPerPixel(WICPixelFormatGUID format); 
+	size_t getBitsPerPixel(WICPixelFormatGUID format);
 	HRESULT convertFormatIfRequired(IWICBitmapFrameDecode* pFrame, IWICFormatConverter** ppConv);
 
 	static IWICImagingFactory* getWICFactory();

--- a/core/platform/winrt/WinRTUtils.cpp
+++ b/core/platform/winrt/WinRTUtils.cpp
@@ -281,7 +281,7 @@ bool createMappedCacheFile(const std::string& srcFilePath, std::string& cacheFil
 void destroyMappedCacheFile(const std::string& key)
 {
     auto value = UserDefault::getInstance()->getStringForKey(key.c_str());
-    
+
     if (!value.empty()) {
         FileUtils::getInstance()->removeFile(value);
     }

--- a/core/platform/winrt/xaml/AxmolRenderer.h
+++ b/core/platform/winrt/xaml/AxmolRenderer.h
@@ -34,8 +34,8 @@ class AxmolRenderer
 public:
     AxmolRenderer(int width,
                   int height,
-                  float dpi, 
-        Windows::Graphics::Display::DisplayOrientations orientation, 
+                  float dpi,
+        Windows::Graphics::Display::DisplayOrientations orientation,
         Windows::UI::Core::CoreDispatcher const& dispatcher, Windows::UI::Xaml::Controls::Panel const& panel);
     AxmolRenderer(const AxmolRenderer&) = delete;
     ~AxmolRenderer();

--- a/core/platform/winrt/xaml/OpenGLES.cpp
+++ b/core/platform/winrt/xaml/OpenGLES.cpp
@@ -40,7 +40,7 @@ OpenGLES::~OpenGLES()
 
 void OpenGLES::Initialize()
 {
-    const EGLint configAttributes[] = 
+    const EGLint configAttributes[] =
     {
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
@@ -51,9 +51,9 @@ void OpenGLES::Initialize()
         EGL_NONE
     };
 
-    const EGLint contextAttributes[] = 
-    { 
-        EGL_CONTEXT_CLIENT_VERSION, 2, 
+    const EGLint contextAttributes[] =
+    {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
         EGL_NONE
     };
 
@@ -68,14 +68,14 @@ void OpenGLES::Initialize()
 //         // Its syntax is subject to change, though. Please update your Visual Studio templates if you experience compilation issues with it.
 //         EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE,
 // #endif
-        
-        // EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that enables ANGLE to automatically call 
-        // the IDXGIDevice3::Trim method on behalf of the application when it gets suspended. 
+
+        // EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that enables ANGLE to automatically call
+        // the IDXGIDevice3::Trim method on behalf of the application when it gets suspended.
         // Calling IDXGIDevice3::Trim when an application is suspended is a Windows Store application certification requirement.
         EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
-    
+
     const EGLint fl9_3DisplayAttributes[] =
     {
         // These can be used to request ANGLE's D3D11 renderer, with D3D11 Feature Level 9_3.
@@ -102,7 +102,7 @@ void OpenGLES::Initialize()
         EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
-    
+
     EGLConfig config = NULL;
 
     // eglGetPlatformDisplayEXT is an alternative to eglGetDisplay. It allows us to pass in display attributes, used to configure D3D11.
@@ -113,15 +113,15 @@ void OpenGLES::Initialize()
     }
 
     //
-    // To initialize the display, we make three sets of calls to eglGetPlatformDisplayEXT and eglInitialize, with varying 
+    // To initialize the display, we make three sets of calls to eglGetPlatformDisplayEXT and eglInitialize, with varying
     // parameters passed to eglGetPlatformDisplayEXT:
     // 1) The first calls uses "defaultDisplayAttributes" as a parameter. This corresponds to D3D11 Feature Level 10_0+.
-    // 2) If eglInitialize fails for step 1 (e.g. because 10_0+ isn't supported by the default GPU), then we try again 
+    // 2) If eglInitialize fails for step 1 (e.g. because 10_0+ isn't supported by the default GPU), then we try again
     //    using "fl9_3DisplayAttributes". This corresponds to D3D11 Feature Level 9_3.
-    // 3) If eglInitialize fails for step 2 (e.g. because 9_3+ isn't supported by the default GPU), then we try again 
+    // 3) If eglInitialize fails for step 2 (e.g. because 9_3+ isn't supported by the default GPU), then we try again
     //    using "warpDisplayAttributes".  This corresponds to D3D11 Feature Level 11_0 on WARP, a D3D11 software rasterizer.
     //
-    
+
     // This tries to initialize EGL to D3D11 Feature Level 10_0+. See above comment for details.
     mEglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, defaultDisplayAttributes);
     if (mEglDisplay == EGL_NO_DISPLAY)
@@ -195,7 +195,7 @@ EGLSurface OpenGLES::CreateSurface(SwapChainPanel const& panel, const Size* rend
     {
         throw winrt::hresult_error(E_INVALIDARG, L"SwapChainPanel parameter is invalid");
     }
-    
+
     if (renderSurfaceSize != nullptr && resolutionScale != nullptr)
     {
         throw winrt::hresult_error(E_INVALIDARG, L"A size and a scale can't both be specified");
@@ -212,7 +212,7 @@ EGLSurface OpenGLES::CreateSurface(SwapChainPanel const& panel, const Size* rend
 //#endif
         EGL_NONE
     };
-    
+
     // Create a PropertySet and initialize with the EGLNativeWindowType.
     PropertySet surfaceCreationProperties = PropertySet();
     surfaceCreationProperties.Insert(winrt::hstring(EGLNativeWindowTypeProperty), panel);

--- a/core/renderer/CMakeLists.txt
+++ b/core/renderer/CMakeLists.txt
@@ -18,7 +18,7 @@ set(_AX_RENDERER_HEADER
     renderer/TextureCache.h
     renderer/TextureCube.h
     renderer/TrianglesCommand.h
-    
+
     renderer/backend/Backend.h
     renderer/backend/Buffer.h
     renderer/backend/CommandBuffer.h
@@ -39,8 +39,8 @@ set(_AX_RENDERER_HEADER
     renderer/backend/ShaderModule.h
     renderer/backend/Texture.h
     renderer/backend/Types.h
-    renderer/backend/VertexLayout.h    
-    
+    renderer/backend/VertexLayout.h
+
     )
 
 set(_AX_RENDERER_SRC
@@ -61,7 +61,7 @@ set(_AX_RENDERER_SRC
     renderer/TextureCube.cpp
     renderer/TrianglesCommand.cpp
     renderer/Shaders.cpp
-    
+
     renderer/backend/ProgramManager.cpp
     renderer/backend/ProgramStateRegistry.cpp
 

--- a/core/renderer/CallbackCommand.h
+++ b/core/renderer/CallbackCommand.h
@@ -59,7 +59,7 @@ public:
 
     /**
      * @brief Reset the command state for reuse
-     * 
+     *
      */
     void reset();
 

--- a/core/renderer/GroupCommand.h
+++ b/core/renderer/GroupCommand.h
@@ -77,7 +77,7 @@ public:
 
     /**
      * @brief Reset the command state for reuse
-     * 
+     *
      */
     void reset();
 

--- a/core/renderer/Material.cpp
+++ b/core/renderer/Material.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2015-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/Material.h
+++ b/core/renderer/Material.h
@@ -2,7 +2,7 @@
  Copyright (c) 2015-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/RenderCommand.cpp
+++ b/core/renderer/RenderCommand.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/RenderCommand.h
+++ b/core/renderer/RenderCommand.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/RenderState.cpp
+++ b/core/renderer/RenderState.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2014 GamePlay3D team
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
 

--- a/core/renderer/RenderState.h
+++ b/core/renderer/RenderState.h
@@ -3,7 +3,7 @@
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2014 GamePlay3D team
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
 

--- a/core/renderer/TextureAtlas.h
+++ b/core/renderer/TextureAtlas.h
@@ -5,7 +5,7 @@ Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
 https://axmol.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/TextureCache.cpp
+++ b/core/renderer/TextureCache.cpp
@@ -850,7 +850,7 @@ void VolatileTextureMgr::addImage(Texture2D* tt, Image* image)
         return;
 
     VolatileTexture* vt = findVolotileTexture(tt);
-    
+
     if(vt->_uiImage != image) {
         AX_SAFE_RELEASE(vt->_uiImage);
         image->retain();

--- a/core/renderer/TextureCache.h
+++ b/core/renderer/TextureCache.h
@@ -83,7 +83,7 @@ public:
      * @lua NA
      */
     virtual std::string getDescription() const;
-    
+
     /** Gets a 2x2 white texture  */
     Texture2D* getWhiteTexture();
 
@@ -114,7 +114,7 @@ public:
      @param filepath The file path.
      @param callback A callback function would be invoked after the image is loaded.
      @since v0.8
-     
+
      @remark Please don't invoke Texture2D::setDefaultAlphaPixelFormat in main GL thread before invoke this API.
     */
     virtual void addImageAsync(std::string_view filepath, const std::function<void(Texture2D*)>& callback);

--- a/core/renderer/TrianglesCommand.cpp
+++ b/core/renderer/TrianglesCommand.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/TrianglesCommand.h
+++ b/core/renderer/TrianglesCommand.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/backend/VertexLayout.cpp
+++ b/core/renderer/backend/VertexLayout.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/backend/VertexLayout.h
+++ b/core/renderer/backend/VertexLayout.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/renderer/backend/metal/CommandBufferMTL.h
+++ b/core/renderer/backend/metal/CommandBufferMTL.h
@@ -137,7 +137,7 @@ public:
      * @ see `drawElements(PrimitiveType primitiveType, IndexFormat indexType, unsigned int count, unsigned int offset)`
      */
     void setIndexBuffer(Buffer* buffer) override;
-    
+
     void setInstanceBuffer(Buffer* buffer) override;
 
     /**
@@ -167,7 +167,7 @@ public:
                               std::size_t count,
                               std::size_t offset,
                               bool wireframe) override;
-    
+
     void drawElementsInstanced(PrimitiveType primitiveType,
                                IndexFormat indexType,
                                std::size_t count,
@@ -200,7 +200,7 @@ public:
      * @param callback A callback to deal with pixel data read.
      */
     void readPixels(RenderTarget* rt, std::function<void(const PixelBufferDescriptor&)> callback) override;
-    
+
     id<MTLRenderCommandEncoder> getRenderCommandEncoder() const { return _mtlRenderEncoder; }
 
     id<MTLCommandBuffer> getMTLCommandBuffer() const { return _mtlCommandBuffer; }

--- a/core/renderer/backend/metal/DriverMTL.h
+++ b/core/renderer/backend/metal/DriverMTL.h
@@ -81,11 +81,11 @@ public:
     /* The max vertex attribs, it's not how many device supports which may be lower. */
     static constexpr uint32_t MAX_VERTEX_ATTRIBS = 16;
 
-    /* The vertex data buffers binding index start, the glslcc(SPIRV-Cross), default UBO binding index is 0, 
+    /* The vertex data buffers binding index start, the glslcc(SPIRV-Cross), default UBO binding index is 0,
     scope is per stage in MSL
      */
     static constexpr uint32_t VBO_BINDING_INDEX_START = 0;
-    
+
     /* The vertex instancing buffer binding index */
     static constexpr uint32_t VBO_INSTANCING_BINDING_INDEX = VBO_BINDING_INDEX_START + 1;
 

--- a/core/renderer/backend/metal/DriverMTL.mm
+++ b/core/renderer/backend/metal/DriverMTL.mm
@@ -397,7 +397,7 @@ DriverBase* DriverBase::getInstance()
     return _instance;
 }
 
-void DriverBase::destroyInstance() 
+void DriverBase::destroyInstance()
 {
     AX_SAFE_DELETE(_instance);
 }

--- a/core/renderer/backend/metal/RenderTargetMTL.mm
+++ b/core/renderer/backend/metal/RenderTargetMTL.mm
@@ -61,7 +61,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassDescriptor& par
             // We're rendering into our temporary MSAA texture and doing an automatic resolve.
             // We should not be attempting to load anything into the MSAA texture.
             assert(descriptor.colorAttachments[i].loadAction != MTLLoadActionLoad);
-            
+
             descriptor.colorAttachments[i].texture = multisampledColor[i];
             descriptor.colorAttachments[i].level = 0;
             descriptor.colorAttachments[i].slice = 0;
@@ -108,7 +108,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassDescriptor& par
         // We're rendering into our temporary MSAA texture and doing an automatic resolve.
         // We should not be attempting to load anything into the MSAA texture.
         assert(descriptor.depthAttachment.loadAction != MTLLoadActionLoad);
-        
+
         descriptor.depthAttachment.texture = multisampledDepth;
         descriptor.depthAttachment.level = 0;
         descriptor.depthAttachment.slice = 0;
@@ -121,7 +121,7 @@ void RenderTargetMTL::applyRenderPassAttachments(const RenderPassDescriptor& par
         }
     }
 #endif
-    
+
     _dirtyFlags = TargetBufferFlags::NONE;
 }
 

--- a/core/renderer/backend/metal/ShaderModuleMTL.h
+++ b/core/renderer/backend/metal/ShaderModuleMTL.h
@@ -124,9 +124,9 @@ private:
 
     hlookup::string_map<UniformInfo> _activeUniformInfos;
     hlookup::string_map<AttributeBindInfo> _attributeInfo;
-    
+
     int _attributeLocation[ATTRIBUTE_MAX];
-    
+
     int _maxLocation = -1;
     UniformInfo _builtinUniforms[UNIFORM_MAX];
 

--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -145,7 +145,7 @@ ShaderModuleMTL::ShaderModuleMTL(id<MTLDevice> mtlDevice, ShaderStage stage, std
 
                 // refl_storage_buffers: ignore
                 ibs.advance(refl.num_storage_buffers * sizeof(sgs_refl_buffer));
-                
+
                 assert(ibs.tell() - refl_data_offset == refl_size);
             }
             else
@@ -192,14 +192,14 @@ ShaderModuleMTL::~ShaderModuleMTL()
 void ShaderModuleMTL::parseAttibute(SLCReflectContext* context)
 {
     auto ibs = context->ibs;
-    
+
     for (int i = 0; i < context->refl->num_inputs; ++i)
     {
         std::string_view name = _sgs_read_name(ibs);
         auto loc = ibs->read<int32_t>();
-        
+
         ibs->advance(sizeof(sgs_refl_input) - offsetof(sgs_refl_input, semantic));
-        
+
         AttributeBindInfo attributeInfo;
         attributeInfo.location = loc;
         _attributeInfo[name]   = attributeInfo;
@@ -217,7 +217,7 @@ void ShaderModuleMTL::parseUniform(SLCReflectContext* context)
         auto ub_size_bytes = ibs->read<uint32_t>();
         ibs->advance(sizeof(sgs_refl_ub::array_size));
         auto ub_num_members = ibs->read<uint16_t>();
-        
+
         for (int k = 0; k < ub_num_members; ++k)
         {
             UniformInfo uniform;
@@ -226,7 +226,7 @@ void ShaderModuleMTL::parseUniform(SLCReflectContext* context)
             auto format     = ibs->read<uint32_t>();
             auto size_bytes = ibs->read<uint32_t>();
             auto array_size = ibs->read<uint16_t>();
-            
+
             uniform.count               = array_size;
             uniform.location            = ub_binding;
             uniform.size                = size_bytes;
@@ -250,7 +250,7 @@ void ShaderModuleMTL::parseTexture(SLCReflectContext* context)
     {
         std::string_view name = _sgs_read_name(ibs);
         auto binding = ibs->read<int32_t>();
-        
+
         ibs->advance(sizeof(sgs_refl_texture) - offsetof(sgs_refl_texture, image_dim));
 
         UniformInfo uniform;

--- a/core/renderer/backend/opengl/CommandBufferGLES2.cpp
+++ b/core/renderer/backend/opengl/CommandBufferGLES2.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
 
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,7 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
- 
+
 #include "CommandBufferGLES2.h"
 
 #if !defined(__APPLE__) && AX_TARGET_PLATFORM != AX_PLATFORM_WINRT

--- a/core/renderer/backend/opengl/CommandBufferGLES2.h
+++ b/core/renderer/backend/opengl/CommandBufferGLES2.h
@@ -1,7 +1,7 @@
 /****************************************************************************
 
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,7 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
- 
+
  #pragma once
 
 #include "CommandBufferGL.h"

--- a/core/renderer/shaders/base.glsl
+++ b/core/renderer/shaders/base.glsl
@@ -36,7 +36,7 @@
 #  define RG8_CHANNEL xy
 
 #  define FWIDTH(dist) 0.4
-    
+
 #else
 
 #  define vfloat_def(x, y) float x[y]

--- a/core/renderer/shaders/colorTexture.frag
+++ b/core/renderer/shaders/colorTexture.frag
@@ -7,7 +7,7 @@ layout(std140) uniform fs_ub {
     vec4 u_color;
 };
 
-layout(binding = 0) uniform sampler2D u_tex0; 
+layout(binding = 0) uniform sampler2D u_tex0;
 
 layout(location = SV_Target0) out vec4 FragColor;
 

--- a/core/renderer/shaders/dualSampler_hsv.frag
+++ b/core/renderer/shaders/dualSampler_hsv.frag
@@ -4,7 +4,7 @@ precision highp int;
 
 #include "colorUtils.glsl"
 
-layout(location = TEXCOORD0) in vec2 v_texCoord;  
+layout(location = TEXCOORD0) in vec2 v_texCoord;
 layout(location = COLOR0) in vec4 v_color;
 
 layout(binding = 0) uniform sampler2D u_tex0;
@@ -16,12 +16,12 @@ layout(std140) uniform fs_ub {
 
 layout(location = SV_Target0) out vec4 FragColor;
 
-void main() 
-{ 
+void main()
+{
     vec4 texColor = vec4(texture(u_tex0, v_texCoord).rgb, texture(u_tex1, v_texCoord).r);
     texColor.rgb *= texColor.a; // Premultiply with Alpha channel
-    
+
     texColor.rgb = transformHSV(texColor.rgb, u_hsv);
 
-    FragColor = texColor * v_color; 
-} 
+    FragColor = texColor * v_color;
+}

--- a/core/renderer/shaders/hsv.frag
+++ b/core/renderer/shaders/hsv.frag
@@ -4,7 +4,7 @@ precision highp int;
 
 #include "colorUtils.glsl"
 
-layout(location = TEXCOORD0) in vec2 v_texCoord;  
+layout(location = TEXCOORD0) in vec2 v_texCoord;
 layout(location = COLOR0) in vec4 v_color;
 layout(binding = 0) uniform sampler2D u_tex0;
 
@@ -14,10 +14,10 @@ layout(std140) uniform fs_ub {
 
 layout(location = SV_Target0) out vec4 FragColor;
 
-void main() 
+void main()
 {
     vec4 outColor = texture(u_tex0, v_texCoord);
     outColor.rgb = transformHSV(outColor.rgb, u_hsv);
 
-    FragColor = outColor * v_color.a; 
-} 
+    FragColor = outColor * v_color.a;
+}

--- a/core/renderer/shaders/particle.vert
+++ b/core/renderer/shaders/particle.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-                                              
+
 layout(location = POSITION) in vec4 a_position;
 layout(location = COLOR0) in vec4 a_color;
 layout(location = TEXCOORD0) in vec2 a_texCoord;

--- a/core/renderer/shaders/quadColor.vert
+++ b/core/renderer/shaders/quadColor.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-                                              
+
 layout(location = POSITION) in vec4 a_position;
 layout(location = COLOR0) in vec4 a_color;
 

--- a/core/renderer/shaders/quadTexture.vert
+++ b/core/renderer/shaders/quadTexture.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-                                              
+
 layout(location = POSITION) in vec4 a_position;
 layout(location = COLOR0) in vec4 a_color;
 layout(location = TEXCOORD0) in vec2 a_texCoord;

--- a/core/renderer/shaders/videoTextureI420.frag
+++ b/core/renderer/shaders/videoTextureI420.frag
@@ -13,7 +13,7 @@ layout(binding = 1) uniform sampler2D u_tex1; // U sample: ChromaTexture
 layout(binding = 2) uniform sampler2D u_tex2; // V sample: ChromaTexture
 
 layout(std140) uniform fs_ub {
-    mat4 colorTransform; 
+    mat4 colorTransform;
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -25,7 +25,7 @@ void main()
     YUV.x = texture(u_tex0, v_texCoord).x; // Y
     YUV.y = texture(u_tex1, v_texCoord).x; // U
     YUV.z = texture(u_tex2, v_texCoord).x; // V
-	
+
     /* Convert YUV to RGB */
     vec4 OutColor;
     OutColor.xyz = trasnformYUV(YUV, colorTransform);

--- a/core/renderer/shaders/videoTextureNV12.frag
+++ b/core/renderer/shaders/videoTextureNV12.frag
@@ -12,7 +12,7 @@ layout(binding = 0) uniform sampler2D u_tex0; // Y sample: LumaTexture
 layout(binding = 1) uniform sampler2D u_tex1; // UV sample: ChromaTexture
 
 layout(std140) uniform fs_ub {
-    mat4 colorTransform; 
+    mat4 colorTransform;
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -23,7 +23,7 @@ void main()
 
     YUV.x = texture(u_tex0, v_texCoord).x; // Y
     YUV.yz = texture(u_tex1, v_texCoord).RG8_CHANNEL; // CbCr
-	
+
     /* Convert YUV to RGB */
     vec4 OutColor;
     OutColor.xyz = trasnformYUV(YUV, colorTransform);

--- a/core/renderer/shaders/videoTextureYUY2.frag
+++ b/core/renderer/shaders/videoTextureYUY2.frag
@@ -11,7 +11,7 @@ layout(binding = 0) uniform sampler2D u_tex0; // Y sample
 layout(binding = 1) uniform sampler2D u_tex1; // UV sample
 
 layout(std140) uniform fs_ub {
-    mat4 colorTransform; 
+    mat4 colorTransform;
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -19,7 +19,7 @@ layout(location = SV_Target0) out vec4 FragColor;
 void main()
 {
     vec3 YUV;
-    
+
     /* For dual sampler */
     YUV.x = texture(u_tex0, v_texCoord).x;
     YUV.yz = texture(u_tex1, v_texCoord).yw;

--- a/core/ui/CMakeLists.txt
+++ b/core/ui/CMakeLists.txt
@@ -108,7 +108,7 @@ elseif(ANDROID)
         # it's special for android, not a common file
         ui/UIWebView/UIWebView.cpp
         )
- 
+
 endif()
 
 if(AX_ENABLE_MEDIA)

--- a/core/ui/UIEditBox/Mac/UIMultilineTextField.m
+++ b/core/ui/UIEditBox/Mac/UIMultilineTextField.m
@@ -1,19 +1,19 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 zilongshanren
- 
+
  https://axmol.dev/
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,7 +38,7 @@
 -(void)dealloc
 {
     self.placeHolder = nil;
-    
+
     [super dealloc];
 }
 

--- a/core/ui/UIEditBox/Mac/UIPasswordTextField.m
+++ b/core/ui/UIEditBox/Mac/UIPasswordTextField.m
@@ -1,19 +1,19 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 zilongshanren
- 
+
  https://axmol.dev/
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -112,7 +112,7 @@
     if (self = [super initWithFrame:frameRect]) {
         [self setLineBreakMode:NSLineBreakByTruncatingTail];
     }
-    
+
     return self;
 }
 

--- a/core/ui/UIEditBox/Mac/UISingleLineTextField.m
+++ b/core/ui/UIEditBox/Mac/UISingleLineTextField.m
@@ -1,19 +1,19 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 zilongshanren
- 
+
  https://axmol.dev/
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,7 +39,7 @@
 {
     // Get the parent's idea of where we should draw
     NSRect newRect = [super drawingRectForBounds:theRect];
-    
+
     // When the text field is being
     // edited or selected, we have to turn off the magic because it screws up
     // the configuration of the field editor.  We sneak around this by
@@ -49,7 +49,7 @@
     {
         // Get our ideal size for current text
         NSSize textSize = [self cellSizeForBounds:theRect];
-        
+
         // Center that in the proposed rect
         float heightDelta = newRect.size.height - textSize.height;
         if (heightDelta > 0)
@@ -58,7 +58,7 @@
             newRect.origin.y += (heightDelta / 2);
         }
     }
-    
+
     return newRect;
 }
 
@@ -108,7 +108,7 @@
     if ([super initWithFrame:frameRect]) {
         [self setLineBreakMode:NSLineBreakByTruncatingTail];
     }
-    
+
     return self;
 }
 

--- a/core/ui/UIEditBox/Mac/UITextFieldFormatter.m
+++ b/core/ui/UIEditBox/Mac/UITextFieldFormatter.m
@@ -1,19 +1,19 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 zilongshanren
- 
+
  https://axmol.dev/
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,7 +37,7 @@
     if (self) {
         _maximumLength = INT_MAX;
     }
-    
+
     return self;
 }
 

--- a/core/ui/UIEditBox/UIEditBox.cpp
+++ b/core/ui/UIEditBox/UIEditBox.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2012 James Chen
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBox.h
+++ b/core/ui/UIEditBox/UIEditBox.h
@@ -3,7 +3,7 @@
  Copyright (c) 2012 James Chen
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-android.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-android.h
@@ -3,7 +3,7 @@
  Copyright (c) 2012 James Chen
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -4,7 +4,7 @@
  Copyright (c) 2013-2015 zilongshanren
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -4,7 +4,7 @@
  Copyright (c) 2013-2015 zilongshanren
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -3,7 +3,7 @@
  Copyright (c) 2012 James Chen
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/core/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -4,7 +4,7 @@
  Copyright (c) 2013-2015 zilongshanren
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-linux.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-linux.cpp
@@ -3,7 +3,7 @@
  Copyright (c) 2015 hanxi
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -210,7 +210,7 @@ static void dialogFocusOutCallback(GtkWidget* widget, gpointer user_data)
 static bool load_gtk3() {
     static bool s_loaded = false;
     static void* gtk3 = 0;
-    
+
     if(!s_loaded) {
         s_loaded = true;
 

--- a/core/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -3,7 +3,7 @@
  Copyright (c) 2015 hanxi
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -3,7 +3,7 @@
  Copyright (c) 2012 Jozef Pridavok
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/core/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -3,7 +3,7 @@
  Copyright (c) 2012 Jozef Pridavok
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-stub.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-stub.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIEditBox/UIEditBoxImpl-wasm.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-wasm.cpp
@@ -153,7 +153,7 @@ void EditBoxImplWasm::setNativeVisible(bool visible)
 {
     EM_ASM({
         var input = Module.axmolSharedInput = Module.axmolSharedInput || document.createElement("input");
-        
+
         if ($0 == 0)
             input.style.display = "none";
         else
@@ -172,7 +172,7 @@ void EditBoxImplWasm::setNativeVisible(bool visible)
                     input.type = 'password';
                 }
             }
-            
+
             input.style.display = "";
             var canvas = document.getElementById('canvas');
             var inputParent = input.parentNode;
@@ -212,7 +212,7 @@ void EditBoxImplWasm::nativeOpenKeyboard()
     _activeEditBox = this;
 
     this->editBoxEditingDidBegin();
-    
+
     EM_ASM({
         var input = Module.axmolSharedInput = Module.axmolSharedInput || document.createElement("input");
         // sync input value from native and focus

--- a/core/ui/UIEditBox/UIEditBoxImpl-wasm.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-wasm.h
@@ -66,7 +66,7 @@ public:
     bool isEditingMode() const { return _editingMode; }
 private:
     void createEditCtrl(EditBox::InputMode inputMode);
-    
+
     static bool s_isInitialized;
     static int s_editboxChildID;
     static void lazyInit();

--- a/core/ui/UIEditBox/UIEditBoxImpl.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl.h
@@ -3,7 +3,7 @@
  Copyright (c) 2012 James Chen
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIHBox.h
+++ b/core/ui/UIHBox.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UILayout.cpp
+++ b/core/ui/UILayout.cpp
@@ -448,7 +448,7 @@ void Layout::setStencilClippingSize(const Vec2& /*size*/)
     if (_clippingEnabled && _clippingType == ClippingType::STENCIL)
     {
         _clippingStencil->clear();
-        _clippingStencil->drawSolidRect(Vec2::ZERO, _contentSize, Color4F::GREEN);  // Fix issue #1546 
+        _clippingStencil->drawSolidRect(Vec2::ZERO, _contentSize, Color4F::GREEN);  // Fix issue #1546
     }
 }
 

--- a/core/ui/UILayoutManager.h
+++ b/core/ui/UILayoutManager.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UILayoutParameter.cpp
+++ b/core/ui/UILayoutParameter.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UILayoutParameter.h
+++ b/core/ui/UILayoutParameter.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIRelativeBox.cpp
+++ b/core/ui/UIRelativeBox.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIScrollViewBar.cpp
+++ b/core/ui/UIScrollViewBar.cpp
@@ -154,7 +154,7 @@ void ScrollViewBar::setAutoHideEnabled(bool autoHideEnabled)
 {
     if (_autoHideEnabled == autoHideEnabled)
         return;
-    
+
     _autoHideEnabled = autoHideEnabled;
     if (!_autoHideEnabled)
     {

--- a/core/ui/UIVBox.cpp
+++ b/core/ui/UIVBox.cpp
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIVBox.h
+++ b/core/ui/UIVBox.h
@@ -2,7 +2,7 @@
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIWebView/UIWebView-inl.h
+++ b/core/ui/UIWebView/UIWebView-inl.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIWebView/UIWebView.mm
+++ b/core/ui/UIWebView/UIWebView.mm
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIWebView/UIWebViewImpl-android.h
+++ b/core/ui/UIWebView/UIWebViewImpl-android.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIWebView/UIWebViewImpl-ios.h
+++ b/core/ui/UIWebView/UIWebViewImpl-ios.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIWebView/UIWebViewImpl-ios.mm
+++ b/core/ui/UIWebView/UIWebViewImpl-ios.mm
@@ -2,7 +2,7 @@
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/core/ui/UIWebView/UIWebViewImpl-win32.h
+++ b/core/ui/UIWebView/UIWebViewImpl-win32.h
@@ -2,7 +2,7 @@
  Copyright (c) 2014 cocos2d-x.org
  Author: Jeff Wang <wohaaitinciu@gmail.com>
  Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
- 
+
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This PR only trims trailing whitespace for source files in `core` folder. I skipped `*.java` files since I think Android Studio likes to litter it with whitespace, but I can make a PR that cleans those files too.

You can reject this PR if you don't think it's worth the noise, but I think it would be nice to get rid of these annoyances.