### PR TITLE
Node: fix `setPosition()` and `setPositionNormalized()` not switching normalized mode if positions match

### DIFF
--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -522,7 +522,7 @@ void Node::getPosition(float* x, float* y) const
 
 void Node::setPosition(float x, float y)
 {
-    if (_position.x == x && _position.y == y)
+    if (_position.x == x && _position.y == y && !_usingNormalizedPosition)
         return;
 
     _position.x = x;
@@ -587,7 +587,7 @@ const Vec2& Node::getPositionNormalized() const
 /// position setter
 void Node::setPositionNormalized(const Vec2& position)
 {
-    if (_normalizedPosition.equals(position))
+    if (_normalizedPosition.equals(position) && _usingNormalizedPosition)
         return;
 
     _normalizedPosition      = position;

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -43,6 +43,8 @@ set(GAME_SOURCE
     Source/AppDelegate.cpp
     Source/TestUtils.cpp
 
+    Source/core/2d/NodeTests.cpp
+
     Source/core/base/MapTests.cpp
     Source/core/base/UTF8Tests.cpp
     Source/core/base/UtilsTests.cpp

--- a/tests/unit-tests/Source/core/2d/NodeTests.cpp
+++ b/tests/unit-tests/Source/core/2d/NodeTests.cpp
@@ -1,0 +1,62 @@
+/****************************************************************************
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+ https://axmol.dev/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#include <doctest.h>
+#include <float.h>
+#include "2d/Node.h"
+
+using namespace ax;
+
+TEST_SUITE("2d/Node") {
+    TEST_CASE("normalized_position") {
+        auto parent = Node();
+        auto node = Node();
+
+        parent.setContentSize(Vec2(200.0f, 100.0f));
+        node.setParent(&parent);
+        CHECK_EQ(0.0f, node.getPosition().x);
+        CHECK_EQ(0.0f, node.getPosition().y);
+        CHECK_EQ(0.0f, node.getNormalizedPosition().x);
+        CHECK_EQ(0.0f, node.getNormalizedPosition().y);
+
+        node.setPositionNormalized({0.5f, 0.5f});
+        node.visit(nullptr, Mat4::IDENTITY, Node::FLAGS_CONTENT_SIZE_DIRTY);
+        CHECK_EQ(100.0f, node.getPosition().x);
+        CHECK_EQ(50.0f, node.getPosition().y);
+        CHECK_EQ(0.5f, node.getNormalizedPosition().x);
+        CHECK_EQ(0.5f, node.getNormalizedPosition().y);
+
+        parent.setContentSize(Vec2(400.0f, 200.0f));
+        node.setPosition(100.0f, 50.0f);
+        node.visit(nullptr, Mat4::IDENTITY, Node::FLAGS_CONTENT_SIZE_DIRTY);
+        CHECK_EQ(100.0f, node.getPosition().x);
+        CHECK_EQ(50.0f, node.getPosition().y);
+
+        node.setPosition(0.0f, 0.0f);
+        node.setPositionNormalized({0.5f, 0.5f});
+        node.visit(nullptr, Mat4::IDENTITY, Node::FLAGS_CONTENT_SIZE_DIRTY);
+        CHECK_EQ(200.0f, node.getPosition().x);
+        CHECK_EQ(100.0f, node.getPosition().y);
+    }
+}


### PR DESCRIPTION
This fixes two bugs where `Node::setPosition()` and `Node::setPositionNormalized()` doesn't turn on or off normalized position mode if position being set is same as current position.