### PR TITLE
Fix custom shader output

### DIFF
--- a/core/renderer/TrianglesCommand.cpp
+++ b/core/renderer/TrianglesCommand.cpp
@@ -68,7 +68,7 @@ void TrianglesCommand::init(float globalOrder,
         blendDescriptor.sourceRGBBlendFactor = blendDescriptor.sourceAlphaBlendFactor = blendType.src;
         blendDescriptor.destinationRGBBlendFactor = blendDescriptor.destinationAlphaBlendFactor = blendType.dst;
 
-        if (_batchId == -1)
+        if (_batchId == std::numeric_limits<uint64_t>::max())
             setSkipBatching(true);
 
         if (!isSkipBatching())

--- a/core/renderer/TrianglesCommand.h
+++ b/core/renderer/TrianglesCommand.h
@@ -119,7 +119,7 @@ protected:
 
     // Cached value to determine to generate material id or not.
     BlendFunc _blendType              = BlendFunc::DISABLE;
-    uint64_t _batchId                 = 0;
+    uint64_t _batchId                 = std::numeric_limits<uint64_t>::max();
     backend::TextureBackend* _texture = nullptr;
 };
 

--- a/core/renderer/backend/Program.h
+++ b/core/renderer/backend/Program.h
@@ -152,7 +152,7 @@ public:
      * Get program id.
      * @return The program id.
      */
-    int64_t getProgramId() const { return _programId; }
+    uint64_t getProgramId() const { return _programId; }
 
     /**
      * Get uniform buffer size in bytes that can hold all the uniforms.

--- a/core/renderer/backend/ProgramManager.h
+++ b/core/renderer/backend/ProgramManager.h
@@ -157,9 +157,9 @@ protected:
     };
 
     BuiltinRegInfo _builtinRegistry[(int)backend::ProgramType::BUILTIN_COUNT];
-    std::unordered_map<int64_t, BuiltinRegInfo> _customRegistry;
+    std::unordered_map<uint64_t, BuiltinRegInfo> _customRegistry;
 
-    std::unordered_map<int64_t, Program*> _cachedPrograms;  ///< The cached program object.
+    std::unordered_map<uint64_t, Program*> _cachedPrograms;  ///< The cached program object.
 
     XXH64_state_s* _programIdGen;
 

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -399,7 +399,7 @@ protected:
     VertexLayout* _vertexLayout = nullptr;
     bool _ownVertexLayout       = false;
 
-    uint64_t _batchId = -1;
+    uint64_t _batchId = std::numeric_limits<uint64_t>::max();
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     EventListenerCustom* _backToForegroundListener = nullptr;


### PR DESCRIPTION
## Describe your changes

The batch ID and program ID should be `uint64_t`, but in places they were being used as `int64_t`, causing incorrect results of conditional statements that check if batching should be enabled.

This fixes the issue of incorrect output when the same custom shader is used on multiple sprites.

## Issue ticket number and link
#2104 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
