### PR TITLE
Resolve issue with widget positioning when using normalized coordinates

### DIFF
--- a/core/ui/UIWidget.h
+++ b/core/ui/UIWidget.h
@@ -271,7 +271,6 @@ public:
      * @lua NA
      */
     virtual void addCCSEventListener(const ccWidgetEventCallback& callback);
-    /**/
 
     /**
      * Changes the position (x,y) of the widget in OpenGL coordinates
@@ -282,6 +281,12 @@ public:
      * @param pos  The position (x,y) of the widget in OpenGL coordinates
      */
     virtual void setPosition(const Vec2& pos) override;
+
+    /** Sets the position (x,y) using values between 0 and 1.
+     *
+     * @param position The normalized position (x,y) of the node, using value between 0 and 1.
+     */
+    void setPositionNormalized(const Vec2& position) override;
 
     /**
      * Set the percent(x,y) of the widget in OpenGL coordinates


### PR DESCRIPTION
## Describe your changes
If widget nodes use normalized positioning, then that normalized positioning should be used for calculations, and should not be overriden by pixel positioning.  This resolves the incorrect child widget positioning that appeared due to the recent unrelated fixes in PR #2102

Add the `Widget::setPositionNormalized(const Vec2& position)` override to ensure it behaves the same as `Widget::setPosition()`.

## Issue ticket number and link
#2108 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
