### PR TITLE
Remove unreferenced sprite from test scene

### DIFF
--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
-
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+ 
  https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
@@ -421,7 +421,7 @@ void RenderTextureZbuffer::renderScreenShot()
     this->addChild(sprite, 999999);
     sprite->setColor(Color3B::GREEN);
 
-    sprite->runAction(Sequence::create(FadeTo::create(2, 0), Hide::create(), nullptr));
+    sprite->runAction(Sequence::create(FadeTo::create(2, 0), RemoveSelf::create(), nullptr));
 }
 
 RenderTexturePartTest::RenderTexturePartTest()


### PR DESCRIPTION
## Describe your changes

For the `RenderTextureZbuffer` test, a new sprite is created every time the touch event ends, and then an action fades it to 0 opacity, but it remains in the scene.  This ends up using more and more memory as more sprites are created.

Since the sprite is no longer required in the scene, then it should be removed.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
