### PR TITLE
Set RenderTexture content size on creation

### DIFF
--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -166,6 +166,8 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         h                          = (int)(h * AX_CONTENT_SCALE_FACTOR());
         _fullviewPort              = Rect(0, 0, w, h);
 
+        setContentSize(Vec2(static_cast<float>(w), static_cast<float>(h)));
+        
         // textures must be power of two squared
         int powW = 0;
         int powH = 0;


### PR DESCRIPTION
## Describe your changes
Currently, when a `RenderTexture` is created, its content size remains as `0,0`, so the only way to get the size of the `RenderTexture` is to call `RenderTexture->getSprite()->getContentSize()`.  I'm not sure why this was never set, but the change in this PR ensures that the content size of the `RenderTexture` is set on creation.

This PR should not affect the current behavior of the `RenderTexture` in any way.

## Issue ticket number and link
#2045 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
