### PR TITLE
Update sweep.h  (fix invalid UTF-8)

### DIFF
--- a/3rdparty/poly2tri/sweep/sweep.h
+++ b/3rdparty/poly2tri/sweep/sweep.h
@@ -33,7 +33,7 @@
  * Zalik, B.(2008)'Sweep-line algorithm for constrained Delaunay triangulation',
  * International Journal of Geographical Information Science
  *
- * "FlipScan" Constrained Edge Algorithm invented by Thomas Åhlén, thahlen@gmail.com
+ * "FlipScan" Constrained Edge Algorithm invented by Thomas Ahlen, thahlen@gmail.com
  */
 
 #pragma once


### PR DESCRIPTION
## Describe your changes
fix invalid UTF-8

Fix this warning:
\axmol\3rdparty\poly2tri\sweep\sweep.h(1,1): warning C4828: The file contains a character starting at offset 0x773 that is illegal in the current source character set (codepage 65001).
\axmol\3rdparty\poly2tri\sweep\sweep.h(1,1): warning C4828: The file contains a character starting at offset 0x776 that is illegal in the current source character set (codepage 65001).


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
