### PR TITLE
Fix for incorrect bits per pixel set on texture reload

### DIFF
--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1325,7 +1325,7 @@ void Director::createStatsLabel()
         return;
     }
 
-    texture = _textureCache->addImage(image, "/ax_fps_images", PixelFormat::RGBA4);
+    texture = _textureCache->addImage(image, "/ax_fps_images", image->getPixelFormat());
     AX_SAFE_RELEASE(image);
 
     /*

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1325,7 +1325,7 @@ void Director::createStatsLabel()
         return;
     }
 
-    texture = _textureCache->addImage(image, "/ax_fps_images", image->getPixelFormat());
+    texture = _textureCache->addImage(image, "/ax_fps_images", PixelFormat::RGBA4);
     AX_SAFE_RELEASE(image);
 
     /*

--- a/core/renderer/Texture2D.cpp
+++ b/core/renderer/Texture2D.cpp
@@ -334,7 +334,7 @@ bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
     }
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    VolatileTextureMgr::findVolotileTexture(this);
+    VolatileTextureMgr::getOrAddVolatileTexture(this);
 #endif
 
     backend::TextureDescriptor textureDescriptor;

--- a/core/renderer/TextureCache.cpp
+++ b/core/renderer/TextureCache.cpp
@@ -861,7 +861,7 @@ void VolatileTextureMgr::addImage(Texture2D* tt, Image* image)
     }
 }
 
-VolatileTexture* VolatileTextureMgr::findVolotileTexture(Texture2D* tt)
+VolatileTexture* VolatileTextureMgr::getOrAddVolatileTexture(Texture2D* tt)
 {
     VolatileTexture* vt = nullptr;
     for (const auto& texture : _textures)

--- a/core/renderer/TextureCache.cpp
+++ b/core/renderer/TextureCache.cpp
@@ -838,7 +838,7 @@ void VolatileTextureMgr::addImageTexture(Texture2D* tt, std::string_view imageFi
         return;
     }
 
-    VolatileTexture* vt = findVolotileTexture(tt);
+    VolatileTexture* vt = getOrAddVolatileTexture(tt);
 
     vt->_cashedImageType = VolatileTexture::kImageFile;
     vt->_fileName        = imageFileName;
@@ -850,7 +850,7 @@ void VolatileTextureMgr::addImage(Texture2D* tt, Image* image)
     if (tt == nullptr || image == nullptr)
         return;
 
-    VolatileTexture* vt = findVolotileTexture(tt);
+    VolatileTexture* vt = getOrAddVolatileTexture(tt);
 
     if(vt->_uiImage != image) {
         AX_SAFE_RELEASE(vt->_uiImage);
@@ -894,7 +894,7 @@ void VolatileTextureMgr::addDataTexture(Texture2D* tt,
         return;
     }
 
-    VolatileTexture* vt = findVolotileTexture(tt);
+    VolatileTexture* vt = getOrAddVolatileTexture(tt);
 
     vt->_cashedImageType = VolatileTexture::kImageData;
     vt->_textureData     = data;
@@ -910,7 +910,7 @@ void VolatileTextureMgr::addStringTexture(Texture2D* tt, std::string_view text, 
         return;
     }
 
-    VolatileTexture* vt = findVolotileTexture(tt);
+    VolatileTexture* vt = getOrAddVolatileTexture(tt);
 
     vt->_cashedImageType = VolatileTexture::kString;
     vt->_text            = text;

--- a/core/renderer/TextureCache.h
+++ b/core/renderer/TextureCache.h
@@ -313,7 +313,8 @@ public:
 
     // find VolatileTexture by Texture2D*
     // if not found, create a new one
-    static VolatileTexture* findVolotileTexture(Texture2D* tt);
+    AX_DEPRECATED(2.2) VolatileTexture* findVolotileTexture(Texture2D* tt) { return getOrAddVolatileTexture(tt); }
+    VolatileTexture* getOrAddVolatileTexture(Texture2D* tt);
 
 private:
     static void reloadTexture(Texture2D* texture, std::string_view filename, backend::PixelFormat pixelFormat);

--- a/core/renderer/TextureCache.h
+++ b/core/renderer/TextureCache.h
@@ -313,8 +313,8 @@ public:
 
     // find VolatileTexture by Texture2D*
     // if not found, create a new one
-    AX_DEPRECATED(2.2) VolatileTexture* findVolotileTexture(Texture2D* tt) { return getOrAddVolatileTexture(tt); }
-    VolatileTexture* getOrAddVolatileTexture(Texture2D* tt);
+    AX_DEPRECATED(2.2) static VolatileTexture* findVolotileTexture(Texture2D* tt) { return getOrAddVolatileTexture(tt); }
+    static VolatileTexture* getOrAddVolatileTexture(Texture2D* tt);
 
 private:
     static void reloadTexture(Texture2D* texture, std::string_view filename, backend::PixelFormat pixelFormat);

--- a/core/renderer/backend/Texture.cpp
+++ b/core/renderer/backend/Texture.cpp
@@ -36,8 +36,13 @@ void TextureBackend::updateTextureDescriptor(const ax::backend::TextureDescripto
     _textureType   = descriptor.textureType;
     _textureFormat = descriptor.textureFormat;
     _textureUsage  = descriptor.textureUsage;
-    _width         = descriptor.width;
-    _height        = descriptor.height;
+    _width        = (std::max)(descriptor.width, (uint32_t)1);
+    _height       = (std::max)(descriptor.height, (uint32_t)1);
+
+    if (_bitsPerPixel == 0)
+    {
+        _bitsPerPixel = (uint8_t)(8 * 4);
+    }
 }
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -168,17 +168,9 @@ void Texture2DGL::initWithZeros()
     // FIXME: Don't call at Texture2DGL::updateTextureDescriptor, when the texture is compressed, initWithZeros will
     // cause GL Error: 0x501 We call at here once to ensure depth buffer works well. Ensure the final data size at least
     // 4 byte
-
-    _width        = (std::max)(_width, (uint32_t)1);
-    _height       = (std::max)(_height, (uint32_t)1);
-
-    constexpr auto maxBitsPerPixel = (uint8_t)(8 * 4);
-    if (_bitsPerPixel == 0)
-    {
-        _bitsPerPixel = maxBitsPerPixel;
-    }
-
     auto size     = _width * _height * _bitsPerPixel / 8;
+    assert(size > 0);
+
     uint8_t* data = (uint8_t*)malloc(size);
     memset(data, 0, size);
     updateData(data, _width, _height, 0);

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -171,7 +171,12 @@ void Texture2DGL::initWithZeros()
 
     _width        = (std::max)(_width, (uint32_t)1);
     _height       = (std::max)(_height, (uint32_t)1);
-    _bitsPerPixel = (std::max)(_bitsPerPixel, (uint8_t)(8 * 4));
+
+    constexpr auto maxBitsPerPixel = (uint8_t)(8 * 4);
+    if (_bitsPerPixel > maxBitsPerPixel || _bitsPerPixel == 0)
+    {
+        _bitsPerPixel = maxBitsPerPixel;
+    }
 
     auto size     = _width * _height * _bitsPerPixel / 8;
     uint8_t* data = (uint8_t*)malloc(size);

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -173,7 +173,7 @@ void Texture2DGL::initWithZeros()
     _height       = (std::max)(_height, (uint32_t)1);
 
     constexpr auto maxBitsPerPixel = (uint8_t)(8 * 4);
-    if (_bitsPerPixel > maxBitsPerPixel || _bitsPerPixel == 0)
+    if (_bitsPerPixel == 0)
     {
         _bitsPerPixel = maxBitsPerPixel;
     }


### PR DESCRIPTION
## Describe your changes

~~The pixel format of the FPS texture was being set incorrectly, which ended up crashing Android applications after attempting to recover from a GL context loss.~~

~~The change made simply fixes the pixel format of that texture entry in the texture cache.~~

The true cause of the issue was the bits per pixel setting of the cached texture being overwritten during recovery from the GL context loss.

## Issue ticket number and link
#2126 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
