### PR TITLE
[Android] RenderTexture data needs to be saved to the cache before the GLSurfaceView context is lost

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -248,6 +248,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
         paused = true;
         super.onPause();
         AxmolEngine.onPause();
+        mGLSurfaceView.onPause();
         mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
     }
 
@@ -255,7 +256,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     protected void onStop() {
         super.onStop();
         rendererPaused = true;
-        mGLSurfaceView.onPause();
+        mGLSurfaceView.onStop();
     }
 
     @Override
@@ -314,7 +315,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
         // AxmolGLSurfaceView
         this.mGLSurfaceView = this.onCreateView();
-        this.mGLSurfaceView.setPreserveEGLContextOnPause(true);
+        this.mGLSurfaceView.setPreserveEGLContextOnPause(false);
 
         // ...add to FrameLayout
         mFrameLayout.addView(this.mGLSurfaceView);

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -315,7 +315,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
         // AxmolGLSurfaceView
         this.mGLSurfaceView = this.onCreateView();
-        this.mGLSurfaceView.setPreserveEGLContextOnPause(false);
+        this.mGLSurfaceView.setPreserveEGLContextOnPause(true);
 
         // ...add to FrameLayout
         mFrameLayout.addView(this.mGLSurfaceView);

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -203,6 +203,9 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
                 AxmolGLSurfaceView.this.mRenderer.handleOnPause();
             }
         });
+    }
+
+    public void onStop() {
         super.onPause();
     }
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -188,6 +188,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
     @Override
     public void onResume() {
         if (mPaused) {
+            mPaused = false;
             super.onResume();
             this.queueEvent(new Runnable() {
                 @Override

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -62,6 +62,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
     private boolean mMultipleTouchEnabled = true;
+    private boolean mPaused = true;
 
     public boolean isSoftKeyboardShown() {
         return mSoftKeyboardShown;
@@ -186,13 +187,15 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public void onResume() {
-        super.onResume();
-        this.queueEvent(new Runnable() {
-            @Override
-            public void run() {
-                AxmolGLSurfaceView.this.mRenderer.handleOnResume();
-            }
-        });
+        if (mPaused) {
+            super.onResume();
+            this.queueEvent(new Runnable() {
+                @Override
+                public void run() {
+                    AxmolGLSurfaceView.this.mRenderer.handleOnResume();
+                }
+            });
+        }
     }
 
     @Override
@@ -206,6 +209,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
     }
 
     public void onStop() {
+        mPaused = true;
         super.onPause();
     }
 


### PR DESCRIPTION
## Describe your changes

If we set `this.mGLSurfaceView.setPreserveEGLContextOnPause(false);` to test for GL context loss, and put the application into the background so it is no longer visible, the GL context is destroyed before the `RenderTexture` data is saved into the cache.  When the application is brought back to the foreground, the `RenderTexture` instances that are recovered are all blank.

This PR changes the behavior to the following:

AxmolAcitivity.onPause() is called
AxmolGLSurfaceView.onPause() is called (we do NOT call `super.onPause();` in this override)
`EVENT_COME_TO_BACKGROUND` is broadcast
`RenderTexture::listenToBackground(EventCustom* /*event*/)` is called to save texture data in the cache

Now, if the `Activity.onStop()` is also called, meaning the application should no longer be visible, then we call a new method named `AxmolGLSurfaceView.onStop()`.  Inside this method we call `super.onPause()`, which contains the logic that can destroy the GL context.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
