### PR TITLE
Fix RenderTargetGL FBO not recreate when recv EVENT_RENDERER_RECREATED

### DIFF
--- a/core/renderer/backend/opengl/RenderTargetGL.cpp
+++ b/core/renderer/backend/opengl/RenderTargetGL.cpp
@@ -34,6 +34,14 @@ RenderTargetGL::RenderTargetGL(bool defaultRenderTarget, DriverGL* driver) : Ren
     if (!defaultRenderTarget)
     {
         glGenFramebuffers(1, &_FBO);
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+        _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
+            glGenFramebuffers(1, &_FBO);
+            _dirtyFlags = TargetBufferFlags::ALL;
+        });
+        Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener,
+                                                                                         -1);
+#endif
     }
     else
     {
@@ -44,6 +52,10 @@ RenderTargetGL::~RenderTargetGL()
 {
     if (!_defaultRenderTarget)
     {
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+        Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
+#endif
+
         bindFrameBuffer();
 
         for (auto slot = 0; slot < MAX_COLOR_ATTCHMENT; ++slot)

--- a/core/renderer/backend/opengl/RenderTargetGL.h
+++ b/core/renderer/backend/opengl/RenderTargetGL.h
@@ -23,6 +23,9 @@ public:
 
 public:
     GLuint _FBO = 0;
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    EventListenerCustom* _rendererRecreatedListener{nullptr};
+#endif
 };
 
 NS_AX_BACKEND_END

--- a/core/renderer/backend/opengl/TextureGL.cpp
+++ b/core/renderer/backend/opengl/TextureGL.cpp
@@ -138,10 +138,11 @@ Texture2DGL::Texture2DGL(const TextureDescriptor& descriptor)
     updateTextureDescriptor(descriptor);
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    // Listen this event to restored texture id after coming to foreground on Android.
+    // Listen this event to restored texture id after coming to foreground on GLES.
     _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
         _textureInfo.onRendererRecreated(GL_TEXTURE_2D);
-        this->initWithZeros();
+        if (_usedForRT)
+            this->ensureTexStorageForRT();
     });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
@@ -156,18 +157,17 @@ void Texture2DGL::updateTextureDescriptor(const ax::backend::TextureDescriptor& 
 
     updateSamplerDescriptor(descriptor.samplerDescriptor);
 
-    if (descriptor.textureUsage == TextureUsage::RENDER_TARGET)
-        initWithZeros();
+    const bool useForRT = descriptor.textureUsage == TextureUsage::RENDER_TARGET;
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+    _usedForRT = useForRT;
+#endif
+    if(useForRT) {
+        ensureTexStorageForRT();
+    }
 }
 
-void Texture2DGL::initWithZeros()
+void Texture2DGL::ensureTexStorageForRT()
 {
-    // !!!Only used for depth stencil render buffer
-    // For example, a texture used as depth buffer will not invoke updateData(), see cpp-tests 'Effect Basic/Effects
-    // Advanced'.
-    // FIXME: Don't call at Texture2DGL::updateTextureDescriptor, when the texture is compressed, initWithZeros will
-    // cause GL Error: 0x501 We call at here once to ensure depth buffer works well. Ensure the final data size at least
-    // 4 byte
     auto size     = _width * _height * _bitsPerPixel / 8;
     assert(size > 0);
 

--- a/core/renderer/backend/opengl/TextureGL.h
+++ b/core/renderer/backend/opengl/TextureGL.h
@@ -203,13 +203,14 @@ public:
     int getCount() const override { return _textureInfo.maxIdx + 1; }
 
 private:
-    void initWithZeros();
+    void ensureTexStorageForRT();
 
     TextureInfoGL _textureInfo;
     EventListener* _rendererRecreatedListener = nullptr;
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     bool _generateMipmaps = false;
+    bool _usedForRT = false;
 #endif
 };
 


### PR DESCRIPTION
Improve code style ensure tex storage for render target attachment

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
