### PR TITLE
ActionManagerTests CrashTest refinment. 

### DIFF
--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
@@ -68,7 +68,7 @@ std::string ActionManagerTest::subtitle() const
 
 //------------------------------------------------------------------
 //
-// Test1
+// CrashTest
 //
 //------------------------------------------------------------------
 
@@ -125,12 +125,12 @@ void CrashTest::logCbkAfterFadeOut()
 
 std::string CrashTest::subtitle() const
 {
-    return "Test 1. Should not crash";
+    return "CrashTest. Remove Node during ongoing ActionInterval. AXMOL must not crash.";
 }
 
 //------------------------------------------------------------------
 //
-// Test2
+// LogicTest
 //
 //------------------------------------------------------------------
 void LogicTest::onEnter()

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
@@ -76,23 +76,23 @@ void CrashTest::onEnter()
 {
     ActionManagerTest::onEnter();
 
-    auto l = Label::createWithTTF("Remove Node during ongoing ActionInterval. AXMOL must not crash.", "fonts/Thonburi.ttf", 16.0f);
-    addChild(l);
-    l->setPosition(VisibleRect::center().x, VisibleRect::top().y - 75);
+    auto explanationLabel = Label::createWithTTF("Remove Node during ongoing ActionInterval. AXMOL must not crash.", "fonts/Thonburi.ttf", 16.0f);
+    addChild(explanationLabel);
+    explanationLabel->setPosition(VisibleRect::center().x, VisibleRect::top().y - 75);
 
-    auto child = Sprite::create(s_pathGrossini);
-    child->setPosition(VisibleRect::center());
-    addChild(child, 1, kTagGrossini);
+    auto grossiniSprite = Sprite::create(s_pathGrossini);
+    grossiniSprite->setPosition(VisibleRect::center());
+    addChild(grossiniSprite, 1, kTagGrossini);
 
     // Grossini should be rotated by 90 degrees during 3000ms,
     // but rotation will be interruped at 1500ms by call of removeThis() callback.
     AXLOGI("Create RotateBy ActionInterval which should last for 3000 ms");
-    child->runAction(RotateBy::create(3.0f, 90));
+    grossiniSprite->runAction(RotateBy::create(3.0f, 90));
 
     // This Sequence of 4 Actions will be started at the same frame as Grossini rotation,
     // but also will not be finished because of removeThis() callback call.
     AXLOGI("Create Sequence of 4 Actions: DelayTime (1500ms), CrashTest::logCbkAfterDelayTime, Fadeout (1500ms), CrashTest::logCbkAfterFadeOut");
-    child->runAction(Sequence::create(DelayTime::create(1.5f),
+    grossiniSprite->runAction(Sequence::create(DelayTime::create(1.5f),
                                       CallFunc::create(AX_CALLBACK_0(CrashTest::logCbkAfterDelayTime, this)),
                                       FadeOut::create(1.5f),
                                       CallFunc::create(AX_CALLBACK_0(CrashTest::logCbkAfterFadeOut, this)),
@@ -102,7 +102,7 @@ void CrashTest::onEnter()
     // At 1500ms Grossini will be removed by the call of removeThis() callback. At that point
     // RotateBy Action will still be ongoing and FadeOut Action will be created. AXMOL must not crash at that point.
     AXLOGI("Create Sequence of 2 Actions: DelayTime (1500ms), CrashTest::removeThis");
-    child->runAction(Sequence::create(DelayTime::create(1.5f),
+    grossiniSprite->runAction(Sequence::create(DelayTime::create(1.5f),
                                       CallFunc::create(AX_CALLBACK_0(CrashTest::removeThis, this)),
                                       nullptr));
 }
@@ -111,8 +111,8 @@ void CrashTest::removeThis()
 {
     AXLOGI("CrashTest::removeThis() is called");
 
-    auto child = getChildByTag(kTagGrossini);
-    removeChild(child, true);
+    auto grossiniSprite = getChildByTag(kTagGrossini);
+    removeChild(grossiniSprite, true);
 }
 
 void CrashTest::logCbkAfterDelayTime()

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
@@ -112,9 +112,7 @@ void CrashTest::removeThis()
     AXLOGI("CrashTest::removeThis() is called");
 
     auto child = getChildByTag(kTagGrossini);
-    child->removeChild(child, true);
-
-    getTestSuite()->enterNextTest();
+    removeChild(child, true);
 }
 
 void CrashTest::logCbkAfterDelayTime()

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
@@ -38,13 +38,13 @@ enum
 ActionManagerTests::ActionManagerTests()
 {
     ADD_TEST_CASE(CrashTest);
-    ADD_TEST_CASE(LogicTest);
-    ADD_TEST_CASE(PauseTest);
-    ADD_TEST_CASE(StopActionTest);
-    ADD_TEST_CASE(StopAllActionsTest);
-    ADD_TEST_CASE(StopActionsByFlagsTest);
+    //ADD_TEST_CASE(LogicTest);
+    //ADD_TEST_CASE(PauseTest);
+    //ADD_TEST_CASE(StopActionTest);
+    //ADD_TEST_CASE(StopAllActionsTest);
+    //ADD_TEST_CASE(StopActionsByFlagsTest);
     ADD_TEST_CASE(ResumeTest);
-    ADD_TEST_CASE(Issue14050Test);
+    //ADD_TEST_CASE(Issue14050Test);
 }
 
 //------------------------------------------------------------------
@@ -82,17 +82,26 @@ void CrashTest::onEnter()
 
     // Sum of all action's duration is 1.5 second.
     child->runAction(RotateBy::create(1.5f, 90));
-    child->runAction(Sequence::create(DelayTime::create(1.4f), FadeOut::create(1.1f), nullptr));
+    child->runAction(
+        Sequence::create(DelayTime::create(1.4f),
+                         CallFunc::create(AX_CALLBACK_0(CrashTest::logCallback, this)),
+                         FadeOut::create(1.1f),
+                         CallFunc::create(AX_CALLBACK_0(CrashTest::logCallback, this)),
+                         nullptr));
 
+    AXLOG("CrashTest::onEnter()");
     // After 1.5 second, self will be removed.
     child->runAction(Sequence::create(DelayTime::create(1.4f),
-                                      CallFunc::create(AX_CALLBACK_0(CrashTest::removeThis, this)), nullptr));
+                                      CallFunc::create(AX_CALLBACK_0(CrashTest::removeThis, this)),
+                                      nullptr));
 }
 
 void CrashTest::removeThis()
 {
     auto child = getChildByTag(kTagGrossini);
     child->removeChild(child, true);
+
+    AXLOG("CrashTest::removeThis()");
 
     getTestSuite()->enterNextTest();
 }

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
@@ -76,6 +76,10 @@ void CrashTest::onEnter()
 {
     ActionManagerTest::onEnter();
 
+    auto l = Label::createWithTTF("Remove Node during ongoing ActionInterval. AXMOL must not crash.", "fonts/Thonburi.ttf", 16.0f);
+    addChild(l);
+    l->setPosition(VisibleRect::center().x, VisibleRect::top().y - 75);
+
     auto child = Sprite::create(s_pathGrossini);
     child->setPosition(VisibleRect::center());
     addChild(child, 1, kTagGrossini);
@@ -125,7 +129,7 @@ void CrashTest::logCbkAfterFadeOut()
 
 std::string CrashTest::subtitle() const
 {
-    return "CrashTest. Remove Node during ongoing ActionInterval. AXMOL must not crash.";
+    return "CrashTest";
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.h
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.h
@@ -54,9 +54,6 @@ public:
     void removeThis();
     void logCbkAfterDelayTime();
     void logCbkAfterFadeOut();
-
-private:
-    int logCallbackCnt;
 };
 
 class LogicTest : public ActionManagerTest

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.h
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.h
@@ -52,7 +52,11 @@ public:
     virtual std::string subtitle() const override;
     virtual void onEnter() override;
     void removeThis();
-    void logCallback() { AXLOG("CrashTest::logCallback()"); }
+    void logCbkAfterDelayTime();
+    void logCbkAfterFadeOut();
+
+private:
+    int logCallbackCnt;
 };
 
 class LogicTest : public ActionManagerTest

--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.h
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.h
@@ -52,6 +52,7 @@ public:
     virtual std::string subtitle() const override;
     virtual void onEnter() override;
     void removeThis();
+    void logCallback() { AXLOG("CrashTest::logCallback()"); }
 };
 
 class LogicTest : public ActionManagerTest


### PR DESCRIPTION
## Describe your changes
- Add descriptive comments to CrashTest code.
- Change timing to more meaningful values.
- Add logging to check timing.
- Fix Grossini sprite removal in CrashTest. Original code was trying to remove Grossini Sprite from itself, not from the scene.

Please check explanation here: https://github.com/axmolengine/axmol/discussions/2155

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
