### PR TITLE
Fix label in PauseTest.

### DIFF
--- a/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Source/ActionManagerTest/ActionManagerTest.cpp
@@ -138,13 +138,14 @@ std::string LogicTest::subtitle() const
 
 void PauseTest::onEnter()
 {
+    AXLOGI("PauseTest::onEnter() is called");
     //
     // This test MUST be done in 'onEnter' and not on 'init'
     // otherwise the paused action will be resumed at 'onEnter' time
     //
     ActionManagerTest::onEnter();
 
-    auto l = Label::createWithTTF("After 5 seconds grossini should move", "fonts/Thonburi.ttf", 16.0f);
+    auto l = Label::createWithTTF("After 3 seconds Grossini should move.", "fonts/Thonburi.ttf", 16.0f);
     addChild(l);
     l->setPosition(VisibleRect::center().x, VisibleRect::top().y - 75);
 
@@ -165,6 +166,7 @@ void PauseTest::onEnter()
 
 void PauseTest::unpause(float dt)
 {
+    AXLOGI("PauseTest::unpause() is called");
     unschedule(AX_SCHEDULE_SELECTOR(PauseTest::unpause));
     auto node     = getChildByTag(kTagGrossini);
     auto director = Director::getInstance();


### PR DESCRIPTION
## Describe your changes

- PauseTest label states that Grossini should move after 5 seconds. But there is just 3 second delay in code. 
- Add logging to check time in console.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
