### PR TITLE
Fix LuaJit Compilations

### DIFF
--- a/3rdparty/lua/lua-cjson/CMakeLists.txt
+++ b/3rdparty/lua/lua-cjson/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(${target_name} STATIC
 if(NOT AX_USE_LUAJIT)
   target_include_directories(${target_name} PRIVATE ../${AX_LUA_ENGINE})
 else()
-  target_include_directories(${target_name} PRIVATE ../${AX_LUA_ENGINE}/include)
+  target_include_directories(${target_name} PRIVATE ../${AX_LUA_ENGINE}/_x/include)
 endif()
 target_include_directories(${target_name} PUBLIC .)
 

--- a/3rdparty/lua/tolua/CMakeLists.txt
+++ b/3rdparty/lua/tolua/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(${target_name} STATIC
 if(NOT AX_USE_LUAJIT)
   target_include_directories(${target_name} PRIVATE ../${AX_LUA_ENGINE})
 else()
-  target_include_directories(${target_name} PRIVATE ../${AX_LUA_ENGINE}/include)
+  target_include_directories(${target_name} PRIVATE ../${AX_LUA_ENGINE}/_x/include)
 endif()
 target_include_directories(${target_name} PUBLIC .)
 

--- a/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -3098,7 +3098,8 @@ bool luaval_to_stageUniformLocation(lua_State* L, int pos, ax::backend::StageUni
         pos -= 1; // since we'll be pushing keys for table access
 
     lua_pushstring(L, "location");
-    if (lua_gettable(L, pos) == LUA_TNIL)
+    lua_gettable(L, pos);
+    if (lua_isnil(L, -1))
     {
         AXASSERT(false, "invalidate UniformLocation value");
     }
@@ -3106,7 +3107,8 @@ bool luaval_to_stageUniformLocation(lua_State* L, int pos, ax::backend::StageUni
     lua_pop(L, 1);
 
     lua_pushstring(L, "offset");
-    if (lua_gettable(L, pos) == LUA_TNIL)
+    lua_gettable(L, pos);
+    if (lua_isnil(L, -1))
     {
         AXASSERT(false, "invalidate UniformLocation value");
     }
@@ -3138,7 +3140,8 @@ bool luaval_to_uniformLocation(lua_State* L, int pos, ax::backend::UniformLocati
         return false;
 
     lua_pushstring(L, "vertStage");
-    if (lua_gettable(L, pos) == LUA_TNIL)
+    lua_gettable(L, pos);
+    if (lua_isnil(L, -1))
     {
         AXASSERT(false, "invalidate UniformLocation value");
     }
@@ -3146,7 +3149,8 @@ bool luaval_to_uniformLocation(lua_State* L, int pos, ax::backend::UniformLocati
     lua_pop(L, 1);
 
     lua_pushstring(L, "fragStage");
-    if (lua_gettable(L, pos) == LUA_TNIL)
+    lua_gettable(L, pos);
+    if (lua_isnil(L, -1))
     {
         AXASSERT(false, "invalidate UniformLocation value");
     }


### PR DESCRIPTION
## Describe your changes
Since `_1kfetch_dist` downloads package components in `{package_name}/_x`
https://github.com/axmolengine/axmol/blob/7098180e83c662a9ee472bd29a32287bbe67269f/1k/fetch.cmake#L48-L49
Changing `tolua` and `lua-cjson` CMakeLists.txt configuration to point to that `_x` folder for `luajit`. And some changes for the basic conversion to support both plain lua and luajit.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
