### PR TITLE
[Android] Fix fps issue when certain animation intervals are set

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -38,6 +38,7 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
 
     // The final animation interval which is used in 'onDrawFrame'
     private static long sAnimationInterval = (long) (1.0f / 60f * AxmolRenderer.NANOSECONDSPERSECOND);
+    private static float FPS_CONTROL_THRESHOLD = 1.0f / 1200.0f * AxmolRenderer.NANOSECONDSPERSECOND;
 
     // ===========================================================
     // Fields
@@ -91,19 +92,15 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
     @Override
     public void onDrawFrame(final GL10 gl) {
         /*
-         * Fix 60fps limiting doesn't work when high-end device is working in 120fps mode.
+         * Render time MUST be counted in, or the FPS will slower than appointed.
          */
-        if (AxmolRenderer.sAnimationInterval <= 1.0f / 1200.0f * AxmolRenderer.NANOSECONDSPERSECOND) {
-            AxmolRenderer.nativeRender();
-        } else {
-            final long now = System.nanoTime();
-            final long interval = now - this.mLastTickInNanoSeconds;
-
-            /*
-             * Render time MUST be counted in, or the FPS will slower than appointed.
-            */
-            this.mLastTickInNanoSeconds = now;
-            AxmolRenderer.nativeRender();
+        AxmolRenderer.nativeRender();
+        /*
+         * No need to use algorithm in default(60,90,120... FPS) situation,
+         * since onDrawFrame() was called by system 60 times per second by default.
+         */
+        if (AxmolRenderer.sAnimationInterval > AxmolRenderer.FPS_CONTROL_THRESHOLD) {
+            final long interval = System.nanoTime() - this.mLastTickInNanoSeconds;
 
             if (interval < AxmolRenderer.sAnimationInterval) {
                 try {
@@ -111,6 +108,8 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
                 } catch (final Exception e) {
                 }
             }
+
+            this.mLastTickInNanoSeconds = System.nanoTime();
         }
     }
 


### PR DESCRIPTION
## Describe your changes

An issue was introduced with this PR #1504 that causes incorrect FPS when certain animation interval values are used, such as 1/30, which results in 50-53FPS on certain devices.

Fix was suggested by @halx99, and testing on both 60hz and 120Hz devices, the FPS now correctly matches the animation interval.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
