### PR TITLE
Optimize DrawNode

### DIFF
--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -235,33 +235,39 @@ void DrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
     }
 }
 
+static void udpateCommand(CustomCommand& cmd, const axstd::pod_vector<V2F_C4B_T2F>& buffer)
+{
+    if (buffer.empty())
+    {
+        cmd.setVertexBuffer(nullptr);
+    }
+    else
+    {
+        cmd.createVertexBuffer(sizeof(V2F_C4B_T2F), buffer.size(), CustomCommand::BufferUsage::STATIC);
+        cmd.updateVertexBuffer(buffer.data(), buffer.size() * sizeof(V2F_C4B_T2F));
+    }
+
+    cmd.setVertexDrawInfo(0, buffer.size());
+}
+
 void DrawNode::updateBuffers()
 {
     if (_trianglesDirty)
     {
         _trianglesDirty = false;
-        _customCommandTriangle.createVertexBuffer(sizeof(V2F_C4B_T2F), _triangles.size(), CustomCommand::BufferUsage::STATIC);
-        if (!_triangles.empty())
-            _customCommandTriangle.updateVertexBuffer(_triangles.data(), _triangles.size() * sizeof(V2F_C4B_T2F));
-        _customCommandTriangle.setVertexDrawInfo(0, _triangles.size());
+        udpateCommand(_customCommandTriangle, _triangles);
     }
 
     if (_pointsDirty)
     {
         _pointsDirty = false;
-        _customCommandPoint.createVertexBuffer(sizeof(V2F_C4B_T2F), _points.size(), CustomCommand::BufferUsage::STATIC);
-        if (!_points.empty())
-            _customCommandPoint.updateVertexBuffer(_points.data(), _points.size() * sizeof(V2F_C4B_T2F));
-        _customCommandPoint.setVertexDrawInfo(0, _points.size());
+        udpateCommand(_customCommandPoint, _points);
     }
 
     if (_linesDirty)
     {
         _linesDirty = false;
-        _customCommandLine.createVertexBuffer(sizeof(V2F_C4B_T2F), _lines.size(), CustomCommand::BufferUsage::STATIC);
-        if (!_lines.empty())
-            _customCommandLine.updateVertexBuffer(_lines.data(), _lines.size() * sizeof(V2F_C4B_T2F));
-        _customCommandLine.setVertexDrawInfo(0, _lines.size());
+        udpateCommand(_customCommandLine, _lines);
     }
 }
 

--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -890,7 +890,7 @@ void DrawNode::_drawPolygon(const Vec2* verts,
 
     vertex_count *= 3;
 
-    auto triangles = (V2F_C4B_T2F_Triangle*)expandBufferAndGetPointer(_triangles, vertex_count);
+    auto triangles = reinterpret_cast<V2F_C4B_T2F_Triangle*>(expandBufferAndGetPointer(_triangles, vertex_count));
     _trianglesDirty = true;
 
     // start drawing...
@@ -1091,7 +1091,7 @@ void DrawNode::_drawSegment(const Vec2& from,
 
         unsigned int vertex_count = 3 * ((etStart != DrawNode::EndType::Butt) ? 2 : 0) + 3 * 2 +
                                     3 * ((etEnd != DrawNode::EndType::Butt) ? 2 : 0);
-        auto triangles = (V2F_C4B_T2F_Triangle*)expandBufferAndGetPointer(_triangles, vertex_count);
+        auto triangles = reinterpret_cast<V2F_C4B_T2F_Triangle*>(expandBufferAndGetPointer(_triangles, vertex_count));
         _trianglesDirty = true;
 
         int ii = 0;
@@ -1187,7 +1187,7 @@ void DrawNode::_drawSegment(const Vec2& from,
 void DrawNode::_drawDot(const Vec2& pos, float radius, const Color4B& color)
 {
     unsigned int vertex_count = 2 * 3;
-    auto triangles = (V2F_C4B_T2F_Triangle*)expandBufferAndGetPointer(_triangles, vertex_count);
+    auto triangles = reinterpret_cast<V2F_C4B_T2F_Triangle*>(expandBufferAndGetPointer(_triangles, vertex_count));
     _trianglesDirty = true;
 
     V2F_C4B_T2F a = {Vec2(pos.x - radius, pos.y - radius), color, Vec2(-1.0f, -1.0f)};
@@ -1253,7 +1253,7 @@ void DrawNode::_drawTriangle(Vec2* vertices3,
     {
         applyTransform(vertices3, vertices3, vertex_count);
 
-        auto triangles = (V2F_C4B_T2F_Triangle*)expandBufferAndGetPointer(_triangles, vertex_count);
+        auto triangles = reinterpret_cast<V2F_C4B_T2F_Triangle*>(expandBufferAndGetPointer(_triangles, vertex_count));
         _trianglesDirty = true;
 
         triangles[0] = {{vertices3[0], fillColor, Vec2::ZERO},

--- a/core/2d/DrawNode.h
+++ b/core/2d/DrawNode.h
@@ -585,8 +585,6 @@ protected:
     axstd::pod_vector<V2F_C4B_T2F> _points;
     axstd::pod_vector<V2F_C4B_T2F> _lines;
 
-    Color4B _pointColor;
-    int _pointSize = 0;
     float _lineWidth        = 1.0f;
     float _defaultLineWidth = 1.0f;
 

--- a/core/2d/DrawNode.h
+++ b/core/2d/DrawNode.h
@@ -448,7 +448,7 @@ public:
     void setIsConvex(bool isConvex)
     {
         AXLOGW("'setIsConvex()' No longer supported. Use the new drawPolygon API.");
-    }; 
+    };
 
 
      /** draw a segment with a radius and color.
@@ -556,10 +556,7 @@ public:
     virtual bool init() override;
 
 protected:
-    void ensureCapacityTriangle(int count);
-    void ensureCapacityPoint(int count);
-    void ensureCapacityLine(int count);
-
+    void updateBuffers();
     void updateShader();
     void updateShaderInternal(CustomCommand& cmd,
                               uint32_t programType,
@@ -572,32 +569,27 @@ protected:
     void updateBlendState(CustomCommand& cmd);
     void updateUniforms(const Mat4& transform, CustomCommand& cmd);
 
-    int _bufferCapacityTriangle  = 0;
-    int _bufferCountTriangle     = 0;
-    V2F_C4B_T2F* _bufferTriangle = nullptr;
-    CustomCommand _customCommandTriangle;
-    bool _dirtyTriangle = false;
+    bool _trianglesDirty: 1 = false;
+    bool _pointsDirty: 1 = false;
+    bool _linesDirty: 1 = false;
 
-    int _bufferCapacityPoint  = 0;
-    int _bufferCountPoint     = 0;
-    V2F_C4B_T2F* _bufferPoint = nullptr;
-    Color4B _pointColor;
-    int _pointSize = 0;
-
-    int _bufferCapacityLine  = 0;
-    int _bufferCountLine     = 0;
-    V2F_C4B_T2F* _bufferLine = nullptr;
-
-    CustomCommand _customCommandPoint;
-    CustomCommand _customCommandLine;
-    bool _dirtyPoint = false;
-    bool _dirtyLine  = false;
+    bool _isolated: 1 = false;
 
     BlendFunc _blendFunc;
 
-    bool _isolated          = false;
+    CustomCommand _customCommandTriangle;
+    CustomCommand _customCommandPoint;
+    CustomCommand _customCommandLine;
+
+    axstd::pod_vector<V2F_C4B_T2F> _triangles;
+    axstd::pod_vector<V2F_C4B_T2F> _points;
+    axstd::pod_vector<V2F_C4B_T2F> _lines;
+
+    Color4B _pointColor;
+    int _pointSize = 0;
     float _lineWidth        = 1.0f;
     float _defaultLineWidth = 1.0f;
+
 private:
     // Internal function _drawPoint
     void _drawPoint(const Vec2& position,
@@ -711,7 +703,7 @@ public:
         float defaultLineWidth = 1.0f;
 
         // Drawing flags
-        bool transform = true;
+        bool transform = false;
         bool drawOrder = false;
 
         /** Set the DrawNode drawOrder

--- a/core/2d/DrawNode.h
+++ b/core/2d/DrawNode.h
@@ -608,7 +608,8 @@ private:
     void _drawDot(const Vec2& pos, float radius, const Color4B& color);
 
     // Internal function _drawTriangle
-    void _drawTriangle(const Vec2* vertices3,
+    // Note: modifies supplied vertex array
+    void _drawTriangle(Vec2* vertices3,
                        const Color4B& borderColor,
                        const Color4B& fillColor,
                        bool solid      = true,
@@ -682,6 +683,8 @@ private:
      * @js NA
      */
     axstd::pod_vector<Vec2> _transform(const Vec2* vertices, unsigned int& count, bool closedPolygon = false);
+
+    void applyTransform(const Vec2* from, Vec2* to, unsigned int count);
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(DrawNode);

--- a/core/renderer/CustomCommand.cpp
+++ b/core/renderer/CustomCommand.cpp
@@ -157,13 +157,13 @@ void CustomCommand::createIndexBuffer(IndexFormat format, std::size_t capacity, 
     _indexBuffer = backend::DriverBase::getInstance()->newBuffer(_indexSize * capacity, backend::BufferType::INDEX, usage);
 }
 
-void CustomCommand::updateVertexBuffer(void* data, std::size_t offset, std::size_t length)
+void CustomCommand::updateVertexBuffer(const void* data, std::size_t offset, std::size_t length)
 {
     assert(_vertexBuffer);
     _vertexBuffer->updateSubData(data, offset, length);
 }
 
-void CustomCommand::updateIndexBuffer(void* data, std::size_t offset, std::size_t length)
+void CustomCommand::updateIndexBuffer(const void* data, std::size_t offset, std::size_t length)
 {
     assert(_indexBuffer);
     _indexBuffer->updateSubData(data, offset, length);
@@ -192,13 +192,13 @@ void CustomCommand::setIndexBuffer(backend::Buffer* indexBuffer, IndexFormat for
     _indexSize   = computeIndexSize();
 }
 
-void CustomCommand::updateVertexBuffer(void* data, std::size_t length)
+void CustomCommand::updateVertexBuffer(const void* data, std::size_t length)
 {
     assert(_vertexBuffer);
     _vertexBuffer->updateData(data, length);
 }
 
-void CustomCommand::updateIndexBuffer(void* data, std::size_t length)
+void CustomCommand::updateIndexBuffer(const void* data, std::size_t length)
 {
     assert(_indexBuffer);
     _indexBuffer->updateData(data, length);

--- a/core/renderer/CustomCommand.h
+++ b/core/renderer/CustomCommand.h
@@ -129,13 +129,13 @@ TODO: should remove it.
     @param data Specifies a pointer to the new data that will be copied into the data store.
     @param length Specifies the length in bytes of the data store region being replaced.
     */
-    void updateVertexBuffer(void* data, std::size_t length);
+    void updateVertexBuffer(const void* data, std::size_t length);
     /**
     Update index buffer contents.
     @param data Specifies a pointer to the new data that will be copied into the data store.
     @param length Specifies the size in bytes of the data store region being replaced.
     */
-    void updateIndexBuffer(void* data, std::size_t length);
+    void updateIndexBuffer(const void* data, std::size_t length);
     /**
     Update some or all contents of vertex buffer.
     @param data Specifies a pointer to the new data that will be copied into the data store.
@@ -143,7 +143,7 @@ TODO: should remove it.
     in bytes.
     @param length Specifies the size in bytes of the data store region being replaced.
     */
-    void updateVertexBuffer(void* data, std::size_t offset, std::size_t length);
+    void updateVertexBuffer(const void* data, std::size_t offset, std::size_t length);
     /**
     Update some or call contents of index buffer
     @param data Specifies a pointer to the new data that will be copied into the data store.
@@ -151,7 +151,7 @@ TODO: should remove it.
     in bytes.
     @param length Specifies the size in bytes of the data store region being replaced.
     */
-    void updateIndexBuffer(void* data, std::size_t offset, std::size_t length);
+    void updateIndexBuffer(const void* data, std::size_t offset, std::size_t length);
 
     /**
     Get vertex buffer capacity.

--- a/tests/cpp-tests/Source/DrawNodeTest/DrawNodeTest.cpp
+++ b/tests/cpp-tests/Source/DrawNodeTest/DrawNodeTest.cpp
@@ -1387,6 +1387,7 @@ DrawNodeBaseTest::DrawNodeBaseTest()
     if (!drawNode)
     {
         drawNode = DrawNode::create();
+        drawNode->properties.setTransform(true);
         addChild(drawNode);
     }
     menuItemDrawOrder->setFontSize(10);
@@ -1585,6 +1586,7 @@ DrawNodeMorphTest_SolidPolygon::DrawNodeMorphTest_SolidPolygon()
     {
 
         drawNodeArray[n] = DrawNode::create();
+        drawNodeArray[n]->properties.setTransform(true);
         addChild(drawNodeArray[n]);
         drawNodeArray[n]->setPosition(
             Vec2(AXRANDOM_MINUS1_1() * size.width / 4, AXRANDOM_MINUS1_1() * size.height / 4) + Vec2(100, 100));
@@ -1714,6 +1716,7 @@ DrawNodeMorphTest_Polygon::DrawNodeMorphTest_Polygon()
     for (size_t n = 0; n < 10; n++)
     {
         drawNodeArray[n] = DrawNode::create();
+        drawNodeArray[n]->properties.setTransform(true);
         addChild(drawNodeArray[n]);
         drawNodeArray[n]->setPosition(
             Vec2(AXRANDOM_MINUS1_1() * size.width / 4, AXRANDOM_MINUS1_1() * size.height / 4) + Vec2(100, 100));
@@ -3112,6 +3115,7 @@ DrawNodeAxmolTest2::DrawNodeAxmolTest2()
     }
 
     drawNode = DrawNode::create();
+    drawNode->properties.setTransform(true);
     addChild(drawNode, 10);
 
     scheduleUpdate();
@@ -3432,9 +3436,11 @@ DrawNodeSpLinesTest::DrawNodeSpLinesTest()
     _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 
     drawNodeCP = DrawNode::create();
+    drawNodeCP->properties.setTransform(true);
     addChild(drawNodeCP, 50);
 
     drawNode = DrawNode::create();
+    drawNode->properties.setTransform(true);
     addChild(drawNode, 30);
 
     screen = Director::getInstance()->getVisibleSize();


### PR DESCRIPTION
This PR does some DrawNode optimizations:
* Disabled transform by default, which had significant performance impact by default.
* Use `pod_vector` for storing and growing buffers.
* Don't update actual vertex buffer every time `drawXXX()` is called.
* Avoid unnecessary allocations on some `drawXXX()` methods in `_transform()`.

There's still a lot of `drawXXX()` methods that do unnecessary allocations that have a big impact on performance.

Also there are `_lineWidth` and `_defaultLineWidth` members that can be set by the user but do nothing. Seems like a bug that probably breaks old behavior.