### PR TITLE
Fix incorrect static value usage in JNI array methods

### DIFF
--- a/core/platform/android/GLViewImpl-android.cpp
+++ b/core/platform/android/GLViewImpl-android.cpp
@@ -150,7 +150,7 @@ Rect GLViewImpl::getSafeAreaRect() const
     float insetLeft = 0.0f;
     float insetRight = 0.0f;
 
-    static int* cornerRadii =
+    static axstd::pod_vector<int32_t> cornerRadii =
             JniHelper::callStaticIntArrayMethod("org/axmol/lib/AxmolEngine", "getDeviceCornerRadii");
 
     if (isScreenRound)
@@ -172,13 +172,13 @@ Rect GLViewImpl::getSafeAreaRect() const
             // landscape: no changes with X-coords
         }
     }
-    else if (deviceAspectRatio >= WIDE_SCREEN_ASPECT_RATIO_ANDROID || cornerRadii != nullptr)
+    else if (deviceAspectRatio >= WIDE_SCREEN_ASPECT_RATIO_ANDROID || cornerRadii.size() >= 4)
     {
         // almost all devices on the market have round corners if
         // deviceAspectRatio more than 2 (@see "android.max_aspect" parameter in AndroidManifest.xml)
 
         // cornerRadii is only available in API31+ (Android 12+)
-        if (cornerRadii != nullptr)
+        if (cornerRadii.size() >= 4)
         {
             float radiiBottom = cornerRadii[0] / _scaleY;
             float radiiLeft   = cornerRadii[1] / _scaleX;
@@ -240,9 +240,10 @@ Rect GLViewImpl::getSafeAreaRect() const
     if (isCutoutEnabled)
     {
         // screen with enabled cutout area (ex. Google Pixel 3 XL, Huawei P20, Asus ZenFone 5, etc)
-        static int* safeInsets =
-            JniHelper::callStaticIntArrayMethod("org/axmol/lib/AxmolEngine", "getSafeInsets");
-        if (safeInsets != nullptr)
+        static axstd::pod_vector<int32_t> safeInsets =
+                JniHelper::callStaticIntArrayMethod("org/axmol/lib/AxmolEngine", "getSafeInsets");
+
+        if (safeInsets.size() >= 4)
         {
             float safeInsetBottom = safeInsets[0] / _scaleY;
             float safeInsetLeft   = safeInsets[1] / _scaleX;

--- a/core/platform/android/jni/JniHelper.h
+++ b/core/platform/android/jni/JniHelper.h
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include "platform/PlatformMacros.h"
 #include "math/Vec3.h"
 #include "jni/jni.hpp"
+#include "base/axstd.h"
 
 namespace jni
 {
@@ -221,12 +222,11 @@ public:
 
     /**
     @brief Call of Java static float* method
-    @return address of JniMethodInfo if there are proper JniMethodInfo; otherwise nullptr.
+    @return axstd::pod_vector
     */
     template <typename... Ts>
-    static float* callStaticFloatArrayMethod(const char* className, const char* methodName, Ts&&... xs)
+    static axstd::pod_vector<float> callStaticFloatArrayMethod(const char* className, const char* methodName, Ts&&... xs)
     {
-        static float ret[32];
         ax::JniMethodInfo t;
         const char* signature = jni::TypeSignature<jni::Array<jfloat>(std::decay_t<Ts>...)>{}();
         if (ax::JniHelper::getStaticMethodInfo(t, className, methodName, signature))
@@ -239,38 +239,35 @@ public:
             {
                 t.env->DeleteLocalRef(t.classID);
                 deleteLocalRefs(t.env, localRefs);
-                return nullptr;
+                return {};
             }
 
             jsize len = t.env->GetArrayLength(array);
-            if (len <= 32)
+            axstd::pod_vector<float> result(len);
+            jfloat* elems = t.env->GetFloatArrayElements(array, 0);
+            if (elems)
             {
-                jfloat* elems = t.env->GetFloatArrayElements(array, 0);
-                if (elems)
-                {
-                    memcpy(ret, elems, sizeof(float) * len);
-                    t.env->ReleaseFloatArrayElements(array, elems, 0);
-                };
-            }
+                memcpy(result.data(), elems, sizeof(float) * len);
+                t.env->ReleaseFloatArrayElements(array, elems, 0);
+            };
             t.env->DeleteLocalRef(t.classID);
             deleteLocalRefs(t.env, localRefs);
-            return &ret[0];
+            return result;
         }
         else
         {
             reportError(className, methodName, signature);
         }
-        return nullptr;
+        return {};
     }
 
     /**
     @brief Call of Java static int* method
-    @return address of JniMethodInfo if there are proper JniMethodInfo; otherwise nullptr.
+    @return axstd::pod_vector
     */
     template <typename... Ts>
-    static int* callStaticIntArrayMethod(const char* className, const char* methodName, Ts&&... xs)
+    static axstd::pod_vector<int32_t> callStaticIntArrayMethod(const char* className, const char* methodName, Ts&&... xs)
     {
-        static int ret[32];
         ax::JniMethodInfo t;
         const char* signature = jni::TypeSignature<jni::Array<jint>(std::decay_t<Ts>...)>{}();
         if (ax::JniHelper::getStaticMethodInfo(t, className, methodName, signature))
@@ -283,28 +280,26 @@ public:
             {
                 t.env->DeleteLocalRef(t.classID);
                 deleteLocalRefs(t.env, localRefs);
-                return nullptr;
+                return {};
             }
 
             jsize len = t.env->GetArrayLength(array);
-            if (len <= 32)
+            axstd::pod_vector<int32_t> result(len);
+            jint* elems = t.env->GetIntArrayElements(array, 0);
+            if (elems)
             {
-                jint* elems = t.env->GetIntArrayElements(array, 0);
-                if (elems)
-                {
-                    memcpy(ret, elems, sizeof(int) * len);
-                    t.env->ReleaseIntArrayElements(array, elems, 0);
-                };
-            }
+                memcpy(result.data(), elems, sizeof(int32_t) * len);
+                t.env->ReleaseIntArrayElements(array, elems, 0);
+            };
             t.env->DeleteLocalRef(t.classID);
             deleteLocalRefs(t.env, localRefs);
-            return &ret[0];
+            return result;
         }
         else
         {
             reportError(className, methodName, signature);
         }
-        return nullptr;
+        return {};
     }
 
     /**


### PR DESCRIPTION
## Describe your changes

Refer to issue #2175 for the discussion regarding this issue.

JNI helper methods should not be caching data.

Use `axstd::pod_vector` instead of raw pointers to array data for `callStaticIntArrayMethod` and `callStaticFloatArrayMethod`.  Array size is no longer limited to 32 items.

## Issue ticket number and link
#2175 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
