### PR TITLE
DownloaderCURL: fix too many open files and other fixes

### DIFF
--- a/core/network/Downloader-curl.cpp
+++ b/core/network/Downloader-curl.cpp
@@ -89,6 +89,8 @@ public:
 
     virtual ~DownloadTaskCURL()
     {
+        AXLOGD("Destruct DownloadTaskCURL {}", fmt::ptr(this));
+
         if (_errCode != DownloadTask::ERROR_TASK_DUPLICATED)
         {
             auto lock = std::lock_guard<std::mutex>(_sStoragePathSetMutex);
@@ -103,11 +105,6 @@ public:
 
         _fs.reset();
         _fsMd5.reset();
-
-        if (_requestHeaders)
-            curl_slist_free_all(_requestHeaders);
-
-        AXLOGD("Destruct DownloadTaskCURL {}", fmt::ptr(this));
     }
 
     bool init(std::string_view filename, std::string_view tempSuffix)
@@ -318,15 +315,12 @@ private:
     std::recursive_mutex _mutex;
 
     // header info
-    bool _acceptRanges;
     int64_t _totalBytesExpected = -1; // some server may not send data size, so set it to -1
 
     curl_off_t _speed = 0;
     CURL* _curl = nullptr;
     curl_socket_t _sockfd = -1;  // store the sockfd to support cancel download manually
     bool _cancelled       = false;
-
-    curl_slist* _requestHeaders = nullptr;
 
     // progress
     bool _alreadyDownloaded = false;
@@ -483,7 +477,6 @@ private:
 
         /* Resolve host domain to ip */
         std::string internalURL = task->requestURL;
-        // Curl_custom_setup(handle, internalURL, (void**)& coTask->_requestHeaders);
 
         // set url
         curl_easy_setopt(handle, CURLOPT_URL, internalURL.c_str());

--- a/core/network/Downloader-curl.cpp
+++ b/core/network/Downloader-curl.cpp
@@ -82,7 +82,7 @@ public:
     int serialId;
     DownloaderCURL& owner;
 
-    DownloadTaskCURL(DownloaderCURL& o) : serialId(_sSerialId++), owner(o)
+    explicit DownloadTaskCURL(DownloaderCURL& o) : serialId(_sSerialId++), owner(o)
     {
         AXLOGD("Construct DownloadTaskCURL {}", fmt::ptr(this));
     }

--- a/core/network/Downloader-curl.h
+++ b/core/network/Downloader-curl.h
@@ -61,7 +61,7 @@ protected:
     static void _updateTaskProgressInfo(DownloadTask& task, int64_t totalExpected = -1);
 
     // scheduler for update processing and finished task in main schedule
-    void _onDownloadFinished(DownloadTask& task, int checkState = 0);
+    void _onDownloadFinished(DownloadTask& task);
 
     // scheduler for update processing and finished task in main schedule
     void _onUpdate(float);

--- a/core/network/Downloader-curl.h
+++ b/core/network/Downloader-curl.h
@@ -52,10 +52,6 @@ protected:
     class Impl;
     std::shared_ptr<Impl> _impl;
 
-    // for transfer data on schedule
-    DownloadTaskCURL* _currTask;  // temp ref
-    std::function<int64_t(void*, int64_t)> _transferDataToBuffer;
-
     void _lazyScheduleUpdate();
 
     static void _updateTaskProgressInfo(DownloadTask& task, int64_t totalExpected = -1);

--- a/core/network/Downloader-wasm.cpp
+++ b/core/network/Downloader-wasm.cpp
@@ -228,10 +228,8 @@ namespace ax { namespace network {
             }
 
             DownloadTaskEmscripten *coTask = iter->second;
-            function<int64_t(void*, int64_t)> transferDataToBuffer; // just a placeholder
-            // int dl = dlNow - coTask->bytesReceived;
             coTask->bytesReceived = dlNow;
-            downloader->onTaskProgress(*coTask->task, transferDataToBuffer);
+            downloader->onTaskProgress(*coTask->task);
         }
 
         void DownloaderEmscripten::onError(emscripten_fetch_t *fetch)

--- a/core/network/Downloader.cpp
+++ b/core/network/Downloader.cpp
@@ -91,8 +91,7 @@ Downloader::Downloader(const DownloaderHints& hints)
 {
     AXLOGD("Construct Downloader {}", fmt::ptr(this));
     _impl.reset(new DownloaderImpl(hints));
-    _impl->onTaskProgress = [this](const DownloadTask& task,
-                                   std::function<int64_t(void* buffer, int64_t len)>& /*transferDataToBuffer*/) {
+    _impl->onTaskProgress = [this](const DownloadTask& task) {
         if (onTaskProgress)
         {
             onTaskProgress(task);

--- a/core/network/IDownloaderImpl.h
+++ b/core/network/IDownloaderImpl.h
@@ -51,9 +51,7 @@ class IDownloaderImpl
 public:
     virtual ~IDownloaderImpl() {}
 
-    std::function<void(const DownloadTask& task,
-                       std::function<int64_t(void* buffer, int64_t len)>& transferDataToBuffer)>
-        onTaskProgress;
+    std::function<void(const DownloadTask& task)> onTaskProgress;
 
     std::function<void(const DownloadTask& task,
                        int errorCode,


### PR DESCRIPTION
This PR contains fixes for `DownloaderCURL`:

* Fix for too many open files.
* Fix `_onDownloadFinished` being called on wrong thread.
* Fix multithreaded access to `_sStoragePathSet` not being synchronized.
* Removes unused `transferDataToBuffer` (leftover from old Cocos implementation) and some other unused variables.

Main fix is for too many open files. On old Androids there's ~1000 open file limit. If you happen to schedule a lot of download tasks, then `DownloaderCURL` exhausts all file handles and downloads start to fail. Also due to the same reason on Adreno GPUs drivers fail and app freezes with errors:
```
Adreno  : DequeueBuffer: dequeueBuffer failed
GLThread: eglSwapBuffers failed: EGL_BAD_SURFACE
```