### PR TITLE
`AxmolActivity` refactoring and fixes

### DIFF
--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -151,6 +151,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
+        Log.i(TAG, "onCreate()");
         super.onCreate(savedInstanceState);
 
         // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
@@ -202,8 +203,20 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     // ===========================================================
 
     @Override
+    protected void onStart() {
+        Log.i(TAG, "onStart()");
+        super.onStart();
+    }
+
+    @Override
+    protected void onRestart() {
+        Log.i(TAG, "onRestart()");
+        super.onRestart();
+    }
+
+    @Override
     protected void onResume() {
-    	Log.d(TAG, "onResume()");
+    	Log.i(TAG, "onResume()");
         paused = false;
         super.onResume();
        	if (this.hasFocus) {
@@ -213,7 +226,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
-    	Log.d(TAG, "onWindowFocusChanged() hasFocus=" + hasFocus);
+    	Log.i(TAG, "onWindowFocusChanged() hasFocus=" + hasFocus);
         super.onWindowFocusChanged(hasFocus);
 
         this.hasFocus = hasFocus;
@@ -244,7 +257,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
     @Override
     protected void onPause() {
-    	Log.d(TAG, "onPause()");
+    	Log.i(TAG, "onPause()");
         paused = true;
         super.onPause();
         AxmolEngine.onPause();
@@ -254,6 +267,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
     @Override
     protected void onStop() {
+        Log.i(TAG, "onStop()");
         super.onStop();
         rendererPaused = true;
         mGLSurfaceView.onStop();
@@ -261,6 +275,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
 
     @Override
     protected void onDestroy() {
+        Log.i(TAG, "onDestroy()");
         super.onDestroy();
     }
 

--- a/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolActivity.java
@@ -70,10 +70,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     private static AxmolActivity sContext = null;
     private WebViewHelper mWebViewHelper = null;
     private EditBoxHelper mEditBoxHelper = null;
-    private boolean hasFocus = false;
     private boolean showVirtualButton = false;
-    private boolean paused = true;
-    private boolean rendererPaused = true;
 
     public AxmolGLSurfaceView getGLSurfaceView(){
         return  mGLSurfaceView;
@@ -206,6 +203,40 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     protected void onStart() {
         Log.i(TAG, "onStart()");
         super.onStart();
+
+        mGLSurfaceView.onResume();
+    }
+
+    @Override
+    protected void onResume() {
+    	Log.i(TAG, "onResume()");
+        super.onResume();
+
+        hideVirtualButton();
+        AxmolEngine.onResume();
+        mGLSurfaceView.handleOnResume();
+        mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
+    }
+
+    @Override
+    protected void onPause() {
+    	Log.i(TAG, "onPause()");
+
+        AxmolEngine.onPause();
+        mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
+        mGLSurfaceView.handleOnPause();
+
+        super.onPause();
+    }
+
+    @Override
+    protected void onStop() {
+        Log.i(TAG, "onStop()");
+
+        mGLSurfaceView.waitForPauseToComplete();
+        mGLSurfaceView.onPause();
+
+        super.onStop();
     }
 
     @Override
@@ -215,68 +246,15 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
     }
 
     @Override
-    protected void onResume() {
-    	Log.i(TAG, "onResume()");
-        paused = false;
-        super.onResume();
-       	if (this.hasFocus) {
-            resume();
-        }
+    protected void onDestroy() {
+        Log.i(TAG, "onDestroy()");
+        super.onDestroy();
     }
 
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
-    	Log.i(TAG, "onWindowFocusChanged() hasFocus=" + hasFocus);
+        Log.i(TAG, "onWindowFocusChanged() hasFocus=" + hasFocus);
         super.onWindowFocusChanged(hasFocus);
-
-        this.hasFocus = hasFocus;
-        if (this.hasFocus && !paused) {
-            resume();
-        }
-    }
-
-    private void resume() {
-        this.hideVirtualButton();
-        AxmolEngine.onResume();
-        if (rendererPaused) {
-            mGLSurfaceView.onResume();
-            rendererPaused = false;
-        }
-        mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
-    }
-
-    private void resumeIfHasFocus() {
-        //It is possible for the app to receive the onWindowsFocusChanged(true) event
-        //even though it is locked or asleep
-        boolean readyToPlay = !isDeviceLocked() && !isDeviceAsleep();
-
-        if(hasFocus && readyToPlay) {
-            resume();
-        }
-    }
-
-    @Override
-    protected void onPause() {
-    	Log.i(TAG, "onPause()");
-        paused = true;
-        super.onPause();
-        AxmolEngine.onPause();
-        mGLSurfaceView.onPause();
-        mGLSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
-    }
-
-    @Override
-    protected void onStop() {
-        Log.i(TAG, "onStop()");
-        super.onStop();
-        rendererPaused = true;
-        mGLSurfaceView.onStop();
-    }
-
-    @Override
-    protected void onDestroy() {
-        Log.i(TAG, "onDestroy()");
-        super.onDestroy();
     }
 
     @Override

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -37,6 +37,8 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
+import java.util.concurrent.CountDownLatch;
+
 public class AxmolGLSurfaceView extends GLSurfaceView {
     // ===========================================================
     // Constants
@@ -62,7 +64,8 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
     private boolean mMultipleTouchEnabled = true;
-    private boolean mPaused = true;
+
+    private CountDownLatch mNativePauseComplete;
 
     public boolean isSoftKeyboardShown() {
         return mSoftKeyboardShown;
@@ -184,35 +187,6 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
     // ===========================================================
     // Methods for/from SuperClass/Interfaces
     // ===========================================================
-
-    @Override
-    public void onResume() {
-        if (mPaused) {
-            mPaused = false;
-            super.onResume();
-            this.queueEvent(new Runnable() {
-                @Override
-                public void run() {
-                    AxmolGLSurfaceView.this.mRenderer.handleOnResume();
-                }
-            });
-        }
-    }
-
-    @Override
-    public void onPause() {
-        this.queueEvent(new Runnable() {
-            @Override
-            public void run() {
-                AxmolGLSurfaceView.this.mRenderer.handleOnPause();
-            }
-        });
-    }
-
-    public void onStop() {
-        mPaused = true;
-        super.onPause();
-    }
 
     @Override
     public boolean onTouchEvent(final MotionEvent pMotionEvent) {
@@ -426,6 +400,38 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
     // ===========================================================
     // Methods
     // ===========================================================
+
+    public void handleOnResume() {
+        this.queueEvent(new Runnable() {
+            @Override
+            public void run() {
+                AxmolGLSurfaceView.this.mRenderer.handleOnResume();
+            }
+        });
+    }
+
+    public void handleOnPause() {
+        mNativePauseComplete = new CountDownLatch(1);
+
+        CountDownLatch complete = mNativePauseComplete;
+        this.queueEvent(new Runnable() {
+            @Override
+            public void run() {
+                AxmolGLSurfaceView.this.mRenderer.handleOnPause();
+                complete.countDown();
+            }
+        });
+    }
+
+    public void waitForPauseToComplete() {
+        while (mNativePauseComplete.getCount() > 0) {
+            try {
+                mNativePauseComplete.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
     // ===========================================================
     // Inner and Anonymous Classes

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -428,7 +428,6 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
             try {
                 mNativePauseComplete.await();
             } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
         }
     }

--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -47,8 +47,9 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
     private long mLastTickInNanoSeconds;
     private int mScreenWidth;
     private int mScreenHeight;
-    private boolean mNativeInitCompleted = false;
-    private boolean mIsPaused = false;
+
+    private static boolean gNativeInitialized = false;
+    private static boolean gNativeIsPaused = false;
 
     // ===========================================================
     // Constructors
@@ -76,11 +77,11 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
         AxmolRenderer.nativeInit(this.mScreenWidth, this.mScreenHeight);
         this.mLastTickInNanoSeconds = System.nanoTime();
 
-        if (mNativeInitCompleted) {
+        if (gNativeInitialized) {
             // This must be from an OpenGL context loss
             nativeOnContextLost();
         } else {
-            mNativeInitCompleted = true;
+            gNativeInitialized = true;
         }
     }
 
@@ -160,17 +161,17 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
          * onSurfaceCreated is invoked. Can not invoke any
          * native method before onSurfaceCreated is invoked
          */
-        if (!mNativeInitCompleted)
+        if (!gNativeInitialized)
             return;
 
         AxmolRenderer.nativeOnPause();
-        mIsPaused = true;
+        gNativeIsPaused = true;
     }
 
     public void handleOnResume() {
-        if (mIsPaused) {
+        if (gNativeIsPaused) {
             AxmolRenderer.nativeOnResume();
-            mIsPaused = false;
+            gNativeIsPaused = false;
         }
     }
 


### PR DESCRIPTION
This PR refactors and simplifies how the state of the app activity is managed and also:

* Fixes `nativeOnResume()` not being called after a system popup is displayed. (Easy repro: turn on bluetooth in quick settings menu and wait couple seconds for a popup to show up, then close it).
* Fix `AxmolRenderer` forgetting paused state when `AxmolActivity` is relaunched, during which the old objects are destroyed and recreated. (Easy repro: in Android settings change global font size).

I have tested this extensively on several devices, and everything seems to work. But it would be nice if more people tested it.