### PR TITLE
Update to locate Microsoft Build Tools

### DIFF
--- a/1k/1kiss.ps1
+++ b/1k/1kiss.ps1
@@ -774,7 +774,7 @@ function find_vs() {
         if (!$required_vs_ver) { $required_vs_ver = '12.0+' }
         
         $require_comps = @('Microsoft.Component.MSBuild', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
-        $vs_installs = ConvertFrom-Json "$(&$VSWHERE_EXE -version $required_vs_ver.TrimEnd('+') -format 'json' -requires $require_comps)"
+        $vs_installs = ConvertFrom-Json "$(&$VSWHERE_EXE -version $required_vs_ver.TrimEnd('+') -format 'json' -all -products Microsoft.VisualStudio.Product.BuildTools -requires $require_comps)"
         $ErrorActionPreference = $eap
 
         if ($vs_installs) {

--- a/core/platform/apple/FileUtils-apple.h
+++ b/core/platform/apple/FileUtils-apple.h
@@ -65,9 +65,11 @@ public:
     virtual std::string getPathForDirectory(std::string_view dir,
                                             std::string_view searchPath) const override;
 
-private:
-    virtual bool isFileExistInternal(std::string_view filePath) const override;
-    virtual bool removeDirectory(std::string_view dirPath) const override;
+    protected:
+        virtual bool isFileExistInternal(std::string_view filePath) const override;
+
+    private:
+        virtual bool removeDirectory(std::string_view dirPath) const override;
 
     struct IMPL;
     std::unique_ptr<IMPL> pimpl_;


### PR DESCRIPTION
Locate build tool only installs, for when no full Visual Studio install

## Describe your changes
Updated command line option to locate BuildTool only installs of the Visual Studio Build tools - for when there is no full install of visual studio - CI server or when running other IDE's like Jetbrains.