### PR TITLE
Fix gray alpha png

### DIFF
--- a/core/2d/Sprite.cpp
+++ b/core/2d/Sprite.cpp
@@ -434,7 +434,14 @@ void Sprite::setTexture(Texture2D* texture)
     }
 
     if (needsUpdatePS)
-        setProgramState(backend::ProgramType::POSITION_TEXTURE_COLOR);
+    {
+        const PixelFormat pixelFormat = _texture->getPixelFormat();
+
+        if (pixelFormat == PixelFormat::RG8)
+            setProgramState(backend::ProgramType::POSITION_TEXTURE_GRAY_ALPHA);
+        else
+            setProgramState(backend::ProgramType::POSITION_TEXTURE_COLOR);
+    }
     else
         updateProgramStateTexture(_texture);
 }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -461,7 +461,7 @@ if(LINUX)
 
     # including GTK3.0 and WebKit2Gtk4.x
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(GKT3 REQUIRED gtk+-3.0)
+    pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
 
     set(_webkit2gtk_vers "4.1;4.0")
     foreach(_ver ${_webkit2gtk_vers})

--- a/core/platform/Image.cpp
+++ b/core/platform/Image.cpp
@@ -2606,7 +2606,7 @@ void Image::premultiplyAlpha()
         for (int i = 0; i < _width * _height; i++)
         {
             uint8_t* p   = _data + i * 2;
-            twoBytes[i] = ((p[0] * p[1] + 1) >> 8) | (p[1] << 8);
+            twoBytes[i] = ((p[0] * (p[1] + 1)) >> 8) | (p[1] << 8);
         }
     }
 

--- a/core/renderer/Shaders.cpp
+++ b/core/renderer/Shaders.cpp
@@ -39,6 +39,7 @@ AX_DLL const std::string_view positionTexture_frag                 = "positionTe
 AX_DLL const std::string_view positionTextureColor_vert            = "positionTextureColor_vs"sv;
 AX_DLL const std::string_view positionTextureColor_frag            = "positionTextureColor_fs"sv;
 AX_DLL const std::string_view positionTextureColorAlphaTest_frag   = "positionTextureColorAlphaTest_fs"sv;
+AX_DLL const std::string_view positionTextureGrayAlpha_frag        = "positionTextureGrayAlpha_fs"sv;
 AX_DLL const std::string_view label_normal_frag                    = "label_normal_fs"sv;
 AX_DLL const std::string_view label_outline_frag                   = "label_outline_fs"sv;
 AX_DLL const std::string_view label_distanceNormal_frag            = "label_distanceNormal_fs"sv;

--- a/core/renderer/Shaders.h
+++ b/core/renderer/Shaders.h
@@ -47,6 +47,7 @@ extern AX_DLL const std::string_view positionTexture_frag;
 extern AX_DLL const std::string_view positionTextureColor_vert;
 extern AX_DLL const std::string_view positionTextureColor_frag;
 extern AX_DLL const std::string_view positionTextureColorAlphaTest_frag;
+extern AX_DLL const std::string_view positionTextureGrayAlpha_frag;
 extern AX_DLL const std::string_view label_normal_frag;
 extern AX_DLL const std::string_view label_outline_frag;
 extern AX_DLL const std::string_view label_distanceNormal_frag;

--- a/core/renderer/backend/Enums.h
+++ b/core/renderer/backend/Enums.h
@@ -342,6 +342,7 @@ struct ProgramType
         POSITION_TEXTURE,                     // positionTexture_vert,            positionTexture_frag
         POSITION_TEXTURE_COLOR,               // positionTextureColor_vert,       positionTextureColor_frag
         POSITION_TEXTURE_COLOR_ALPHA_TEST,    // positionTextureColor_vert,       positionTextureColorAlphaTest_frag
+        POSITION_TEXTURE_GRAY_ALPHA,          // positionTextureColor_vert,       positionTextureGrayAlpha_frag
         LABEL_NORMAL,                         // positionTextureColor_vert,       label_normal_frag
         LABLE_OUTLINE,                        // positionTextureColor_vert,       labelOutline_frag
         LABEL_DISTANCE_NORMAL,                // positionTextureColor_vert,       label_distanceNormal_frag

--- a/core/renderer/backend/PixelFormatUtils.cpp
+++ b/core/renderer/backend/PixelFormatUtils.cpp
@@ -145,7 +145,7 @@ static void convertRG8ToRGBA8(const unsigned char* data, size_t dataLen, unsigne
     for (ssize_t i = 0, l = dataLen - 1; i < l; i += 2)
     {
         *outData++ = data[i];      // R
-        *outData++ = data[i];      // G
+        *outData++ = data[i + 1];      // G
         *outData++ = data[i];      // B
         *outData++ = data[i + 1];  // A
     }

--- a/core/renderer/backend/PixelFormatUtils.cpp
+++ b/core/renderer/backend/PixelFormatUtils.cpp
@@ -145,7 +145,7 @@ static void convertRG8ToRGBA8(const unsigned char* data, size_t dataLen, unsigne
     for (ssize_t i = 0, l = dataLen - 1; i < l; i += 2)
     {
         *outData++ = data[i];      // R
-        *outData++ = data[i + 1];      // G
+        *outData++ = data[i];      // G
         *outData++ = data[i];      // B
         *outData++ = data[i + 1];  // A
     }

--- a/core/renderer/backend/ProgramManager.cpp
+++ b/core/renderer/backend/ProgramManager.cpp
@@ -115,6 +115,8 @@ bool ProgramManager::init()
                     VertexLayoutType::Texture);
     registerProgram(ProgramType::POSITION_TEXTURE_COLOR_ALPHA_TEST, positionTextureColor_vert,
                     positionTextureColorAlphaTest_frag, VertexLayoutType::Sprite);
+    registerProgram(ProgramType::POSITION_TEXTURE_GRAY_ALPHA, positionTextureColor_vert,
+                    positionTextureGrayAlpha_frag, VertexLayoutType::Sprite);
     registerProgram(ProgramType::POSITION_UCOLOR, positionUColor_vert, positionColor_frag, VertexLayoutType::Pos);
     registerProgram(ProgramType::DUAL_SAMPLER_GRAY, positionTextureColor_vert, dualSampler_gray_frag,
                     VertexLayoutType::Sprite);

--- a/core/renderer/shaders/positionTextureGrayAlpha.frag
+++ b/core/renderer/shaders/positionTextureGrayAlpha.frag
@@ -1,0 +1,16 @@
+#version 310 es
+precision highp float;
+precision highp int;
+
+layout(location = COLOR0) in vec4 v_color;
+layout(location = TEXCOORD0) in vec2 v_texCoord;
+
+layout(binding = 0) uniform sampler2D u_tex0;
+
+layout(location = SV_Target0) out vec4 FragColor;
+
+void main()
+{
+    vec4 c = texture(u_tex0, v_texCoord);
+    FragColor = v_color * vec4(c.r, c.r, c.r, c.g);
+}

--- a/tests/cpp-tests/Source/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Source/Texture2dTest/Texture2dTest.cpp
@@ -437,6 +437,11 @@ void TexturePNG::onEnter()
     ai88->setPosition(s.width / 4.0f, s.height * 3.0f / 4.0f);
     addChild(ai88);
 
+    // grayscale with alpha, gray+alpha shader.
+    auto ai88s = Sprite::create("Images/test_image_ai88.png", PixelFormat::RG8);
+    ai88s->setPosition(s.width / 4.0f, s.height / 2.0f);
+    addChild(ai88s);
+
     // rgb without alpha
     auto rgb888 = Sprite::create("Images/test_image_rgb888.png");
     rgb888->setPosition(s.width * 3.0f / 4.0f, s.height / 4.0f);
@@ -455,7 +460,7 @@ std::string TexturePNG::title() const
 
 std::string TexturePNG::subtitle() const
 {
-    return "LB:I8, LT:AI8\nRB:RGB888, RT: RGBA8888";
+    return "LB:I8, LM: AI8/RG8 pixel format, LT:AI8\nRB:RGB888, RT: RGBA8888";
 }
 
 //------------------------------------------------------------------
@@ -1634,7 +1639,7 @@ void TexturePixelFormat::onEnter()
     Director::getInstance()->getTextureCache()->removeTexture(sprite5->getTexture());
 
     // A8 image (8-bit)
-    auto sprite6 = Sprite::create("Images/test-rgba1.png", PixelFormat::R8); // 
+    auto sprite6 = Sprite::create("Images/test-rgba1.png", PixelFormat::R8); //
     sprite6->setPosition(Vec2(6 * s.width / 7, s.height / 2 - 32));
     addChild(sprite6, 0);
 


### PR DESCRIPTION
This is mostly what is [described by @rh101 in #2230](https://github.com/axmolengine/axmol/pull/2230#issuecomment-2470123371) with the addition of the following:

- A fix small typo in the CMakeLists.txt for the detection of GTK3.
- A change in `convertRG8ToRGBA8` to copy the pixels as RRRA instead of RARA (as it was introduced in #1839).

I could not reproduce the output shown by @rh101 in its comment without the point above. From my understanding the PNG is loaded into an Image with the correct pixel format (RG8), then this image is passed to a Texture2D alongside a render pixel format set to RGBA. The Texture2D subsequently calls updatWithMipmaps which may convert the pixels into the render format. By the time the Texture2D reaches the Sprite the pixel format of the texture is RGBA.

Tested with cpp-tests' Texture2D/5:PNG Test (Linux) and in my app (Linux and Android).

I hereby invoke @smilediver to double check the loading of two-channels images, and @halx99 for the `convertRG8ToRGBA8` part :)