### PR TITLE
Metal: enable mipmap support

### DIFF
--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -46,6 +46,9 @@ inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept
 
 typedef TargetBufferFlags ClearFlag;
 
+/// @note In Metal, mipmap filter is derived from `magFilter` value: ie `NEAREST_MIPMAP_LINEAR` and
+///     `LINEAR_MIPMAP_LINEAR` will select `LINEAR` filter, while `NEAREST_MIPMAP_NEAREST` and
+///     `LINEAR_MIPMAP_NEAREST` will select `NEAREST` filter.
 struct SamplerDescriptor
 {
     SamplerFilter magFilter         = SamplerFilter::LINEAR;

--- a/core/renderer/backend/metal/TextureMTL.mm
+++ b/core/renderer/backend/metal/TextureMTL.mm
@@ -32,7 +32,7 @@ NS_AX_BACKEND_BEGIN
 
 namespace
 {
-MTLSamplerAddressMode toMTLSamplerAddressMode(SamplerAddressMode mode)
+static MTLSamplerAddressMode toMTLSamplerAddressMode(SamplerAddressMode mode)
 {
     MTLSamplerAddressMode ret = MTLSamplerAddressModeRepeat;
     switch (mode)
@@ -53,7 +53,7 @@ MTLSamplerAddressMode toMTLSamplerAddressMode(SamplerAddressMode mode)
     return ret;
 }
 
-MTLSamplerMinMagFilter toMTLSamplerMinMagFilter(SamplerFilter mode)
+static MTLSamplerMinMagFilter toMTLSamplerMinMagFilter(SamplerFilter mode)
 {
     switch (mode)
     {
@@ -70,7 +70,22 @@ MTLSamplerMinMagFilter toMTLSamplerMinMagFilter(SamplerFilter mode)
     }
 }
 
-bool isColorRenderable(PixelFormat textureFormat)
+static MTLSamplerMipFilter toMTLSamplerMipFilter(SamplerFilter mode)
+{
+    switch (mode)
+    {
+    case SamplerFilter::NEAREST_MIPMAP_LINEAR:
+    case SamplerFilter::LINEAR_MIPMAP_LINEAR:
+        return MTLSamplerMipFilterLinear;
+    case SamplerFilter::NEAREST_MIPMAP_NEAREST:
+    case SamplerFilter::LINEAR_MIPMAP_NEAREST:
+        return MTLSamplerMipFilterNearest;
+    default:
+        return MTLSamplerMipFilterNotMipmapped;
+    }
+}
+
+static bool isColorRenderable(PixelFormat textureFormat)
 {
     switch (textureFormat)
     {
@@ -168,6 +183,8 @@ void TextureInfoMTL::recreateSampler(const SamplerDescriptor& descriptor)
         descriptor.minFilter == SamplerFilter::DONT_CARE ? _minFilter : toMTLSamplerMinMagFilter(descriptor.minFilter);
     mtlDescriptor.magFilter =
         descriptor.magFilter == SamplerFilter::DONT_CARE ? _magFilter : toMTLSamplerMinMagFilter(descriptor.magFilter);
+    mtlDescriptor.mipFilter =
+        descriptor.magFilter == SamplerFilter::DONT_CARE ? _mipFilter : toMTLSamplerMipFilter(descriptor.magFilter);
 
     if (_mtlSamplerState)
     {


### PR DESCRIPTION
Enables support for mipmapped textures in Metal. In Metal, mipmaps were ignored, because `mipFilter` for `MTLSamplerDescriptor` was never set.

Note: new graphic APIs like Metal do not support separate mipmap filters for minifying and magnifying textures, so I had to make a compromise and derive mip filter from the mag filter. I think in the future it would be best to change `SamplerFilter` enum to contain only `LINEAR` and `NEAREST` values and add `SamplerMipFilter` enum to contain `LINEAR`, `NEAREST`, `NONE` and in `SamplerDescriptor` add `SamplerMipFilter mipFilter` field.