### PR TITLE
Fix to allow CTRL+A key combination to work with multiple EditBox instances

### DIFF
--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -76,11 +76,11 @@ EditBoxImpl* __createSystemEditBox(EditBox* pEditBox)
 
 EditBoxImplWin::EditBoxImplWin(EditBox* pEditText)
     : EditBoxImplCommon(pEditText)
-      , _prevWndProc(NULL)
-      , _hwndEdit(NULL)
-      , _changedTextManually(false)
-      , _hasFocus(false)
-      , _endAction(EditBoxDelegate::EditBoxEndAction::UNKNOWN)
+    , _prevWndProc(NULL)
+    , _hwndEdit(NULL)
+    , _changedTextManually(false)
+    , _hasFocus(false)
+    , _endAction(EditBoxDelegate::EditBoxEndAction::UNKNOWN)
 {
     if (!s_isInitialized)
     {

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -73,7 +73,6 @@ private:
     void _WindowProc(HWND, UINT, WPARAM, LPARAM);
 
     WNDPROC _prevWndProc;
-    ATOM _hotKeyIdCtrlA;
 
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -89,6 +88,9 @@ private:
     static HWND s_previousFocusWnd;
     static bool s_isInitialized;
     static HMENU s_editboxChildID;
+    static ATOM s_hotKeyIdCtrlA;
+    static uint64_t s_editBoxCount;
+    static bool s_editBoxFocused;
     static void lazyInit();
 };
 

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -89,7 +89,7 @@ private:
     static bool s_isInitialized;
     static HMENU s_editboxChildID;
     static ATOM s_hotKeyIdCtrlA;
-    static uint64_t s_editBoxCount;
+    static int s_editBoxCount;
     static bool s_editBoxFocused;
     static void lazyInit();
 };


### PR DESCRIPTION
## Describe your changes

PR #2238 only worked with the first instance of an `EditBox`, because it seems that the same hotkey combination cannot be registered more than once globally, regardless of the unique address of the `EditBox` that it is bound to.

The changes in this PR register the `CTRL+A` key combination against the app Win32 window, and specifically checks if an `EditBox` is currently focused before applying the select-all text action.  It also automatically de-registers the `CTRL+A` hotkey if all instances of EditBox are freed.

I'm not certain if this is the best solution to the issue, so if anyone sees any potential issues with this implementation, please leave feedback.

## Issue ticket number and link
#2236 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
