### PR TITLE
Prevent excessive calls to deleteBackward method which may cause crashes on Android

### DIFF
--- a/core/2d/TextFieldTTF.h
+++ b/core/2d/TextFieldTTF.h
@@ -261,7 +261,7 @@ protected:
     virtual void didAttachWithIME() override;
     virtual void didDetachWithIME() override;
     virtual void insertText(const char* text, size_t len) override;
-    virtual void deleteBackward() override;
+    virtual void deleteBackward(size_t numChars) override;
     virtual std::string_view getContentText() override;
     virtual void controlKey(EventKeyboard::KeyCode keyCode) override;
 

--- a/core/base/IMEDelegate.h
+++ b/core/base/IMEDelegate.h
@@ -124,7 +124,7 @@ protected:
     * @js NA
     * @lua NA
     */
-    virtual void deleteBackward(size_t deleteLen) {}
+    virtual void deleteBackward(size_t numChars) {}
 
     /**
     @brief    Called by IMEDispatcher after the user press control key.

--- a/core/base/IMEDelegate.h
+++ b/core/base/IMEDelegate.h
@@ -124,7 +124,7 @@ protected:
     * @js NA
     * @lua NA
     */
-    virtual void deleteBackward() {}
+    virtual void deleteBackward(size_t deleteLen) {}
 
     /**
     @brief    Called by IMEDispatcher after the user press control key.

--- a/core/base/IMEDispatcher.cpp
+++ b/core/base/IMEDispatcher.cpp
@@ -222,7 +222,7 @@ void IMEDispatcher::dispatchInsertText(const char* text, size_t len)
     } while (0);
 }
 
-void IMEDispatcher::dispatchDeleteBackward()
+void IMEDispatcher::dispatchDeleteBackward(int numChars)
 {
     do
     {
@@ -231,7 +231,7 @@ void IMEDispatcher::dispatchDeleteBackward()
         // there is no delegate attached to IME
         AX_BREAK_IF(!_impl->_delegateWithIme);
 
-        _impl->_delegateWithIme->deleteBackward();
+        _impl->_delegateWithIme->deleteBackward(numChars);
     } while (0);
 }
 

--- a/core/base/IMEDispatcher.h
+++ b/core/base/IMEDispatcher.h
@@ -65,7 +65,7 @@ public:
      * @brief Dispatches the delete-backward operation.
      * @lua NA
      */
-    void dispatchDeleteBackward();
+    void dispatchDeleteBackward(int numChars);
 
     /**
      * @brief Dispatches the press control key operation.

--- a/core/platform/GLViewImpl.cpp
+++ b/core/platform/GLViewImpl.cpp
@@ -1220,7 +1220,7 @@ void GLViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scanco
         switch (g_keyCodeMap[key])
         {
         case EventKeyboard::KeyCode::KEY_BACKSPACE:
-            IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+            IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward(1);
             break;
         case EventKeyboard::KeyCode::KEY_HOME:
         case EventKeyboard::KeyCode::KEY_KP_HOME:

--- a/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolGLSurfaceView.java
@@ -458,11 +458,11 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
         });
     }
 
-    public void deleteBackward() {
+    public void deleteBackward(int numChars) {
         this.queueEvent(new Runnable() {
             @Override
             public void run() {
-                AxmolGLSurfaceView.this.mRenderer.handleDeleteBackward();
+                AxmolGLSurfaceView.this.mRenderer.handleDeleteBackward(numChars);
             }
         });
     }

--- a/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
+++ b/core/platform/android/java/src/org/axmol/lib/AxmolRenderer.java
@@ -176,15 +176,15 @@ public class AxmolRenderer implements GLSurfaceView.Renderer {
     }
 
     private static native void nativeInsertText(final String text);
-    private static native void nativeDeleteBackward();
+    private static native void nativeDeleteBackward(final int numChars);
     private static native String nativeGetContentText();
 
     public void handleInsertText(final String text) {
         AxmolRenderer.nativeInsertText(text);
     }
 
-    public void handleDeleteBackward() {
-        AxmolRenderer.nativeDeleteBackward();
+    public void handleDeleteBackward(final int numChars) {
+        AxmolRenderer.nativeDeleteBackward(numChars);
     }
 
     public String getContentText() {

--- a/core/platform/android/java/src/org/axmol/lib/TextInputWrapper.java
+++ b/core/platform/android/java/src/org/axmol/lib/TextInputWrapper.java
@@ -90,8 +90,9 @@ public class TextInputWrapper implements TextWatcher, OnEditorActionListener {
             new_i += 1;
         }
 
-        for (; old_i < this.mText.length(); ++old_i) {
-            this.mGLSurfaceView.deleteBackward();
+        if (old_i < this.mText.length()) {
+            Log.i(TAG, String.format("this.mText.length() - old_i = %d", this.mText.length() - old_i));
+            this.mGLSurfaceView.deleteBackward(this.mText.length() - old_i);
         }
 
         int nModified = s.length() - new_i;
@@ -118,13 +119,14 @@ public class TextInputWrapper implements TextWatcher, OnEditorActionListener {
         if (this.mGLSurfaceView.getEditText() == pTextView && this.isFullScreenEdit()) {
             // user press the action button, delete all old text and insert new text
             if (null != mOriginText) {
-                for (int i = this.mOriginText.length(); i > 0; i--) {
-                    this.mGLSurfaceView.deleteBackward();
+                if (!this.mOriginText.isEmpty()) {
+                    Log.i(TAG, String.format("this.mOriginText.length() = %d", this.mOriginText.length()));
+                    this.mGLSurfaceView.deleteBackward(this.mOriginText.length());
                 }
             }
-            
+
             String text = pTextView.getText().toString();
-            
+
             if (text != null) {
                 /* If user input nothing, translate "\n" to engine. */
                 if ( text.compareTo("") == 0) {
@@ -135,12 +137,12 @@ public class TextInputWrapper implements TextWatcher, OnEditorActionListener {
                     text += '\n';
                 }
             }
-            
+
             final String insertText = text;
             this.mGLSurfaceView.insertText(insertText);
 
         }
-        
+
         if (pActionID == EditorInfo.IME_ACTION_DONE) {
             this.mGLSurfaceView.requestFocus();
         }

--- a/core/platform/android/java/src/org/axmol/lib/TextInputWrapper.java
+++ b/core/platform/android/java/src/org/axmol/lib/TextInputWrapper.java
@@ -91,7 +91,6 @@ public class TextInputWrapper implements TextWatcher, OnEditorActionListener {
         }
 
         if (old_i < this.mText.length()) {
-            Log.i(TAG, String.format("this.mText.length() - old_i = %d", this.mText.length() - old_i));
             this.mGLSurfaceView.deleteBackward(this.mText.length() - old_i);
         }
 
@@ -120,7 +119,6 @@ public class TextInputWrapper implements TextWatcher, OnEditorActionListener {
             // user press the action button, delete all old text and insert new text
             if (null != mOriginText) {
                 if (!this.mOriginText.isEmpty()) {
-                    Log.i(TAG, String.format("this.mOriginText.length() = %d", this.mOriginText.length()));
                     this.mGLSurfaceView.deleteBackward(this.mOriginText.length());
                 }
             }

--- a/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
+++ b/core/platform/android/jni/Java_org_axmol_lib_AxmolRenderer.cpp
@@ -70,9 +70,9 @@ JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeInsertText(JNIEnv*
     ax::IMEDispatcher::sharedDispatcher()->dispatchInsertText(pszText, strlen(pszText));
 }
 
-JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeDeleteBackward(JNIEnv*, jclass)
+JNIEXPORT void JNICALL Java_org_axmol_lib_AxmolRenderer_nativeDeleteBackward(JNIEnv*, jclass, jint numChars)
 {
-    ax::IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+    ax::IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward(numChars);
 }
 
 JNIEXPORT jstring JNICALL Java_org_axmol_lib_AxmolRenderer_nativeGetContentText(JNIEnv* env, jclass)

--- a/core/platform/ios/InputView-ios.mm
+++ b/core/platform/ios/InputView-ios.mm
@@ -98,7 +98,7 @@ THE SOFTWARE.
         [self.myMarkedText release];
         self.myMarkedText = nil;
     }
-    ax::IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+    ax::IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward(1);
 }
 
 - (void)insertText:(nonnull NSString*)text

--- a/core/platform/winrt/InputEvent.cpp
+++ b/core/platform/winrt/InputEvent.cpp
@@ -112,7 +112,7 @@ void KeyboardEvent::execute()
             //Director::getInstance()()->getKeypadDispatcher()->dispatchKeypadMSG(kTypeBackClicked);
             break;
         case AxmolKeyEvent::Back:
-            IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+            IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward(1);
             break;
         case AxmolKeyEvent::Enter:
             IMEDispatcher::sharedDispatcher()->dispatchInsertText("\n", 1);

--- a/core/platform/winrt/Keyboard-winrt.cpp
+++ b/core/platform/winrt/Keyboard-winrt.cpp
@@ -304,7 +304,7 @@ void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, KeyEventAr
             switch (keyCode)
             {
             case EventKeyboard::KeyCode::KEY_BACKSPACE:
-                IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+                IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward(1);
                 break;
             case EventKeyboard::KeyCode::KEY_HOME:
             case EventKeyboard::KeyCode::KEY_KP_HOME:

--- a/core/ui/UITextFieldEx.h
+++ b/core/ui/UITextFieldEx.h
@@ -140,7 +140,7 @@ protected:
     bool canAttachWithIME() override;
     bool canDetachWithIME() override;
 
-    void deleteBackward() override;
+    void deleteBackward(size_t numChars) override;
     std::string_view getContentText() override;
 
     void handleDeleteKeyEvent();

--- a/core/ui/axmol-ui.h
+++ b/core/ui/axmol-ui.h
@@ -40,6 +40,7 @@ THE SOFTWARE.
 #include "ui/UIListView.h"
 #include "ui/UISlider.h"
 #include "ui/UITextField.h"
+#include "ui/UITextFieldEx.h"
 #include "ui/UITextBMFont.h"
 #include "ui/UIPageView.h"
 #include "ui/UIHelper.h"


### PR DESCRIPTION
## Describe your changes
The changes in this PR will prevent situations where a call to `TextField::deleteBackward` is made for every single character when deleting text in large blocks, such as via a Select All -> Backspace operation using the Android virtual keyboard.   When many consecutive calls to `deleteBackward` are made in a single update/frame, it seems to result in a crash.

Just note that this does not change the behavior when the user is deleting one character at a time, since it will still call `TextField::deleteBackward` once per character.  The test cases in cpp-tests, `49:Node: Text Input` confirm that the behaviour is still the same.

## Issue ticket number and link

This possibly relates to all the following issues:
#2240 
#2241 
#2242

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
