### PR TITLE
Detect CTRL+A key combination to select all text in EditBox

### DIFF
--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -306,7 +306,7 @@ void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
     switch (uMsg)
     {
     case WM_KEYDOWN:
-        if (wParam == 'A' && (GetKeyState(VK_CONTROL) & 0x8000) != 0)  // CTRL+A for "Select All"
+        if (_hasFocus && wParam == 'A' && (GetKeyState(VK_CONTROL) & 0x8000) != 0)  // CTRL+A for "Select All"
         {
             ::SendMessageW(_hwndEdit, EM_SETSEL, 0, -1);
         }

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -73,7 +73,6 @@ EditBoxImpl* __createSystemEditBox(EditBox* pEditBox)
 
 EditBoxImplWin::EditBoxImplWin(EditBox* pEditText)
     : EditBoxImplCommon(pEditText)
-    , _hotKeyIdCtrlA(0)
     , _hwndEdit(NULL)
     , _changedTextManually(false)
     , _hasFocus(false)
@@ -101,10 +100,6 @@ void EditBoxImplWin::cleanupEditCtrl()
 {
     if (_hwndEdit)
     {
-        UnregisterHotKey(_hwndEdit, _hotKeyIdCtrlA);
-        GlobalDeleteAtom(_hotKeyIdCtrlA);
-        _hotKeyIdCtrlA = 0;
-
         SetWindowLongPtrW(_hwndEdit, GWLP_WNDPROC, (LONG_PTR)_prevWndProc);
         ::DestroyWindow(_hwndEdit);
         _hasFocus            = false;
@@ -137,9 +132,6 @@ void EditBoxImplWin::createEditCtrl(bool singleLine)
         s_previousFocusWnd = s_hwndCocos;
         this->setNativeFont(this->getNativeDefaultFontName(), this->_fontSize);
         this->setNativeText(this->_text.c_str());
-
-        _hotKeyIdCtrlA = GlobalAddAtom(L"CTRL+A");
-        RegisterHotKey(_hwndEdit, _hotKeyIdCtrlA, MOD_CONTROL | MOD_NOREPEAT, 'A');
     }
 }
 
@@ -313,6 +305,12 @@ void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 {
     switch (uMsg)
     {
+    case WM_KEYDOWN:
+        if (wParam == 'A' && (GetKeyState(VK_CONTROL) & 0x8000) != 0)  // CTRL+A for "Select All"
+        {
+            ::SendMessageW(_hwndEdit, EM_SETSEL, 0, -1);
+        }
+        break;
     case WM_CHAR:
         if (wParam == VK_RETURN)
         {
@@ -367,12 +365,6 @@ void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
         if (this->_editingMode && !::IsWindowVisible(hwnd))
         {
             this->editBoxEditingDidEnd(this->getText(), _endAction);
-        }
-        break;
-    case WM_HOTKEY:
-        if (wParam == (WPARAM)_hotKeyIdCtrlA)
-        {
-            ::SendMessageW(_hwndEdit, EM_SETSEL, 0, -1);
         }
         break;
     default:

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -73,7 +73,6 @@ private:
     void _WindowProc(HWND, UINT, WPARAM, LPARAM);
 
     WNDPROC _prevWndProc;
-    ATOM _hotKeyIdCtrlA;
 
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
## Describe your changes

This is a simpler solution to detecting `CTRL+A` in order to select all text in the EditBox. 

This does not have the side effects present in #2238 and #2246.

## Issue ticket number and link

#2236 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
