### PR TITLE
Add printLeaks call in appropriate location to help developers

### DIFF
--- a/templates/common/proj.ios_mac/mac/main.cpp
+++ b/templates/common/proj.ios_mac/mac/main.cpp
@@ -29,8 +29,20 @@
 
 using namespace ax;
 
-int main(int argc, char* argv[])
+int axmol_main()
 {
+    // create the application instance
     AppDelegate app;
     return Application::getInstance()->run();
+}
+
+int main(int argc, char* argv[])
+{
+    auto result = axmol_main();
+
+#if AX_OBJECT_LEAK_DETECTION
+    Object::printLeaks();
+#endif
+
+    return result;
 }

--- a/templates/common/proj.linux/main.cpp
+++ b/templates/common/proj.linux/main.cpp
@@ -32,9 +32,20 @@
 
 using namespace ax;
 
-int main(int argc, char** argv)
+int axmol_main()
 {
     // create the application instance
     AppDelegate app;
     return Application::getInstance()->run();
+}
+
+int main(int argc, char** argv)
+{
+    auto result = axmol_main();
+
+#if AX_OBJECT_LEAK_DETECTION
+    Object::printLeaks();
+#endif
+
+    return result;
 }

--- a/templates/common/proj.wasm/main.cpp
+++ b/templates/common/proj.wasm/main.cpp
@@ -33,9 +33,20 @@
 
 using namespace ax;
 
-int main(int argc, char** argv)
+int axmol_main()
 {
     // create the application instance
     AppDelegate app;
     return Application::getInstance()->run();
+}
+
+int main(int argc, char** argv)
+{
+    auto result = axmol_main();
+
+#if AX_OBJECT_LEAK_DETECTION
+    Object::printLeaks();
+#endif
+
+    return result;
 }

--- a/templates/common/proj.win32/main.cpp
+++ b/templates/common/proj.win32/main.cpp
@@ -45,13 +45,17 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 
-    // create the application instance
 #ifdef USE_WIN32_CONSOLE
 #    include "platform/win32/EmbedConsole.h"
 #endif
 
-    // create the application instance
-    return axmol_main();
+    auto result = axmol_main();
+
+#if AX_OBJECT_LEAK_DETECTION
+    Object::printLeaks();
+#endif
+
+    return result;
 }
 #else
 int main(int, char**) {


### PR DESCRIPTION
## Describe your changes

If the `printLeaks()` is called in the wrong location, then it could lead to confusion, since it would be reporting memory leaks that aren't actually valid leaks.  The changes in this PR just ensure that it is called in an appropriate location, and enabled by the existing `AX_OBJECT_LEAK_DETECTION` define.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
