### PR TITLE
Add printLeaks call to alternative Win32 main method

### DIFF
--- a/templates/common/proj.win32/main.cpp
+++ b/templates/common/proj.win32/main.cpp
@@ -59,6 +59,12 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
 }
 #else
 int main(int, char**) {
-    return axmol_main();
+    auto result = axmol_main();
+
+#if AX_OBJECT_LEAK_DETECTION
+    Object::printLeaks();
+#endif
+
+    return result;
 }
 #endif


### PR DESCRIPTION
## Describe your changes

Add the `printLeaks()` call to the `main` function used if `_CONSOLE` is defined.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
