### PR TITLE
fix crash when close app (PC platform)

### DIFF
--- a/core/platform/linux/Application-linux.cpp
+++ b/core/platform/linux/Application-linux.cpp
@@ -93,7 +93,6 @@ int Application::run()
     if (glView->isOpenGLReady())
     {
         director->end();
-        director->mainLoop();
         director = nullptr;
     }
     glView->release();

--- a/core/platform/mac/Application-mac.mm
+++ b/core/platform/mac/Application-mac.mm
@@ -93,7 +93,6 @@ int Application::run()
     if (glView->isOpenGLReady())
     {
         director->end();
-        director->mainLoop();
     }
 
     glView->release();

--- a/core/platform/wasm/Application-wasm.cpp
+++ b/core/platform/wasm/Application-wasm.cpp
@@ -137,7 +137,6 @@ int Application::run()
     if (glview->isOpenGLReady())
     {
         director->end();
-        director->mainLoop();
         director = nullptr;
     }
     glview->release();

--- a/core/platform/win32/Application-win32.cpp
+++ b/core/platform/win32/Application-win32.cpp
@@ -124,7 +124,6 @@ int Application::run()
     if (glView->isOpenGLReady())
     {
         director->end();
-        director->mainLoop();
         director = nullptr;
     }
     glView->release();


### PR DESCRIPTION
on PC platform. when using (X) to close,
`director->mainLoop();` right after `director->end();` seems redundant and causes a crash,
after removing `director->mainLoop();` my application works fine,
no crashes because of the order of deleting objects