### PR TITLE
Fix renderer test case batching

### DIFF
--- a/core/renderer/TrianglesCommand.cpp
+++ b/core/renderer/TrianglesCommand.cpp
@@ -68,7 +68,7 @@ void TrianglesCommand::init(float globalOrder,
         blendDescriptor.sourceRGBBlendFactor = blendDescriptor.sourceAlphaBlendFactor = blendType.src;
         blendDescriptor.destinationRGBBlendFactor = blendDescriptor.destinationAlphaBlendFactor = blendType.dst;
 
-        if (_batchId == -1)
+        if (!_pipelineDescriptor.programState->isValidBatchId())
             setSkipBatching(true);
 
         if (!isSkipBatching())

--- a/core/renderer/TrianglesCommand.cpp
+++ b/core/renderer/TrianglesCommand.cpp
@@ -68,7 +68,7 @@ void TrianglesCommand::init(float globalOrder,
         blendDescriptor.sourceRGBBlendFactor = blendDescriptor.sourceAlphaBlendFactor = blendType.src;
         blendDescriptor.destinationRGBBlendFactor = blendDescriptor.destinationAlphaBlendFactor = blendType.dst;
 
-        if (!_pipelineDescriptor.programState->isValidBatchId())
+        if (!_pipelineDescriptor.programState->isBatchable())
             setSkipBatching(true);
 
         if (!isSkipBatching())

--- a/core/renderer/backend/Program.h
+++ b/core/renderer/backend/Program.h
@@ -152,7 +152,7 @@ public:
      * Get program id.
      * @return The program id.
      */
-    int64_t getProgramId() const { return _programId; }
+    uint64_t getProgramId() const { return _programId; }
 
     /**
      * Get uniform buffer size in bytes that can hold all the uniforms.

--- a/core/renderer/backend/ProgramManager.h
+++ b/core/renderer/backend/ProgramManager.h
@@ -157,9 +157,9 @@ protected:
     };
 
     BuiltinRegInfo _builtinRegistry[(int)backend::ProgramType::BUILTIN_COUNT];
-    std::unordered_map<int64_t, BuiltinRegInfo> _customRegistry;
+    std::unordered_map<uint64_t, BuiltinRegInfo> _customRegistry;
 
-    std::unordered_map<int64_t, Program*> _cachedPrograms;  ///< The cached program object.
+    std::unordered_map<uint64_t, Program*> _cachedPrograms;  ///< The cached program object.
 
     XXH64_state_s* _programIdGen;
 

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -175,7 +175,10 @@ bool ProgramState::init(Program* program)
 
     const auto programId = program->getProgramId();
     if (programId < ProgramType::BUILTIN_COUNT)
+    {
         this->_batchId = programId;
+        this->_isValidBatchId = true;
+    }
 
     return true;
 }
@@ -183,6 +186,7 @@ bool ProgramState::init(Program* program)
 void ProgramState::updateBatchId()
 {
     _batchId = XXH64(_uniformBuffers.data(), _uniformBuffers.size(), _program->getProgramId());
+    _isValidBatchId = true;
 }
 
 void ProgramState::resetUniforms()
@@ -229,6 +233,7 @@ ProgramState* ProgramState::clone() const
     cp->_vertexLayout    = !_ownVertexLayout ? _vertexLayout : new VertexLayout(*_vertexLayout);
 
     cp->_batchId = this->_batchId;
+    cp->_isValidBatchId = this->_isValidBatchId;
     return cp;
 }
 

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -177,7 +177,7 @@ bool ProgramState::init(Program* program)
     if (programId < ProgramType::BUILTIN_COUNT)
     {
         this->_batchId = programId;
-        this->_isValidBatchId = true;
+        this->_isBatchable = true;
     }
 
     return true;
@@ -186,7 +186,7 @@ bool ProgramState::init(Program* program)
 void ProgramState::updateBatchId()
 {
     _batchId = XXH64(_uniformBuffers.data(), _uniformBuffers.size(), _program->getProgramId());
-    _isValidBatchId = true;
+    _isBatchable = true;
 }
 
 void ProgramState::resetUniforms()
@@ -233,7 +233,7 @@ ProgramState* ProgramState::clone() const
     cp->_vertexLayout    = !_ownVertexLayout ? _vertexLayout : new VertexLayout(*_vertexLayout);
 
     cp->_batchId = this->_batchId;
-    cp->_isValidBatchId = this->_isValidBatchId;
+    cp->_isBatchable = this->_isBatchable;
     return cp;
 }
 

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -302,6 +302,11 @@ public:
     uint64_t getBatchId() const { return _batchId; };
 
     /*
+     * Gets the state of the batch ID. If true, then batch ID is valid
+     */
+    bool isValidBatchId() const { return _isValidBatchId; };
+
+    /*
     * Update batchID of current program state, by default, custom program was traits with mutable uniforms
     * so batch ID was set to -1 indicate batch was disabled
     */
@@ -399,7 +404,8 @@ protected:
     VertexLayout* _vertexLayout = nullptr;
     bool _ownVertexLayout       = false;
 
-    uint64_t _batchId = -1;
+    uint64_t _batchId    = -1;
+    bool _isValidBatchId = false;
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     EventListenerCustom* _backToForegroundListener = nullptr;

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -304,7 +304,7 @@ public:
     /*
      * Gets the state of the batch ID. If true, then batch ID is valid
      */
-    bool isValidBatchId() const { return _isValidBatchId; };
+    bool isBatchable() const { return _isBatchable; };
 
     /*
     * Update batchID of current program state, by default, custom program was traits with mutable uniforms
@@ -405,7 +405,7 @@ protected:
     bool _ownVertexLayout       = false;
 
     uint64_t _batchId    = -1;
-    bool _isValidBatchId = false;
+    bool _isBatchable = false;
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     EventListenerCustom* _backToForegroundListener = nullptr;

--- a/tests/cpp-tests/Source/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Source/NewRendererTest/NewRendererTest.cpp
@@ -824,7 +824,9 @@ RendererUniformBatch::RendererUniformBatch()
     Size s = Director::getInstance()->getWinSize();
 
     auto blurState  = createBlurProgramState();
+    blurState->updateBatchId();
     auto sepiaState = createSepiaProgramState();
+    sepiaState->updateBatchId();
 
     auto x_inc = s.width / 20;
     auto y_inc = s.height / 6;
@@ -896,8 +898,10 @@ RendererUniformBatch2::RendererUniformBatch2()
 {
     Size s = Director::getInstance()->getWinSize();
 
-    auto blurState  = createBlurProgramState();
+    auto blurState = createBlurProgramState();
+    blurState->updateBatchId();
     auto sepiaState = createSepiaProgramState();
+    sepiaState->updateBatchId();
 
     auto x_inc = s.width / 20;
     auto y_inc = s.height / 6;


### PR DESCRIPTION
## Describe your changes

In cpp-tests -> Renderer -> RendererUniformBatch test, the drawn sprites should be batched, but they are not, so instead of 9 draw calls, it results in over 80.  The changes in this PR ensure that the batch ID of each of the custom shaders is calculated so that the sprites are correctly batched, which fixes the issue.

The other related issue is this:
```
bool ProgramState::init(Program* program)
{
...
    const auto programId = program->getProgramId();
    if (programId < ProgramType::BUILTIN_COUNT)
        this->_batchId = programId;

    return true;
}
```

`Program::getProgramId()` was returning an `int64_t`, which could return a negative number, resulting in the conditional statement being true, when it should not be:
```
if (programId < ProgramType::BUILTIN_COUNT)
```

Unless I'm mistaken, all Program IDs are `uint64_t`, so the result of `Program::getProgramId()` has been updated accordingly, along with the key types of the `std::unordered_map` used to store the `Program` instances.

Added `ProgramState::isValidBatchId()` to check if a valid batch ID has been set.  The reason is that the hashing methods can return any value, even `uint64_t(-1)` (please correct me if I'm wrong on this):

`_batchId = XXH64(_uniformBuffers.data(), _uniformBuffers.size(), _program->getProgramId());`

So, doing a check like the following may result in incorrectly skipping batching:
```
if (_batchId == -1)
    setSkipBatching(true);
```

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
