### PR TITLE
Improve DevSetup.md

### DIFF
--- a/docs/DevSetup.md
+++ b/docs/DevSetup.md
@@ -5,7 +5,7 @@
 - **PowerShell**: used to install Axmol. PowerShell 7 is recommended, it supports Windows, macOS and Linux.
   - Quick installation: 
      - macOS, Ubuntu, ArchLinux: run `setup.ps1` in `axmol` root directory (recommended).
-     - Windows 10+: system installed PowerShell 5.x should work, but in that case you'll need to run the command `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Bypass -Force` in order to allow PowerShell script file to run.
+     - Windows 10+: system installed PowerShell 5.x should work, but in that case you'll need to run the command `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force` in order to allow PowerShell script file to run. This will allow execution of PowerShell scripts for the current process.
   - Manual installation: [Instructions](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) /  [Download](https://github.com/PowerShell/PowerShell/releases)
 - **CMake 3.28.1+**
     - Manual installation is recommended ([download](https://cmake.org/download/)). Make sure to add CMake bin to the system `PATH`, otherwise `axmol build` will auto-setup it to `tools/external/cmake`.


### PR DESCRIPTION
Setting the execution policy of the current user to `Bypass` is dangerous, since it sets this permanently, and allows any PowerShell scripts on the system to run without warning.

It would be best to set the execution policy only for the current process and any child processes at the time the script needs to be run via:
```
Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
```

It should be left up to more advanced users to decide if they wish to use different scopes for the execution policy, but for users unfamiliar with this, the recommended option should be a secure one.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
