### PR TITLE
Fix RenderTexture internal sprite positioning and test cases

### DIFF
--- a/core/2d/RenderTexture.cpp
+++ b/core/2d/RenderTexture.cpp
@@ -232,6 +232,9 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         // retained
         setSprite(Sprite::createWithTexture(_texture2D));
 
+        _sprite->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+        _sprite->setPosition(Vec2(w, h) / 2);
+
 #if defined(AX_USE_GL)
         _sprite->setFlippedY(true);
 #endif
@@ -256,6 +259,24 @@ bool RenderTexture::initWithWidthAndHeight(int w,
     } while (0);
 
     return ret;
+}
+
+void RenderTexture::onEnter()
+{
+    Node::onEnter();
+    if (_sprite)
+    {
+        _sprite->onEnter();
+    }
+}
+
+void RenderTexture::onExit()
+{
+    if (_sprite)
+    {
+        _sprite->onExit();
+    }
+    Node::onExit();
 }
 
 void RenderTexture::setSprite(Sprite* sprite)

--- a/core/2d/RenderTexture.h
+++ b/core/2d/RenderTexture.h
@@ -379,6 +379,24 @@ public:
                                 backend::PixelFormat depthStencilFormat,
                                 bool sharedRenderTarget = true);
 
+    /**
+     * Event callback that is invoked every time when Node enters the 'stage'.
+     * If the Node enters the 'stage' with a transition, this event is called when the transition starts.
+     * During onEnter you can't access a "sister/brother" node.
+     * If you override onEnter, you shall call its parent's one, e.g., Node::onEnter().
+     * @lua NA
+     */
+    void onEnter() override;
+
+    /**
+     * Event callback that is invoked every time the Node leaves the 'stage'.
+     * If the Node leaves the 'stage' with a transition, this event is called when the transition finishes.
+     * During onExit you can't access a sibling node.
+     * If you override onExit, you shall call its parent's one, e.g., Node::onExit().
+     * @lua NA
+     */
+    void onExit() override;
+
 protected:
     virtual void
     beginWithClear(float r, float g, float b, float a, float depthValue, int stencilValue, ClearFlag flags);

--- a/core/2d/RenderTexture.h
+++ b/core/2d/RenderTexture.h
@@ -314,12 +314,6 @@ public:
 
     inline backend::RenderTarget* getRenderTarget() const { return _renderTarget; }
 
-    /** Sets the Sprite being used.
-     *
-     * @param sprite A Sprite.
-     */
-    void setSprite(Sprite* sprite);
-
     /** Flag: Use stack matrix computed from scene hierarchy or generate new modelView and projection matrix.
      *
      * @param keepMatrix Whether or not use stack matrix computed from scene hierarchy or generate new modelView and
@@ -398,6 +392,12 @@ public:
     void onExit() override;
 
 protected:
+    /** Sets the Sprite being used.
+     *
+     * @param sprite A Sprite.
+     */
+    void setSprite(Sprite* sprite);
+
     virtual void
     beginWithClear(float r, float g, float b, float a, float depthValue, int stencilValue, ClearFlag flags);
     // renderer caches and callbacks

--- a/core/2d/Transition.cpp
+++ b/core/2d/Transition.cpp
@@ -1129,7 +1129,6 @@ void TransitionCrossFade::onEnter()
         return;
     }
 
-    inTexture->getSprite()->setAnchorPoint(Vec2(0.5f, 0.5f));
     inTexture->setPosition(size.width / 2, size.height / 2);
     inTexture->setAnchorPoint(Vec2(0.5f, 0.5f));
 
@@ -1141,7 +1140,7 @@ void TransitionCrossFade::onEnter()
     // create the second render texture for outScene
     RenderTexture* outTexture =
         RenderTexture::create((int)size.width, (int)size.height, backend::PixelFormat::RGBA8, PixelFormat::D24S8, false);
-    outTexture->getSprite()->setAnchorPoint(Vec2(0.5f, 0.5f));
+
     outTexture->setPosition(size.width / 2, size.height / 2);
     outTexture->setAnchorPoint(Vec2(0.5f, 0.5f));
 

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -84131,56 +84131,6 @@ int lua_ax_base_RenderTexture_getRenderTarget(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_RenderTexture_setSprite(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::RenderTexture* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.RenderTexture",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::RenderTexture*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderTexture_setSprite'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
-    {
-        ax::Sprite* arg0;
-
-        ok &= luaval_to_object<ax::Sprite>(tolua_S, 2, "ax.Sprite",&arg0, "ax.RenderTexture:setSprite");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderTexture_setSprite'", nullptr);
-            return 0;
-        }
-        cobj->setSprite(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderTexture:setSprite",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderTexture_setSprite'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_base_RenderTexture_setKeepMatrix(lua_State* tolua_S)
 {
     int argc = 0;
@@ -84676,7 +84626,6 @@ int lua_register_ax_base_RenderTexture(lua_State* tolua_S)
         tolua_function(tolua_S,"setAutoDraw",lua_ax_base_RenderTexture_setAutoDraw);
         tolua_function(tolua_S,"getSprite",lua_ax_base_RenderTexture_getSprite);
         tolua_function(tolua_S,"getRenderTarget",lua_ax_base_RenderTexture_getRenderTarget);
-        tolua_function(tolua_S,"setSprite",lua_ax_base_RenderTexture_setSprite);
         tolua_function(tolua_S,"setKeepMatrix",lua_ax_base_RenderTexture_setKeepMatrix);
         tolua_function(tolua_S,"setVirtualViewport",lua_ax_base_RenderTexture_setVirtualViewport);
         tolua_function(tolua_S,"isSharedRenderTarget",lua_ax_base_RenderTexture_isSharedRenderTarget);

--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
@@ -51,6 +51,7 @@ RenderTextureSave::RenderTextureSave()
     _target = RenderTexture::create(s.width, s.height, backend::PixelFormat::RGBA8);
     _target->retain();
     _target->setPosition(Vec2(s.width / 2, s.height / 2));
+    _target->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
 
     // note that the render texture is a Node, and contains a sprite of its texture for convenience,
     // so we can just parent it to the scene like any other Node
@@ -263,6 +264,7 @@ RenderTextureIssue937::RenderTextureIssue937()
     spr_nonpremulti->visit();
     rend->end();
 
+    rend->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
     rend->setPosition(Vec2(s.width / 2 + 16, s.height / 2));
 
     addChild(spr_nonpremulti);
@@ -509,6 +511,7 @@ RenderTextureTestDepthStencil::RenderTextureTestDepthStencil()
     _rtx = RenderTexture::create(s.width, s.height, backend::PixelFormat::RGBA4, PixelFormat::D24S8);
 
     _rtx->setPosition(Vec2(s.width * 0.5f, s.height * 0.5f));
+    _rtx->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
 
     this->addChild(_rtx);
 }
@@ -613,15 +616,23 @@ RenderTextureTargetNode::RenderTextureTargetNode()
     auto s = Director::getInstance()->getWinSize();
 
     /* Create the render texture */
-    auto renderTexture  = RenderTexture::create(s.width, s.height, backend::PixelFormat::RGBA4);
-    this->renderTexture = renderTexture;
+    renderTexture = RenderTexture::create(s.width, s.height, backend::PixelFormat::RGBA4);
 
     renderTexture->setPosition(Vec2(s.width / 2, s.height / 2));
+    renderTexture->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
     // renderTexture->setScale(2.0f);
 
     /* add the sprites to the render texture */
+    _spriteCenterPosition = renderTexture->getContentSize() / 2;
+
+    sprite1->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+    sprite1->setPosition(_spriteCenterPosition);
     renderTexture->addChild(sprite1);
+
+    sprite2->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+    sprite2->setPosition(_spriteCenterPosition);
     renderTexture->addChild(sprite2);
+
     renderTexture->setClearColor(Color4F(0, 0, 0, 0));
     renderTexture->setClearFlags(ClearFlag::COLOR);
 
@@ -658,8 +669,8 @@ void RenderTextureTargetNode::update(float dt)
 {
     static float time = 0;
     float r           = 80;
-    sprite1->setPosition(Vec2(cosf(time * 2) * r, sinf(time * 2) * r));
-    sprite2->setPosition(Vec2(sinf(time * 2) * r, cosf(time * 2) * r));
+    sprite1->setPosition(_spriteCenterPosition + Vec2(cosf(time * 2) * r, sinf(time * 2) * r));
+    sprite2->setPosition(_spriteCenterPosition + Vec2(sinf(time * 2) * r, cosf(time * 2) * r));
 
     time += dt;
 }

--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.h
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.h
@@ -121,6 +121,7 @@ class RenderTextureTargetNode : public RenderTextureTest
 private:
     ax::Sprite *sprite1, *sprite2;
     ax::RenderTexture* renderTexture;
+    ax::Vec2 _spriteCenterPosition;
 
 public:
     CREATE_FUNC(RenderTextureTargetNode);


### PR DESCRIPTION
## Describe your changes
This fixes the issue described in #2300 that only applied to CrossFade transitions, along with the RenderTexture tests that would be affected by the new changes to RenderTexture.

A few things to note about the functionality in RenderTexture:
1. The internal sprite is not a child of the RenderTexture
2. The internal sprite is still rendered in the `RenderTexture::visit()` method
3. The internal sprite must still be activated/deactivated via `Sprite::onEnter()`/`Sprite::onExit()` to ensure actions can be run on it
4. The RenderTexture content size is set to the true size of the RenderTexture.  This change was made in #2120 to fix another issue.  Due to this, the internal sprite is now positioned in the center of the RenderTexture to ensure it renders into the correct position, which fixes the CrossFade transition position issue.

The default `RenderTexture` anchor point is `0,0`, which is the same default as `Node`.  Since the internal sprite is now positioned in the middle of the RenderTexture, and to keep the old behavior, then the RenderTexture instance must have the anchor point set to the center of the parent to ensure the sprite position it correctly on-screen.  So, for example, to render the RenderTexture in the center of the screen, previous usage would have been as follows:

```
renderTexture->setPosition(Vec2(parentWidth / 2, parentHeight / 2));
```

Now, since the internal sprite has been moved to the center of the render texture, this is how it should be done, which now also matches how other node types are displayed (such as `Sprite` etc.):
```
renderTexture->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
renderTexture->setPosition(Vec2(parentWidth / 2, parentHeight / 2));
```

## Issue ticket number and link

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
