### PR TITLE
Fix continues drawCardinalSplines() drawing outside the control points on last control point

### DIFF
--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -484,22 +484,21 @@ void DrawNode::drawCardinalSpline(PointArray* config,
 
     ssize_t p;
     float lt;
+    float dt;
     float deltaT = 1.0f / config->count();
 
     for (unsigned int i = 0; i < segments; i++)
     {
-        float dt = (float)i / segments;
+        dt = (float)i / segments;
+        p  = static_cast<ssize_t>(dt / deltaT);
 
-        // border
-        if (dt == 1)
+        // Check last control point reached
+        if (p >= (config->count() - 1))
         {
-            p  = config->count() - 1;
-            lt = 1;
-        }
-        else
-        {
-            p  = static_cast<ssize_t>(dt / deltaT);
-            lt = (dt - deltaT * (float)p) / deltaT;
+            _vertices[i] = config->getControlPointAtIndex(config->count() - 1);
+            segments     = i + 1;
+            _vertices.resize(segments);
+            break;
         }
 
         // Interpolate
@@ -508,14 +507,8 @@ void DrawNode::drawCardinalSpline(PointArray* config,
         Vec2 pp2 = config->getControlPointAtIndex(p + 1);
         Vec2 pp3 = config->getControlPointAtIndex(p + 2);
 
-        Vec2 newPos    = ccCardinalSplineAt(pp0, pp1, pp2, pp3, tension, lt);
-        _vertices[i].x = newPos.x;
-        _vertices[i].y = newPos.y;
-        if (newPos == config->getControlPointAtIndex(config->count() - 1) && i > 0)
-        {
-            segments = i + 1;
-            break;
-        }
+        lt           = (dt - deltaT * (float)p) / deltaT;
+        _vertices[i] = ccCardinalSplineAt(pp0, pp1, pp2, pp3, tension, lt);
     }
 
     _drawPoly(_vertices.data(), segments, false, color, thickness, true);

--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -484,12 +484,11 @@ void DrawNode::drawCardinalSpline(PointArray* config,
 
     ssize_t p;
     float lt;
-    float dt;
     float deltaT = 1.0f / config->count();
 
     for (unsigned int i = 0; i < segments; i++)
     {
-        dt = (float)i / segments;
+        float dt = (float)i / segments;
         p  = static_cast<ssize_t>(dt / deltaT);
 
         // Check last control point reached

--- a/tests/cpp-tests/Source/DrawNodeTest/DrawNodeTest.cpp
+++ b/tests/cpp-tests/Source/DrawNodeTest/DrawNodeTest.cpp
@@ -3515,8 +3515,17 @@ void DrawNodeSpLinesTest::update(float dt)
 
     drawNode->drawCardinalSpline(array, 0.2f, points.size() * 8, Color4F::GREEN, 20.0f);
     drawNode->drawCardinalSpline(array, 0.2f, points.size() * 8, Color4F::BLUE);
-
     drawNode->drawCardinalSpline(array, 0.2f, points.size() * 16, Color4F(1.0f, 1.0f, 0.5f, 1.0f), 10.0f);
+
+    // Issue #2302 
+    auto array3 = PointArray::create(20);
+    for (int i = 0; i < 10; i++)
+    {
+        array3->addControlPoint(Vec2((i % 2) ? 20 : screen.width - 20, 50 + i * 20));
+        drawNode->drawPoint(array3->getControlPointAtIndex(i), 10, Color4F::BLUE);
+    }
+    drawNode->drawCardinalSpline(array3, 0.1, 20, Color4F::ORANGE);
+
 
     //  drawNode->drawCatmullRom(array, points.size() * 8, Color4F::YELLOW,5);
     // if (points.size()>3)


### PR DESCRIPTION
## Describe your changes
Fix for issue #2302

![image](https://github.com/user-attachments/assets/5a8cb08b-6da4-4b7a-aeee-13aa5bd32f50)


## Issue ticket number and link
#2302

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
