### PR TITLE
Distinguishing between Simplified Chinese and Traditional Chinese in the Win32 Platform

### DIFF
--- a/core/platform/Common.h
+++ b/core/platform/Common.h
@@ -49,7 +49,8 @@ void AX_DLL messageBox(const char* msg, const char* title);
 enum class LanguageType
 {
     ENGLISH = 0,
-    CHINESE,
+    CHINESE_SIMPLIFIED,
+    CHINESE_TRADITIONAL,
     FRENCH,
     ITALIAN,
     GERMAN,

--- a/core/platform/win32/Application-win32.cpp
+++ b/core/platform/win32/Application-win32.cpp
@@ -154,12 +154,25 @@ LanguageType Application::getCurrentLanguage()
     LanguageType ret = LanguageType::ENGLISH;
 
     LCID localeID                    = GetUserDefaultLCID();
-    unsigned short primaryLanguageID = localeID & 0xFF;
+
+    unsigned short primaryLanguageID = PRIMARYLANGID(localeID);
+    unsigned short subLanguageID     = SUBLANGID(localeID);
 
     switch (primaryLanguageID)
     {
     case LANG_CHINESE:
-        ret = LanguageType::CHINESE;
+        switch (subLanguageID)
+        {
+        case SUBLANG_CHINESE_SIMPLIFIED:
+            ret = LanguageType::CHINESE_SIMPLIFIED;
+            break;
+        case SUBLANG_CHINESE_TRADITIONAL:
+            ret = LanguageType::CHINESE_TRADITIONAL;
+            break;
+        default:
+            ret = LanguageType::CHINESE_TRADITIONAL;
+            break;
+        }
         break;
     case LANG_ENGLISH:
         ret = LanguageType::ENGLISH;


### PR DESCRIPTION
The Win32 platform will now support distinguishing between Simplified and Traditional Chinese, allowing developers to build PC games in both languages for their players.