### PR TITLE
Add support for the creation of layers that are set to invisible in tilemap

### DIFF
--- a/core/2d/FastTMXTiledMap.h
+++ b/core/2d/FastTMXTiledMap.h
@@ -103,15 +103,18 @@ public:
      *
      * @return An autorelease object.
      */
-    static FastTMXTiledMap* create(std::string_view tmxFile);
+    static FastTMXTiledMap* create(std::string_view tmxFile, bool allowInvisibleLayers = false);
 
     /** Initializes a TMX Tiled Map with a TMX formatted XML string and a path to TMX resources.
      *
      * @param tmxString A TMX formatted XML string.
      * @param resourcePath A path to TMX resources.
+     * @param allowInvisibleLayers Allow creation of invisible layers. Default is false.
      * @return An autorelease object.
      */
-    static FastTMXTiledMap* createWithXML(std::string_view tmxString, std::string_view resourcePath);
+    static FastTMXTiledMap* createWithXML(std::string_view tmxString,
+                                          std::string_view resourcePath,
+                                          bool allowInvisibleLayers = false);
 
     /** Return the FastTMXLayer for the specific layer.
      *
@@ -225,18 +228,18 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~FastTMXTiledMap();
+    virtual ~FastTMXTiledMap() override;
 
     /** initializes a TMX Tiled Map with a TMX file */
-    bool initWithTMXFile(std::string_view tmxFile);
+    bool initWithTMXFile(std::string_view tmxFile, bool allowInvisibleLayers = false);
 
     /** initializes a TMX Tiled Map with a TMX formatted XML string and a path to TMX resources */
-    bool initWithXML(std::string_view tmxString, std::string_view resourcePath);
+    bool initWithXML(std::string_view tmxString, std::string_view resourcePath, bool allowInvisibleLayers = false);
 
 protected:
     FastTMXLayer* parseLayer(TMXLayerInfo* layerInfo, TMXMapInfo* mapInfo);
     TMXTilesetInfo* tilesetForLayer(TMXLayerInfo* layerInfo, TMXMapInfo* mapInfo);
-    void buildWithMapInfo(TMXMapInfo* mapInfo);
+    void buildWithMapInfo(TMXMapInfo* mapInfo, bool ignoreInvisibleLayers);
 
     /** the map's size property measured in tiles */
     Vec2 _mapSize;


### PR DESCRIPTION
## Describe your changes
The current implementation does not allow the creation of layer nodes from layers that are set to invisible in the tilemap file.  There is no way to create them, so functionality has been added to allow invisible layers to be created.  

The default option is that they are not created, so it does not change existing behavior.

## Issue ticket number and link
#2320 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
