### PR TITLE
fix drawLine wrong when thickness!=1

### DIFF
--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -1058,7 +1058,7 @@ void DrawNode::_drawSegment(const Vec2& from,
     Vec2 vertices[2] = {from, to};
     applyTransform(vertices, vertices, 2);
 
-    if (thickness == 1.0f && !properties.drawOrder)
+    if (thickness <= 1.0f && !properties.drawOrder)
     {
         auto line = expandBufferAndGetPointer(_lines, 2);
         _linesDirty = true;
@@ -1068,12 +1068,16 @@ void DrawNode::_drawSegment(const Vec2& from,
     }
     else
     {
+        float fS = Director::getInstance()->getGLView()->getFrameSize().width;
+        float dS = Director::getInstance()->getGLView()->getDesignResolutionSize().width;
+        float factor = 2 * fS / dS;
+
         Vec2 a  = vertices[0];
         Vec2 b  = vertices[1];
         Vec2 n  = ((b - a).getPerp()).getNormalized();
         Vec2 t  = n.getPerp();
-        Vec2 nw = n * thickness;
-        Vec2 tw = t * thickness;
+        Vec2 nw = n * thickness/ factor;
+        Vec2 tw = t * thickness/ factor;
         Vec2 v0 = b - (nw + tw);
         Vec2 v1 = b + (nw - tw);
         Vec2 v2 = b - nw;


### PR DESCRIPTION
fix drawLine with thickness other than 1
factor = (FrameSize /designResolutionSize)*2
and the smallest thickness that axmol can create is 1, 
so in all cases where the thickness is <1 I think we should draw a line with thickness = 1

See detailed error at #2324

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
