### PR TITLE
Use correct color type to fix debug drawing in PhysicsWorld

### DIFF
--- a/core/physics/PhysicsWorld.cpp
+++ b/core/physics/PhysicsWorld.cpp
@@ -225,8 +225,8 @@ static void DrawCircle(cpVect p,
                        cpSpaceDebugColor fill,
                        cpDataPointer data)
 {
-    const Color4B fillColor(fill.r, fill.g, fill.b, fill.a);
-    const Color4B outlineColor(outline.r, outline.g, outline.b, outline.a);
+    const Color4F fillColor(fill.r, fill.g, fill.b, fill.a);
+    const Color4F outlineColor(outline.r, outline.g, outline.b, outline.a);
     DrawNode* drawNode = static_cast<DrawNode*>(data);
     float radius       = PhysicsHelper::cpfloat2float(r);
     Vec2 centre        = PhysicsHelper::cpv2vec2(p);
@@ -250,7 +250,7 @@ static void DrawFatSegment(cpVect a,
                            cpSpaceDebugColor /*fill*/,
                            cpDataPointer data)
 {
-    const Color4B outlineColor(outline.r, outline.g, outline.b, outline.a);
+    const Color4F outlineColor(outline.r, outline.g, outline.b, outline.a);
     DrawNode* drawNode = static_cast<DrawNode*>(data);
     drawNode->drawSegment(PhysicsHelper::cpv2vec2(a), PhysicsHelper::cpv2vec2(b),
                           PhysicsHelper::cpfloat2float(r == 0 ? _debugDrawThickness : r), outlineColor);
@@ -268,8 +268,8 @@ static void DrawPolygon(int count,
                         cpSpaceDebugColor fill,
                         cpDataPointer data)
 {
-    const Color4B fillColor(fill.r, fill.g, fill.b, fill.a);
-    const Color4B outlineColor(outline.r, outline.g, outline.b, outline.a);
+    const Color4F fillColor(fill.r, fill.g, fill.b, fill.a);
+    const Color4F outlineColor(outline.r, outline.g, outline.b, outline.a);
     DrawNode* drawNode = static_cast<DrawNode*>(data);
     int num            = count;
     Vec2* seg          = new Vec2[num];
@@ -283,7 +283,7 @@ static void DrawPolygon(int count,
 
 static void DrawDot(cpFloat /*size*/, cpVect pos, cpSpaceDebugColor color, cpDataPointer data)
 {
-    const Color4B dotColor(color.r, color.g, color.b, color.a);
+    const Color4F dotColor(color.r, color.g, color.b, color.a);
     DrawNode* drawNode = static_cast<DrawNode*>(data);
     drawNode->drawDot(PhysicsHelper::cpv2vec2(pos), _debugDrawThickness, dotColor);
 }
@@ -322,7 +322,9 @@ void PhysicsWorld::debugDraw()
         _debugDraw = DrawNode::create();
         _debugDraw->setIsolated(true);
         _debugDraw->retain();
-        Director::getInstance()->getRunningScene()->addChild(_debugDraw);
+        auto scene = Director::getInstance()->getRunningScene();
+        scene->addChild(_debugDraw);
+        _debugDraw->setGlobalZOrder(scene->getGlobalZOrder());
     }
 
     cpSpaceDebugDrawOptions drawOptions = {

--- a/core/physics/PhysicsWorld.cpp
+++ b/core/physics/PhysicsWorld.cpp
@@ -317,14 +317,14 @@ static cpSpaceDebugColor ColorForShape(cpShape* shape, cpDataPointer /*data*/)
 
 void PhysicsWorld::debugDraw()
 {
-    if (_debugDraw == nullptr)
+    if (!_debugDraw)
     {
-        _debugDraw = DrawNode::create();
-        _debugDraw->setIsolated(true);
-        _debugDraw->retain();
-        auto scene = Director::getInstance()->getRunningScene();
-        scene->addChild(_debugDraw);
-        _debugDraw->setGlobalZOrder(scene->getGlobalZOrder());
+        return;
+    }
+
+    if (!_debugDraw->getParent())
+    {
+        Director::getInstance()->getRunningScene()->addChild(_debugDraw);
     }
 
     cpSpaceDebugDrawOptions drawOptions = {
@@ -857,10 +857,19 @@ void PhysicsWorld::removeAllBodies()
 
 void PhysicsWorld::setDebugDrawMask(int mask)
 {
-    if (mask == DEBUGDRAW_NONE && _debugDraw)
+    if (mask == DEBUGDRAW_NONE)
     {
-        _debugDraw->removeFromParent();
-        AX_SAFE_RELEASE_NULL(_debugDraw);
+        if (_debugDraw)
+        {
+            _debugDraw->removeFromParent();
+            AX_SAFE_RELEASE_NULL(_debugDraw);
+        }
+    }
+    else if (!_debugDraw)
+    {
+        _debugDraw = DrawNode::create();
+        _debugDraw->setIsolated(true);
+        _debugDraw->retain();
     }
 
     _debugDrawMask = mask;

--- a/core/physics/PhysicsWorld.h
+++ b/core/physics/PhysicsWorld.h
@@ -366,7 +366,14 @@ public:
      *
      * @return An integer number.
      */
-    int getDebugDrawMask() { return _debugDrawMask; }
+    int getDebugDrawMask() const { return _debugDrawMask; }
+
+    /**
+     * Get the debug draw node
+     *
+     * @return Pointer to draw node, which may be nullptr
+     */
+    DrawNode* getDebugDraw() const { return _debugDraw; }
 
     /**
      * To control the step of physics.


### PR DESCRIPTION
## Describe your changes

The color values sent by the physics engine are float values between 0 and 1.0, yet the color type being used is Color4B, which meant that the colors of the DrawNode segments were never set correctly, since it expects values from 0-255.

This change ensures that the correct type is used, being Color4F, which is automatically converted to Color4B due to a converting constructor:
`inline Color4B::Color4B(const Color4F& color) : r(color.r * 255), g(color.g * 255), b(color.b * 255), a(color.a * 255) {}`

Test `40: Node: Physics` now shows the correct debug overlays:

![image](https://github.com/user-attachments/assets/58558acf-2b2e-4277-80d5-a2dd92fd19a9)

Another minor change to create debug draw node at the time the mask is set, so the user can have access to the draw node and set certain attributes, such as the local and global Z orders of the node.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
