### PR TITLE
MenuItem supports more fine-grained callbacks

### DIFF
--- a/core/2d/MenuItem.cpp
+++ b/core/2d/MenuItem.cpp
@@ -53,18 +53,18 @@ MenuItem* MenuItem::create()
     return MenuItem::create((const ccMenuCallback&)nullptr);
 }
 
-MenuItem* MenuItem::create(const ccMenuCallback& callback)
+MenuItem* MenuItem::create(const ccMenuCallback& callbackClick)
 {
     MenuItem* ret = new MenuItem();
-    ret->initWithCallback(callback);
+    ret->initWithCallback(callbackClick);
     ret->autorelease();
     return ret;
 }
 
-bool MenuItem::initWithCallback(const ccMenuCallback& callback)
+bool MenuItem::initWithCallback(const ccMenuCallback& callbackClick)
 {
     setAnchorPoint(Vec2(0.5f, 0.5f));
-    _callback = callback;
+    _callbackClick = callbackClick;
     _enabled  = true;
     _selected = false;
     return true;
@@ -75,20 +75,28 @@ MenuItem::~MenuItem() {}
 void MenuItem::selected()
 {
     _selected = true;
+    if (_callbackSelected)
+    {
+        _callbackSelected(this);
+    }
 }
 
 void MenuItem::unselected()
 {
     _selected = false;
+    if (_callbackUnSelected)
+    {
+        _callbackUnSelected(this);
+    }
 }
 
 void MenuItem::activate()
 {
     if (_enabled)
     {
-        if (_callback)
+        if (_callbackClick)
         {
-            _callback(this);
+            _callbackClick(this);
         }
 #if AX_ENABLE_SCRIPT_BINDING
         BasicScriptData data(this);
@@ -119,9 +127,15 @@ bool MenuItem::isSelected() const
     return _selected;
 }
 
-void MenuItem::setCallback(const ccMenuCallback& callback)
+void MenuItem::setCallback(const ccMenuCallback& callbackClick)
 {
-    _callback = callback;
+    _callbackClick = callbackClick;
+}
+
+void MenuItem::setCallbackSelected(const ccMenuCallback& callbackSelected, const ccMenuCallback& callbackUnSelected)
+{
+    _callbackSelected   = callbackSelected;
+    _callbackUnSelected = callbackUnSelected;
 }
 
 std::string MenuItem::getDescription() const

--- a/core/2d/MenuItem.h
+++ b/core/2d/MenuItem.h
@@ -63,7 +63,7 @@ public:
     /** Creates a MenuItem with no target/selector. */
     static MenuItem* create();
     /** Creates a MenuItem with a target/selector. */
-    static MenuItem* create(const ccMenuCallback& callback);
+    static MenuItem* create(const ccMenuCallback& callbackClick);
 
     /** Returns the outside box. */
     Rect rect() const;
@@ -86,7 +86,14 @@ public:
      * @endcode
      * @lua NA
      */
-    void setCallback(const ccMenuCallback& callback);
+    void setCallback(const ccMenuCallback& callbackClick);
+
+    /** Set the callback of selected and unselected state to the menu item.
+     * @js NA
+     * @lua NA
+     */
+    void setCallbackSelected(const ccMenuCallback& callbackSelected   = nullptr,
+                             const ccMenuCallback& callbackUnSelected = nullptr);
 
     /**
      * @js NA
@@ -96,7 +103,9 @@ public:
     /**
      * @js ctor
      */
-    MenuItem() : _selected(false), _enabled(false), _callback(nullptr) {}
+    MenuItem() : _selected(false), _enabled(false), _callbackClick(nullptr)
+               , _callbackSelected(nullptr), _callbackUnSelected(nullptr)
+    {}
     /**
      * @js NA
      * @lua NA
@@ -106,13 +115,15 @@ public:
     /** Initializes a MenuItem with a target/selector.
      * @lua NA
      */
-    bool initWithCallback(const ccMenuCallback& callback);
+    bool initWithCallback(const ccMenuCallback& callbackClick);
 
 protected:
     bool _selected;
     bool _enabled;
     // callback
-    ccMenuCallback _callback;
+    ccMenuCallback _callbackClick;
+    ccMenuCallback _callbackSelected;
+    ccMenuCallback _callbackUnSelected;
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(MenuItem);


### PR DESCRIPTION
MenuItem supports more fine-grained callbacks, and you can choose to perform separate callback functions when the button is pressed or released.