### PR TITLE
Fix tile animation logic to use correct time per frame

### DIFF
--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -1041,8 +1041,9 @@ void TMXTileAnimTask::stop()
 
 void TMXTileAnimTask::setCurrFrame()
 {
-    _layer->setTileGID(_animation->_frames[_currentFrame]._tileID, _tilePosition, (TMXTileFlags)_flag);
-    _currentFrame = (_currentFrame + 1) % _frameCount;
+    _currentFrame = _nextFrame;
+    _layer->setTileGID((int)_animation->_frames[_currentFrame]._tileID, _tilePosition, (TMXTileFlags)_flag);
+    _nextFrame = (_currentFrame + 1) % _frameCount;
 }
 
 TMXTileAnimTask* TMXTileAnimTask::create(FastTMXLayer* layer, TMXTileAnimInfo* animation, const Vec2& tilePos, uint32_t flag)

--- a/core/2d/FastTMXLayer.h
+++ b/core/2d/FastTMXLayer.h
@@ -425,6 +425,7 @@ protected:
     TMXTileAnimInfo* _animation = nullptr;
     /** Index of the frame that should be drawn currently */
     uint32_t _currentFrame = 0;
+    uint32_t _nextFrame = 0;
     uint32_t _frameCount   = 0;
 };
 


### PR DESCRIPTION
## Describe your changes
Tile animation code would display a frame using the timing of the next frame in the series, which is not correct.

The changes in this PR ensures that the currently displayed frame is displayed using the correct frame time.

## Issue ticket number and link
Discussion #2344

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
