### PR TITLE
Disable Spine references if Spine is not enabled

### DIFF
--- a/extensions/cocostudio/src/cocostudio/SpineSkeletonDataCache.cpp
+++ b/extensions/cocostudio/src/cocostudio/SpineSkeletonDataCache.cpp
@@ -1,5 +1,7 @@
 #include "SpineSkeletonDataCache.h"
 
+#if defined(AX_ENABLE_EXT_SPINE)
+
 #if !defined(AX_SPINE_VERSION) || AX_SPINE_VERSION >= 0x030700
 SpineSkeletonDataCache* SpineSkeletonDataCache::getInstance()
 {
@@ -271,3 +273,5 @@ void SpineSkeletonDataCache::removeAllUnusedData(void)
     }
 }
 #endif
+
+#endif // defined(AX_ENABLE_EXT_SPINE)

--- a/extensions/cocostudio/src/cocostudio/SpineSkeletonDataCache.h
+++ b/extensions/cocostudio/src/cocostudio/SpineSkeletonDataCache.h
@@ -1,5 +1,7 @@
 #ifndef _SPINESKELETONDATACACHE_H_
 #define _SPINESKELETONDATACACHE_H_
+
+#if defined(AX_ENABLE_EXT_SPINE)
 #include <cocos2d.h>
 #include "spine/spine.h"
 #include "spine/spine-cocos2dx.h"
@@ -75,5 +77,7 @@ public:
 };
 
 #endif
+
+#endif // defined(AX_ENABLE_EXT_SPINE)
 
 #endif


### PR DESCRIPTION
## Describe your changes

Spine-related code was still being compiled even though the Spine extension is disabled. This PR disables that code if the extension is not enabled.

## Issue ticket number and link
#2343 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
