### PR TITLE
Increase MAX_AUDIOINSTANCES value to 128 in AudioEngine

### DIFF
--- a/core/audio/alconfig.h
+++ b/core/audio/alconfig.h
@@ -34,17 +34,17 @@
 #if defined(__EMSCRIPTEN__)
     #import <AL/al.h>
     #import <AL/alc.h>
-    #define MAX_AUDIOINSTANCES 24
+    #define MAX_AUDIOINSTANCES 128
 #else
     #if !AX_USE_ALSOFT
     #    import <OpenAL/al.h>
     #    import <OpenAL/alc.h>
-    #    define MAX_AUDIOINSTANCES 24
+    #    define MAX_AUDIOINSTANCES 128
     #else
     #    define AL_ALEXT_PROTOTYPES 1
     #    include "AL/al.h"
     #    include "AL/alc.h"
     #    include "AL/alext.h"
-    #    define MAX_AUDIOINSTANCES 32
+    #    define MAX_AUDIOINSTANCES 128
     #endif
 #endif


### PR DESCRIPTION
Increase the MAX_AUDIOINSTANCES value to 128 in the AudioEngine to enable the game to concurrently play up to 128 audio instances.