### PR TITLE
[Android] Allow project to specify Axmol engine root path

### DIFF
--- a/core/platform/android/libaxmol/axutils.gradle
+++ b/core/platform/android/libaxmol/axutils.gradle
@@ -178,11 +178,19 @@ class AxmolUtils {
         return buildProfiles
     }
 
+    private static getEngineRoot() {
+        def axRoot = System.getProperty("AX_ROOT");
+        if (axRoot == null) {
+            axRoot = System.getenv("AX_ROOT");
+        }
+        return axRoot;
+    }
+
     private static Properties loadProfiles(project, isAxmolAppProj) {
         // build.profiles in axmol engine
         def profiles = new Properties()
         try {
-            profiles.load(new File(Paths.get("${System.env.AX_ROOT}/1k/build.profiles").toUri()).newDataInputStream())
+            profiles.load(new File(Paths.get("${getEngineRoot()}/1k/build.profiles").toUri()).newDataInputStream())
         }
         catch(ignored) {
         }
@@ -311,7 +319,7 @@ class AxmolUtils {
             cmakeBinDirs.add(cmakeBinDir)
         }
 
-        cmakeBinDir = joinPath(Paths.get("${System.env.AX_ROOT}").toAbsolutePath().toString(), 'tools', 'external', 'cmake', 'bin')
+        cmakeBinDir = joinPath(Paths.get("${getEngineRoot()}").toAbsolutePath().toString(), 'tools', 'external', 'cmake', 'bin')
         cmakeBinDirs.add(cmakeBinDir)
 
         // find in cmakeBinDirs
@@ -327,7 +335,7 @@ class AxmolUtils {
 
         if (index == (cmakeBinDirs.size() - 1)) {
             // using  cmakeBinDir=axmol/tools/external/cmake/bin
-            buildProfiles['cmakeDir'] = joinPath(Paths.get("${System.env.AX_ROOT}").toAbsolutePath().toString(), 'tools', 'external', 'cmake')
+            buildProfiles['cmakeDir'] = joinPath(Paths.get("${getEngineRoot()}").toAbsolutePath().toString(), 'tools', 'external', 'cmake')
         }
 
         if(foundCMakeVer == null) {

--- a/templates/common/proj.android/settings.gradle
+++ b/templates/common/proj.android/settings.gradle
@@ -1,8 +1,8 @@
 import java.nio.file.Paths
 
-def embeddedAxmol = false
-if (embeddedAxmol) {
-    System.setProperty("AX_ROOT", "${settingsDir}/../axmol")
+def folder = new File("${settingsDir}/../axmol")
+if (folder.exists()) {
+    System.setProperty("AX_ROOT", folder.path)
 } else {
     System.setProperty("AX_ROOT", "${System.env.AX_ROOT}")
 }

--- a/templates/common/proj.android/settings.gradle
+++ b/templates/common/proj.android/settings.gradle
@@ -1,6 +1,14 @@
 import java.nio.file.Paths
+
+def embeddedAxmol = false
+if (embeddedAxmol) {
+    System.setProperty("AX_ROOT", "${settingsDir}/../axmol")
+} else {
+    System.setProperty("AX_ROOT", "${System.env.AX_ROOT}")
+}
+
 include ':libaxmol'
-project(':libaxmol').projectDir = new File(Paths.get("${System.env.AX_ROOT}/core/platform/android/libaxmol").toUri())
+project(':libaxmol').projectDir = new File(Paths.get("${System.properties.AX_ROOT}/core/platform/android/libaxmol").toUri())
 include ':Dummy'
 project(':Dummy').projectDir = new File(settingsDir, 'app')
 rootProject.name = "Dummy"


### PR DESCRIPTION
Allow Android project to specify Axmol engine path in case the engine is embedded into the project.

The path is now read from `System.properties.AX_ROOT` first instead of `System.env.AX_ROOT`.  If the `System.properties.AX_ROOT` value is not set, then it will default to using `System.env.AX_ROOT` in `axutils.gradle`.

This may help solve the issue mentioned in this [post](https://github.com/axmolengine/axmol/pull/2273#issuecomment-2626991359)

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
