### PR TITLE
Use axmol proguard file in template and clean 

### DIFF
--- a/core/platform/android/libaxmol/proguard-rules.pro
+++ b/core/platform/android/libaxmol/proguard-rules.pro
@@ -16,7 +16,6 @@
 #   public *;
 #}
 
--dontobfuscate
-
 -keep public class dev.axmol.lib.**
 -keepclassmembers public class dev.axmol.lib.** { *; }
+-dontwarn dev.axmol.**

--- a/templates/common/proj.android/app/build.gradle
+++ b/templates/common/proj.android/app/build.gradle
@@ -72,6 +72,7 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFile file(project(':libaxmol').projectDir.toString() + '/proguard-rules.pro')
             if (project.hasProperty("KEY_STORE_FILE")) {
                 signingConfig signingConfigs.release
             }

--- a/templates/common/proj.android/app/proguard-rules.pro
+++ b/templates/common/proj.android/app/proguard-rules.pro
@@ -16,14 +16,6 @@
 #   public *;
 #}
 
-# Proguard Axmol for release
--keep public class dev.axmol.** { *; }
--dontwarn dev.axmol.**
-
-# Proguard Apache HTTP for release
--keep class org.apache.http.** { *; }
--dontwarn org.apache.http.**
-
 # Proguard Android Webivew for release. uncomment if you are using a webview in axmol
 #-keep public class android.net.http.SslError
 #-keep public class android.webkit.WebViewClient


### PR DESCRIPTION
## Describe your changes
Hi!
I have discovered that the axmol lib had a proguard file, but this file is not used in the project. Instead, the project has quite the same rules added, and also unused directives for apache.
The aim is now to use the axmol file and clean the proguard project template.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
