### PR TITLE
[Windows] Ensure vertical scrolling is enabled when EditBox is in multiline mode

### DIFF
--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -117,7 +117,7 @@ void EditBoxImplWin::createEditCtrl(bool singleLine)
         _hwndEdit = ::CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT",  // predefined class
                                       NULL,                       // no window title
                                       WS_CHILD | ES_LEFT | WS_BORDER | WS_EX_TRANSPARENT | WS_TABSTOP | ES_AUTOHSCROLL |
-                                          (singleLine ? 0 : ES_MULTILINE),
+                                          (singleLine ? 0 : ES_AUTOVSCROLL | ES_MULTILINE),
                                       0, 0, 0,
                                       0,                        // set size in WM_SIZE message
                                       s_hwndCocos,              // parent window


### PR DESCRIPTION
## Describe your changes

The EditBox in multiline mode does not move to the next line on Windows, since vertical scrolling is not enabled.  The number of lines is currently limited by the height of the font and the height of the EditBox.

The change in this PR enables vertical scrolling when in multiline mode.

## Issue ticket number and link
#2372

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
