### PR TITLE
[Windows] Ensure EditBox shows text correctly when it receives focus for the first time

### DIFF
--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -359,15 +359,17 @@ void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
             {
                 // The following is a work-around to force the edit box to display
                 // as much text as possible when it receives focus for the first time
-                std::u16string wstrResult;
                 int inputLength = ::GetWindowTextLengthW(hwnd);
-                wstrResult.resize(inputLength);
-
-                ::GetWindowTextW(hwnd, (LPWSTR)wstrResult.data(), inputLength + 1);
-                this->_changedTextManually = true;  // We don't want to trigger the editBoxEditingChanged callback
-                ::SetWindowTextW(hwnd, (LPWSTR)wstrResult.data());
-                ::SendMessage(hwnd, EM_SETSEL, inputLength, -1);
-                ::SendMessage(hwnd, EM_SETSEL, -1, -1);
+                if (inputLength > 0)
+                {
+                    std::u16string wstrResult;
+                    wstrResult.resize(inputLength);
+                    ::GetWindowTextW(hwnd, (LPWSTR)wstrResult.data(), inputLength + 1);
+                    this->_changedTextManually = true;  // We don't want to trigger the editBoxEditingChanged callback
+                    ::SetWindowTextW(hwnd, (LPWSTR)wstrResult.data());
+                    ::SendMessage(hwnd, EM_SETSEL, inputLength, -1);
+                    ::SendMessage(hwnd, EM_SETSEL, -1, -1);
+                }
 
                 _initialfocus = false;
             }

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -355,7 +355,7 @@ void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
             ::PostMessageW(hwnd, WM_ACTIVATE, (WPARAM)s_previousFocusWnd, 0);
             ::PostMessageW(hwnd, WM_SETCURSOR, (WPARAM)s_previousFocusWnd, 0);
 
-            if (_initialfocus && _editBoxInputMode != ax::ui::EditBox::InputMode::ANY)
+            if (_initialFocus && _editBoxInputMode != ax::ui::EditBox::InputMode::ANY)
             {
                 // The following is a work-around to force the edit box to display
                 // as much text as possible when it receives focus for the first time
@@ -371,7 +371,7 @@ void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
                     ::SendMessage(hwnd, EM_SETSEL, -1, -1);
                 }
 
-                _initialfocus = false;
+                _initialFocus = false;
             }
 
             s_previousFocusWnd         = _hwndEdit;

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -77,7 +77,7 @@ private:
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    bool _initialfocus = true;
+    bool _initialFocus = true;
     HWND _hwndEdit;
     bool _changedTextManually;
     bool _hasFocus;

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -77,6 +77,7 @@ private:
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
+    bool _initialfocus = true;
     HWND _hwndEdit;
     bool _changedTextManually;
     bool _hasFocus;


### PR DESCRIPTION
## Describe your changes

For the Win32 implementation of EditBox, a work-around is required so that for the first time the EditBox receives focus, it shows as much text as possible. 

## Issue ticket number and link
#2375 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
