### PR TITLE
Calculate correct positions for underline and strikethrough 

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1753,28 +1753,32 @@ void Label::updateContent()
 
         _lineDrawNode->clear();
 
-        if (_numberOfLines && _currentLabelType != LabelType::STRING_TEXTURE)
+        if (_numberOfLines > 0 && _currentLabelType != LabelType::STRING_TEXTURE)
         {
             // This is the logic for TTF fonts
-            const float charheight = (_textDesiredHeight / _numberOfLines);
-            float thickness        = charheight / 6;
+            float thickness         = (_lineHeight * _fontScale) / 6;
+            float nextTokenY        = _letterOffsetY;
+            auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
+            float lineSpacing       = _lineSpacing * contentScaleFactor;
 
             // atlas font
             for (int i = 0; i < _numberOfLines; ++i)
             {
                 if (_strikethroughEnabled)
                 {
-                    float y = (_numberOfLines - i - 1) * charheight + charheight / 2;
+                    auto y = nextTokenY / contentScaleFactor - _lineHeight * _fontScale / 2;
                     _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
                                             Color4F(lineColor), thickness);
                 }
 
                 if (_underlineEnabled)
                 {
-                    float y = (_numberOfLines - i - 1) * charheight;
+                    auto y = (nextTokenY * _fontScale) / contentScaleFactor - _lineHeight * _fontScale;
                     _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
                                             Color4F(lineColor), thickness);
                 }
+
+                nextTokenY -= _lineHeight * _fontScale + lineSpacing;
             }
         }
         else if (_textSprite) // ...and is the logic for System fonts
@@ -1784,24 +1788,25 @@ void Label::updateContent()
 
             // FIXME: system fonts don't report the height of the font correctly. only the size of the texture, which is POT
             // FIXME: Might not work with different vertical alignments
-            float offsety         = spriteSize.height / _numberOfLines;
-            float thickness       = spriteSize.height / 6 / _numberOfLines;
-    
+            const auto thickness = spriteSize.height / 6 / static_cast<float>(_numberOfLines);
+            const auto lineSize  = spriteSize.height / static_cast<float>(_numberOfLines);
+
             if (_underlineEnabled)
-            {       
+            {
+                const auto baseY = spriteSize.height / (static_cast<float>(_numberOfLines) * lineSize);
                 for (int i = 0; i < _numberOfLines; ++i)
                 {
-                    float y = offsety * i;
+                    float y = baseY + lineSize * i;
                     _lineDrawNode->drawLine(Vec2(0.0f, y), Vec2(spriteSize.width, y), Color4F(lineColor), thickness);
                 }
             }
 
             if (_strikethroughEnabled)
             {  
-                float _of = spriteSize.height / _numberOfLines / 2;
+                const auto baseY    = lineSize - lineSize / 2;
                 for (int i = 0; i < _numberOfLines; ++i)
                 {
-                    float y = _of + offsety * i;
+                    float y = baseY + lineSize * i;
                     _lineDrawNode->drawLine(Vec2(0.0f, y), Vec2(spriteSize.width, y), Color4F(lineColor), thickness);
                 }
             }

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1756,7 +1756,7 @@ void Label::updateContent()
         if (_numberOfLines > 0 && _currentLabelType != LabelType::STRING_TEXTURE)
         {
             // This is the logic for TTF fonts
-            float thickness         = (_lineHeight * _fontScale) / 6;
+            float thickness         = (_lineHeight * _fontScale) * 0.12f;
             float nextTokenY        = _letterOffsetY;
             auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
             float lineSpacing       = _lineSpacing * contentScaleFactor;
@@ -1788,7 +1788,7 @@ void Label::updateContent()
 
             // FIXME: system fonts don't report the height of the font correctly. only the size of the texture, which is POT
             // FIXME: Might not work with different vertical alignments
-            const auto thickness = spriteSize.height / 6 / static_cast<float>(_numberOfLines);
+            const auto thickness = spriteSize.height / static_cast<float>(_numberOfLines) * 0.12f;
             const auto lineSize  = spriteSize.height / static_cast<float>(_numberOfLines);
 
             if (_underlineEnabled)

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1756,10 +1756,10 @@ void Label::updateContent()
         if (_numberOfLines > 0 && _currentLabelType != LabelType::STRING_TEXTURE)
         {
             // This is the logic for TTF fonts
-            float thickness         = (_lineHeight * _fontScale) * 0.12f;
-            float nextTokenY        = _letterOffsetY;
+            float thickness         = std::max((_lineHeight * _fontScale) * 0.12f, 2.f);
+            float nextY             = _letterOffsetY;
             auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
-            float lineSpacing       = _lineSpacing * contentScaleFactor;
+            float lineSpacing       = _lineSpacing;
             float lineHeight        = _lineHeight * _fontScale / contentScaleFactor;
 
             // atlas font
@@ -1767,19 +1767,19 @@ void Label::updateContent()
             {
                 if (_strikethroughEnabled)
                 {
-                    auto y = nextTokenY - lineHeight / 2;
+                    auto y = nextY - lineHeight / 2;
                     _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
                                             Color4F(lineColor), thickness);
                 }
 
                 if (_underlineEnabled)
                 {
-                    auto y = nextTokenY - lineHeight;
+                    auto y = nextY - lineHeight;
                     _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
                                             Color4F(lineColor), thickness);
                 }
 
-                nextTokenY -= lineHeight + lineSpacing;
+                nextY -= lineHeight + lineSpacing;
             }
         }
         else if (_textSprite) // ...and is the logic for System fonts
@@ -1789,8 +1789,8 @@ void Label::updateContent()
 
             // FIXME: system fonts don't report the height of the font correctly. only the size of the texture, which is POT
             // FIXME: Might not work with different vertical alignments
-            const auto thickness = spriteSize.height / static_cast<float>(_numberOfLines) * 0.12f;
             const auto lineSize  = spriteSize.height / static_cast<float>(_numberOfLines);
+            const auto thickness = std::max(lineSize * 0.12f, 2.f);
 
             if (_underlineEnabled)
             {
@@ -1804,7 +1804,8 @@ void Label::updateContent()
 
             if (_strikethroughEnabled)
             {  
-                const auto baseY    = lineSize - lineSize / 2;
+                const auto baseY = lineSize - lineSize / 2;
+                
                 for (int i = 0; i < _numberOfLines; ++i)
                 {
                     float y = baseY + lineSize * i;

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1756,7 +1756,7 @@ void Label::updateContent()
         if (_numberOfLines > 0 && _currentLabelType != LabelType::STRING_TEXTURE)
         {
             // This is the logic for TTF fonts
-            float thickness         = std::max((_lineHeight * _fontScale) * 0.12f, 2.f);
+            float thickness         = std::max(std::ceil(_lineHeight * _fontScale * 0.12f * 2) / 2.f, 2.f);
             float nextY             = _letterOffsetY;
             auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
             float lineSpacing       = _lineSpacing;
@@ -1790,7 +1790,7 @@ void Label::updateContent()
             // FIXME: system fonts don't report the height of the font correctly. only the size of the texture, which is POT
             // FIXME: Might not work with different vertical alignments
             const auto lineSize  = spriteSize.height / static_cast<float>(_numberOfLines);
-            const auto thickness = std::max(lineSize * 0.12f, 2.f);
+            const auto thickness = std::max(std::ceil(lineSize * 0.12f * 2) / 2.f, 2.f);
 
             if (_underlineEnabled)
             {

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1760,25 +1760,26 @@ void Label::updateContent()
             float nextTokenY        = _letterOffsetY;
             auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
             float lineSpacing       = _lineSpacing * contentScaleFactor;
+            float lineHeight        = _lineHeight * _fontScale / contentScaleFactor;
 
             // atlas font
             for (int i = 0; i < _numberOfLines; ++i)
             {
                 if (_strikethroughEnabled)
                 {
-                    auto y = nextTokenY / contentScaleFactor - _lineHeight * _fontScale / 2;
+                    auto y = nextTokenY - lineHeight / 2;
                     _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
                                             Color4F(lineColor), thickness);
                 }
 
                 if (_underlineEnabled)
                 {
-                    auto y = (nextTokenY * _fontScale) / contentScaleFactor - _lineHeight * _fontScale;
+                    auto y = nextTokenY - lineHeight;
                     _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
                                             Color4F(lineColor), thickness);
                 }
 
-                nextTokenY -= _lineHeight * _fontScale + lineSpacing;
+                nextTokenY -= lineHeight + lineSpacing;
             }
         }
         else if (_textSprite) // ...and is the logic for System fonts

--- a/tests/cpp-tests/Source/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Source/LabelTest/LabelTestNew.cpp
@@ -2282,6 +2282,8 @@ LabelLayoutBaseTest::LabelLayoutBaseTest()
 
     this->initAlignmentOption(size);
 
+    this->initUnderlineStrikethroughOption(size);
+
     this->initDrawNode(size);
 
     this->initSliders(size);
@@ -2391,6 +2393,41 @@ void LabelLayoutBaseTest::initAlignmentOption(const ax::Size& size)
                         nullptr);
     menu->alignItemsVerticallyWithPadding(4);
     menu->setPosition(Vec2(size.width - 50, size.height / 2 - 20));
+    this->addChild(menu);
+}
+
+void LabelLayoutBaseTest::initUnderlineStrikethroughOption(const ax::Size& size)
+{
+    // add text alignment settings
+    MenuItemFont::setFontSize(12);
+    auto menu = Menu::create(MenuItemFont::create("Toggle Underline",
+        [this](Object*) {
+            if (_underline)
+            {
+                _label->disableEffect(LabelEffect::UNDERLINE);
+            }
+            else
+            {
+                _label->enableUnderline();
+            }
+            _underline = !_underline;
+        }
+    ),
+    MenuItemFont::create("Toggle Strikethrough",
+        [this](Object*) {
+            if (_strikethrough)
+            {
+                _label->disableEffect(LabelEffect::STRIKETHROUGH);
+            }
+            else
+            {
+                _label->enableStrikethrough();
+            }
+            _strikethrough = !_strikethrough;
+        }
+    ), nullptr);
+    menu->alignItemsVerticallyWithPadding(4);
+    menu->setPosition(Vec2(size.width - 60, 60));
     this->addChild(menu);
 }
 
@@ -3325,39 +3362,39 @@ LabelUnderlineStrikethroughMultiline::LabelUnderlineStrikethroughMultiline()
     ttfConfig.strikethrough = true;
 
     const int count = 7;
-    Label* label[count];
+    Label* labels[count];
 
-    label[0] = Label::createWithSystemFont("SystemFont TextVAlignment::TOP\nusing setTextColor(255, 0, 255, 100)", font, 14, Vec2::ZERO, TextHAlignment::LEFT, TextVAlignment::TOP);
-    label[0]->setTextColor(Color4B(255, 0, 255, 100));
-    label[0]->enableGlow(Color4B::BLUE);
+    labels[0] = Label::createWithSystemFont("SystemFont TextVAlignment::TOP\nusing setTextColor(255, 0, 255, 100)", font, 14, Vec2::ZERO, TextHAlignment::LEFT, TextVAlignment::TOP);
+    labels[0]->setTextColor(Color4B(255, 0, 255, 100));
+    labels[0]->enableGlow(Color4B::BLUE);
 
-    label[1] = Label::createWithSystemFont("SystemFont TextVAlignment::CENTER\nusing setColor(*RED*)", font, 14, Vec2::ZERO, TextHAlignment::RIGHT, TextVAlignment::CENTER);
-    label[1]->setColor(Color3B::RED);
+    labels[1] = Label::createWithSystemFont("SystemFont TextVAlignment::CENTER\nusing setColor(*RED*)", font, 14, Vec2::ZERO, TextHAlignment::RIGHT, TextVAlignment::CENTER);
+    labels[1]->setColor(Color3B::RED);
  
-    label[2] = Label::createWithSystemFont("SystemFont TextVAlignment::BOTTOM\nusingsetTextColor(*YELLOW)", font, 14,
+    labels[2] = Label::createWithSystemFont("SystemFont TextVAlignment::BOTTOM\nusingsetTextColor(*YELLOW)", font, 14,
                                            Vec2::ZERO, TextHAlignment::CENTER, TextVAlignment::BOTTOM);
-    label[2]->setTextColor(Color4B::YELLOW);
+    labels[2]->setTextColor(Color4B::YELLOW);
 
-    label[3] = Label::createWithBMFont("fonts/bitmapFontTest5.fnt", "BMFont\nwith default color", TextHAlignment::CENTER, s.width);
+    labels[3] = Label::createWithBMFont("fonts/bitmapFontTest5.fnt", "BMFont\nwith default color", TextHAlignment::CENTER, s.width);
 
-    label[4] = Label::createWithBMFont("fonts/bitmapFontTest5.fnt", "BMFont\nusing setTextColor(0, 255, 0, 100)",
+    labels[4] = Label::createWithBMFont("fonts/bitmapFontTest5.fnt", "BMFont\nusing setTextColor(0, 255, 0, 100)",
                                        TextHAlignment::CENTER, s.width);
-    label[4]->setTextColor(Color4B(0, 255, 0, 100));
+    labels[4]->setTextColor(Color4B(0, 255, 0, 100));
 
-    label[5] = Label::createWithTTF(ttfConfig,  "TTF setColor(*BLUE*)\nwith multiline 1\nand a much more longer multiline 2",
+    labels[5] = Label::createWithTTF(ttfConfig,  "TTF setColor(*BLUE*)\nwith multiline 1\nand a much more longer multiline 2",
                                     TextHAlignment::LEFT, s.width);
-    label[5]->setColor(Color3B::BLUE);
+    labels[5]->setColor(Color3B::BLUE);
 
-    label[6] = Label::createWithTTF("TTF setTextColor(*RED*)\nwith multiline 1\nand a much more longer multiline 2",
+    labels[6] = Label::createWithTTF("TTF setTextColor(*RED*)\nwith multiline 1\nand a much more longer multiline 2",
                                     font, 14);
-    label[6]->setTextColor(Color4B::RED);
+    labels[6]->setTextColor(Color4B::RED);
 
     for (int i = 0; i < count; i++)
     {
-        label[i]->setPosition(Vec2(label[i]->getBoundingBox().getMaxX() +10, s.height * 0.13f * (i + 1)));
-        label[i]->enableUnderline();
-        label[i]->enableStrikethrough();
-        addChild(label[i]);
+        labels[i]->setPosition(Vec2(labels[i]->getBoundingBox().getMaxX() +10, s.height * 0.13f * (i + 1)));
+        labels[i]->enableUnderline();
+        labels[i]->enableStrikethrough();
+        addChild(labels[i]);
     }
 
     Label* labelSize[10];
@@ -3365,21 +3402,21 @@ LabelUnderlineStrikethroughMultiline::LabelUnderlineStrikethroughMultiline()
     for (int i = 0; i < 10; i++)
     {
         float fs     = (i + 1) * 3;
-        labelSize[i] = Label::createWithTTF("UNTERLINE", "fonts/arial.ttf", fs);
+        labelSize[i] = Label::createWithTTF("UNDERLINE", "fonts/arial.ttf", fs);
         labelSize[i]->setPosition(s.width / 1.3, s.height -50 - y);
         y += (i + 2) * 3;
         labelSize[i]->enableUnderline();
         addChild(labelSize[i]);
     }
 
-    auto menuItemU = MenuItemFont::create("disable/enable underline", [=](ax::Object* sender) {
+    auto menuItemU = MenuItemFont::create("toggle underline", [=](ax::Object* sender) {
         static bool isEnabled = true;
         for (int i = 0; i < count; i++)
         {
             if (isEnabled)
-                label[i]->disableEffect(LabelEffect::UNDERLINE);
+                labels[i]->disableEffect(LabelEffect::UNDERLINE);
             else
-                label[i]->enableUnderline();
+                labels[i]->enableUnderline();
         }
         for (int i = 0; i < 10; i++)
         {
@@ -3388,21 +3425,22 @@ LabelUnderlineStrikethroughMultiline::LabelUnderlineStrikethroughMultiline()
             else
                 labelSize[i]->enableUnderline();
         }
-        isEnabled = (isEnabled) ? false : true;
+        isEnabled = !isEnabled;
     });
     menuItemU->setFontSizeObj(12);
-    auto menuItemS = MenuItemFont::create("disable/enable strikethrough", [=](ax::Object* sender) {
+    auto menuItemS = MenuItemFont::create("toggle strikethrough", [=](ax::Object* sender) {
         static bool isEnabled = true;
         for (int i = 0; i < count; i++)
         {
             if (isEnabled)
-                label[i]->disableEffect(LabelEffect::STRIKETHROUGH);
+                labels[i]->disableEffect(LabelEffect::STRIKETHROUGH);
             else
-                label[i]->enableStrikethrough();
+                labels[i]->enableStrikethrough();
         }
-        isEnabled = (isEnabled) ? false : true;
+        isEnabled = !isEnabled;
     });
     menuItemS->setFontSizeObj(12);
+
     auto menu = Menu::create(menuItemU, menuItemS, NULL);
     addChild(menu);
 
@@ -3442,7 +3480,7 @@ LabelStrikethrough::LabelStrikethrough()
     addChild(_label2a, 0, kTagBitmapAtlas2);
     _label2a->setPosition(Vec2(s.width / 2, s.height * 1 / 3));
 
-    auto menuItem = MenuItemFont::create("disable underline", [&](ax::Object* sender) {
+    auto menuItem = MenuItemFont::create("disable strikethrough", [&](ax::Object* sender) {
         _label2a->disableEffect(LabelEffect::STRIKETHROUGH);
         _label1a->disableEffect(LabelEffect::STRIKETHROUGH);
     });
@@ -3450,7 +3488,7 @@ LabelStrikethrough::LabelStrikethrough()
     auto menu = Menu::createWithItem(menuItem);
     addChild(menu);
     auto winSize = Director::getInstance()->getWinSize();
-    menu->setPosition(winSize.width * 0.9, winSize.height * 0.25f);
+    menu->setPosition(winSize.width * 0.86, winSize.height * 0.25f);
 }
 
 std::string LabelStrikethrough::title() const

--- a/tests/cpp-tests/Source/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Source/LabelTest/LabelTestNew.h
@@ -715,10 +715,11 @@ protected:
     void setAlignmentTop(ax::Object* sender);
     void setAlignmentMiddle(ax::Object* sender);
     void setAlignmentBottom(ax::Object* sender);
-
+    
     void initWrapOption(const ax::Size& size);
     void initToggleLabelTypeOption(const ax::Size& size);
     void initAlignmentOption(const ax::Size& size);
+    void initUnderlineStrikethroughOption(const ax::Size& size);
     void initFontSizeChange(const ax::Size& size);
     void initSliders(const ax::Size& size);
     void initTestLabel(const ax::Size& size);
@@ -726,6 +727,8 @@ protected:
     ax::DrawNode* _drawNode;
     ax::Label* _label;
     int _labelType;
+    bool _underline{};
+    bool _strikethrough{};
 };
 
 class LabelWrapByWordTest : public LabelLayoutBaseTest


### PR DESCRIPTION
## Describe your changes

Changes to calculate the correct positions for undereline and strike-through lines when using `setOverflow(Label::Overflow::SHRINK);`.

For TTF, the changes in this PR will ensure the output is accurate.  

For system fonts, we do not have access to information that would give the best output, so it's a rough estimate of where the lines should be.

TTF:
![image](https://github.com/user-attachments/assets/fb0ad5a4-6557-4ec2-b29c-2ae257fba1d2)

System Font:
![image](https://github.com/user-attachments/assets/32d84015-6b06-436c-a421-fa8a2fb1389b)

## Issue ticket number and link
#2397 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
