### PR TITLE
Update button size if title renderer is changed and ignore size is true

### DIFF
--- a/core/ui/UIButton.cpp
+++ b/core/ui/UIButton.cpp
@@ -177,6 +177,7 @@ void Button::setTitleLabel(Label* label)
 
         addProtectedChild(_titleRenderer, TITLE_RENDERER_Z, -1);
         updateTitleLocation();
+        updateContentSize();
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Ensure button size is updated with the size of the internal label if `Button::_ignoreSize` is `true`.

## Issue ticket number and link
#2400 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
