### PR TITLE
Fix tilemap culling

### DIFF
--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -135,16 +135,14 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
     updateTotalQuads();
 
     auto cam = Camera::getVisitingCamera();
-    if (flags != 0 || _dirty || _quadsDirty || !_cameraPositionDirty.fuzzyEquals(cam->getPosition(), _tileSet->_tileSize.x) ||
-        _cameraZoomDirty != cam->getZoom())
+    auto proj = Director::getInstance()->getProjection();
+    if (flags != 0 || _dirty || _quadsDirty)
     {
-        _cameraPositionDirty = cam->getPosition();
-        auto zoom            = _cameraZoomDirty = cam->getZoom();
-        Vec2 s               = _director->getVisibleSize();
-        const Vec2& anchor   = getAnchorPoint();
-        auto rect            = Rect(cam->getPositionX() - getPositionX() - s.width * zoom * 0.5,
-                                    cam->getPositionY() - getPositionY() - s.height * zoom * 0.5,
-                                    s.width * zoom, s.height * zoom);
+        Vec2 s             = _director->getVisibleSize();
+        const Vec2& anchor = getAnchorPoint();
+        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * (anchor.x == 0.0f ? 0.5f : anchor.x),
+                         Camera::getVisitingCamera()->getPositionY() - s.height * (anchor.y == 0.0f ? 0.5f : anchor.y),
+                         s.width, s.height);
 
         Mat4 inv = transform;
         inv.inverse();

--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -135,7 +135,6 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
     updateTotalQuads();
 
     auto cam = Camera::getVisitingCamera();
-    auto proj = Director::getInstance()->getProjection();
     if (flags != 0 || _dirty || _quadsDirty)
     {
         Vec2 s             = _director->getVisibleSize();

--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -135,13 +135,17 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
     updateTotalQuads();
 
     auto cam = Camera::getVisitingCamera();
-    if (flags != 0 || _dirty || _quadsDirty)
+    if (flags != 0 || _dirty || _quadsDirty ||
+        !_cameraPositionDirty.fuzzyEquals(cam->getPosition(), _tileSet->_tileSize.x) ||
+        _cameraZoomDirty != cam->getZoom())
     {
-        Vec2 s             = _director->getVisibleSize();
-        const Vec2& anchor = getAnchorPoint();
-        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * (anchor.x == 0.0f ? 0.5f : anchor.x),
-                         Camera::getVisitingCamera()->getPositionY() - s.height * (anchor.y == 0.0f ? 0.5f : anchor.y),
-                         s.width, s.height);
+        _cameraPositionDirty = cam->getPosition();
+        auto zoom = _cameraZoomDirty = cam->getZoom();
+        Vec2 s                       = _director->getVisibleSize();
+        const Vec2& anchor           = getAnchorPoint();
+        auto rect                    = Rect(cam->getPositionX() - s.width * zoom * (anchor.x == 0.0f ? 0.5f : anchor.x),
+                                            cam->getPositionY() - s.height * zoom * (anchor.y == 0.0f ? 0.5f : anchor.y), s.width * zoom,
+                                            s.height * zoom);
 
         Mat4 inv = transform;
         inv.inverse();
@@ -169,7 +173,7 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
 
 void FastTMXLayer::updateTiles(const Rect& culledRect)
 {
-    Rect visibleTiles        = Rect(culledRect.origin, culledRect.size * _director->getContentScaleFactor());
+    Rect visibleTiles        = Rect(culledRect.origin, culledRect.size);
     Vec2 mapTileSize         = AX_SIZE_PIXELS_TO_POINTS(_mapTileSize);
     Vec2 tileSize            = AX_SIZE_PIXELS_TO_POINTS(_tileSet->_tileSize);
     Mat4 nodeToTileTransform = _tileToNodeTransform.getInversed();

--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -142,14 +142,9 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
         auto zoom            = _cameraZoomDirty = cam->getZoom();
         Vec2 s               = _director->getVisibleSize();
         const Vec2& anchor   = getAnchorPoint();
-        auto rect            = Rect(cam->getPositionX() - s.width * zoom * (anchor.x == 0.0f ? 0.5f : anchor.x),
-                                    cam->getPositionY() - s.height * zoom * (anchor.y == 0.0f ? 0.5f : anchor.y),
+        auto rect            = Rect(cam->getPositionX() - getPositionX() - s.width * zoom * 0.5,
+                                    cam->getPositionY() - getPositionY() - s.height * zoom * 0.5,
                                     s.width * zoom, s.height * zoom);
-
-        rect.origin.x -= _tileSet->_tileSize.x;
-        rect.origin.y -= _tileSet->_tileSize.y;
-        rect.size.x += s.x * zoom / 2 + _tileSet->_tileSize.x * zoom;
-        rect.size.y += s.y * zoom / 2 + _tileSet->_tileSize.y * zoom;
 
         Mat4 inv = transform;
         inv.inverse();


### PR DESCRIPTION
## Describe your changes
I've reverted the changes to the old ones for now but this seems to break `cpp_tests`. as for normal projects like the sample one provided by @rudiHammad seems to work, I noticed that in cpp_tests even with the cocos2dx implementation, the tiles seem to be culled twice the top and right. there's a discrepancy that I couldn't find somewhere, I'll try to find the old sample I was working with in #1134  

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
