### PR TITLE
[Android] Add a way to disable interactions on the SurfaceView

### DIFF
--- a/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
@@ -64,7 +64,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
     private boolean mMultipleTouchEnabled = true;
-    private boolean mInteractiveEnabled = true;
+    private boolean mInteractive = true;
 
     private CountDownLatch mNativePauseComplete;
 
@@ -84,12 +84,12 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
         this.mMultipleTouchEnabled = multipleTouchEnabled;
     }
 
-    public boolean isInteractiveEnabled() {
-        return mInteractiveEnabled;
+    public boolean isInteractive() {
+        return mInteractive;
     }
 
-    public void setInteractiveEnabled(boolean interactiveEnabled) {
-        this.mInteractiveEnabled = interactiveEnabled;
+    public void setInteractive(boolean interactive) {
+        this.mInteractive = interactive;
     }
 
     // ===========================================================
@@ -223,7 +223,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
         switch (pMotionEvent.getAction() & MotionEvent.ACTION_MASK) {
             case MotionEvent.ACTION_POINTER_DOWN:
-                if (!mInteractiveEnabled) {
+                if (!mInteractive) {
                     break;
                 }
 
@@ -244,7 +244,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
                 break;
 
             case MotionEvent.ACTION_DOWN:
-                if (!mInteractiveEnabled) {
+                if (!mInteractive) {
                     break;
                 }
                 
@@ -368,7 +368,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public boolean onKeyDown(final int pKeyCode, final KeyEvent pKeyEvent) {
-        if (!mInteractiveEnabled) {
+        if (!mInteractive) {
             return false;
         }
 
@@ -396,7 +396,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public boolean onKeyUp(final int keyCode, KeyEvent event) {
-        if (!mInteractiveEnabled) {
+        if (!mInteractive) {
             return false;
         }
 

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
@@ -84,7 +84,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
         this.mMultipleTouchEnabled = multipleTouchEnabled;
     }
 
-    public boolean areInteractionsEnabled() {
+    public boolean isInteractionsEnabled() {
         return mInteractionsEnabled;
     }
 

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
@@ -64,6 +64,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
     private boolean mMultipleTouchEnabled = true;
+    private boolean mInteractionsEnabled = true;
 
     private CountDownLatch mNativePauseComplete;
 
@@ -81,6 +82,14 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     public void setMultipleTouchEnabled(boolean multipleTouchEnabled) {
         this.mMultipleTouchEnabled = multipleTouchEnabled;
+    }
+
+    public boolean areInteractionsEnabled() {
+        return mInteractionsEnabled;
+    }
+
+    public void setInteractionsEnabled(boolean interactionsEnabled) {
+        this.mInteractionsEnabled = interactionsEnabled;
     }
 
     // ===========================================================
@@ -214,6 +223,10 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
         switch (pMotionEvent.getAction() & MotionEvent.ACTION_MASK) {
             case MotionEvent.ACTION_POINTER_DOWN:
+                if (!mInteractionsEnabled) {
+                    break;
+                }
+
                 final int indexPointerDown = pMotionEvent.getAction() >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
                 if (!mMultipleTouchEnabled && indexPointerDown != 0) {
                     break;
@@ -231,6 +244,10 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
                 break;
 
             case MotionEvent.ACTION_DOWN:
+                if (!mInteractionsEnabled) {
+                    break;
+                }
+                
                 // there are only one finger on the screen
                 final int idDown = pMotionEvent.getPointerId(0);
                 final float xDown = xs[0];
@@ -351,6 +368,10 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public boolean onKeyDown(final int pKeyCode, final KeyEvent pKeyEvent) {
+        if (!mInteractionsEnabled) {
+            return false;
+        }
+
         switch (pKeyCode) {
             case KeyEvent.KEYCODE_BACK:
             case KeyEvent.KEYCODE_MENU:
@@ -375,6 +396,10 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public boolean onKeyUp(final int keyCode, KeyEvent event) {
+        if (!mInteractionsEnabled) {
+            return false;
+        }
+
         switch (keyCode) {
             case KeyEvent.KEYCODE_BACK:
             case KeyEvent.KEYCODE_MENU:

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolGLSurfaceView.java
@@ -64,7 +64,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
     private boolean mMultipleTouchEnabled = true;
-    private boolean mInteractionsEnabled = true;
+    private boolean mInteractiveEnabled = true;
 
     private CountDownLatch mNativePauseComplete;
 
@@ -84,12 +84,12 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
         this.mMultipleTouchEnabled = multipleTouchEnabled;
     }
 
-    public boolean isInteractionsEnabled() {
-        return mInteractionsEnabled;
+    public boolean isInteractiveEnabled() {
+        return mInteractiveEnabled;
     }
 
-    public void setInteractionsEnabled(boolean interactionsEnabled) {
-        this.mInteractionsEnabled = interactionsEnabled;
+    public void setInteractiveEnabled(boolean interactiveEnabled) {
+        this.mInteractiveEnabled = interactiveEnabled;
     }
 
     // ===========================================================
@@ -223,7 +223,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
         switch (pMotionEvent.getAction() & MotionEvent.ACTION_MASK) {
             case MotionEvent.ACTION_POINTER_DOWN:
-                if (!mInteractionsEnabled) {
+                if (!mInteractiveEnabled) {
                     break;
                 }
 
@@ -244,7 +244,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
                 break;
 
             case MotionEvent.ACTION_DOWN:
-                if (!mInteractionsEnabled) {
+                if (!mInteractiveEnabled) {
                     break;
                 }
                 
@@ -368,7 +368,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public boolean onKeyDown(final int pKeyCode, final KeyEvent pKeyEvent) {
-        if (!mInteractionsEnabled) {
+        if (!mInteractiveEnabled) {
             return false;
         }
 
@@ -396,7 +396,7 @@ public class AxmolGLSurfaceView extends GLSurfaceView {
 
     @Override
     public boolean onKeyUp(final int keyCode, KeyEvent event) {
-        if (!mInteractionsEnabled) {
+        if (!mInteractiveEnabled) {
             return false;
         }
 


### PR DESCRIPTION
## Describe your changes
I needed a way to disable the interactions on Android, but nor `surfaceView.setEnabled(false)` nor `surfaceView.setClickable(false);` is working as it was in the past.
I added a Getter and Setter to be able to disable interactions on the events on the surface view directly:
- Key up & down
- Touch Down only so any gestures already started could end

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
