### PR TITLE
Log frame names instead of hash values in the call to removeUnusedSpriteFrames()

### DIFF
--- a/core/2d/SpriteFrameCache.cpp
+++ b/core/2d/SpriteFrameCache.cpp
@@ -167,7 +167,7 @@ void SpriteFrameCache::removeUnusedSpriteFrames()
         {
             toRemoveFrames.emplace_back(iter.first);
             spriteFrame->getTexture()->removeSpriteFrameCapInset(spriteFrame);
-            AXLOGD("SpriteFrameCache: removing unused frame: {}", iter.first);
+            AXLOGD("SpriteFrameCache: removing unused frame: {}", spriteFrame->getName());
             removed = true;
         }
     }


### PR DESCRIPTION
## Describe your changes

With the recent changes to `SpriteFrameCache`, the debug log message in `removeUnusedSpriteFrames()` is now displaying hash values, which doesn't really seem to be useful information:
```
D/[2025-03-13 19:05:18.263][TID:9960]SpriteFrameCache: removing unused frame: 4578326371618782654
D/[2025-03-13 19:05:18.263][TID:9960]SpriteFrameCache: removing unused frame: 7607822781973598231
D/[2025-03-13 19:05:18.263][TID:9960]SpriteFrameCache: removing unused frame: 14136097346131993478
D/[2025-03-13 19:05:18.263][TID:9960]SpriteFrameCache: removing unused frame: 3851631321398992221
D/[2025-03-13 19:05:18.263][TID:9960]SpriteFrameCache: removing unused frame: 17398677411129466848
```

The change in this PR revert the log message to output the frame name instead, for example:
```
D/[2025-03-13 19:19:32.558][TID:9fcc]SpriteFrameCache: removing unused frame: images/Image01.png
D/[2025-03-13 19:19:32.558][TID:9fcc]SpriteFrameCache: removing unused frame: images/Image02.png
D/[2025-03-13 19:19:32.558][TID:9fcc]SpriteFrameCache: removing unused frame: images/Image03.png
D/[2025-03-13 19:19:32.558][TID:9fcc]SpriteFrameCache: removing unused frame: images/Image04.png
D/[2025-03-13 19:19:32.558][TID:9fcc]SpriteFrameCache: removing unused frame: images/Image05.png
```

@halx99 If the hash value is still useful information, then perhaps we can have both hash and name printed out.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
