### PR TITLE
Prevent getCurrentTime() from returning 0 at the end of the audio track playback

### DIFF
--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -829,6 +829,10 @@ float AudioEngineImpl::getCurrentTime(AUDIO_ID audioID)
             {
                 AXLOGE("{}, audio id:{},error code:{:#x}", __FUNCTION__, audioID, error);
             }
+            else if (ret == 0.0f && player->isFinished())
+            {
+                ret = player->_audioCache->_duration;
+            }
         }
     }
 

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -829,10 +829,11 @@ float AudioEngineImpl::getCurrentTime(AUDIO_ID audioID)
             {
                 AXLOGE("{}, audio id:{},error code:{:#x}", __FUNCTION__, audioID, error);
             }
-            else if (ret == 0.0f && player->isFinished())
-            {
-                ret = player->_audioCache->_duration;
-            }
+        }
+
+        if (ret == 0.0f && player->isFinished())
+        {
+            ret = player->_audioCache->_duration;
         }
     }
 


### PR DESCRIPTION
## Describe your changes

If the audio track started playing, and it has reached the end, then `getCurrentTime()` should return the total sound duration instead of 0.  The changes in this PR are a possible solution to the problem.  I'm not too familiar with that code to work out if there is a better way to fix this issue.

## Issue ticket number and link
#2451

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
