### PR TITLE
[Android] FileUtils::listFiles implementation that works with empty folders

### DIFF
--- a/core/platform/android/FileUtils-android.cpp
+++ b/core/platform/android/FileUtils-android.cpp
@@ -290,7 +290,7 @@ std::vector<std::string> FileUtilsAndroid::listFiles(std::string_view dirPath) c
         relativePath.erase(relativePath.length() - 1);
     }
 
-    fileList = JniHelper::callStaticStringArrayMethod("dev/axmol/lib/AxmolEngine", "getFileList", relativePath);
+    fileList = JniHelper::callStaticStringArrayMethod("dev/axmol/lib/AxmolEngine", "getAssetsList", relativePath);
 
     return fileList;
 }

--- a/core/platform/android/FileUtils-android.cpp
+++ b/core/platform/android/FileUtils-android.cpp
@@ -291,12 +291,6 @@ std::vector<std::string> FileUtilsAndroid::listFiles(std::string_view dirPath) c
     }
 
     fileList = JniHelper::callStaticStringArrayMethod("dev/axmol/lib/AxmolEngine", "getFileList", relativePath);
-    for (auto& entryName : fileList)
-    {
-        if (isDirectoryExistInternal(entryName))
-            entryName += "/";
-        entryName = fullPath + "/" + entryName;
-    }
 
     return fileList;
 }

--- a/core/platform/android/FileUtils-android.cpp
+++ b/core/platform/android/FileUtils-android.cpp
@@ -242,15 +242,32 @@ int64_t FileUtilsAndroid::getFileSize(std::string_view filepath) const
 
 std::vector<std::string> FileUtilsAndroid::listFiles(std::string_view dirPath) const
 {
-
     if (!dirPath.empty() && dirPath[0] == '/')
         return FileUtils::listFiles(dirPath);
 
     std::vector<std::string> fileList;
-    std::string fullPath = fullPathForDirectory(dirPath);
-
     static const std::string apkprefix("assets/");
     std::string relativePath;
+
+    if (obbfile)
+    {
+        std::string fullPath = fullPathForDirectory(dirPath);
+
+        size_t position = fullPath.find(apkprefix);
+        if (0 == position)
+        {
+            // "assets/" is at the beginning of the path and we don't want it
+            relativePath += fullPath.substr(apkprefix.size());
+        }
+        else
+        {
+            relativePath = fullPath;
+        }
+
+        return obbfile->listFiles(relativePath);
+    }
+
+    std::string fullPath = std::string(dirPath); // don't call fullPathForDirectory(dirPath), since empty folders will not return a valid result
     size_t position = fullPath.find(apkprefix);
     if (0 == position)
     {
@@ -261,9 +278,6 @@ std::vector<std::string> FileUtilsAndroid::listFiles(std::string_view dirPath) c
     {
         relativePath = fullPath;
     }
-
-    if (obbfile)
-        return obbfile->listFiles(relativePath);
 
     if (nullptr == assetmanager)
     {
@@ -276,22 +290,14 @@ std::vector<std::string> FileUtilsAndroid::listFiles(std::string_view dirPath) c
         relativePath.erase(relativePath.length() - 1);
     }
 
-    auto* dir = AAssetManager_openDir(assetmanager, relativePath.c_str());
-    if (nullptr == dir)
+    fileList = JniHelper::callStaticStringArrayMethod("dev/axmol/lib/AxmolEngine", "getFileList", relativePath);
+    for (auto& entryName : fileList)
     {
-        LOGD("... FileUtilsAndroid::failed to open dir %s", relativePath.c_str());
-        AAssetDir_close(dir);
-        return fileList;
+        if (isDirectoryExistInternal(entryName))
+            entryName += "/";
+        entryName = fullPath + "/" + entryName;
     }
-    const char* tmpDir = nullptr;
-    while ((tmpDir = AAssetDir_getNextFileName(dir)) != nullptr)
-    {
-        std::string filepath(tmpDir);
-        if (isDirectoryExistInternal(filepath))
-            filepath += "/";
-        fileList.emplace_back(fullPath + filepath);
-    }
-    AAssetDir_close(dir);
+
     return fileList;
 }
 

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolEngine.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolEngine.java
@@ -747,7 +747,7 @@ public class AxmolEngine {
         return sAccelerometer;
     }
 
-    public static String[] getFileList(String path) {
+    public static String[] getAssetsList(String path) {
         try {
             String basePath;
             if (!path.isEmpty()) {

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolEngine.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolEngine.java
@@ -749,7 +749,24 @@ public class AxmolEngine {
 
     public static String[] getFileList(String path) {
         try {
-            String[] list = getAssetManager().list(path);
+            String basePath;
+            if (!path.isEmpty()) {
+                basePath = path + "/";
+            } else {
+                basePath = path;
+            }
+
+            AssetManager assetManager = getAssetManager();
+            String[] list = assetManager.list(path);
+            for (int i = 0; i < list.length; i++) {
+                try {
+                    list[i] = basePath + list[i];
+                    java.io.InputStream stream = assetManager.open(list[i]);
+                    stream.close(); // if we got to here, then it is a file
+                } catch (IOException e) {
+                    list[i] += "/";
+                }
+            }
             return list;
         } catch (IOException e) {
             e.printStackTrace();

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolEngine.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolEngine.java
@@ -746,4 +746,14 @@ public class AxmolEngine {
 
         return sAccelerometer;
     }
+
+    public static String[] getFileList(String path) {
+        try {
+            String[] list = getAssetManager().list(path);
+            return list;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/core/platform/android/jni/JniHelper.h
+++ b/core/platform/android/jni/JniHelper.h
@@ -221,6 +221,50 @@ public:
     }
 
     /**
+    @brief Call of Java static String* method
+    @return axstd::pod_vector
+    */
+    template <typename... Ts>
+    static std::vector<std::string> callStaticStringArrayMethod(const char* className, const char* methodName, Ts&&... xs)
+    {
+        ax::JniMethodInfo t;
+        const auto signature = "(Ljava/lang/String;)[Ljava/lang/String;";
+        if (ax::JniHelper::getStaticMethodInfo(t, className, methodName, signature))
+        {
+            LocalRefMapType localRefs;
+            jobjectArray array =
+                    (jobjectArray)t.env->CallStaticObjectMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
+
+            if (array == nullptr)
+            {
+                t.env->DeleteLocalRef(t.classID);
+                deleteLocalRefs(t.env, localRefs);
+                return {};
+            }
+
+            jsize len = t.env->GetArrayLength(array);
+            std::vector<std::string> result(len);
+            for (int i=0; i < len; ++i)
+            {
+                jstring string = (jstring)t.env->GetObjectArrayElement(array, i);
+                const char* arrayItem = t.env->GetStringUTFChars(string, 0);
+                result[i] = std::move((std::string(arrayItem)));
+                t.env->ReleaseStringUTFChars(string, arrayItem);
+                t.env->DeleteLocalRef(string);
+            }
+
+            t.env->DeleteLocalRef(t.classID);
+            deleteLocalRefs(t.env, localRefs);
+            return result;
+        }
+        else
+        {
+            reportError(className, methodName, signature);
+        }
+        return {};
+    }
+
+    /**
     @brief Call of Java static float* method
     @return axstd::pod_vector
     */

--- a/core/platform/android/jni/JniHelper.h
+++ b/core/platform/android/jni/JniHelper.h
@@ -221,8 +221,8 @@ public:
     }
 
     /**
-    @brief Call of Java static String* method
-    @return axstd::pod_vector
+    @brief Call of Java static method
+    @return std::vector<std::string>
     */
     template <typename... Ts>
     static std::vector<std::string> callStaticStringArrayMethod(const char* className, const char* methodName, Ts&&... xs)


### PR DESCRIPTION
## Describe your changes

This is an attempt to fix the issue of empty folder names missing from `FileUtils::listFiles()` on Android when the path is in the assets folder (within the APK).

This now uses the Java implementation of `AssetManager.list()`, which does return all file and folder names.  This will then use 
`AssetManager.open()` to check if the path is a file or folder, but if anyone knows of a better way to handle this, then please state what it is.  

Files in the `assets` folder will be relative to that folder, and the "assets/" prefix will not be added to them, since it is not required.

## Issue ticket number and link
#2458 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
