### PR TITLE
[WASM] set _APP_RES_FOLDER if not defined to be able to specify directories of Resources

### DIFF
--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -538,7 +538,8 @@ if(AX_WASM_ENABLE_DEVTOOLS)
     string(APPEND _AX_WASM_EXPORTS ",_axmol_dev_pause,_axmol_dev_resume,_axmol_dev_step")
 endif()
 set(AX_WASM_EXPORTS "${_AX_WASM_EXPORTS}" CACHE STRING "" FORCE)
-
+set(AX_WASM_RES_FOLDER "${_APP_SOURCE_DIR}/Content")
+        
 # stupid & pitfall: function not emcc not output .html
 macro (ax_setup_app_props app_name)
     if(WINRT)
@@ -569,8 +570,7 @@ macro (ax_setup_app_props app_name)
         # string(APPEND EMSCRIPTEN_LINK_FLAGS " -s SEPARATE_DWARF_URL=https://xxx:8080/axmolwasm/axmolwasm/build/HelloLua.debug.wasm")
         # string(APPEND EMSCRIPTEN_LINK_FLAGS " -gseparate-dwarf=HelloLua.debug.wasm")
 
-        set(_APP_RES_FOLDER "${_APP_SOURCE_DIR}/Content")
-        foreach(FOLDER IN LISTS _APP_RES_FOLDER)
+        foreach(FOLDER IN LISTS AX_WASM_RES_FOLDER)
             string(APPEND EMSCRIPTEN_LINK_FLAGS " --preload-file ${FOLDER}/@/")
         endforeach()
 

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -538,7 +538,7 @@ if(AX_WASM_ENABLE_DEVTOOLS)
     string(APPEND _AX_WASM_EXPORTS ",_axmol_dev_pause,_axmol_dev_resume,_axmol_dev_step")
 endif()
 set(AX_WASM_EXPORTS "${_AX_WASM_EXPORTS}" CACHE STRING "" FORCE)
-        
+
 # stupid & pitfall: function not emcc not output .html
 macro (ax_setup_app_props app_name)
     if(WINRT)

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -538,7 +538,6 @@ if(AX_WASM_ENABLE_DEVTOOLS)
     string(APPEND _AX_WASM_EXPORTS ",_axmol_dev_pause,_axmol_dev_resume,_axmol_dev_step")
 endif()
 set(AX_WASM_EXPORTS "${_AX_WASM_EXPORTS}" CACHE STRING "" FORCE)
-set(AX_WASM_RES_FOLDER "${CMAKE_CURRENT_SOURCE_DIR}/Content")
         
 # stupid & pitfall: function not emcc not output .html
 macro (ax_setup_app_props app_name)
@@ -570,7 +569,10 @@ macro (ax_setup_app_props app_name)
         # string(APPEND EMSCRIPTEN_LINK_FLAGS " -s SEPARATE_DWARF_URL=https://xxx:8080/axmolwasm/axmolwasm/build/HelloLua.debug.wasm")
         # string(APPEND EMSCRIPTEN_LINK_FLAGS " -gseparate-dwarf=HelloLua.debug.wasm")
 
-        foreach(FOLDER IN LISTS AX_WASM_RES_FOLDER)
+        if (NOT DEFINED _APP_RES_FOLDER)
+            set(_APP_RES_FOLDER "${_APP_SOURCE_DIR}/Content")
+        endif()
+        foreach(FOLDER IN LIST _APP_RES_FOLDER)
             string(APPEND EMSCRIPTEN_LINK_FLAGS " --preload-file ${FOLDER}/@/")
         endforeach()
 

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -572,7 +572,7 @@ macro (ax_setup_app_props app_name)
         if (NOT DEFINED _APP_RES_FOLDER)
             set(_APP_RES_FOLDER "${_APP_SOURCE_DIR}/Content")
         endif()
-        foreach(FOLDER IN LIST _APP_RES_FOLDER)
+        foreach(FOLDER IN LISTS _APP_RES_FOLDER)
             string(APPEND EMSCRIPTEN_LINK_FLAGS " --preload-file ${FOLDER}/@/")
         endforeach()
 

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -538,7 +538,7 @@ if(AX_WASM_ENABLE_DEVTOOLS)
     string(APPEND _AX_WASM_EXPORTS ",_axmol_dev_pause,_axmol_dev_resume,_axmol_dev_step")
 endif()
 set(AX_WASM_EXPORTS "${_AX_WASM_EXPORTS}" CACHE STRING "" FORCE)
-set(AX_WASM_RES_FOLDER "${_APP_SOURCE_DIR}/Content")
+set(AX_WASM_RES_FOLDER "${CMAKE_CURRENT_SOURCE_DIR}/Content")
         
 # stupid & pitfall: function not emcc not output .html
 macro (ax_setup_app_props app_name)


### PR DESCRIPTION
## Describe your changes

Currently there is no way to specify the directory/ies of the resources for Wasm (it is "Content/")
~~I added `AX_WASM_RES_FOLDER` to be able to specify the directories~~

I changed to check if _APP_RES_FOLDER is defined before setting it so we can set it to whatever directories we need for Wasm resources

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
