### PR TITLE
Fix character, underline and strikethrough drawing over label boundary for Overflow::CLAMP mode

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1181,10 +1181,10 @@ bool Label::computeHorizontalKernings(const std::u32string& stringToRender)
         return true;
 }
 
-bool Label::isHorizontalClamped(float letterPositionX, int lineIndex)
+bool Label::isHorizontalClamped(float letterPositionX, float letterWidth, int lineIndex)
 {
     auto wordWidth       = this->_linesWidth[lineIndex];
-    bool letterOverClamp = (letterPositionX > _contentSize.width || letterPositionX < 0);
+    bool letterOverClamp = ((letterPositionX + letterWidth) > _contentSize.width || letterPositionX < 0);
     if (!_enableWrap)
     {
         return letterOverClamp;
@@ -1231,11 +1231,11 @@ bool Label::updateQuads()
             }
 
             auto lineIndex = _lettersInfo[ctr].lineIndex;
-            auto px        = _lettersInfo[ctr].positionX + letterDef.width / 2 * _fontScale + _linesOffsetX[lineIndex];
+            auto px        = _lettersInfo[ctr].positionX + _linesOffsetX[lineIndex];
 
             if (_labelWidth > 0.f)
             {
-                if (this->isHorizontalClamped(px, lineIndex))
+                if (this->isHorizontalClamped(px, letterDef.width * _fontScale, lineIndex))
                 {
                     if (_overflow == Overflow::CLAMP)
                     {

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1765,20 +1765,38 @@ void Label::updateContent()
             // atlas font
             for (int i = 0; i < _numberOfLines; ++i)
             {
+                float startOffset = 0;
+                float endOffset   = 0;
+
+                if (_overflow == Overflow::CLAMP)
+                {
+                    startOffset = std::max(0.f, _linesOffsetX[i]);
+                    if (_hAlignment == TextHAlignment::LEFT || _hAlignment == TextHAlignment::CENTER)
+                    {
+                        endOffset = std::min(_linesWidth[i] + startOffset, _labelDimensions.width - startOffset);
+                    }
+                    else  // _hAlignment == TextHAlignment::RIGHT
+                    {
+                        endOffset = std::min(_linesWidth[i] + startOffset, _labelDimensions.width);
+                    }
+                }
+                else
+                {
+                    startOffset = _linesOffsetX[i];
+                    endOffset   = _linesWidth[i] + _linesOffsetX[i];
+                }
+
                 if (_strikethroughEnabled)
                 {
                     auto y = nextY - lineHeight / 2;
-                    _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
-                                            Color4F(lineColor), thickness);
+                    _lineDrawNode->drawLine(Vec2(startOffset, y), Vec2(endOffset, y), Color4F(lineColor), thickness);
                 }
 
                 if (_underlineEnabled)
                 {
                     auto y = nextY - lineHeight;
-                    _lineDrawNode->drawLine(Vec2(_linesOffsetX[i], y), Vec2(_linesWidth[i] + _linesOffsetX[i], y),
-                                            Color4F(lineColor), thickness);
+                    _lineDrawNode->drawLine(Vec2(startOffset, y), Vec2(endOffset, y), Color4F(lineColor), thickness);
                 }
-
                 nextY -= lineHeight + lineSpacing;
             }
         }

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -800,7 +800,7 @@ protected:
     bool setTTFConfigInternal(const TTFConfig& ttfConfig);
     bool updateTTFConfigInternal();
     void setBMFontSizeInternal(float fontSize);
-    bool isHorizontalClamped(float letterPositionX, int lineIndex);
+    bool isHorizontalClamped(float letterPositionX, float letterWidth, int lineIndex);
     void restoreFontSize();
     void updateLetterSpriteScale(Sprite* sprite);
     int getFirstCharLen(const std::u32string& utf32Text, int startIndex, int textLen) const;


### PR DESCRIPTION
## Describe your changes

Ensure that underline and strike-through lines are clamped correctly when overflow is set to `Overflow::CLAMP`

This also fixes the issue of characters being drawn over the label boundary when using `Overflow::CLAMP`.

Label tests 56 and 57 cover this in the cpp-tests project.

## Issue ticket number and link
#2513 
#2516

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
