### PR TITLE
Fix for clamped and left-aligned text with certain character sets

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1184,7 +1184,7 @@ bool Label::computeHorizontalKernings(const std::u32string& stringToRender)
 bool Label::isHorizontalClamped(float letterPositionX, float letterWidth, int lineIndex)
 {
     auto wordWidth       = this->_linesWidth[lineIndex];
-    bool letterOverClamp = ((letterPositionX + letterWidth) > _contentSize.width || letterPositionX < 0);
+    bool letterOverClamp = ((letterPositionX + letterWidth) > _contentSize.width || (letterPositionX + letterWidth / 2) < 0);
     if (!_enableWrap)
     {
         return letterOverClamp;


### PR DESCRIPTION
## Describe your changes

With left-alignment, it seems that certain characters can result in negative X position, even though the left-aligned text should be at 0.

This change just partially reverts the calculation to how it was previously, but only for the left position of the text, using half the width to check if it is out bounds, `(letterPositionX + letterWidth / 2) < 0`. 

## Issue ticket number and link
#2516 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
