### PR TITLE
[FairyGUI] Add support for blending

### DIFF
--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -184,10 +184,10 @@ void DrawNode::updateBlendState(CustomCommand& cmd)
     }
     else
     {
-        blendDescriptor.sourceRGBBlendFactor        = backend::BlendFactor::ONE;
-        blendDescriptor.destinationRGBBlendFactor   = backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
-        blendDescriptor.sourceAlphaBlendFactor      = backend::BlendFactor::ONE;
-        blendDescriptor.destinationAlphaBlendFactor = backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
+        blendDescriptor.sourceRGBBlendFactor        = _blendFunc.src;
+        blendDescriptor.destinationRGBBlendFactor   = _blendFunc.dst;
+        blendDescriptor.sourceAlphaBlendFactor      = _blendFunc.src;
+        blendDescriptor.destinationAlphaBlendFactor = _blendFunc.dst;
         setOpacityModifyRGB(true);
     }
 }

--- a/core/2d/DrawNode.h
+++ b/core/2d/DrawNode.h
@@ -56,7 +56,7 @@ class PointArray;
  * Faster than the "drawing primitives" since they draws everything in one single batch.
  * @since v2.1
  */
-class AX_DLL DrawNode : public Node
+class AX_DLL DrawNode : public Node, public BlendProtocol
 {
 public:
     /** Different draw modus types.
@@ -517,7 +517,7 @@ public:
     /** Get the color mixed mode.
      * @lua NA
      */
-    const BlendFunc& getBlendFunc() const;
+    const BlendFunc& getBlendFunc() const override;
     /** Set the color mixed mode.
      * @code
      * When this function bound into js or lua,the parameter will be changed
@@ -525,7 +525,7 @@ public:
      * @endcode
      * @lua NA
      */
-    void setBlendFunc(const BlendFunc& blendFunc);
+    void setBlendFunc(const BlendFunc& blendFunc) override;
 
     // Overrides
     virtual void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;

--- a/extensions/fairygui/src/fairygui/GObject.cpp
+++ b/extensions/fairygui/src/fairygui/GObject.cpp
@@ -29,6 +29,7 @@ GObject::GObject() : _scale{1, 1},
                      _handlingController(false),
                      _touchable(true),
                      _grayed(false),
+                     _blendMode(BlendMode::Normal),
                      _finalGrayed(false),
                      _draggable(false),
                      _dragBounds(nullptr),
@@ -404,6 +405,15 @@ void GObject::setTooltips(const std::string& value)
     {
         addEventListener(UIEventType::RollOver, AX_CALLBACK_1(GObject::onRollOver, this), EventTag(this));
         addEventListener(UIEventType::RollOut, AX_CALLBACK_1(GObject::onRollOut, this), EventTag(this));
+    }
+}
+
+void GObject::setBlendMode(BlendMode blendMode)
+{
+    if (_blendMode != blendMode)
+    {
+        _blendMode = blendMode;
+        BlendModeUtils::apply(displayObject(), blendMode);
     }
 }
 
@@ -869,7 +879,7 @@ void GObject::setup_beforeAdd(ByteBuffer* buffer, int beginPos)
         setTouchable(false);
     if (buffer->readBool())
         setGrayed(true);
-    buffer->readByte(); //blendMode
+    setBlendMode((BlendMode)buffer->readByte());
     buffer->readByte(); //filter
 
     const std::string& str = buffer->readS();

--- a/extensions/fairygui/src/fairygui/GObject.h
+++ b/extensions/fairygui/src/fairygui/GObject.h
@@ -5,6 +5,7 @@
 #include "FairyGUIMacros.h"
 #include "Relations.h"
 #include "cocos2d.h"
+#include "display/BlendMode.h"
 #include "event/UIEventDispatcher.h"
 #include "gears/GearBase.h"
 
@@ -97,6 +98,9 @@ public:
 
     const std::string& getTooltips() const { return _tooltips; }
     void setTooltips(const std::string& value);
+
+    BlendMode getBlendMode() const { return _blendMode; }
+    void setBlendMode(BlendMode blendMode);
 
     void* getData() const { return _data; };
     void setData(void* value) { _data = value; }
@@ -205,6 +209,7 @@ protected:
     bool _touchable;
     bool _grayed;
     bool _finalGrayed;
+    BlendMode _blendMode;
 
 private:
     bool internalVisible() const;

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -1,0 +1,65 @@
+#include "BlendMode.h"
+#include "renderer/backend/Enums.h"
+
+NS_FGUI_BEGIN
+using namespace ax;
+
+namespace
+{
+std::vector<BlendFunc> blendModes {
+    {backend::BlendFactor::SRC_ALPHA, backend::BlendFactor::ONE_MINUS_SRC_ALPHA},  // normal
+    {backend::BlendFactor::ONE, backend::BlendFactor::ONE},                        // none
+    {backend::BlendFactor::SRC_ALPHA, backend::BlendFactor::ONE},                  // add
+    {backend::BlendFactor::DST_COLOR, backend::BlendFactor::ONE_MINUS_SRC_ALPHA},  // mul
+    {backend::BlendFactor::ONE, backend::BlendFactor::ONE_MINUS_SRC_COLOR},        // screen
+    {backend::BlendFactor::ZERO, backend::BlendFactor::ONE_MINUS_SRC_ALPHA},       // erase
+    {backend::BlendFactor::ZERO, backend::BlendFactor::SRC_ALPHA},                 // mask
+    {backend::BlendFactor::ONE_MINUS_DST_ALPHA, backend::BlendFactor::DST_ALPHA},  // below
+    {backend::BlendFactor::ONE, backend::BlendFactor::ZERO},                       // off
+    {backend::BlendFactor::SRC_ALPHA, backend::BlendFactor::ONE_MINUS_SRC_ALPHA},  // custom1
+    {backend::BlendFactor::SRC_ALPHA, backend::BlendFactor::ONE_MINUS_SRC_ALPHA},  // custom2
+    {backend::BlendFactor::SRC_ALPHA, backend::BlendFactor::ONE_MINUS_SRC_ALPHA},  // custom2
+};
+}
+
+void BlendModeUtils::apply(ax::Node* node, BlendMode blendMode)
+{
+    auto blendIndex = static_cast<size_t>(blendMode);
+    if (blendIndex >= blendModes.size())
+    {
+        AXLOGE("[FairyGUI] Invalid BlendMode: {}", blendIndex);
+        return;
+    }
+
+    auto& blendFunc = blendModes[blendIndex];
+    auto&& children = node->getChildren();
+    for (auto&& child : children)
+    {
+        auto sprite = dynamic_cast<Sprite*>(child);
+        if (!sprite)
+            continue;
+
+        auto& currentBlendFunc = sprite->getBlendFunc();
+        if (currentBlendFunc.src != blendFunc.src && currentBlendFunc.dst != blendFunc.dst)
+        {
+            sprite->setBlendFunc(blendFunc);
+        }
+    }
+}
+
+void BlendModeUtils::override(BlendMode blendMode,
+                              ax::backend::BlendFactor srcFactor,
+                              ax::backend::BlendFactor dstFactor)
+{
+    auto blendIndex = static_cast<size_t>(blendMode);
+    if (blendIndex >= blendModes.size())
+    {
+        AXLOGE("[FairyGUI] Invalid BlendMode: {}", blendIndex);
+        return;
+    }
+
+    blendModes[blendIndex].src = srcFactor;
+    blendModes[blendIndex].dst = dstFactor;
+}
+
+NS_FGUI_END

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -40,13 +40,13 @@ void BlendModeUtils::apply(ax::Node* node, BlendMode blendMode)
 
 void BlendModeUtils::apply(ax::Node* node, const ax::BlendFunc& blendFunc)
 {
-    auto sprite = dynamic_cast<Sprite*>(node);
-    if (sprite)
+    auto blendProtocol = dynamic_cast<BlendProtocol*>(node);
+    if (blendProtocol)
     {
-        auto& currentBlendFunc = sprite->getBlendFunc();
+        auto& currentBlendFunc = blendProtocol->getBlendFunc();
         if (currentBlendFunc.src != blendFunc.src && currentBlendFunc.dst != blendFunc.dst)
         {
-            sprite->setBlendFunc(blendFunc);
+            blendProtocol->setBlendFunc(blendFunc);
         }
     }
 

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -32,6 +32,17 @@ void BlendModeUtils::apply(ax::Node* node, BlendMode blendMode)
     }
 
     auto& blendFunc = blendModes[blendIndex];
+
+    auto self = dynamic_cast<Sprite*>(node);
+    if (self)
+    {
+        auto& currentBlendFunc = self->getBlendFunc();
+        if (currentBlendFunc.src != blendFunc.src && currentBlendFunc.dst != blendFunc.dst)
+        {
+            self->setBlendFunc(blendFunc);
+        }
+    }
+
     auto&& children = node->getChildren();
     for (auto&& child : children)
     {

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -22,8 +22,6 @@ std::vector<BlendFunc> blendModes {
 };
 }
 
-
-
 void BlendModeUtils::apply(ax::Node* node, BlendMode blendMode)
 {
     if (!node)

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -44,7 +44,7 @@ void BlendModeUtils::apply(ax::Node* node, const ax::BlendFunc& blendFunc)
     if (blendProtocol)
     {
         auto& currentBlendFunc = blendProtocol->getBlendFunc();
-        if (currentBlendFunc.src != blendFunc.src && currentBlendFunc.dst != blendFunc.dst)
+        if (currentBlendFunc.src != blendFunc.src || currentBlendFunc.dst != blendFunc.dst)
         {
             blendProtocol->setBlendFunc(blendFunc);
         }

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -57,7 +57,7 @@ void BlendModeUtils::apply(ax::Node* node, const ax::BlendFunc& blendFunc)
     }
 }
 
-void BlendModeUtils::override(BlendMode blendMode,
+void BlendModeUtils::overrideBlendMode(BlendMode blendMode,
                               ax::backend::BlendFactor srcFactor,
                               ax::backend::BlendFactor dstFactor)
 {

--- a/extensions/fairygui/src/fairygui/display/BlendMode.cpp
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.cpp
@@ -22,8 +22,13 @@ std::vector<BlendFunc> blendModes {
 };
 }
 
+
+
 void BlendModeUtils::apply(ax::Node* node, BlendMode blendMode)
 {
+    if (!node)
+        return;
+
     auto blendIndex = static_cast<size_t>(blendMode);
     if (blendIndex >= blendModes.size())
     {
@@ -32,29 +37,25 @@ void BlendModeUtils::apply(ax::Node* node, BlendMode blendMode)
     }
 
     auto& blendFunc = blendModes[blendIndex];
+    apply(node, blendFunc);
+}
 
-    auto self = dynamic_cast<Sprite*>(node);
-    if (self)
+void BlendModeUtils::apply(ax::Node* node, const ax::BlendFunc& blendFunc)
+{
+    auto sprite = dynamic_cast<Sprite*>(node);
+    if (sprite)
     {
-        auto& currentBlendFunc = self->getBlendFunc();
+        auto& currentBlendFunc = sprite->getBlendFunc();
         if (currentBlendFunc.src != blendFunc.src && currentBlendFunc.dst != blendFunc.dst)
         {
-            self->setBlendFunc(blendFunc);
+            sprite->setBlendFunc(blendFunc);
         }
     }
 
     auto&& children = node->getChildren();
     for (auto&& child : children)
     {
-        auto sprite = dynamic_cast<Sprite*>(child);
-        if (!sprite)
-            continue;
-
-        auto& currentBlendFunc = sprite->getBlendFunc();
-        if (currentBlendFunc.src != blendFunc.src && currentBlendFunc.dst != blendFunc.dst)
-        {
-            sprite->setBlendFunc(blendFunc);
-        }
+        apply(child, blendFunc);
     }
 }
 

--- a/extensions/fairygui/src/fairygui/display/BlendMode.h
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "cocos2d.h"
+#include "FairyGUIMacros.h"
+
+NS_FGUI_BEGIN
+
+enum class BlendMode
+{
+    Normal,
+    None,
+    Add,
+    Multiply,
+    Screen,
+    Erase,
+    Mask,
+    Below,
+    Off,
+    Custom1,
+    Custom2,
+    Custom3
+};
+
+class BlendModeUtils
+{
+public:
+    static void apply(ax::Node* node, BlendMode blendMode);
+    static void override(BlendMode blendMode, ax::backend::BlendFactor srcFactor, ax::backend::BlendFactor dstFactor);
+};
+
+NS_FGUI_END

--- a/extensions/fairygui/src/fairygui/display/BlendMode.h
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.h
@@ -25,6 +25,9 @@ class BlendModeUtils
 public:
     static void apply(ax::Node* node, BlendMode blendMode);
     static void override(BlendMode blendMode, ax::backend::BlendFactor srcFactor, ax::backend::BlendFactor dstFactor);
+
+protected:
+    static void apply(ax::Node* node, const ax::BlendFunc& blendFunc);
 };
 
 NS_FGUI_END

--- a/extensions/fairygui/src/fairygui/display/BlendMode.h
+++ b/extensions/fairygui/src/fairygui/display/BlendMode.h
@@ -24,7 +24,9 @@ class BlendModeUtils
 {
 public:
     static void apply(ax::Node* node, BlendMode blendMode);
-    static void override(BlendMode blendMode, ax::backend::BlendFactor srcFactor, ax::backend::BlendFactor dstFactor);
+    static void overrideBlendMode(BlendMode blendMode,
+                                  ax::backend::BlendFactor srcFactor,
+                                  ax::backend::BlendFactor dstFactor);
 
 protected:
     static void apply(ax::Node* node, const ax::BlendFunc& blendFunc);


### PR DESCRIPTION
## Describe your changes

 `DrawNode` now inherits from `BlendProtocol`, since it does support blending.  Also, ensure that the set `BlendFunc` is actually used, because it was hard-coded previously, so never used the correct blending modes. The change should not affect existing usage at all, since the default `BlendFunc` was `BlendFunc::ALPHA_PREMULTIPLIED`, which is `{backend::BlendFactor::ONE, backend::BlendFactor::ONE_MINUS_SRC_ALPHA}`, the same as what was being hard-coded:

```
blendDescriptor.sourceRGBBlendFactor        = backend::BlendFactor::ONE;
blendDescriptor.destinationRGBBlendFactor   = backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
blendDescriptor.sourceAlphaBlendFactor      = backend::BlendFactor::ONE;
blendDescriptor.destinationAlphaBlendFactor = backend::BlendFactor::ONE_MINUS_SRC_ALPHA;
```
Which is now:
```
blendDescriptor.sourceRGBBlendFactor        = _blendFunc.src;
blendDescriptor.destinationRGBBlendFactor   = _blendFunc.dst;
blendDescriptor.sourceAlphaBlendFactor      = _blendFunc.src;
blendDescriptor.destinationAlphaBlendFactor = _blendFunc.dst;
```

Nothing else changes, as this is primarily an enhancement to allow blending when using FairyGUI components.  The FairyGUI code changes are based of FairyGUI libraries for other engines, so the API is similar to their other implementations.

## Issue ticket number and link
#2486 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
