### PR TITLE
Undef the pre-processor definitions to stay unity build friendly

### DIFF
--- a/core/platform/android/javaactivity-android.cpp
+++ b/core/platform/android/javaactivity-android.cpp
@@ -151,3 +151,5 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnSurfaceChanged(J
     ax::Application::getInstance()->applicationScreenSizeChanged(w, h);
 }
 }
+#undef LOGD
+#undef LOG_TAG


### PR DESCRIPTION
[X] I have performed a self-review of my code.
