### PR TITLE
Improve ZipUtils::decompressGZ

### DIFF
--- a/core/base/ZipUtils.h
+++ b/core/base/ZipUtils.h
@@ -231,8 +231,8 @@ private:
                                      unsigned char** out,
                                      ssize_t* outLength,
                                      ssize_t outLengthHint);
-    static inline void decodeEncodedPvr(unsigned int* data, ssize_t len);
-    static inline unsigned int checksumPvr(const unsigned int* data, ssize_t len);
+    static void decodeEncodedPvr(unsigned int* data, ssize_t len);
+    static unsigned int checksumPvr(const unsigned int* data, ssize_t len);
 
     static unsigned int s_uEncryptedPvrKeyParts[4];
     static unsigned int s_uEncryptionKey[1024];


### PR DESCRIPTION
- Fix decompressGZ  inf-loop when input data invalid
- Valid input size
- Parsing uncompress size and reserve exactly avoid waste memory

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
