### PR TITLE
Update android devenv to support android 16

### DIFF
--- a/1k/build.profiles
+++ b/1k/build.profiles
@@ -50,7 +50,7 @@ ndk=r23d
 
 # The android target sdk version, @gradle
 # as latest as possible
-target_sdk=35
+target_sdk=36
 
 # The android min sdk version, @gradle
 # as min as possible
@@ -62,11 +62,11 @@ gradle=8.13
 
 # The android gradle plugin, @setup.ps1
 # as stable as possible, match with build-tools,android-studio
-agp=8.7.3
+agp=8.10.0
 
 # The android build-tools, @axmol-cmdline @gradle
 # as stable as possible, match with agp,android-studio
-buildtools=34.0.0
+buildtools=35.0.0
 
 # The android studio, @hint
 # as latest as possible, but match with agp, build-tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-- Fix https://github.com/axmolengine/axmol/issues/2545 install pwsh fail on ubuntu-25.04
+- Fix https://github.com/axmolengine/axmol/issues/2545 install pwsh fail on ubuntu-25.04 by @halx99
 - Fix wasm build fail on windows by @halx99 in https://github.com/axmolengine/axmol/pull/2511
 - Fix PNG_ARM_NEON_OPT flag by @halx99 in https://github.com/axmolengine/axmol/pull/2512
 - Fix #2504 play opus audio fail when build with Apple OpenAL.framework by @halx99 in https://github.com/axmolengine/axmol/pull/2506

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,18 @@
 ### Bug fixes
 
 - Fix https://github.com/axmolengine/axmol/issues/2545 install pwsh fail on ubuntu-25.04
-- Fix wasm build fail on windows host by @halx99 in https://github.com/axmolengine/axmol/pull/2511
+- Fix wasm build fail on windows by @halx99 in https://github.com/axmolengine/axmol/pull/2511
 - Fix PNG_ARM_NEON_OPT flag by @halx99 in https://github.com/axmolengine/axmol/pull/2512
 - Fix #2504 play opus audio fail when build with Apple OpenAL.framework by @halx99 in https://github.com/axmolengine/axmol/pull/2506
 - Fix typo in pkg_check_modules for GTK3. by @j-jorge in https://github.com/axmolengine/axmol/pull/2534
 - Fix character, underline and strikethrough drawing over label boundary for Overflow::CLAMP mode by @rh101 in https://github.com/axmolengine/axmol/pull/2515
 - Fix for clamped and left-aligned text with certain character sets by @rh101 in https://github.com/axmolengine/axmol/pull/2518
 - Fix wasm raise runtime error due to HEAPU8 was not exported by @halx99
+- Fix decompressGZ infinite-loop when input data invalid by @halx99 in https://github.com/axmolengine/axmol/pull/2544
 
 ### Improvements
 
 - Improve ZipUtils::decompressGZ by @halx99 in https://github.com/axmolengine/axmol/pull/2544
-  - Fix decompressGZ inf-loop when input data invalid
   - Parsing uncompress size and reserve exactly avoid waste memory
   - Valid input size
 - Improve ogg audio files, detect codec via file header by @halx99 in https://github.com/axmolengine/axmol/pull/2500
@@ -38,6 +38,13 @@
 - Improve isolate project axslcc find prompt by @halx99
 - Move simd intrinsics detection from 3rd into core by @halx99
 - Add minimum version to build docs support by @halx99, now the ci will only build & deploy axmol-2.3+ docs
+- Remove deprecated DSL config: renderscriptDebuggable by @halx99 in https://github.com/axmolengine/axmol/pull/2546
+
+### SDKs & Tools updates
+
+- agp: 8.7.3 => 8.10.0
+- android target sdk: 35 => 36
+- android sdk build tools: 34.0.0 => 35.0.0
 
 ### 3rdparty updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## axmol-2.6.0 ?? 2025
 
+### Significant changes relative to 2.5.0:
+
+- Update android devenv to support android 16 by @halx99 in https://github.com/axmolengine/axmol/pull/2546
+- Update Android Studio minimum required version to `2024.3.2`
+
 ### Bug fixes
 
 - Fix https://github.com/axmolengine/axmol/issues/2545 install pwsh fail on ubuntu-25.04 by @halx99

--- a/docs/DevSetup.md
+++ b/docs/DevSetup.md
@@ -162,19 +162,19 @@ Please see the [Windows workflow guide](https://github.com/axmolengine/axmol/iss
 
 ### Android (with Android Studio)
 
-  1. Install [Android Studio 2024.2.1+](https://developer.android.com/studio).
+  1. Install [Android Studio 2024.3.2+](https://developer.android.com/studio).
   2. When starting Android Studio for the first time, it will guide you through the installation of the SDK and other tools. Please make sure that you do install them.
   3. Ensure that the ANDROID_HOME environment variable is set up correctly to point to the Android SDK folder.
   4. Open a *new* Powershell instance, and enter the `axmol` root directory in Powershell.
   5. Run `./setup.ps1 -p android` to download the a supported version of the NDK, which in this case is r23d. You can set a project to use a different version of the NDK.
   6. Start Android Studio and choose [Open an existing Android Studio Project] and select your project. For example, the existing `cpp-test` project located in `axmol\tests\cpp-tests\proj.android`.
   7. Start Android Studio and open 'Tools' -> 'SDKManager', then switch to 'SDK Tools', check the 'Show Package Details' field, and choose the following tools clicking the button 'Apply' to install them:  
-     - Android SDK Platform 34  
-     - Android Gradle Plugin (AGP) 8.7.3
-     - Android SDK Build-Tools 34.0.0 match with AGP, refer to: <https://developer.android.com/studio/releases/gradle-plugin>
-     - Gradle 8.11.1
+     - Android SDK Platform 36
+     - Android Gradle Plugin (AGP) 8.10.0
+     - Android SDK Build-Tools 35.0.0 match with AGP, refer to: <https://developer.android.com/studio/releases/gradle-plugin>
+     - Gradle 8.13
      - NDK r23c, if you need support Android 15 16KB page size, you must use r23d or r27+
-     - __IMPORTANT__: NDK r26+ is required for C++20 support.
+     - __IMPORTANT__: axmol itself not use all c++20 features, so just require ndk-r23c+, if you need more c++20 feature in your game project, consider use NDK r26+
   8. Wait for the `Gradle sync` to finish.
 
 Note: if you use non-SDK provided CMake, you will need to download `ninja` from <https://github.com/ninja-build/ninja/releases>, and copy `ninja.exe` to CMake's bin directory.

--- a/templates/common/proj.android/app/build.gradle
+++ b/templates/common/proj.android/app/build.gradle
@@ -69,7 +69,6 @@ android {
         release {
             debuggable false
             jniDebuggable false
-            renderscriptDebuggable false
             minifyEnabled true
             shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -82,7 +81,6 @@ android {
         debug {
             debuggable true
             jniDebuggable true
-            renderscriptDebuggable true
         }
     }
 

--- a/templates/common/proj.android/build.gradle
+++ b/templates/common/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/cpp-tests/proj.android/app/build.gradle
+++ b/tests/cpp-tests/proj.android/app/build.gradle
@@ -69,7 +69,6 @@ android {
         release {
             debuggable false
             jniDebuggable false
-            renderscriptDebuggable false
             minifyEnabled true
             shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -81,7 +80,6 @@ android {
         debug {
             debuggable true
             jniDebuggable true
-            renderscriptDebuggable true
         }
     }
 

--- a/tests/cpp-tests/proj.android/build.gradle
+++ b/tests/cpp-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/fairygui-tests/proj.android/app/build.gradle
+++ b/tests/fairygui-tests/proj.android/app/build.gradle
@@ -69,7 +69,6 @@ android {
         release {
             debuggable false
             jniDebuggable false
-            renderscriptDebuggable false
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -81,7 +80,6 @@ android {
         debug {
             debuggable true
             jniDebuggable true
-            renderscriptDebuggable true
         }
     }
 

--- a/tests/fairygui-tests/proj.android/build.gradle
+++ b/tests/fairygui-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/live2d-tests/proj.android/app/build.gradle
+++ b/tests/live2d-tests/proj.android/app/build.gradle
@@ -69,7 +69,6 @@ android {
         release {
             debuggable false
             jniDebuggable false
-            renderscriptDebuggable false
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -81,7 +80,6 @@ android {
         debug {
             debuggable true
             jniDebuggable true
-            renderscriptDebuggable true
         }
     }
 

--- a/tests/live2d-tests/proj.android/build.gradle
+++ b/tests/live2d-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/lua-tests/proj.android/app/build.gradle
+++ b/tests/lua-tests/proj.android/app/build.gradle
@@ -69,7 +69,6 @@ android {
         release {
             debuggable false
             jniDebuggable false
-            renderscriptDebuggable false
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -81,7 +80,6 @@ android {
         debug {
             debuggable true
             jniDebuggable true
-            renderscriptDebuggable true
         }
     }
 

--- a/tests/lua-tests/proj.android/build.gradle
+++ b/tests/lua-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/unit-tests/proj.android/app/build.gradle
+++ b/tests/unit-tests/proj.android/app/build.gradle
@@ -69,7 +69,6 @@ android {
         release {
             debuggable false
             jniDebuggable false
-            renderscriptDebuggable false
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -83,7 +82,6 @@ android {
         debug {
             debuggable true
             jniDebuggable true
-            renderscriptDebuggable true
         }
     }
 

--- a/tests/unit-tests/proj.android/build.gradle
+++ b/tests/unit-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
- target_sdk: 35 => 36
- agp: 8.7.3 => 8.10.0
- buildtools: 34.0.0 => 35.0.0
- Remove deprecated DSL config: renderscriptDebuggable

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
