### PR TITLE
Update build.gradle - simplify, remove coping and pointing directly to assets folders

### DIFF
--- a/templates/common/proj.android/app/build.gradle
+++ b/templates/common/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime/axslc"]
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime"]
     }
 
     externalNativeBuild {

--- a/templates/common/proj.android/app/build.gradle
+++ b/templates/common/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "build/assets"
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime/axslc"]
     }
 
     externalNativeBuild {
@@ -93,40 +93,7 @@ android {
     }
 }
 
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    tasks.register("copy${variantName}ContentToAssets") {
-        doFirst {
-            delete "${projectDir}/build/assets"
-        }
-        doLast {
-            copy {
-                from "${projectDir}/../../Content"
-                into "${projectDir}/build/assets"
-                exclude "**/*.gz"
-            }
-            copy {
-                from "${projectDir}/build/runtime/axslc"
-                into "${projectDir}/build/assets/axslc"
-            }
-        }
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
-}
-
-project.afterEvaluate {
-    android.applicationVariants.configureEach { variant ->
-        def variantName = variant.name.capitalize()
-        def externalNativeBuild = tasks.named("externalNativeBuild${variantName}")
-        if (externalNativeBuild) {
-            def copyContentToAssets = tasks.named("copy${variantName}ContentToAssets")
-            copyContentToAssets
-            copyContentToAssets.get().dependsOn externalNativeBuild
-            tasks.named("compile${variantName}JavaWithJavac").get().dependsOn copyContentToAssets
-        }
-    }
 }

--- a/tests/cpp-tests/proj.android/app/build.gradle
+++ b/tests/cpp-tests/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "build/assets"
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime"]
     }
 
     externalNativeBuild {
@@ -88,40 +88,7 @@ android {
     }
 }
 
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    tasks.register("copy${variantName}ContentToAssets") {
-        doFirst {
-            delete "${projectDir}/build/assets"
-        }
-        doLast {
-            copy {
-                from "${projectDir}/../../Content"
-                into "${projectDir}/build/assets"
-                exclude "**/*.gz"
-            }
-            copy {
-                from "${projectDir}/build/runtime/axslc"
-                into "${projectDir}/build/assets/axslc"
-            }
-        }
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
-}
-
-project.afterEvaluate {
-    android.applicationVariants.configureEach { variant ->
-        def variantName = variant.name.capitalize()
-        def externalNativeBuild = tasks.named("externalNativeBuild${variantName}")
-        if (externalNativeBuild) {
-            def copyContentToAssets = tasks.named("copy${variantName}ContentToAssets")
-            copyContentToAssets
-            copyContentToAssets.get().dependsOn externalNativeBuild
-            tasks.named("compile${variantName}JavaWithJavac").get().dependsOn copyContentToAssets
-        }
-    }
 }

--- a/tests/fairygui-tests/proj.android/app/build.gradle
+++ b/tests/fairygui-tests/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "build/assets"
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime"]
     }
 
     externalNativeBuild {
@@ -88,40 +88,7 @@ android {
     }
 }
 
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    tasks.register("copy${variantName}ContentToAssets") {
-        doFirst {
-            delete "${projectDir}/build/assets"
-        }
-        doLast {
-            copy {
-                from "${projectDir}/../../Content"
-                into "${projectDir}/build/assets"
-                exclude "**/*.gz"
-            }
-            copy {
-                from "${projectDir}/build/runtime/axslc"
-                into "${projectDir}/build/assets/axslc"
-            }
-        }
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
-}
-
-project.afterEvaluate {
-    android.applicationVariants.configureEach { variant ->
-        def variantName = variant.name.capitalize()
-        def externalNativeBuild = tasks.named("externalNativeBuild${variantName}")
-        if (externalNativeBuild) {
-            def copyContentToAssets = tasks.named("copy${variantName}ContentToAssets")
-            copyContentToAssets
-            copyContentToAssets.get().dependsOn externalNativeBuild
-            tasks.named("compile${variantName}JavaWithJavac").get().dependsOn copyContentToAssets
-        }
-    }
 }

--- a/tests/live2d-tests/proj.android/app/build.gradle
+++ b/tests/live2d-tests/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "build/assets"
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime"]
     }
 
     externalNativeBuild {
@@ -88,40 +88,7 @@ android {
     }
 }
 
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    tasks.register("copy${variantName}ContentToAssets") {
-        doFirst {
-            delete "${projectDir}/build/assets"
-        }
-        doLast {
-            copy {
-                from "${projectDir}/../../Content"
-                into "${projectDir}/build/assets"
-                exclude "**/*.gz"
-            }
-            copy {
-                from "${projectDir}/build/runtime/axslc"
-                into "${projectDir}/build/assets/axslc"
-            }
-        }
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
-}
-
-project.afterEvaluate {
-    android.applicationVariants.configureEach { variant ->
-        def variantName = variant.name.capitalize()
-        def externalNativeBuild = tasks.named("externalNativeBuild${variantName}")
-        if (externalNativeBuild) {
-            def copyContentToAssets = tasks.named("copy${variantName}ContentToAssets")
-            copyContentToAssets
-            copyContentToAssets.get().dependsOn externalNativeBuild
-            tasks.named("compile${variantName}JavaWithJavac").get().dependsOn copyContentToAssets
-        }
-    }
 }

--- a/tests/lua-tests/proj.android/app/build.gradle
+++ b/tests/lua-tests/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "build/assets"
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime"]
     }
 
     externalNativeBuild {
@@ -88,40 +88,7 @@ android {
     }
 }
 
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    tasks.register("copy${variantName}ContentToAssets") {
-        doFirst {
-            delete "${projectDir}/build/assets"
-        }
-        doLast {
-            copy {
-                from "${projectDir}/../../Content"
-                into "${projectDir}/build/assets"
-                exclude "**/*.gz"
-            }
-            copy {
-                from "${projectDir}/build/runtime/axslc"
-                into "${projectDir}/build/assets/axslc"
-            }
-        }
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
-}
-
-project.afterEvaluate {
-    android.applicationVariants.configureEach { variant ->
-        def variantName = variant.name.capitalize()
-        def externalNativeBuild = tasks.named("externalNativeBuild${variantName}")
-        if (externalNativeBuild) {
-            def copyContentToAssets = tasks.named("copy${variantName}ContentToAssets")
-            copyContentToAssets
-            copyContentToAssets.get().dependsOn externalNativeBuild
-            tasks.named("compile${variantName}JavaWithJavac").get().dependsOn copyContentToAssets
-        }
-    }
 }

--- a/tests/unit-tests/proj.android/app/build.gradle
+++ b/tests/unit-tests/proj.android/app/build.gradle
@@ -44,7 +44,7 @@ android {
         java.srcDir "src"
         res.srcDir "res"
         manifest.srcFile "AndroidManifest.xml"
-        assets.srcDir "build/assets"
+        assets.srcDirs = ["../../Content", "${projectDir}/build/runtime"]
     }
 
     externalNativeBuild {
@@ -90,40 +90,7 @@ android {
     }
 }
 
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    tasks.register("copy${variantName}ContentToAssets") {
-        doFirst {
-            delete "${projectDir}/build/assets"
-        }
-        doLast {
-            copy {
-                from "${projectDir}/../../Content"
-                into "${projectDir}/build/assets"
-                exclude "**/*.gz"
-            }
-            copy {
-                from "${projectDir}/build/runtime/axslc"
-                into "${projectDir}/build/assets/axslc"
-            }
-        }
-    }
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
-}
-
-project.afterEvaluate {
-    android.applicationVariants.configureEach { variant ->
-        def variantName = variant.name.capitalize()
-        def externalNativeBuild = tasks.named("externalNativeBuild${variantName}")
-        if (externalNativeBuild) {
-            def copyContentToAssets = tasks.named("copy${variantName}ContentToAssets")
-            copyContentToAssets
-            copyContentToAssets.get().dependsOn externalNativeBuild
-            tasks.named("compile${variantName}JavaWithJavac").get().dependsOn copyContentToAssets
-        }
-    }
 }


### PR DESCRIPTION
## Describe your changes

simplify gradle script and removing copy assests functionality

If there is needed for different assets for different platform configuration having separate folder(s) is one of the options to achieve that (assestsAndroid/asssestWin etc)

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
