### PR TITLE
Fixed blending so that the fairygui animation clip renders with the correct blend function

### DIFF
--- a/extensions/fairygui/src/fairygui/GMovieClip.cpp
+++ b/extensions/fairygui/src/fairygui/GMovieClip.cpp
@@ -462,9 +462,14 @@ void ActionMovieClip::drawFrame()
 
     _displayFrame = _frame;
     AnimationFrame* frame = frames.at(_frame);
-    //auto blend = static_cast<Sprite*>(_target)->getBlendFunc();
-    static_cast<Sprite*>(_target)->setSpriteFrame(frame->getSpriteFrame());
-    //static_cast<Sprite*>(_target)->setBlendFunc(blend);
+
+    auto sprite = static_cast<Sprite*>(_target);
+    if (sprite == nullptr)
+        return;
+
+    auto currentBlend = sprite->getBlendFunc();
+    sprite->setSpriteFrame(frame->getSpriteFrame());
+    sprite->setBlendFunc(currentBlend);
 }
 
 NS_FGUI_END


### PR DESCRIPTION

Currently, the blend mode of the Fairygui Animation Clip does not work correctly, even though GObject already supports **setBlendMode**.
 
Solution:

We need to update the blend mode after assigning a new frame.      

![image](https://github.com/user-attachments/assets/4ca72c3e-83ef-4828-bcdb-48a2f87a51f3)

![image](https://github.com/user-attachments/assets/21c866d7-1ccf-4f87-bdb4-71fc0c19e18f)

