### PR TITLE
Update and re-enable Scene3D test

### DIFF
--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -194,7 +194,7 @@ list(APPEND GAME_HEADER
      Source/ReleasePoolTest/ReleasePoolTest.h
      Source/InputTest/MouseTest.h
      Source/SpineTest/SpineTest.h
-    #  Source/Scene3DTest/Scene3DTest.h
+     Source/Scene3DTest/Scene3DTest.h
      Source/ParticleTest/ParticleTest.h
      Source/EffectsTest/EffectsTest.h
      Source/UITest/UITest.h
@@ -319,7 +319,7 @@ list(APPEND GAME_SOURCE
      Source/ShaderTest/ShaderTest.cpp
      Source/ShaderTest/ShaderTest2.cpp
      Source/SpineTest/SpineTest.cpp
-    #  Source/Scene3DTest/Scene3DTest.cpp
+     Source/Scene3DTest/Scene3DTest.cpp
      Source/MeshRendererTest/DrawNode3D.cpp
      Source/DrawNodeTest/DrawNodeTest.cpp
      Source/MeshRendererTest/MeshRendererTest.cpp

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -26,7 +27,7 @@
 
 #include "ui/CocosGUI.h"
 #include "renderer/RenderState.h"
-#include <spine/spine-cocos2dx.h>
+#include <spine/spine-axmol.h>
 
 #include "../testResource.h"
 #include "../TerrainTest/TerrainTest.h"
@@ -43,7 +44,7 @@ public:
     {
         glDisable(GL_CULL_FACE);
         SkeletonAnimation::draw(renderer, transform, transformFlags);
-        RenderState::StateBlock::invalidate(ax::RenderState::StateBlock::RS_ALL_ONES);
+        //RenderState::StateBlock::invalidate(ax::RenderState::StateBlock::RS_ALL_ONES);
     }
 
     static SkeletonAnimationCullingFix* createWithFile(std::string_view skeletonDataFile,
@@ -51,8 +52,8 @@ public:
                                                        float scale = 1)
     {
         SkeletonAnimationCullingFix* node = new SkeletonAnimationCullingFix();
-        spAtlas* atlas                    = spAtlas_createFromFile(atlasFile.c_str(), 0);
-        node->initWithJsonFile(skeletonDataFile, atlas, scale);
+        spine::Atlas* atlas               = new spine::Atlas(std::string(atlasFile).c_str(), nullptr);
+        node->initWithJsonFile(std::string(skeletonDataFile), atlas, scale);
         node->autorelease();
         return node;
     }
@@ -77,12 +78,12 @@ class Scene3DTestScene : public TestCase
 public:
     CREATE_FUNC(Scene3DTestScene);
 
-    bool onTouchBegan(Touch* touch, Event* event) { return true; }
-    void onTouchEnd(Touch*, Event*);
+    bool onTouchBegan(Touch* touch, ax::Event* event) { return true; }
+    void onTouchEnd(Touch*, ax::Event*);
 
 private:
     Scene3DTestScene();
-    virtual ~Scene3DTestScene();
+    ~Scene3DTestScene() override;
     bool init() override;
 
     void createWorld3D();
@@ -364,8 +365,8 @@ void Scene3DTestScene::createWorld3D()
 {
     // create skybox
     // create and set our custom shader
-    auto shader = GLProgram::createWithFilenames("MeshRendererTest/cube_map.vert", "MeshRendererTest/cube_map.frag");
-    auto state  = GLProgramState::create(shader);
+    auto shader = ProgramManager::getInstance()->loadProgram("custom/cube_map_vs", "custom/cube_map_fs");
+    auto state  = new ProgramState(shader);
 
     // create the second texture for cylinder
     _textureCube = TextureCube::create("MeshRendererTest/skybox/left.jpg", "MeshRendererTest/skybox/right.jpg",
@@ -373,14 +374,15 @@ void Scene3DTestScene::createWorld3D()
                                        "MeshRendererTest/skybox/front.jpg", "MeshRendererTest/skybox/back.jpg");
     // set texture parameters
     Texture2D::TexParams tRepeatParams;
-    tRepeatParams.magFilter    = GL_LINEAR;
-    tRepeatParams.minFilter    = GL_LINEAR;
-    tRepeatParams.sAddressMode = GL_MIRRORED_REPEAT;
-    tRepeatParams.tAddressMode = GL_MIRRORED_REPEAT;
+    tRepeatParams.magFilter    = backend::SamplerFilter::LINEAR;
+    tRepeatParams.minFilter    = backend::SamplerFilter::LINEAR;
+    tRepeatParams.sAddressMode = backend::SamplerAddressMode::MIRROR_REPEAT;
+    tRepeatParams.tAddressMode = backend::SamplerAddressMode::MIRROR_REPEAT;
     _textureCube->setTexParameters(tRepeatParams);
 
     // pass the texture sampler to our custom shader
-    state->setUniformTexture("u_cubeTex", _textureCube);
+    const auto cubeTexLoc = state->getUniformLocation("u_cubeTex");
+    state->setUniform(cubeTexLoc, _textureCube, sizeof(ax::TextureCube));
 
     // add skybox
     _skyBox = Skybox::create();
@@ -419,7 +421,7 @@ void Scene3DTestScene::createWorld3D()
     rootps->setPosition3D(Vec3(0, 150, 0));
     auto moveby  = MoveBy::create(2.0f, Vec2(50.0f, 0.0f));
     auto moveby1 = MoveBy::create(2.0f, Vec2(-50.0f, 0.0f));
-    rootps->runAction(RepeatForever::create(Sequence::create(moveby, moveby1, nullptr)));
+    rootps->runAction(RepeatForever::create(ax::Sequence::create(moveby, moveby1, nullptr)));
     rootps->startParticleSystem();
 
     _player->addChild(rootps, 0);
@@ -831,7 +833,7 @@ void Scene3DTestScene::createDescDlg()
     }
 }
 
-void Scene3DTestScene::onTouchEnd(Touch* touch, Event* event)
+void Scene3DTestScene::onTouchEnd(Touch* touch, ax::Event* event)
 {
     auto location = touch->getLocation();
     auto camera   = _gameCameras[CAMERA_WORLD_3D_SCENE];

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -35,6 +35,8 @@
 using namespace ax;
 using namespace spine;
 
+static AxmolTextureLoader textureLoader;
+
 class SkeletonAnimationCullingFix : public SkeletonAnimation
 {
 public:
@@ -52,7 +54,7 @@ public:
                                                        float scale = 1)
     {
         SkeletonAnimationCullingFix* node = new SkeletonAnimationCullingFix();
-        spine::Atlas* atlas               = new spine::Atlas(std::string(atlasFile).c_str(), nullptr);
+        spine::Atlas* atlas               = new spine::Atlas(std::string(atlasFile).c_str(), &textureLoader);
         node->initWithJsonFile(std::string(skeletonDataFile), atlas, scale);
         node->autorelease();
         return node;
@@ -682,9 +684,9 @@ void Scene3DTestScene::createDetailDlg()
     // add a spine ffd animation on it
     auto skeletonNode =
         SkeletonAnimationCullingFix::createWithFile("spine/goblins-pro.json", "spine/goblins.atlas", 1.5f);
+    skeletonNode->setSlotsToSetupPose();
     skeletonNode->setAnimation(0, "walk", true);
     skeletonNode->setSkin("goblin");
-
     skeletonNode->setScale(0.25);
     Size windowSize = Director::getInstance()->getWinSize();
     skeletonNode->setPosition(Vec2(dlgSize.width / 2, remove->getContentSize().height / 2 + 2 * margin));
@@ -863,7 +865,7 @@ void Scene3DTestScene::onTouchEnd(Touch* touch, ax::Event* event)
             dir.y = 0;
             dir.normalize();
             _player->_headingAngle = -1 * acos(dir.dot(Vec3(0, 0, -1)));
-            dir.cross(dir, Vec3(0, 0, -1), &_player->_headingAxis);
+            Vec3::cross(dir, Vec3(0, 0, -1), &_player->_headingAxis);
             _player->_targetPos = collisionPoint;
             _player->forward();
         }

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -684,9 +684,9 @@ void Scene3DTestScene::createDetailDlg()
     // add a spine ffd animation on it
     auto skeletonNode =
         SkeletonAnimationCullingFix::createWithFile("spine/goblins-pro.json", "spine/goblins.atlas", 1.5f);
-    skeletonNode->setSlotsToSetupPose();
     skeletonNode->setAnimation(0, "walk", true);
     skeletonNode->setSkin("goblin");
+
     skeletonNode->setScale(0.25);
     Size windowSize = Director::getInstance()->getWinSize();
     skeletonNode->setPosition(Vec2(dlgSize.width / 2, remove->getContentSize().height / 2 + 2 * margin));

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -42,7 +42,7 @@ public:
 
     virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t transformFlags) override
     {
-        glDisable(GL_CULL_FACE);
+        renderer->setCullMode(CullMode::NONE);
         SkeletonAnimation::draw(renderer, transform, transformFlags);
         //RenderState::StateBlock::invalidate(ax::RenderState::StateBlock::RS_ALL_ONES);
     }

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.h
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/tests/cpp-tests/Source/controller.cpp
+++ b/tests/cpp-tests/Source/controller.cpp
@@ -46,7 +46,7 @@ public:
 #    pragma message("The optional extension Effekseer is enabled.")
         addTest("Effekseer", []() { return new EffekseerTests(); });
 #endif
-//        addTest("Node: Scene3D", [](){return new Scene3DTests(); });
+        addTest("Node: Scene3D", [](){return new Scene3DTests(); });
 #if defined(AX_PLATFORM_PC) || (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID) || defined(__EMSCRIPTEN__)
         addTest("ImGui", []() { return new ImGuiTests(); });
 #endif


### PR DESCRIPTION
## Describe your changes

The `Scene3DTest.cpp/.h` were never updated during the transition from Cocos2d-x v3 to v4, and it has remained that way during the porting to Axmol, since it was never part of the build (disabled in `CMakeLists.txt`) to be noticed.  It's now updated, and works, but may have some bugs.

I'm not quite sure what this line is for, or what to change it to in Axmol, so I would appreciate some guidance:
```
RenderState::StateBlock::invalidate(ax::RenderState::StateBlock::RS_ALL_ONES);
```

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
