### PR TITLE
Label fixes for wrapping, overflow and alignment

### DIFF
--- a/core/2d/FontAtlas.cpp
+++ b/core/2d/FontAtlas.cpp
@@ -229,7 +229,7 @@ void FontAtlas::initWithSettings(void* opaque /*simdjson::ondemand::document*/)
         auto letterInfo   = field.value();
         tempDef.U         = static_cast<float>(letterInfo["U"].get_double());
         tempDef.V         = static_cast<float>(letterInfo["V"].get_double());
-        tempDef.xAdvance  = static_cast<float>(letterInfo["advance"].get_double());
+        tempDef.xAdvance  = static_cast<int>(letterInfo["advance"].get_double());
         tempDef.width     = static_cast<float>(letterInfo["width"].get_double());
         tempDef.height    = static_cast<float>(letterInfo["height"].get_double());
         tempDef.offsetX   = static_cast<float>(letterInfo["offsetX"].get_double());
@@ -421,10 +421,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
                 }
             }
             glyphHeight = static_cast<int>(bitmapHeight) + _letterPadding + _letterEdgeExtend;
-            if (glyphHeight > _currLineHeight)
-            {
-                _currLineHeight = glyphHeight;
-            }
+            _currLineHeight = std::max(glyphHeight, _currLineHeight);
             charRenderer->renderCharAt(_currentPageData, (int)_currentPageOrigX + adjustForExtend,
                                        (int)_currentPageOrigY + adjustForExtend, bitmap, bitmapWidth, bitmapHeight,
                                         _width, _height);
@@ -442,8 +439,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
         }
         else
         {
-            if (bitmap)
-                delete[] bitmap;
+            delete[] bitmap;
 
             tempDef.validDefinition = !!tempDef.xAdvance;
             tempDef.width           = 0;

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1090,7 +1090,7 @@ bool Label::alignText()
         return true;
     }
 
-    bool ret     = true;
+    bool ret = true;
     do
     {
         _fontAtlas->prepareLetterDefinitions(_utf32Text);
@@ -1128,42 +1128,33 @@ bool Label::alignText()
         _linesWidth.clear();
 
         const auto currentFontSize = getRenderingFontSize();
-        const auto atLimit         = currentFontSize <= 1.f;
+
+        const auto atMinimumFontSizeLimit = currentFontSize <= 1.f;
 
         bool redoProcess;
         if (_maxLineWidth > 0.f && !_lineBreakWithoutSpaces)
         {
-            redoProcess = !multilineTextWrapByWord(atLimit);
+            redoProcess = !multilineTextWrapByWord(atMinimumFontSizeLimit);
         }
         else
         {
-            redoProcess = !multilineTextWrapByChar(atLimit);
+            redoProcess = !multilineTextWrapByChar(atMinimumFontSizeLimit);
         }
 
-        if (!redoProcess && _overflow == Overflow::SHRINK && !atLimit)
+        if (!redoProcess && _overflow == Overflow::SHRINK && !atMinimumFontSizeLimit)
         {
-            auto fontSize = this->getRenderingFontSize();
-
-            if (fontSize > 0)
+            if (isVerticalClamp() || isHorizontalClamp())
             {
-                if (isVerticalClamp() || isHorizontalClamp())
-                {
-                    redoProcess = true;
-                }
+                redoProcess = true;
             }
         }
 
-        if (redoProcess && currentFontSize > 1)
+        if (redoProcess)
         {
             auto newFontSize = currentFontSize - 1;
             if (newFontSize >= 1)
             {
                 scaleFontSize(newFontSize);
-                if (_currentLabelType == LabelType::BMFONT)
-                {
-                    resetAtlas();
-                }
-
                 continue;
             }
         }
@@ -1200,7 +1191,7 @@ bool Label::computeHorizontalKernings(const std::u32string& stringToRender)
         return true;
 }
 
-bool Label::isHorizontalClamped(float letterPositionX, float letterWidth, int lineIndex)
+bool Label::isLetterHorizontallyClamped(float letterPositionX, float letterWidth, int lineIndex)
 {
     auto wordWidth       = this->_linesWidth[lineIndex];
     bool letterOverClamp = ((letterPositionX + letterWidth) > _contentSize.width || (letterPositionX + letterWidth / 2) < 0);
@@ -1254,9 +1245,9 @@ bool Label::updateQuads()
 
             if (_labelWidth > 0.f)
             {
-                if (this->isHorizontalClamped(px, letterDef.width * _fontScale, lineIndex))
+                if (this->isLetterHorizontallyClamped(px, letterDef.width * _fontScale, lineIndex))
                 {
-                    if (_overflow == Overflow::CLAMP)
+                    if (_overflow == Overflow::CLAMP || _overflow == Overflow::SHRINK)
                     {
                         _reusedRect.size.width = 0;
                     }
@@ -1365,7 +1356,7 @@ void Label::scaleFontSize(float fontSize)
 
     if (shouldUpdateContent)
     {
-        this->resetAtlas();
+        this->clearTextures();
     }
 }
 
@@ -1711,7 +1702,7 @@ void Label::setCameraMask(unsigned short mask, bool applyChildren)
     }
 }
 
-void Label::resetAtlas()
+void Label::clearTextures()
 {
     if (_systemFontDirty)
     {
@@ -1744,33 +1735,11 @@ void Label::resetAtlas()
 
 void Label::updateContent()
 {
-    if (_systemFontDirty)
-    {
-        if (_fontAtlas)
-        {
-            _batchNodes.clear();
-            _batchCommands.clear();
-            AX_SAFE_RELEASE_NULL(_reusedLetter);
-            FontAtlasCache::releaseFontAtlas(_fontAtlas);
-            _fontAtlas = nullptr;
-        }
-
-        _systemFontDirty = false;
-    }
-
-    AX_SAFE_RELEASE_NULL(_textSprite);
-    AX_SAFE_RELEASE_NULL(_shadowNode);
+    clearTextures();
     bool updateFinished = true;
 
     if (_fontAtlas)
     {
-        std::u32string utf32String;
-        if (StringUtils::UTF8ToUTF32(_utf8Text, utf32String))
-        {
-            _utf32Text = utf32String;
-        }
-
-        computeHorizontalKernings(_utf32Text);
         updateFinished = alignText();
     }
     else
@@ -3074,19 +3043,26 @@ bool Label::multilineTextWrap(bool breakOnChar, bool ignoreOverflow)
 
     _numberOfLines     = lineIndex + 1;
     _textDesiredHeight = (_numberOfLines * _lineHeight * _fontScale) / contentScaleFactor;
+
     if (_numberOfLines > 1)
         _textDesiredHeight += (_numberOfLines - 1) * _lineSpacing;  // ?? use scaled lineSpacing
+
     Vec2 contentSize(_labelWidth, _labelHeight);
+
     if (_labelWidth <= 0.f)
         contentSize.width = longestLine;
+
     if (_labelHeight <= 0.f)
         contentSize.height = _textDesiredHeight;
+
     setContentSize(contentSize);
 
     _tailoredTopY    = contentSize.height;
     _tailoredBottomY = 0.f;
+
     if (highestY > 0.f)
         _tailoredTopY = contentSize.height + highestY;
+
     if (lowestY < -_textDesiredHeight)
         _tailoredBottomY = _textDesiredHeight + lowestY;
 
@@ -3152,51 +3128,6 @@ bool Label::isHorizontalClamp()
     }
 
     return letterClamp;
-}
-
-void Label::shrinkLabelToContentSize(const std::function<bool(void)>& lambda)
-{
-    float fontSize = this->getRenderingFontSize();
-
-    int i                     = 0;
-    auto letterDefinition     = _fontAtlas->_letterDefinitions;
-    auto tempLetterDefinition = letterDefinition;
-    float originalLineHeight  = _lineHeight;
-    bool flag                 = true;
-    while (lambda())
-    {
-        ++i;
-        float newFontSize = fontSize - i;
-        flag              = false;
-        if (newFontSize <= 0)
-        {
-            break;
-        }
-        float scale = newFontSize / fontSize;
-        std::swap(_fontAtlas->_letterDefinitions, tempLetterDefinition);
-        _fontAtlas->scaleFontLetterDefinition(scale);
-        this->setLineHeight(originalLineHeight * scale);
-        if (_maxLineWidth > 0.f && !_lineBreakWithoutSpaces)
-        {
-            multilineTextWrapByWord();
-        }
-        else
-        {
-            multilineTextWrapByChar();
-        }
-        computeAlignmentOffset();
-        tempLetterDefinition = letterDefinition;
-    }
-    this->setLineHeight(originalLineHeight);
-    std::swap(_fontAtlas->_letterDefinitions, letterDefinition);
-
-    if (!flag)
-    {
-        if (fontSize - i >= 0)
-        {
-            this->scaleFontSize(fontSize - i);
-        }
-    }
 }
 
 void Label::recordLetterInfo(const ax::Vec2& point, char32_t utf32Char, int letterIndex, int lineIndex)

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1090,7 +1090,7 @@ bool Label::alignText()
         return true;
     }
 
-    bool ret = true;
+    bool ret     = true;
     do
     {
         _fontAtlas->prepareLetterDefinitions(_utf32Text);
@@ -1126,40 +1126,59 @@ bool Label::alignText()
         _lengthOfString    = 0;
         _textDesiredHeight = 0.f;
         _linesWidth.clear();
+
+        const auto currentFontSize = getRenderingFontSize();
+        const auto atLimit         = currentFontSize <= 1.f;
+
+        bool redoProcess;
         if (_maxLineWidth > 0.f && !_lineBreakWithoutSpaces)
         {
-            multilineTextWrapByWord();
+            redoProcess = !multilineTextWrapByWord(atLimit);
         }
         else
         {
-            multilineTextWrapByChar();
+            redoProcess = !multilineTextWrapByChar(atLimit);
         }
-        computeAlignmentOffset();
 
-        if (_overflow == Overflow::SHRINK)
+        if (!redoProcess && _overflow == Overflow::SHRINK && !atLimit)
         {
-            float fontSize = this->getRenderingFontSize();
+            auto fontSize = this->getRenderingFontSize();
 
-            if (fontSize > 0 && isVerticalClamp())
+            if (fontSize > 0)
             {
-                this->shrinkLabelToContentSize(AX_CALLBACK_0(Label::isVerticalClamp, this));
+                if (isVerticalClamp() || isHorizontalClamp())
+                {
+                    redoProcess = true;
+                }
             }
         }
 
-        if (!updateQuads())
+        if (redoProcess && currentFontSize > 1)
         {
-            ret = false;
-            if (_overflow == Overflow::SHRINK)
+            auto newFontSize = currentFontSize - 1;
+            if (newFontSize >= 1)
             {
-                this->shrinkLabelToContentSize(AX_CALLBACK_0(Label::isHorizontalClamp, this));
+                scaleFontSize(newFontSize);
+                if (_currentLabelType == LabelType::BMFONT)
+                {
+                    resetAtlas();
+                }
+
+                continue;
             }
-            break;
         }
 
-        updateLabelLetters();
+        break;
 
-        updateColor();
-    } while (0);
+    } while (true);
+
+    computeAlignmentOffset();
+
+    updateQuads();
+
+    updateLabelLetters();
+
+    updateColor();
 
     return ret;
 }
@@ -1231,7 +1250,7 @@ bool Label::updateQuads()
             }
 
             auto lineIndex = _lettersInfo[ctr].lineIndex;
-            auto px        = _lettersInfo[ctr].positionX + _linesOffsetX[lineIndex];
+            auto px        = _lettersInfo[ctr].positionX;
 
             if (_labelWidth > 0.f)
             {
@@ -1240,18 +1259,6 @@ bool Label::updateQuads()
                     if (_overflow == Overflow::CLAMP)
                     {
                         _reusedRect.size.width = 0;
-                    }
-                    else if (_overflow == Overflow::SHRINK)
-                    {
-                        if (_contentSize.width > letterDef.width)
-                        {
-                            ret = false;
-                            break;
-                        }
-                        else
-                        {
-                            _reusedRect.size.width = 0;
-                        }
                     }
                 }
             }
@@ -1358,7 +1365,7 @@ void Label::scaleFontSize(float fontSize)
 
     if (shouldUpdateContent)
     {
-        this->updateContent();
+        this->resetAtlas();
     }
 }
 
@@ -1701,6 +1708,37 @@ void Label::setCameraMask(unsigned short mask, bool applyChildren)
     if (_shadowNode)
     {
         _shadowNode->setCameraMask(mask, applyChildren);
+    }
+}
+
+void Label::resetAtlas()
+{
+    if (_systemFontDirty)
+    {
+        if (_fontAtlas)
+        {
+            _batchNodes.clear();
+            _batchCommands.clear();
+            AX_SAFE_RELEASE_NULL(_reusedLetter);
+            FontAtlasCache::releaseFontAtlas(_fontAtlas);
+            _fontAtlas = nullptr;
+        }
+
+        _systemFontDirty = false;
+    }
+
+    AX_SAFE_RELEASE_NULL(_textSprite);
+    AX_SAFE_RELEASE_NULL(_shadowNode);
+
+    if (_fontAtlas)
+    {
+        std::u32string utf32String;
+        if (StringUtils::UTF8ToUTF32(_utf8Text, utf32String))
+        {
+            _utf32Text = utf32String;
+        }
+
+        computeHorizontalKernings(_utf32Text);
     }
 }
 
@@ -2868,7 +2906,7 @@ void Label::updateFontScale()
     }
 }
 
-bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int, int)>& nextTokenLen)
+bool Label::multilineTextWrap(bool breakOnChar, bool ignoreOverflow)
 {
     int textLen               = getStringLength();
     int lineIndex             = 0;
@@ -2904,7 +2942,31 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             continue;
         }
 
-        auto tokenLen         = nextTokenLen(_utf32Text, index, textLen);
+        int tokenLen;
+        if (breakOnChar)
+        {
+            tokenLen = getFirstCharLen(_utf32Text, index, textLen);
+        }
+        else
+        {
+            tokenLen = getFirstWordLen(_utf32Text, index, textLen);
+            if (!ignoreOverflow && !_lineBreakWithoutSpaces && tokenLen > 0 && (index + tokenLen) < textLen)
+            {
+                auto tokenLastChar = _utf32Text[index + tokenLen - 1];
+                if (!StringUtils::isCJKUnicode(tokenLastChar) && !StringUtils::isUnicodeSpace(tokenLastChar))
+                {
+                    // Work out if this token is valid based on the desired output
+                    auto nextChar = _utf32Text[index + tokenLen];
+                    if (_overflow == Overflow::SHRINK && !StringUtils::isUnicodeSpace(nextChar) &&
+                        !StringUtils::isCJKUnicode(nextChar))
+                    {
+                        // No point continuing here
+                        return false;
+                    }
+                }
+            }
+        }
+
         float tokenHighestY   = highestY;
         float tokenLowestY    = lowestY;
         float tokenRight      = letterRight;
@@ -2979,10 +3041,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             }
             nextChangeSize = true;
 
-            if (tokenHighestY < letterPosition.y)
-                tokenHighestY = letterPosition.y;
-            if (tokenLowestY > letterPosition.y - letterDef.height * _fontScale)
-                tokenLowestY = letterPosition.y - letterDef.height * _fontScale;
+            tokenHighestY = std::max(tokenHighestY, letterPosition.y);
+            tokenLowestY = std::min(tokenLowestY, letterPosition.y - letterDef.height * _fontScale);
         }
 
         if (newLine)
@@ -2992,10 +3052,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
 
         nextTokenX  = nextLetterX;
         letterRight = tokenRight;
-        if (highestY < tokenHighestY)
-            highestY = tokenHighestY;
-        if (lowestY > tokenLowestY)
-            lowestY = tokenLowestY;
+        highestY = std::max(highestY, tokenHighestY);
+        lowestY = std::min(lowestY, tokenLowestY);
 
         index += tokenLen;
     }
@@ -3010,8 +3068,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
         _linesWidth.emplace_back(letterRight - nextWhitespaceWidth);
         for (auto&& lineWidth : _linesWidth)
         {
-            if (longestLine < lineWidth)
-                longestLine = lineWidth;
+            longestLine = std::max(longestLine, lineWidth);
         }
     }
 
@@ -3036,14 +3093,14 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
     return true;
 }
 
-bool Label::multilineTextWrapByWord()
+bool Label::multilineTextWrapByWord(bool ignoreOverflow)
 {
-    return multilineTextWrap(AX_CALLBACK_3(Label::getFirstWordLen, this));
+    return multilineTextWrap(false, ignoreOverflow);
 }
 
-bool Label::multilineTextWrapByChar()
+bool Label::multilineTextWrapByChar(bool ignoreOverflow)
 {
-    return multilineTextWrap(AX_CALLBACK_3(Label::getFirstCharLen, this));
+    return multilineTextWrap(true, ignoreOverflow);
 }
 
 bool Label::isVerticalClamp()

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -2950,15 +2950,15 @@ bool Label::multilineTextWrap(bool breakOnChar, bool ignoreOverflow)
         else
         {
             tokenLen = getFirstWordLen(_utf32Text, index, textLen);
-            if (!ignoreOverflow && !_lineBreakWithoutSpaces && tokenLen > 0 && (index + tokenLen) < textLen)
+            if (!ignoreOverflow && _overflow == Overflow::SHRINK && !_lineBreakWithoutSpaces && tokenLen > 0 &&
+                (index + tokenLen) < textLen)
             {
                 auto tokenLastChar = _utf32Text[index + tokenLen - 1];
                 if (!StringUtils::isCJKUnicode(tokenLastChar) && !StringUtils::isUnicodeSpace(tokenLastChar))
                 {
                     // Work out if this token is valid based on the desired output
                     auto nextChar = _utf32Text[index + tokenLen];
-                    if (_overflow == Overflow::SHRINK && !StringUtils::isUnicodeSpace(nextChar) &&
-                        !StringUtils::isCJKUnicode(nextChar))
+                    if (!StringUtils::isUnicodeSpace(nextChar) && !StringUtils::isCJKUnicode(nextChar))
                     {
                         // No point continuing here
                         return false;
@@ -3125,7 +3125,7 @@ bool Label::isHorizontalClamp()
         {
             auto& letterDef = _fontAtlas->_letterDefinitions[_lettersInfo[ctr].utf32Char];
 
-            auto px        = _lettersInfo[ctr].positionX + letterDef.width / 2 * _fontScale;
+            auto px        = _lettersInfo[ctr].positionX + letterDef.width * _fontScale;
             auto lineIndex = _lettersInfo[ctr].lineIndex;
 
             if (_labelWidth > 0.f)

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1191,10 +1191,12 @@ bool Label::computeHorizontalKernings(const std::u32string& stringToRender)
         return true;
 }
 
-bool Label::isLetterHorizontallyClamped(float letterPositionX, float letterWidth, int lineIndex)
+bool Label::isLetterHorizontallyClamped(float letterPositionX, float letterWidth, int lineIndex, float offsetX)
 {
-    auto wordWidth       = this->_linesWidth[lineIndex];
-    bool letterOverClamp = ((letterPositionX + letterWidth) > _contentSize.width || (letterPositionX + letterWidth / 2) < 0);
+    const auto wordWidth       = this->_linesWidth[lineIndex];
+    const auto minPos          = offsetX < 0 ? letterPositionX - offsetX : letterPositionX;
+    const auto maxPos          = letterPositionX + letterWidth;
+    const auto letterOverClamp = maxPos >= _contentSize.width || minPos < 0;
     if (!_enableWrap)
     {
         return letterOverClamp;
@@ -1215,16 +1217,17 @@ bool Label::updateQuads()
 
     for (int ctr = 0; ctr < _lengthOfString; ++ctr)
     {
-        if (_lettersInfo[ctr].valid)
+        auto& letterInfo = _lettersInfo[ctr];
+        if (letterInfo.valid)
         {
-            auto& letterDef = _fontAtlas->_letterDefinitions[_lettersInfo[ctr].utf32Char];
+            auto& letterDef = _fontAtlas->_letterDefinitions[letterInfo.utf32Char];
 
             _reusedRect.size.height = letterDef.height;
             _reusedRect.size.width  = letterDef.width;
             _reusedRect.origin.x    = letterDef.U;
             _reusedRect.origin.y    = letterDef.V;
 
-            auto py = _lettersInfo[ctr].positionY + _letterOffsetY;
+            auto py = letterInfo.positionY + _letterOffsetY;
             if (_labelHeight > 0.f)
             {
                 if (py > _tailoredTopY)
@@ -1240,14 +1243,15 @@ bool Label::updateQuads()
                 }
             }
 
-            auto lineIndex = _lettersInfo[ctr].lineIndex;
-            auto px        = _lettersInfo[ctr].positionX;
+            auto lineIndex = letterInfo.lineIndex;
+            auto px        = letterInfo.positionX + _linesOffsetX[lineIndex];
+            auto offsetX   = letterInfo.offsetX;
 
             if (_labelWidth > 0.f)
             {
-                if (this->isLetterHorizontallyClamped(px, letterDef.width * _fontScale, lineIndex))
+                if (this->isLetterHorizontallyClamped(px, letterDef.width * _fontScale, lineIndex, offsetX))
                 {
-                    if (_overflow == Overflow::CLAMP || _overflow == Overflow::SHRINK)
+                    if (_overflow == Overflow::CLAMP)
                     {
                         _reusedRect.size.width = 0;
                     }
@@ -1257,10 +1261,10 @@ bool Label::updateQuads()
             if (_reusedRect.size.height > 0.f && _reusedRect.size.width > 0.f)
             {
                 _reusedLetter->setTextureRect(_reusedRect, letterDef.rotated, _reusedRect.size);
-                float letterPositionX = _lettersInfo[ctr].positionX + _linesOffsetX[_lettersInfo[ctr].lineIndex];
+                float letterPositionX = letterInfo.positionX + _linesOffsetX[lineIndex];
                 _reusedLetter->setPosition(letterPositionX, py);
                 auto index = static_cast<int>(_batchNodes.at(letterDef.textureID)->getTextureAtlas()->getTotalQuads());
-                _lettersInfo[ctr].atlasIndex = index;
+                letterInfo.atlasIndex = index;
 
                 this->updateLetterSpriteScale(_reusedLetter);
 
@@ -2987,7 +2991,7 @@ bool Label::multilineTextWrap(bool breakOnChar, bool ignoreOverflow)
                 letterPosition.x = letterX;
             }
             letterPosition.y = (nextTokenY - letterDef.offsetY * _fontScale) / contentScaleFactor;
-            recordLetterInfo(letterPosition, character, letterIndex, lineIndex);
+            recordLetterInfo(letterPosition, character, letterIndex, lineIndex, letterDef.offsetX, letterDef.offsetY);
 
             if (nextChangeSize)
             {
@@ -3130,7 +3134,7 @@ bool Label::isHorizontalClamp()
     return letterClamp;
 }
 
-void Label::recordLetterInfo(const ax::Vec2& point, char32_t utf32Char, int letterIndex, int lineIndex)
+void Label::recordLetterInfo(const ax::Vec2& point, char32_t utf32Char, int letterIndex, int lineIndex, float offsetX, float offsetY)
 {
     if (static_cast<std::size_t>(letterIndex) >= _lettersInfo.size())
     {
@@ -3143,6 +3147,8 @@ void Label::recordLetterInfo(const ax::Vec2& point, char32_t utf32Char, int lett
     _lettersInfo[letterIndex].positionX  = point.x;
     _lettersInfo[letterIndex].positionY  = point.y;
     _lettersInfo[letterIndex].atlasIndex = -1;
+    _lettersInfo[letterIndex].offsetX    = offsetX;
+    _lettersInfo[letterIndex].offsetY    = offsetY;
 }
 
 void Label::recordPlaceholderInfo(int letterIndex, char32_t utf32Char)

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -741,6 +741,8 @@ protected:
         float positionY;
         int atlasIndex;
         int lineIndex;
+        float offsetX;
+        float offsetY;
     };
 
     struct BatchCommand
@@ -783,7 +785,12 @@ protected:
     void computeAlignmentOffset();
     bool computeHorizontalKernings(const std::u32string& stringToRender);
 
-    void recordLetterInfo(const ax::Vec2& point, char32_t utf32Char, int letterIndex, int lineIndex);
+    void recordLetterInfo(const ax::Vec2& point,
+                          char32_t utf32Char,
+                          int letterIndex,
+                          int lineIndex,
+                          float offsetX,
+                          float offsetY);
     void recordPlaceholderInfo(int letterIndex, char32_t utf16Char);
 
     bool updateQuads();
@@ -801,7 +808,7 @@ protected:
     bool setTTFConfigInternal(const TTFConfig& ttfConfig);
     bool updateTTFConfigInternal();
     void setBMFontSizeInternal(float fontSize);
-    bool isLetterHorizontallyClamped(float letterPositionX, float letterWidth, int lineIndex);
+    bool isLetterHorizontallyClamped(float letterPositionX, float letterWidth, int lineIndex, float offsetX);
     void restoreFontSize();
     void updateLetterSpriteScale(Sprite* sprite);
     int getFirstCharLen(const std::u32string& utf32Text, int startIndex, int textLen) const;

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -762,7 +762,7 @@ protected:
         CustomCommand shadowCommand;
     };
 
-    void resetAtlas();
+    void clearTextures();
 
     virtual void setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled = false, bool useA8Shader = false);
     bool getFontLetterDef(char32_t character, FontLetterDefinition& letterDef) const;
@@ -774,7 +774,6 @@ protected:
     bool multilineTextWrapByChar(bool ignoreOverflow = false);
     bool multilineTextWrapByWord(bool ignoreOverflow = false);
     bool multilineTextWrap(bool breakOnChar, bool ignoreOverflow);
-    void shrinkLabelToContentSize(const std::function<bool(void)>& lambda);
     bool isHorizontalClamp();
     bool isVerticalClamp();
     void rescaleWithOriginalFontSize();
@@ -802,7 +801,7 @@ protected:
     bool setTTFConfigInternal(const TTFConfig& ttfConfig);
     bool updateTTFConfigInternal();
     void setBMFontSizeInternal(float fontSize);
-    bool isHorizontalClamped(float letterPositionX, float letterWidth, int lineIndex);
+    bool isLetterHorizontallyClamped(float letterPositionX, float letterWidth, int lineIndex);
     void restoreFontSize();
     void updateLetterSpriteScale(Sprite* sprite);
     int getFirstCharLen(const std::u32string& utf32Text, int startIndex, int textLen) const;

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -762,6 +762,8 @@ protected:
         CustomCommand shadowCommand;
     };
 
+    void resetAtlas();
+
     virtual void setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled = false, bool useA8Shader = false);
     bool getFontLetterDef(char32_t character, FontLetterDefinition& letterDef) const;
 
@@ -769,9 +771,9 @@ protected:
 
     void drawSelf(bool visibleByCamera, Renderer* renderer, uint32_t flags);
 
-    bool multilineTextWrapByChar();
-    bool multilineTextWrapByWord();
-    bool multilineTextWrap(const std::function<int(const std::u32string&, int, int)>& lambda);
+    bool multilineTextWrapByChar(bool ignoreOverflow = false);
+    bool multilineTextWrapByWord(bool ignoreOverflow = false);
+    bool multilineTextWrap(bool breakOnChar, bool ignoreOverflow);
     void shrinkLabelToContentSize(const std::function<bool(void)>& lambda);
     bool isHorizontalClamp();
     bool isVerticalClamp();

--- a/tests/cpp-tests/Source/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Source/LabelTest/LabelTestNew.h
@@ -707,6 +707,7 @@ public:
     void updateDrawNodeSize(const ax::Size& drawNodeSize);
     ax::extension::ControlStepper* makeControlStepper();
     void valueChanged(ax::Object* sender, ax::extension::Control::EventType controlEvent);
+    void onExit() override;
 
 protected:
     void setAlignmentLeft(ax::Object* sender);


### PR DESCRIPTION
## Describe your changes
This PR is an attempt to address several issues:

1. Incorrect text wrapping in the middle of words even when `_lineBreakWithoutSpaces` is `false`
2. Incorrect text wrapping when shrink should be used
3. Missing character at the end of text line depending on alignment
4. Label doing a forced content recalculation every loop when no content or dimensions have changed, and when certain text, dimensions and overflow settings are used.

I've tested as much as I've been able to, including the tests in cpp-tests, but it would be good if these changes are tested by others on their projects to see if there are any issues.

Label test vertical slider flipped the opposite direction so that 0% is down the bottom and 100% is up the top.

## Issue ticket number and link
#2503 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
