### PR TITLE
Add locating vs build tools without full vs installed

### DIFF
--- a/1k/1kiss.ps1
+++ b/1k/1kiss.ps1
@@ -854,7 +854,7 @@ function find_vs() {
 
         # refer: https://learn.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2022
         $require_comps = @('Microsoft.VisualStudio.Component.VC.Tools.x86.x64', 'Microsoft.VisualStudio.Product.BuildTools')
-        $vs_installs = ConvertFrom-Json "$(&$VSWHERE_EXE -version $required_vs_ver.TrimEnd('+') -format 'json' -requires $require_comps -requiresAny -prerelease)"
+        $vs_installs = ConvertFrom-Json "$(&$VSWHERE_EXE -products * -version $required_vs_ver.TrimEnd('+') -format 'json' -requires $require_comps -requiresAny -prerelease)"
         $ErrorActionPreference = $eap
 
         if ($vs_installs) {


### PR DESCRIPTION
Locate buildTools on CI servers where no full VS installed

## Describe your changes
Updated 1kiss script to locate visual studio buildTools

Current vswhere call just locates full installs of visual studio.

When using a CI server or different IDE like Jetbrains there is no need for full visual studio install, just build tools so script fails when searching for non existent visual studio

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
