### PR TITLE
[WASM] Add javascript click listener to cancel the 'touches' on non touchable devices

### DIFF
--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -533,7 +533,7 @@ set(AX_WASM_SHELL_FILE "${_AX_ROOT}/core/platform/wasm/shell_minimal.html" CACHE
 
 option(AX_WASM_ENABLE_DEVTOOLS "Enable wasm devtools" ON)
 
-set(_AX_WASM_EXPORTS "_main,_axmol_webglcontextlost,_axmol_webglcontextrestored,_axmol_hdoc_visibilitychange")
+set(_AX_WASM_EXPORTS "_main,_axmol_webglcontextlost,_axmol_webglcontextrestored,_axmol_hdoc_visibilitychange,_axmol_onwebclickcallback")
 if(AX_WASM_ENABLE_DEVTOOLS)
     string(APPEND _AX_WASM_EXPORTS ",_axmol_dev_pause,_axmol_dev_resume,_axmol_dev_step")
 endif()

--- a/core/platform/GLViewImpl.h
+++ b/core/platform/GLViewImpl.h
@@ -174,6 +174,7 @@ protected:
     void onGLFWMouseMoveCallBack(GLFWwindow* window, double x, double y);
 #if defined(__EMSCRIPTEN__)
     void onWebTouchCallback(int eventType, const EmscriptenTouchEvent* touchEvent);
+    void onWebClickCallback();
 #endif
     void onGLFWMouseScrollCallback(GLFWwindow* window, double x, double y);
     void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);


### PR DESCRIPTION
Currently, in WASM, we can run on devices with touch capabilities (like mobile) or not (desktop with mouse).
In the first case, if the touch is going out of screen it is cancelled, or released if finger doesn't touch the device screen anymore.
In the second case, we know the mouse is clicked, moved but if we move outside the app window and release the mouse no event is triggered, which means the move is in a bad state , still not ended for the GLView.

The only way I found to fix this is to add a javascript click listener *only* for non touch devices, that triggers an Module call  to be used by the GLView to cancel the 'touch' event, if one was existing.