### PR TITLE
Add close code and reason for Websocket close / onClose

### DIFF
--- a/core/network/WebSocket-wasm.h
+++ b/core/network/WebSocket-wasm.h
@@ -175,7 +175,7 @@ public:
      *  @brief Closes the connection to server synchronously.
      *  @note It's a synchronous method, it will not return until websocket thread exits.
      */
-    void close(uint16_t code = 1000, std::string_view reason = "Normal closure");
+    void close(uint16_t code = 1000, std::string_view reason = "Normal close");
 
     /**
      *  @brief Closes the connection to server asynchronously.
@@ -183,7 +183,7 @@ public:
      *        If using 'closeAsync' to close websocket connection,
      *        be careful of not using destructed variables in the callback of 'onClose'.
      */
-    void closeAsync(uint16_t code = 1000, std::string_view reason = "Normal closure");
+    void closeAsync(uint16_t code = 1000, std::string_view reason = "Normal close");
 
     /**
      *  @brief Gets current state of connection.

--- a/core/network/WebSocket-wasm.h
+++ b/core/network/WebSocket-wasm.h
@@ -122,7 +122,7 @@ public:
          *
          * @param ws The WebSocket object connected.
          */
-        virtual void onClose(WebSocket* ws) = 0;
+        virtual void onClose(WebSocket* ws, uint16_t code, std::string_view reason) = 0;
         /**
          * This function is to be called in the following cases:
          * 1. client connection is failed.
@@ -175,7 +175,7 @@ public:
      *  @brief Closes the connection to server synchronously.
      *  @note It's a synchronous method, it will not return until websocket thread exits.
      */
-    void close();
+    void close(uint16_t code = 1000, std::string_view reason = "Normal closure");
 
     /**
      *  @brief Closes the connection to server asynchronously.
@@ -183,7 +183,7 @@ public:
      *        If using 'closeAsync' to close websocket connection,
      *        be careful of not using destructed variables in the callback of 'onClose'.
      */
-    void closeAsync();
+    void closeAsync(uint16_t code = 1000, std::string_view reason = "Normal closure");
 
     /**
      *  @brief Gets current state of connection.

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -232,11 +232,13 @@ bool WebSocket::open(Delegate* delegate,
                      std::string_view caFilePath,
                      std::string_view protocols)
 {
-    _delegate   = delegate;
-    _url        = url;
-    _caFilePath = FileUtils::getInstance()->fullPathForFilename(caFilePath);
-    _requestUri = Uri::parse(url);
-    _protocols  = protocols;
+    _delegate    = delegate;
+    _url         = url;
+    _caFilePath  = FileUtils::getInstance()->fullPathForFilename(caFilePath);
+    _requestUri  = Uri::parse(url);
+    _protocols   = protocols;
+    _closeCode   = ws::detail::close_code::none;
+    _closeReason = "";
 
     setupParsers();
     generateHandshakeSecKey();
@@ -283,7 +285,7 @@ void WebSocket::dispatchEvents()
                 _delegate->onOpen(this);
                 break;
             case Event::Type::ON_CLOSE:
-                _delegate->onClose(this);
+                _delegate->onClose(this, _closeCode, _closeReason);
                 break;
             case Event::Type::ON_ERROR:
                 _delegate->onError(this, static_cast<ErrorEvent*>(event)->getErrorCode());
@@ -388,6 +390,14 @@ int WebSocket::on_frame_end(websocket_parser* parser)
             break;
         case WS_OP_CLOSE:
             AXLOGD("WS: control frame: CLOSE");
+            if (ws->_receivedData.size() > 1)
+            {
+                if(ws->_closeCode == 0)
+                    ws->_closeCode = ((uint16_t) ws->_receivedData.data()[0]) << 8 | ws->_receivedData.data()[1];
+                
+                if (ws->_receivedData.size() > 2 && ws->_closeReason.empty())
+                    ws->_closeReason = std::string(ws->_receivedData.data()[3], ws->_receivedData.size() - 2);
+            }
             break;
         case WS_OP_PING:
             AXLOGD("WS: control frame: PING");
@@ -436,13 +446,27 @@ void WebSocket::send(const void* data, unsigned int len)
  *  @brief Closes the connection to server synchronously.
  *  @note It's a synchronous method, it will not return until websocket thread exits.
  */
-void WebSocket::close()
+void WebSocket::close(uint16_t code, std::string_view reason)
 {
     if (_state < State::CLOSING)
     {
+        _closeCode   = code;
+        _closeReason = reason;
+        
         if (_service->is_open(0))
         {
             _state = State::CLOSING;
+            
+            char closeData[sizeof(code)+reason.size()];
+            memcpy(closeData, &code, sizeof(code));
+            
+            if (!reason.empty())
+            {
+                memcpy(closeData+sizeof(code), reason.data(), reason.size());
+            }
+            
+            WebSocketProtocol::sendFrame(*this, closeData, sizeof(closeData), ws::detail::opcode::close);
+            
             _service->close(0);
 
             if (_transport)
@@ -470,7 +494,7 @@ void WebSocket::close()
  *        If using 'closeAsync' to close websocket connection,
  *        be careful of not using destructed variables in the callback of 'onClose'.
  */
-void WebSocket::closeAsync()
+void WebSocket::closeAsync(uint16_t code, std::string_view reason)
 {
     if (_state < State::CLOSING)
     {
@@ -494,7 +518,8 @@ void WebSocket::generateHandshakeSecKey()
 
     auto signContent = _handshakeSecKey;
     signContent += "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"sv;
-    _verifySecKey   = utils::computeDigest(signContent, "sha1"sv, utils::DigestPresent::Base64);
+    auto digest   = utils::computeDigest(signContent, "sha1"sv, false);
+    _verifySecKey = utils::base64Encode(std::span{digest});
 }
 
 void WebSocket::handleNetworkEvent(yasio::io_event* event)
@@ -633,6 +658,11 @@ void WebSocket::handleNetworkEvent(yasio::io_event* event)
         break;
     case YEK_ON_CLOSE:
         _transport = nullptr;
+        if(_closeCode == ws::detail::close_code::none)
+        {
+            _closeCode = ws::detail::close_code::abnormal;
+            _closeReason = "Abnormal close";
+        }
         if (_state == State::OPEN || _state == State::CLOSING)
         {
             _state = State::CLOSED;

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -451,7 +451,7 @@ void WebSocket::close(uint16_t code, std::string_view reason)
     if (_state < State::CLOSING)
     {
         _closeCode   = code;
-        _closeReason = std::string(reason.data(), reason.size());
+        _closeReason = std::string(reason);
         
         if (_service->is_open(0))
         {

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -518,8 +518,7 @@ void WebSocket::generateHandshakeSecKey()
 
     auto signContent = _handshakeSecKey;
     signContent += "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"sv;
-    auto digest   = utils::computeDigest(signContent, "sha1"sv, false);
-    _verifySecKey = utils::base64Encode(std::span{digest});
+    _verifySecKey   = utils::computeDigest(signContent, "sha1"sv, utils::DigestPresent::Base64);
 }
 
 void WebSocket::handleNetworkEvent(yasio::io_event* event)

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -457,15 +457,15 @@ void WebSocket::close(uint16_t code, std::string_view reason)
         {
             _state = State::CLOSING;
             
-            char closeData[sizeof(code)+_closeReason.size()];
-            memcpy(closeData, &code, sizeof(code));
+            std::vector<char> closeData(sizeof(_closeCode)+reason.size());
+            memcpy(closeData.data(), &_closeCode, sizeof(_closeCode));
             
             if (!reason.empty())
             {
-                memcpy(closeData+sizeof(code), _closeReason.data(), _closeReason.size());
+                memcpy(closeData.data()+sizeof(_closeCode), reason.data(), reason.size());
             }
             
-            WebSocketProtocol::sendFrame(*this, closeData, sizeof(closeData), ws::detail::opcode::close);
+            WebSocketProtocol::sendFrame(*this, closeData.data(), closeData.size(), ws::detail::opcode::close);
             
             _service->close(0);
 

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -451,7 +451,7 @@ void WebSocket::close(uint16_t code, std::string_view reason)
     if (_state < State::CLOSING)
     {
         _closeCode   = code;
-        _closeReason = std::string(reason);
+        _closeReason = reason;
         
         if (_service->is_open(0))
         {

--- a/core/network/WebSocket.cpp
+++ b/core/network/WebSocket.cpp
@@ -451,18 +451,18 @@ void WebSocket::close(uint16_t code, std::string_view reason)
     if (_state < State::CLOSING)
     {
         _closeCode   = code;
-        _closeReason = reason;
+        _closeReason = std::string(reason.data(), reason.size());
         
         if (_service->is_open(0))
         {
             _state = State::CLOSING;
             
-            char closeData[sizeof(code)+reason.size()];
+            char closeData[sizeof(code)+_closeReason.size()];
             memcpy(closeData, &code, sizeof(code));
             
             if (!reason.empty())
             {
-                memcpy(closeData+sizeof(code), reason.data(), reason.size());
+                memcpy(closeData+sizeof(code), _closeReason.data(), _closeReason.size());
             }
             
             WebSocketProtocol::sendFrame(*this, closeData, sizeof(closeData), ws::detail::opcode::close);

--- a/core/network/WebSocket.h
+++ b/core/network/WebSocket.h
@@ -275,7 +275,7 @@ public:
      *  @brief Closes the connection to server synchronously.
      *  @note It's a synchronous method, it will not return until websocket thread exits.
      */
-    void close(uint16_t code = 1000, std::string_view reason = "Normal closure");
+    void close(uint16_t code = 1000, std::string_view reason = "Normal close");
 
     /**
      *  @brief Closes the connection to server asynchronously.
@@ -283,7 +283,7 @@ public:
      *        If using 'closeAsync' to close websocket connection,
      *        be careful of not using destructed variables in the callback of 'onClose'.
      */
-    void closeAsync(uint16_t code = 1000, std::string_view reason = "Normal closure");
+    void closeAsync(uint16_t code = 1000, std::string_view reason = "Normal close");
 
     /**
      *  @brief Gets current state of connection.

--- a/core/network/WebSocket.h
+++ b/core/network/WebSocket.h
@@ -137,7 +137,7 @@ public:
     public:
         CloseEvent() { this->_type = Type::ON_CLOSE; }
     };
-
+    
     class ErrorEvent : public Event
     {
     public:
@@ -220,8 +220,10 @@ public:
          * _readyState is State::CLOSING,this function is to be called.
          *
          * @param ws The WebSocket object connected.
+         * @param code the close code.
+         * @param reason the close reason.
          */
-        virtual void onClose(WebSocket* ws) = 0;
+        virtual void onClose(WebSocket* ws, uint16_t code, std::string_view reason) = 0;
         /**
          * This function is to be called in the following cases:
          * 1. client connection is failed.
@@ -273,7 +275,7 @@ public:
      *  @brief Closes the connection to server synchronously.
      *  @note It's a synchronous method, it will not return until websocket thread exits.
      */
-    void close();
+    void close(uint16_t code = 1000, std::string_view reason = "Normal closure");
 
     /**
      *  @brief Closes the connection to server asynchronously.
@@ -281,7 +283,7 @@ public:
      *        If using 'closeAsync' to close websocket connection,
      *        be careful of not using destructed variables in the callback of 'onClose'.
      */
-    void closeAsync();
+    void closeAsync(uint16_t code = 1000, std::string_view reason = "Normal closure");
 
     /**
      *  @brief Gets current state of connection.
@@ -423,6 +425,8 @@ protected:
     /// the http status code returned from server, e.g. 200, 404, refer to
     /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
     int _responseCode = -1;
+    uint16_t _closeCode;
+    std::string _closeReason;
 
     // for receiveData
     yasio::sbyte_buffer _receivedData;

--- a/core/network/WebSocket.h
+++ b/core/network/WebSocket.h
@@ -137,7 +137,7 @@ public:
     public:
         CloseEvent() { this->_type = Type::ON_CLOSE; }
     };
-    
+
     class ErrorEvent : public Event
     {
     public:

--- a/extensions/scripting/lua-bindings/manual/network/lua_websocket.cpp
+++ b/extensions/scripting/lua-bindings/manual/network/lua_websocket.cpp
@@ -116,7 +116,7 @@ void LuaWebSocket::onMessage(WebSocket* ws, const WebSocket::Data& data)
     }
 }
     
-void LuaWebSocket::onClose(WebSocket* ws)
+void LuaWebSocket::onClose(WebSocket* ws, uint16_t code, std::string_view reason)
 {
     LuaWebSocket* luaWs = dynamic_cast<LuaWebSocket*>(ws);
     if (NULL != luaWs) {

--- a/extensions/scripting/lua-bindings/manual/network/lua_websocket.h
+++ b/extensions/scripting/lua-bindings/manual/network/lua_websocket.h
@@ -43,7 +43,7 @@ public:
     ~LuaWebSocket() override;;
     void onOpen(WebSocket* ws) override;
     void onMessage(WebSocket* ws, const WebSocket::Data& data) override;
-    void onClose(WebSocket* ws) override;
+    void onClose(WebSocket* ws, uint16_t code, std::string_view reason) override;
     void onError(WebSocket* ws, const WebSocket::ErrorCode& error) override;
     
     enum WebSocketScriptHandlerType

--- a/tests/cpp-tests/Source/NetworkTest/WebSocketTest/WebSocketTest.cpp
+++ b/tests/cpp-tests/Source/NetworkTest/WebSocketTest/WebSocketTest.cpp
@@ -243,7 +243,7 @@ void WebSocketTest::onMessage(network::WebSocket* ws, const network::WebSocket::
     }
 }
 
-void WebSocketTest::onClose(network::WebSocket* ws)
+void WebSocketTest::onClose(network::WebSocket* ws, uint16_t code, std::string_view reason)
 {
     AXLOGD("onClose: websocket instance ({}) closed.", fmt::ptr(ws));
     if (ws == _wsiSendText)
@@ -402,7 +402,7 @@ void WebSocketCloseTest::onMessage(network::WebSocket* ws, const network::WebSoc
     AXLOGD("Websocket get message from {}", fmt::ptr(ws));
 }
 
-void WebSocketCloseTest::onClose(network::WebSocket* ws)
+void WebSocketCloseTest::onClose(network::WebSocket* ws, uint16_t code, std::string_view reason)
 {
     AXLOGD("websocket ({}) closed.", fmt::ptr(ws));
     // if (ws == _wsiTest) {
@@ -546,7 +546,7 @@ void WebSocketDelayTest::onMessage(network::WebSocket* ws, const network::WebSoc
     }
 }
 
-void WebSocketDelayTest::onClose(network::WebSocket* ws)
+void WebSocketDelayTest::onClose(network::WebSocket* ws, uint16_t code, std::string_view reason)
 {
     AXLOGD("onClose: websocket instance ({}) closed.", fmt::ptr(ws));
     if (ws == _wsiSendText)

--- a/tests/cpp-tests/Source/NetworkTest/WebSocketTest/WebSocketTest.h
+++ b/tests/cpp-tests/Source/NetworkTest/WebSocketTest/WebSocketTest.h
@@ -87,7 +87,7 @@ public:
 
     virtual void onOpen(ax::network::WebSocket* ws)override;
     virtual void onMessage(ax::network::WebSocket* ws, const ax::network::WebSocket::Data& data)override;
-    virtual void onClose(ax::network::WebSocket* ws)override;
+    virtual void onClose(ax::network::WebSocket* ws, uint16_t code, std::string_view reason)override;
     virtual void onError(ax::network::WebSocket* ws, const ax::network::WebSocket::ErrorCode& error)override;
 
     WebSocketCloseTest();

--- a/tests/cpp-tests/Source/NetworkTest/WebSocketTest/WebSocketTest.h
+++ b/tests/cpp-tests/Source/NetworkTest/WebSocketTest/WebSocketTest.h
@@ -54,7 +54,7 @@ public:
     
     virtual void onOpen(ax::network::WebSocket* ws)override;
     virtual void onMessage(ax::network::WebSocket* ws, const ax::network::WebSocket::Data& data)override;
-    virtual void onClose(ax::network::WebSocket* ws)override;
+    virtual void onClose(ax::network::WebSocket* ws, uint16_t code, std::string_view reason)override;
     virtual void onError(ax::network::WebSocket* ws, const ax::network::WebSocket::ErrorCode& error)override;
     
     // Menu Callbacks
@@ -113,7 +113,7 @@ public:
     
     virtual void onOpen(ax::network::WebSocket* ws)override;
     virtual void onMessage(ax::network::WebSocket* ws, const ax::network::WebSocket::Data& data)override;
-    virtual void onClose(ax::network::WebSocket* ws)override;
+    virtual void onClose(ax::network::WebSocket* ws, uint16_t code, std::string_view reason)override;
     virtual void onError(ax::network::WebSocket* ws, const ax::network::WebSocket::ErrorCode& error)override;
     
     // Menu Callbacks


### PR DESCRIPTION
This PR allows us to give a code and a reason to a websocket `close` and have these too on the `onClose` callback.