### PR TITLE
Add mouse events listener for Widgets

### DIFF
--- a/core/base/EventDispatcher.cpp
+++ b/core/base/EventDispatcher.cpp
@@ -1222,8 +1222,6 @@ void EventDispatcher::dispatchMouseEvent(EventMouse* event)
     if (nullptr == listeners)
         return;
 
-    bool isSwallowed = false;
-
     auto onMouseEvent = [&](EventListener* l) -> bool {  // Return true to break
         EventListenerMouse* listener = static_cast<EventListenerMouse*>(l);
 

--- a/core/base/EventDispatcher.cpp
+++ b/core/base/EventDispatcher.cpp
@@ -975,6 +975,11 @@ void EventDispatcher::dispatchEvent(Event* event, bool forced)
         dispatchTouchEvent(static_cast<EventTouch*>(event));
         return;
     }
+    else if (event->getType() == Event::Type::MOUSE)
+    {
+        dispatchMouseEvent(static_cast<EventMouse*>(event));
+        return;
+    }
 
     auto listenerID = __getListenerID(event);
 
@@ -1202,6 +1207,88 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
         {
             return;
         }
+    }
+
+    updateListeners(event);
+}
+
+void EventDispatcher::dispatchMouseEvent(EventMouse* event)
+{
+    sortEventListeners(EventListenerMouse::LISTENER_ID);
+
+    auto listeners = getListeners(EventListenerMouse::LISTENER_ID);
+
+    // If there aren't any mouse listeners, return directly.
+    if (nullptr == listeners)
+        return;
+
+    bool isSwallowed = false;
+
+    auto onMouseEvent = [&](EventListener* l) -> bool {  // Return true to break
+        EventListenerMouse* listener = static_cast<EventListenerMouse*>(l);
+
+        // Skip if the listener was removed.
+        if (!listener->_isRegistered)
+            return false;
+
+        event->setCurrentTarget(listener->_node);
+
+        bool isClaimed = false;
+
+        switch (event->getMouseEventType())
+        {
+        case EventMouse::MouseEventType::MOUSE_UP:
+            if (listener->onMouseUp)
+            {
+                isClaimed = listener->onMouseUp(event);
+            }
+            break;
+        case EventMouse::MouseEventType::MOUSE_DOWN:
+            if (listener->onMouseDown)
+            {
+                isClaimed = listener->onMouseDown(event);
+            }
+            break;
+        case EventMouse::MouseEventType::MOUSE_MOVE:
+            if (listener->onMouseMove)
+            {
+                isClaimed = listener->onMouseMove(event);
+            }
+            break;
+        case EventMouse::MouseEventType::MOUSE_SCROLL:
+            if (listener->onMouseScroll)
+            {
+                isClaimed = listener->onMouseScroll(event);
+            }
+            break;
+        case EventMouse::MouseEventType::MOUSE_NONE:
+            break;
+        default:
+            AXASSERT(false, "The type is invalid.");
+            break;
+        }
+        
+
+        // If the event was stopped, return directly.
+        if (event->isStopped())
+        {
+            updateListeners(event);
+            return true;
+        }
+
+        if (isClaimed && listener->_isRegistered && listener->_needSwallow)
+        {
+            return true;
+        }
+
+        return false;
+    };
+
+    //
+    dispatchTouchEventToListeners(listeners, onMouseEvent);
+    if (event->isStopped())
+    {
+        return;
     }
 
     updateListeners(event);

--- a/core/base/EventDispatcher.h
+++ b/core/base/EventDispatcher.h
@@ -48,6 +48,7 @@ namespace ax
 
 class Event;
 class EventTouch;
+class EventMouse;
 class Node;
 class EventCustom;
 class EventListenerCustom;
@@ -281,6 +282,10 @@ protected:
     /** Touch event needs to be processed different with other events since it needs support ALL_AT_ONCE and ONE_BY_NONE
      * mode. */
     void dispatchTouchEvent(EventTouch* event);
+
+    /** Mouse Scroll event needs to be processed different with other events since it needs support ALL_AT_ONCE and ONE_BY_NONE
+     * mode. */
+    void dispatchMouseEvent(EventMouse* event);
 
     /** Associates node with event listener */
     void associateNodeAndEventListener(Node* node, EventListener* listener);

--- a/core/base/EventListenerMouse.cpp
+++ b/core/base/EventListenerMouse.cpp
@@ -36,6 +36,16 @@ bool EventListenerMouse::checkAvailable()
     return true;
 }
 
+void EventListenerMouse::setSwallowMouse(bool needSwallow)
+{
+    _needSwallow = needSwallow;
+}
+
+bool EventListenerMouse::isSwallowMouse()
+{
+    return _needSwallow;
+}
+
 EventListenerMouse* EventListenerMouse::create()
 {
     auto ret = new EventListenerMouse();
@@ -60,6 +70,7 @@ EventListenerMouse* EventListenerMouse::clone()
         ret->onMouseDown   = onMouseDown;
         ret->onMouseMove   = onMouseMove;
         ret->onMouseScroll = onMouseScroll;
+        ret->_needSwallow  = _needSwallow;
     }
     else
     {
@@ -69,7 +80,11 @@ EventListenerMouse* EventListenerMouse::clone()
 }
 
 EventListenerMouse::EventListenerMouse()
-    : onMouseDown(nullptr), onMouseUp(nullptr), onMouseMove(nullptr), onMouseScroll(nullptr)
+    : onMouseDown(nullptr)
+    , onMouseUp(nullptr)
+    , onMouseMove(nullptr)
+    , onMouseScroll(nullptr)
+    , _needSwallow(false)
 {}
 
 bool EventListenerMouse::init()

--- a/core/base/EventListenerMouse.cpp
+++ b/core/base/EventListenerMouse.cpp
@@ -89,32 +89,7 @@ EventListenerMouse::EventListenerMouse()
 
 bool EventListenerMouse::init()
 {
-    auto listener = [this](Event* event) {
-        auto mouseEvent = static_cast<EventMouse*>(event);
-        switch (mouseEvent->_mouseEventType)
-        {
-        case EventMouse::MouseEventType::MOUSE_DOWN:
-            if (onMouseDown != nullptr)
-                onMouseDown(mouseEvent);
-            break;
-        case EventMouse::MouseEventType::MOUSE_UP:
-            if (onMouseUp != nullptr)
-                onMouseUp(mouseEvent);
-            break;
-        case EventMouse::MouseEventType::MOUSE_MOVE:
-            if (onMouseMove != nullptr)
-                onMouseMove(mouseEvent);
-            break;
-        case EventMouse::MouseEventType::MOUSE_SCROLL:
-            if (onMouseScroll != nullptr)
-                onMouseScroll(mouseEvent);
-            break;
-        default:
-            break;
-        }
-    };
-
-    if (EventListener::init(Type::MOUSE, LISTENER_ID, listener))
+    if (EventListener::init(Type::MOUSE, LISTENER_ID, nullptr))
     {
         return true;
     }

--- a/core/base/EventListenerMouse.h
+++ b/core/base/EventListenerMouse.h
@@ -54,17 +54,33 @@ public:
      */
     static EventListenerMouse* create();
 
+    /** Whether or not to swall scrolls.
+     *
+     * @param needSwallow True if needs to swall scroll.
+     */
+    void setSwallowMouse(bool needSwallow);
+    /** Is swall scroll or not.
+     *
+     * @return True if needs to swall scroll.
+     */
+    bool isSwallowMouse();
+
     /// Overrides
     virtual EventListenerMouse* clone() override;
     virtual bool checkAvailable() override;
 
-    std::function<void(EventMouse* event)> onMouseDown;
-    std::function<void(EventMouse* event)> onMouseUp;
-    std::function<void(EventMouse* event)> onMouseMove;
-    std::function<void(EventMouse* event)> onMouseScroll;
+    std::function<bool(EventMouse* event)> onMouseDown;
+    std::function<bool(EventMouse* event)> onMouseUp;
+    std::function<bool(EventMouse* event)> onMouseMove;
+    std::function<bool(EventMouse* event)> onMouseScroll;
 
     EventListenerMouse();
     bool init();
+
+private:
+    bool _needSwallow;
+
+    friend class EventDispatcher;
 };
 
 }

--- a/core/base/EventMouse.h
+++ b/core/base/EventMouse.h
@@ -76,6 +76,12 @@ public:
      */
     EventMouse(MouseEventType mouseEventCode);
 
+    /** Get mouse event type.
+     *
+     * @return The type of the event.
+     */
+    MouseEventType getMouseEventType() const { return _mouseEventType; }
+
     /** Set mouse scroll data.
      *
      * @param scrollX The scroll data of x axis.

--- a/core/ui/UIScrollView.cpp
+++ b/core/ui/UIScrollView.cpp
@@ -87,6 +87,7 @@ ScrollView::ScrollView()
     , _scrollTime(DEFAULT_TIME_IN_SEC_FOR_SCROLL_TO_ITEM)
 {
     setTouchEnabled(true);
+    setMouseEnabled(true);
     _propagateTouchEvents = false;
 }
 
@@ -131,6 +132,7 @@ bool ScrollView::init()
         {
             initScrollBar();
         }
+
         return true;
     }
     return false;
@@ -1084,6 +1086,35 @@ void ScrollView::onTouchCancelled(Touch* touch, Event* unusedEvent)
         handleReleaseLogic(touch);
     }
     _isInterceptTouch = false;
+}
+
+bool ScrollView::onMouseScroll(Event* event)
+{
+    bool pass = Widget::onMouseScroll(event);
+
+    if(pass)
+    {
+        auto mouseEvent = static_cast<EventMouse*>(event);
+        float mouseFactor = 10.f;
+        Vec2 move;
+
+        if (_direction == Direction::HORIZONTAL)
+        {
+            move = Vec2(mouseEvent->getScrollY()*mouseFactor, 0.f);
+        }
+        else
+        {
+            move = Vec2(0.f, mouseEvent->getScrollY()*mouseFactor);
+        }
+
+        bool origBounce = _bounceEnabled;
+        _bounceEnabled = false;
+        scrollChildren(move);
+        _bounceEnabled = origBounce;
+        processScrollingEndedEvent();
+    }
+
+    return pass;
 }
 
 void ScrollView::update(float dt)

--- a/core/ui/UIScrollView.cpp
+++ b/core/ui/UIScrollView.cpp
@@ -1095,7 +1095,7 @@ bool ScrollView::onMouseScroll(Event* event)
     if(pass)
     {
         auto mouseEvent = static_cast<EventMouse*>(event);
-        float mouseFactor = 10.f;
+        float mouseFactor = 20.f;
         Vec2 move;
 
         if (_direction == Direction::HORIZONTAL)

--- a/core/ui/UIScrollView.h
+++ b/core/ui/UIScrollView.h
@@ -357,6 +357,7 @@ public:
     void onTouchMoved(Touch* touch, Event* unusedEvent) override;
     void onTouchEnded(Touch* touch, Event* unusedEvent) override;
     void onTouchCancelled(Touch* touch, Event* unusedEvent) override;
+    bool onMouseScroll(Event* event) override;
     void update(float dt) override;
 
     /**

--- a/core/ui/UIWidget.h
+++ b/core/ui/UIWidget.h
@@ -41,6 +41,7 @@ namespace ax
 {
 
 class EventListenerTouchOneByOne;
+class EventListenerMouse;
 class Camera;
 
 namespace ui
@@ -201,11 +202,27 @@ public:
     void setBrightStyle(BrightStyle style);
 
     /**
+     * Sets whether the widget is mouse enabled.
+     *
+     * The default value is false, a widget is default to mouse disabled.
+     *
+     * @param enabled   True if the widget is mouse enabled, false if the widget is mouse disabled.
+     */
+    virtual void setMouseEnabled(bool enabled);
+
+    /**
      * Determines if the widget is touch enabled
      *
      * @return true if the widget is touch enabled, false if the widget is touch disabled.
      */
     bool isTouchEnabled() const;
+
+    /**
+     * Determines if the widget is mouse enabled
+     *
+     * @return true if the widget is mouse enabled, false if the widget is mouse disabled.
+     */
+    bool isMouseEnabled() const;
 
     /**
      * Determines if the widget is highlighted
@@ -482,6 +499,30 @@ public:
     virtual void onTouchCancelled(Touch* touch, Event* unusedEvent);
 
     /**
+     * A callback which will be called when a mouse up event is issued.
+     *@param event The mouse event info.
+     */
+    virtual bool onMouseUp(Event* event);
+
+    /**
+     * A callback which will be called when a mouse down event is issued.
+     *@param event The mouse event info.
+     */
+    virtual bool onMouseDown(Event* event);
+
+    /**
+     * A callback which will be called when a mouse move event is issued.
+     *@param event The mouse event info.
+     */
+    virtual bool onMouseMove(Event* event);
+
+    /**
+     * A callback which will be called when a mouse scroll event is issued.
+     *@param event The mouse event info.
+     */
+    virtual bool onMouseScroll(Event* event);
+
+    /**
      * Sets a LayoutParameter to widget.
      *
      * @see LayoutParameter
@@ -601,6 +642,20 @@ public:
      * @since v3.3
      */
     bool isSwallowTouches() const;
+
+     /**
+     * Toggle widget swallow mouse option.
+     * @brief Specify widget to swallow mouse or not
+     * @param swallow True to swallow mouse, false otherwise.
+     */
+    void setSwallowMouse(bool swallow);
+
+    /**
+     * Return whether the widget is swallowing mouse or not
+     * @return Whether mouse is swallowed.
+     */
+    bool isSwallowMouse() const;
+
 
     /**
      * Query whether widget is focused or not.
@@ -758,6 +813,8 @@ protected:
     // call back function called widget's state changed to dark.
     virtual void onPressStateChangedToDisabled();
 
+    virtual bool onMouseEvent(Event* event);
+
     void pushDownEvent();
     void moveEvent();
 
@@ -788,6 +845,7 @@ protected:
     bool _enabled;
     bool _bright;
     bool _touchEnabled;
+    bool _mouseEnabled;
     bool _highlight;
     bool _affectByClipping;
     bool _ignoreSize;
@@ -813,6 +871,9 @@ protected:
     Vec2 _touchBeganPosition;
     Vec2 _touchMovePosition;
     Vec2 _touchEndPosition;
+
+    bool _mouseHitted;
+    EventListenerMouse* _mouseListener;
 
     bool _flippedX;
     bool _flippedY;

--- a/extensions/ImGui/src/ImGui/ImGuiPresenter.cpp
+++ b/extensions/ImGui/src/ImGui/ImGuiPresenter.cpp
@@ -178,13 +178,9 @@ public:
         _trackLayer->getEventDispatcher()->addEventListenerWithSceneGraphPriority(listener, _trackLayer);
 
         // add by halx99
-        auto stopAnyMouse = [=](EventMouse* event) {
-            if (ImGui::GetIO().WantCaptureMouse)
-            {
-                event->stopPropagation();
-            }
-        };
-        auto mouseListener         = EventListenerMouse::create();
+        auto stopAnyMouse = [=](EventMouse* event) -> bool { return ImGui::GetIO().WantCaptureMouse; };
+        auto mouseListener = EventListenerMouse::create();
+        mouseListener->setSwallowMouse(true);
         mouseListener->onMouseDown = mouseListener->onMouseUp = stopAnyMouse;
         _trackLayer->getEventDispatcher()->addEventListenerWithSceneGraphPriority(mouseListener, _trackLayer);
         scene->addChild(_trackLayer, INT_MAX);
@@ -242,13 +238,9 @@ public:
         eventDispatcher->addEventListenerWithFixedPriority(_touchListener, highestPriority);
 
         // add by halx99
-        auto stopAnyMouse = [=](EventMouse* event) {
-            if (ImGui::GetIO().WantCaptureMouse)
-            {
-                event->stopPropagation();
-            }
-        };
-        _mouseListener              = utils::newInstance<EventListenerMouse>();
+        auto stopAnyMouse = [=](EventMouse* event) -> bool { return ImGui::GetIO().WantCaptureMouse; };
+        _mouseListener = utils::newInstance<EventListenerMouse>();
+        _mouseListener->setSwallowMouse(true);
         _mouseListener->onMouseDown = _mouseListener->onMouseUp = stopAnyMouse;
         eventDispatcher->addEventListenerWithFixedPriority(_mouseListener, highestPriority);
 #endif

--- a/extensions/fairygui/src/fairygui/event/InputProcessor.cpp
+++ b/extensions/fairygui/src/fairygui/event/InputProcessor.cpp
@@ -558,7 +558,7 @@ bool InputProcessor::onMouseDown(ax::EventMouse * event)
 bool InputProcessor::onMouseUp(ax::EventMouse * event)
 {
     if (event->getMouseButton() == EventMouse::MouseButton::BUTTON_LEFT)
-        return;
+        return true;
 
     auto camera = Camera::getVisitingCamera();
     Vec2 pt = event->getLocation();
@@ -692,8 +692,6 @@ bool InputProcessor::onMouseScroll(ax::EventMouse * event)
     ti->mouseWheelDelta = 0;
 
     _activeProcessor = nullptr;
-
-    AXLOG("InputProcessor::onMouseScroll %p", this);
 
     return true;
 }

--- a/extensions/fairygui/src/fairygui/event/InputProcessor.cpp
+++ b/extensions/fairygui/src/fairygui/event/InputProcessor.cpp
@@ -523,10 +523,10 @@ void InputProcessor::onTouchCancelled(Touch* touch, Event* /*unusedEvent*/)
     _activeProcessor = nullptr;
 }
 
-void InputProcessor::onMouseDown(ax::EventMouse * event)
+bool InputProcessor::onMouseDown(ax::EventMouse * event)
 {
     if (event->getMouseButton() == EventMouse::MouseButton::BUTTON_LEFT)
-        return;
+        return true;
 
     auto camera = Camera::getVisitingCamera();
     Vec2 pt = event->getLocation();
@@ -551,9 +551,11 @@ void InputProcessor::onMouseDown(ax::EventMouse * event)
     target->bubbleEvent(UIEventType::TouchBegin);
 
     _activeProcessor = nullptr;
+
+    return true;
 }
 
-void InputProcessor::onMouseUp(ax::EventMouse * event)
+bool InputProcessor::onMouseUp(ax::EventMouse * event)
 {
     if (event->getMouseButton() == EventMouse::MouseButton::BUTTON_LEFT)
         return;
@@ -615,16 +617,18 @@ void InputProcessor::onMouseUp(ax::EventMouse * event)
     ti->button = EventMouse::MouseButton::BUTTON_UNSET;
 
     _activeProcessor = nullptr;
+
+    return true;
 }
 
-void InputProcessor::onMouseMove(ax::EventMouse * event)
+bool InputProcessor::onMouseMove(ax::EventMouse * event)
 {
     TouchInfo* ti = getTouch(0);
     auto pt = event->getLocation();
     Vec2 npos = UIRoot->worldToRoot(pt);
     if (std::abs(ti->pos.x - npos.x) < 1
         && std::abs(ti->pos.y - npos.y) < 1)
-        return;
+        return true;
 
     auto camera = Camera::getVisitingCamera();
     GObject* target = _owner->hitTest(pt, camera);
@@ -664,9 +668,11 @@ void InputProcessor::onMouseMove(ax::EventMouse * event)
     }
 
     _activeProcessor = nullptr;
+
+    return true;
 }
 
-void InputProcessor::onMouseScroll(ax::EventMouse * event)
+bool InputProcessor::onMouseScroll(ax::EventMouse * event)
 {
     auto camera = Camera::getVisitingCamera();
     Vec2 pt = event->getLocation();
@@ -686,6 +692,10 @@ void InputProcessor::onMouseScroll(ax::EventMouse * event)
     ti->mouseWheelDelta = 0;
 
     _activeProcessor = nullptr;
+
+    AXLOG("InputProcessor::onMouseScroll %p", this);
+
+    return true;
 }
 
 void InputProcessor::onKeyDown(ax::EventKeyboard::KeyCode keyCode, ax::Event * event)

--- a/extensions/fairygui/src/fairygui/event/InputProcessor.h
+++ b/extensions/fairygui/src/fairygui/event/InputProcessor.h
@@ -43,10 +43,10 @@ private:
     void onTouchEnded(ax::Touch * touch, ax::Event *);
     void onTouchCancelled(ax::Touch * touch, ax::Event *);
 
-    void onMouseDown(ax::EventMouse* event);
-    void onMouseUp(ax::EventMouse* event);
-    void onMouseMove(ax::EventMouse* event);
-    void onMouseScroll(ax::EventMouse* event);
+    bool onMouseDown(ax::EventMouse* event);
+    bool onMouseUp(ax::EventMouse* event);
+    bool onMouseMove(ax::EventMouse* event);
+    bool onMouseScroll(ax::EventMouse* event);
 
     void onKeyDown(ax::EventKeyboard::KeyCode keyCode, ax::Event*);
     void onKeyUp(ax::EventKeyboard::KeyCode keyCode, ax::Event*);

--- a/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
+++ b/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
@@ -5486,37 +5486,45 @@ static void cloneMouseHandler(const EventListenerMouse* src,
         {
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_DOWN:
         {
-            dst->onMouseDown = [=](Event* event) {
+            dst->onMouseDown = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)dst, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+
+                return true;
             };
         }
         break;
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_UP:
         {
-            dst->onMouseUp = [=](Event* event) {
+            dst->onMouseUp = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)dst, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+
+                return true;
             };
         }
         break;
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_MOVE:
         {
-            dst->onMouseMove = [=](Event* event) {
+            dst->onMouseMove = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)dst, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+
+                return true;
             };
         }
         break;
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_SCROLL:
         {
-            dst->onMouseScroll = [=](Event* event) {
+            dst->onMouseScroll = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)dst, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+
+                return true;
             };
         }
         break;

--- a/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
+++ b/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
@@ -5630,19 +5630,21 @@ static int toaxlua_EventListenerMouse_registerScriptHandler(lua_State* tolua_S)
         {
             ScriptHandlerMgr::getInstance()->addObjectHandler((void*)self, handler, type);
 
-            self->onMouseDown = [=](Event* event) {
+            self->onMouseDown = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)self, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+                return true;
             };
         }
         break;
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_UP:
         {
-            self->onMouseUp = [=](Event* event) {
+            self->onMouseUp = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)self, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+                return true;
             };
 
             ScriptHandlerMgr::getInstance()->addObjectHandler((void*)self, handler, type);
@@ -5650,10 +5652,11 @@ static int toaxlua_EventListenerMouse_registerScriptHandler(lua_State* tolua_S)
         break;
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_MOVE:
         {
-            self->onMouseMove = [=](Event* event) {
+            self->onMouseMove = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)self, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+                return true;
             };
 
             ScriptHandlerMgr::getInstance()->addObjectHandler((void*)self, handler, type);
@@ -5661,10 +5664,11 @@ static int toaxlua_EventListenerMouse_registerScriptHandler(lua_State* tolua_S)
         break;
         case ScriptHandlerMgr::HandlerType::EVENT_MOUSE_SCROLL:
         {
-            self->onMouseScroll = [=](Event* event) {
+            self->onMouseScroll = [=](Event* event) -> bool {
                 LuaEventMouseData mouseData(event);
                 BasicScriptData data((void*)self, (void*)&mouseData);
                 LuaEngine::getInstance()->handleEvent(type, (void*)&data);
+                return true;
             };
 
             ScriptHandlerMgr::getInstance()->addObjectHandler((void*)self, handler, type);

--- a/templates/cpp/Source/MainScene.cpp
+++ b/templates/cpp/Source/MainScene.cpp
@@ -166,28 +166,32 @@ void MainScene::onTouchesEnded(const std::vector<ax::Touch*>& touches, ax::Event
     }
 }
 
-void MainScene::onMouseDown(Event* event)
+bool MainScene::onMouseDown(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
     // AXLOGD("onMouseDown detected, Key: %d", static_cast<int>(e->getMouseButton()));
+    return true;
 }
 
-void MainScene::onMouseUp(Event* event)
+bool MainScene::onMouseUp(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
     AXLOGD("onMouseUp detected, Key: %d", static_cast<int>(e->getMouseButton()));
+    return true;
 }
 
-void MainScene::onMouseMove(Event* event)
+bool MainScene::onMouseMove(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
     // AXLOGD("onMouseMove detected, X:{}  Y:{}", e->getCursorX(), e->getCursorY());
+    return true;
 }
 
-void MainScene::onMouseScroll(Event* event)
+bool MainScene::onMouseScroll(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
     // AXLOGD("onMouseScroll detected, X:{}  Y:{}", e->getScrollX(), e->getScrollY());
+    return true;
 }
 
 void MainScene::onKeyPressed(EventKeyboard::KeyCode code, Event* event)

--- a/templates/cpp/Source/MainScene.h
+++ b/templates/cpp/Source/MainScene.h
@@ -50,10 +50,10 @@ public:
     void onTouchesEnded(const std::vector<ax::Touch*>& touches, ax::Event* event);
 
     // mouse
-    void onMouseDown(ax::Event* event);
-    void onMouseUp(ax::Event* event);
-    void onMouseMove(ax::Event* event);
-    void onMouseScroll(ax::Event* event);
+    bool onMouseDown(ax::Event* event);
+    bool onMouseUp(ax::Event* event);
+    bool onMouseMove(ax::Event* event);
+    bool onMouseScroll(ax::Event* event);
 
     // Keyboard
     void onKeyPressed(ax::EventKeyboard::KeyCode code, ax::Event* event);

--- a/tests/cpp-tests/Source/BaseTest.cpp
+++ b/tests/cpp-tests/Source/BaseTest.cpp
@@ -94,7 +94,7 @@ public:
         ScrollView::onTouchEnded(touch, event);
     }
 
-    void onMouseScroll(Event* event)
+    bool onMouseScroll(Event* event)
     {
         auto mouseEvent = static_cast<EventMouse*>(event);
         float moveY     = mouseEvent->getScrollY() * 20;
@@ -114,6 +114,8 @@ public:
             offset.y = maxOffset.y;
         }
         this->setContentOffset(offset);
+
+        return true;
     }
 
 protected:

--- a/tests/cpp-tests/Source/Box2DTestBed/Box2DTestBed.cpp
+++ b/tests/cpp-tests/Source/Box2DTestBed/Box2DTestBed.cpp
@@ -187,7 +187,7 @@ void Box2DTestBed::onKeyReleased(EventKeyboard::KeyCode code, Event* event)
     m_test->KeyboardUp((static_cast<int>(code) - 59));  // its a bad hack!
 }
 
-void Box2DTestBed::onMouseDown(Event* event)
+bool Box2DTestBed::onMouseDown(Event* event)
 {
     EventMouse* e = (EventMouse*)event;
     button[(int)EventMouse::MouseButton::BUTTON_LEFT]   = false;
@@ -205,16 +205,20 @@ void Box2DTestBed::onMouseDown(Event* event)
         button[(int)EventMouse::MouseButton::BUTTON_MIDDLE] = true;
         break;
     }
+
+    return true;
 }
 
-void Box2DTestBed::onMouseUp(Event* event)
+bool Box2DTestBed::onMouseUp(Event* event)
 {
     button[(int)EventMouse::MouseButton::BUTTON_LEFT]   = false;
     button[(int)EventMouse::MouseButton::BUTTON_RIGHT]  = false;
     button[(int)EventMouse::MouseButton::BUTTON_MIDDLE] = false;
+
+    return true;
 }
 
-void Box2DTestBed::onMouseMove(Event* event)
+bool Box2DTestBed::onMouseMove(Event* event)
 {
     EventMouse* e = (EventMouse*)event;
     auto pt = e->getLocation();
@@ -226,12 +230,16 @@ void Box2DTestBed::onMouseMove(Event* event)
         (pos.y < oldPos.y) ? g_debugDraw.debugNodeOffset.y -= 2 : g_debugDraw.debugNodeOffset.y += 2;
     }
     oldPos = pos;
+
+    return true;
 }
 
-void Box2DTestBed::onMouseScroll(Event* event)
+bool Box2DTestBed::onMouseScroll(Event* event)
 {
     EventMouse* e = (EventMouse*)event;
     g_debugDraw.mRatio += e->getScrollY();
+
+    return true;
 }
 
 void Box2DTestBed::onEnter()

--- a/tests/cpp-tests/Source/Box2DTestBed/Box2DTestBed.h
+++ b/tests/cpp-tests/Source/Box2DTestBed/Box2DTestBed.h
@@ -73,10 +73,10 @@ public:
     void onKeyPressed(ax::EventKeyboard::KeyCode code, ax::Event* event);
     void onKeyReleased(ax::EventKeyboard::KeyCode code, ax::Event* event);
 
-    void onMouseDown(ax::Event* event);
-    void onMouseUp(ax::Event* event);
-    void onMouseMove(ax::Event* event);
-    void onMouseScroll(ax::Event* event);
+    bool onMouseDown(ax::Event* event);
+    bool onMouseUp(ax::Event* event);
+    bool onMouseMove(ax::Event* event);
+    bool onMouseScroll(ax::Event* event);
 
     ax::EventListenerTouchOneByOne* _touchListener;
     ax::EventListenerKeyboard* _keyboardListener;

--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
@@ -425,7 +425,7 @@ void ChipmunkTestBed::onEnter()
     label->setString("");
 }
 
-void ChipmunkTestBed::onMouseDown(Event* event)
+bool ChipmunkTestBed::onMouseDown(Event* event)
 {
     EventMouse* e = (EventMouse*)event;
 
@@ -461,9 +461,11 @@ void ChipmunkTestBed::onMouseDown(Event* event)
         ChipmunkDemoRightDown  = cpTrue;
         ChipmunkDemoRightClick = cpTrue;
     }
+
+    return true;
 }
 
-void ChipmunkTestBed::onMouseUp(Event* event)
+bool ChipmunkTestBed::onMouseUp(Event* event)
 {
     EventMouse* e = (EventMouse*)event;
     mousePresses  = false;
@@ -476,9 +478,11 @@ void ChipmunkTestBed::onMouseUp(Event* event)
     ChipmunkDemoLeftDown   = cpFalse;
     ChipmunkDemoRightDown  = cpFalse;
     ChipmunkDemoRightClick = cpFalse;
+
+    return true;
 }
 
-void ChipmunkTestBed::onMouseMove(Event* event)
+bool ChipmunkTestBed::onMouseMove(Event* event)
 {
     EventMouse* e = (EventMouse*)event;
     auto pt = e->getLocation();
@@ -486,6 +490,8 @@ void ChipmunkTestBed::onMouseMove(Event* event)
     ChipmunkDemoMouse.y = pt.y - physicsDebugNodeOffset.y;
 
     cpBodySetPosition(mouse_body, ChipmunkDemoMouse);
+
+    return true;
 }
 
 void ChipmunkTestBed::updateInit(ChipmunkDemo tt)

--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.h
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.h
@@ -48,9 +48,9 @@ public:
     void update(float dt) override;
     virtual void initPhysics();
 
-    void onMouseDown(ax::Event* event);
-    void onMouseUp(ax::Event* event);
-    void onMouseMove(ax::Event* event);
+    bool onMouseDown(ax::Event* event);
+    bool onMouseUp(ax::Event* event);
+    bool onMouseMove(ax::Event* event);
     void DrawInfo();
     void updateInit(ChipmunkDemo tt);
 

--- a/tests/cpp-tests/Source/InputTest/MouseTest.cpp
+++ b/tests/cpp-tests/Source/InputTest/MouseTest.cpp
@@ -73,35 +73,43 @@ MouseEventTest::~MouseEventTest()
     _eventDispatcher->removeEventListener(_mouseListener);
 }
 
-void MouseEventTest::onMouseDown(Event* event)
+bool MouseEventTest::onMouseDown(Event* event)
 {
     EventMouse* e   = (EventMouse*)event;
     std::string str = "Mouse Down detected, Key: ";
     str += tostr(static_cast<int>(e->getMouseButton()));
     _labelAction->setString(str.c_str());
+
+    return true;
 }
 
-void MouseEventTest::onMouseUp(Event* event)
+bool MouseEventTest::onMouseUp(Event* event)
 {
     EventMouse* e   = (EventMouse*)event;
     std::string str = "Mouse Up detected, Key: ";
     str += tostr(static_cast<int>(e->getMouseButton()));
     _labelAction->setString(str.c_str());
+
+    return true;
 }
 
-void MouseEventTest::onMouseMove(Event* event)
+bool MouseEventTest::onMouseMove(Event* event)
 {
     EventMouse* e   = (EventMouse*)event;
     auto loc = e->getLocation();
     std::string str = fmt::format("MousePosition:({},{})", loc.x, loc.y);
     _labelPosition->setString(str);
+
+    return true;
 }
 
-void MouseEventTest::onMouseScroll(Event* event)
+bool MouseEventTest::onMouseScroll(Event* event)
 {
     EventMouse* e   = (EventMouse*)event;
     std::string str = fmt::format("Mouse Scroll detected, X:{} Y:{}", e->getScrollX(), e->getScrollY());
     _labelAction->setString(str.c_str());
+
+    return true;
 }
 
 std::string MouseEventTest::title() const
@@ -124,9 +132,15 @@ HideMouseTest::HideMouseTest()
 {
 
     _lis              = EventListenerMouse::create();
-    _lis->onMouseDown = [](Event* e) { Director::getInstance()->getGLView()->setCursorVisible(false); };
+    _lis->onMouseDown = [](Event* e) -> bool {
+        Director::getInstance()->getGLView()->setCursorVisible(false);
+        return true;
+    };
 
-    _lis->onMouseUp = [](Event* e) { Director::getInstance()->getGLView()->setCursorVisible(true); };
+    _lis->onMouseUp = [](Event* e) -> bool {
+        Director::getInstance()->getGLView()->setCursorVisible(true);
+        return true;
+    };
 
     _eventDispatcher->addEventListenerWithSceneGraphPriority(_lis, this);
 }

--- a/tests/cpp-tests/Source/InputTest/MouseTest.h
+++ b/tests/cpp-tests/Source/InputTest/MouseTest.h
@@ -42,10 +42,10 @@ public:
     MouseEventTest();
     ~MouseEventTest();
 
-    void onMouseDown(ax::Event* event);
-    void onMouseUp(ax::Event* event);
-    void onMouseMove(ax::Event* event);
-    void onMouseScroll(ax::Event* event);
+    bool onMouseDown(ax::Event* event);
+    bool onMouseUp(ax::Event* event);
+    bool onMouseMove(ax::Event* event);
+    bool onMouseScroll(ax::Event* event);
 
     virtual std::string title() const override;
     virtual std::string subtitle() const override;

--- a/tests/cpp-tests/Source/SpineTest/SpineTest.cpp
+++ b/tests/cpp-tests/Source/SpineTest/SpineTest.cpp
@@ -288,11 +288,13 @@ bool IKExample::init()
     // the current mouse location. The location is converted
     // to the skeleton's coordinate system.
     EventListenerMouse* mouseListener = EventListenerMouse::create();
-    mouseListener->onMouseMove        = [this](ax::Event* event) -> void {
+    mouseListener->onMouseMove        = [this](ax::Event* event) -> bool {
         // convert the mosue location to the skeleton's coordinate space
         // and store it.
         EventMouse* mouseEvent = dynamic_cast<EventMouse*>(event);
         position               = skeletonNode->convertToNodeSpace(mouseEvent->getLocationInView());
+
+        return true;
     };
     _eventDispatcher->addEventListenerWithSceneGraphPriority(mouseListener, this);
 


### PR DESCRIPTION
Hi,
I wanted to add a mouse scroll listener on the UIScrollView to be able to scroll with the mouse. Basically it works, but if we have several scroll views then they will all move, even if the mouse is not over them.

To be able to have only the top widget to handle the mouse scroll and not others, we need to implement the same touches events mechanism but for mouse events. So this will work for scroll event, but also press, released, and moved.
We can also, as for touches, add a listener to our own widgets.
