### PR TITLE
Fixed statsLabel not show after Director::restart()

### DIFF
--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1048,6 +1048,7 @@ void Director::reset()
     AX_SAFE_RELEASE_NULL(_FPSLabel);
     AX_SAFE_RELEASE_NULL(_drawnBatchesLabel);
     AX_SAFE_RELEASE_NULL(_drawnVerticesLabel);
+    _isStatusLabelUpdated = true;
 
     // purge bitmap cache
     FontFNT::purgeCachedData();


### PR DESCRIPTION
I recently have a use case where i need to do Director::restart() and notice that the statsLabel is missing after a restart, after digging around a little bit its seem the issue is we dont set  _isStatusLabelUpdated so the statsLabel never get recreated.
