### PR TITLE
Fix linux crash on exiting cpp-tests after running Scene3DTest

### DIFF
--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1076,7 +1076,7 @@ void Director::cleanupDirector()
 {
     reset();
 
-    // cleanup graphics before release glView, otherwise, will cause crash on linux
+    // should cleanup graphics resources before release glView, otherwise, will cause crash on linux
     AX_SAFE_DELETE(_renderer);
     backend::DriverBase::destroyInstance();
 

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1076,7 +1076,8 @@ void Director::cleanupDirector()
 {
     reset();
 
-    // should cleanup graphics resources before release glView, otherwise, will cause crash on linux
+    // If any graphics resources not cleanup or leaked, will crash on linux when destroy graphics context,
+    // so we should cleanup any graphics resources.
     AX_SAFE_DELETE(_renderer);
     backend::DriverBase::destroyInstance();
 

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -262,10 +262,11 @@ void ProgramState::setUniform(const backend::UniformLocation& uniformLocation, c
 #endif
 }
 
-void ProgramState::setVertexUniform(int location, const void* data, std::size_t size, std::size_t offset)
+void ProgramState::setVertexUniform(int location, const void* data, std::size_t size, int offset)
 {
-    if (location < 0)
+    if (location < 0 || offset < 0)
         return;
+
 #if AX_GLES_PROFILE != 200
     assert(location + offset + size <= _vertexUniformBufferSize);
     memcpy(_uniformBuffers.data() + location + offset, data, size);
@@ -276,9 +277,9 @@ void ProgramState::setVertexUniform(int location, const void* data, std::size_t 
 }
 
 #ifdef AX_USE_METAL
-void ProgramState::setFragmentUniform(int location, const void* data, std::size_t size, std::size_t offset)
+void ProgramState::setFragmentUniform(int location, const void* data, std::size_t size, int offset)
 {
-    if (location < 0)
+    if (location < 0 || offset < 0)
         return;
 
     memcpy(_uniformBuffers.data() + _vertexUniformBufferSize + location + offset, data, size);

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -336,7 +336,7 @@ protected:
      * @param data Specifies the new values to be used for the specified uniform variable.
      * @param size Specifies the uniform data size.
      */
-    void setVertexUniform(int location, const void* data, std::size_t size, std::size_t offset);
+    void setVertexUniform(int location, const void* data, std::size_t size, int offset);
 
 #ifdef AX_USE_METAL
     /**
@@ -345,7 +345,7 @@ protected:
      * @param data Specifies the new values to be used for the specified uniform variable.
      * @param size Specifies the uniform data size.
      */
-    void setFragmentUniform(int location, const void* data, std::size_t size, std::size_t offset);
+    void setFragmentUniform(int location, const void* data, std::size_t size, int offset);
 #endif
 
     /**

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -366,9 +366,6 @@ bool Scene3DTestScene::init()
 void Scene3DTestScene::createWorld3D()
 {
     // create skybox
-    // create and set our custom shader
-    auto shader = ProgramManager::getInstance()->loadProgram("custom/cube_map_vs", "custom/cube_map_fs");
-    auto state  = new ProgramState(shader);
 
     // create the second texture for cylinder
     _textureCube = TextureCube::create("MeshRendererTest/skybox/left.jpg", "MeshRendererTest/skybox/right.jpg",
@@ -381,10 +378,6 @@ void Scene3DTestScene::createWorld3D()
     tRepeatParams.sAddressMode = backend::SamplerAddressMode::MIRROR_REPEAT;
     tRepeatParams.tAddressMode = backend::SamplerAddressMode::MIRROR_REPEAT;
     _textureCube->setTexParameters(tRepeatParams);
-
-    // pass the texture sampler to our custom shader
-    const auto cubeTexLoc = state->getUniformLocation("u_cubeTex");
-    state->setUniform(cubeTexLoc, _textureCube, sizeof(ax::TextureCube));
 
     // add skybox
     _skyBox = Skybox::create();

--- a/tests/lua-tests/Content/src/Scene3DTest/Scene3DTest.lua
+++ b/tests/lua-tests/Content/src/Scene3DTest/Scene3DTest.lua
@@ -310,10 +310,7 @@ function Scene3DTest:create3DWorld()
     self._player:addChild(rootps, 0)
 
     --then, create skybox
-    --create and set our custom shader
 
-    local program = axb.ProgramManager:getInstance():loadProgram('custom/cube_map_vs', 'custom/cube_map_fs')
-    local state = ccb.ProgramState:new(program)
     --create the second texture for cylinder
     self._textureCube = cc.TextureCube:create("MeshRendererTest/skybox/left.jpg", "MeshRendererTest/skybox/right.jpg",
                                        "MeshRendererTest/skybox/top.jpg", "MeshRendererTest/skybox/bottom.jpg",
@@ -322,10 +319,6 @@ function Scene3DTest:create3DWorld()
     --set texture parameters
     local tRepeatParams = { magFilter = ccb.SamplerFilter.LINEAR , minFilter = ccb.SamplerFilter.LINEAR , sAddressMode = ccb.SamplerAddressMode.MIRRORED_REPEAT  , tAddressMode = ccb.SamplerAddressMode.MIRRORED_REPEAT }
     self._textureCube:setTexParameters(tRepeatParams)
-
-    --pass the texture sampler to our custom shader
-    local cubeTexLoc = state:getUniformLocation("u_cubeTex")
-    state:setTexture(cubeTexLoc, 0, self._textureCube:getBackendTexture())
 
     --add skybox
     self._skyBox = cc.Skybox:create()


### PR DESCRIPTION
## Describe your changes

- Improve programState set uniform validation
- Fix linux crash on exiting cpp-tests if Scene3DTest was executed


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
