### PR TITLE
Add parameter `-r` for `axmol new` command to regenerates the missing…

### DIFF
--- a/templates/cpp/axproj-template.json
+++ b/templates/cpp/axproj-template.json
@@ -9,12 +9,17 @@
         {
             "action": "cp",
             "from": "$env:AX_ROOT/.clang-format",
-            "to": "${projectDir}/"
+            "to": "${projectDir}/.clang-format"
         },
         {
             "action": "cp",
             "from": "$env:AX_ROOT/.editorconfig",
-            "to": "${projectDir}/"
+            "to": "${projectDir}/.editorconfig"
+        },
+        {
+            "action": "cp",
+            "from": "$env:AX_ROOT/.gitignore",
+            "to": "${projectDir}/.gitignore"
         },
         {
             "action": "rep",

--- a/templates/lua/axproj-template.json
+++ b/templates/lua/axproj-template.json
@@ -9,12 +9,17 @@
         {
             "action": "cp",
             "from": "$env:AX_ROOT/.clang-format",
-            "to": "${projectDir}/"
+            "to": "${projectDir}/.clang-format"
         },
         {
             "action": "cp",
             "from": "$env:AX_ROOT/.editorconfig",
-            "to": "${projectDir}/"
+            "to": "${projectDir}/.editorconfig"
+        },
+        {
+            "action": "cp",
+            "from": "$env:AX_ROOT/.gitignore",
+            "to": "${projectDir}/.gitignore"
         },
         {
             "action": "rep",
@@ -50,7 +55,7 @@
         {
             "action": "cp",
             "from": "$env:AX_ROOT/extensions/scripting/lua-bindings/manual/lua_module_register.h",
-            "to": "${projectDir}/Source/"
+            "to": "${projectDir}/Source/lua_module_register.h"
         },
         {
             "action": "ren",

--- a/tools/cmdline/axmol.ps1
+++ b/tools/cmdline/axmol.ps1
@@ -250,20 +250,25 @@ usage: axmol new -p dev.axmol.hellocpp -d path/to/project -l cpp --portrait <Pro
 Creates a new project.
 
 positional arguments:
-    PROJECT_NAME          Set the project name.
+    PROJECT_NAME        [mandatory] Set the project name.
 
 options:
     -h                  Show this help message and exit
     -p PACKAGE_NAME
-                        Set a package name for project.
+                        [optional] Set a package name for project, default is dev.axmol.demo.
     -d DIRECTORY
-                        Set the path where to place the new project.
+                        [optional] Set the path where to place the new project, default is current directory.
     -l {cpp,lua}
-                        Major programming language you want to use, should be [cpp | lua]
+                        [optional] Major programming language you want to use, should be [cpp | lua], default is cpp.
     --portrait
-                        Set the project be portrait.
+                        [optional] set the project be portrait, default is landscape.
     -i[solated]
-                        optionl, if present, will copy full engine sources to path/to/project/axmol
+                        [optional] if present, will copy full engine sources to path/to/project/axmol
+    -r[epair]
+                        [optional] if present, will create missing common files in the project directory without overwriting existing content.
+    -f[orceOverwrite]
+                        [optional] if present, will overwrite existing files in the project directory, except for the .axproj file, the Content folder, and the Source folder.
+
 "@;
     };
     build  = @{

--- a/tools/cmdline/axmol_new.ps1
+++ b/tools/cmdline/axmol_new.ps1
@@ -47,13 +47,19 @@ if($projectExists -and !$repair) {
     return
 }
 
+if(!$projectExists) { $repair = $false }
+
 # replace, file/files, from/pattern
 
 $template_cfg_file = Join-Path $sourcePath 'axproj-template.json'
 $template_cfg = ConvertFrom-Json (Get-Content $template_cfg_file -Raw)
 
 # variable for replace
-println "Creating project $projectName ..."
+if(!$repair) {
+    println "Creating project $projectName ..."
+} else {
+    println "Repairing project $projectName ..."
+}
 println "==> packageName: $packageName"
 println "==> destinationPath: $destinationPath"
 println "==> lang: $lang"
@@ -205,4 +211,8 @@ if (!$repair -or !(Test-Path $proj_file -PathType Leaf)) {
     println "Skipping repairing: $proj_file, already exists."
 }
 
-println "Create project $projectName done."
+if(!$repair) {
+    println "Create project $projectName done."
+} else {
+    println "Repair project $projectName done."
+}

--- a/tools/cmdline/axmol_new.ps1
+++ b/tools/cmdline/axmol_new.ps1
@@ -2,7 +2,8 @@ param(
     $packageName,
     $directory,
     $lang,
-    [switch]$isolated
+    [switch]$isolated,
+    [switch]$repair
 )
 
 $params = [System.Collections.ArrayList]$args
@@ -40,9 +41,8 @@ if(!(Test-Path $sourcePath)) {
 
 $destinationPath = Join-Path $directory $projectName
 
-if(!(Test-Path $destinationPath -PathType Container)) {
-    Copy-Item $sourcePath $destinationPath -Recurse -Container -Force
-} else {
+$projectExists = Test-Path $destinationPath -PathType Container
+if($projectExists -and !$repair) {
     println "$destinationPath folder is already exist."
     return
 }
@@ -53,13 +53,52 @@ $template_cfg_file = Join-Path $sourcePath 'axproj-template.json'
 $template_cfg = ConvertFrom-Json (Get-Content $template_cfg_file -Raw)
 
 # variable for replace
-$projectDir = $(Resolve-Path $destinationPath).Path
-
 println "Creating project $projectName ..."
 println "==> packageName: $packageName"
 println "==> destinationPath: $destinationPath"
 println "==> lang: $lang"
 println "==> is_portrait: $is_portrait"
+
+# copy language spec files
+if(!$projectExists) {
+    Copy-Item $sourcePath $destinationPath -Recurse -Container -Force
+}
+
+$projectDir = $(Resolve-Path $destinationPath).Path
+
+function repair_directories ($Source, $Destination) {
+    if($Source -match '[\\/]\*$') {
+        $Source = $Source -replace '[\\/]\*$', ''
+    }
+
+    if (-not (Test-Path -LiteralPath $Source)) {
+        Throw "Source path '$Source' does not exist."
+    }
+
+    if (-not (Test-Path -LiteralPath $Destination)) {
+        New-Item -ItemType Directory $Destination | Out-Null
+    }
+
+    Get-ChildItem -LiteralPath $Source | ForEach-Object {
+        $target = Join-Path -Path $Destination -ChildPath $_.Name
+
+        if ($_.PSIsContainer) {
+            if (-not (Test-Path -LiteralPath $target)) {
+                New-Item -ItemType Directory $target | Out-Null
+            }
+            repair_directories -Source $_.FullName -Destination $target
+        }
+        else {
+            if (!(Test-Path $target -PathType Leaf)) {
+                println "Repairing: $target"
+                Copy-Item $_.FullName -Destination $target -Force
+            }
+            else {
+                println "Skipping repairing: $target, already exists."
+            }
+        }
+    }
+}
 
 # actionParam
 #   rep
@@ -92,10 +131,16 @@ function perform_action($actionParam) {
             }
         }
         'cp' {
+            $to = realpath $to
             if (!$actionParam.is_dir) {
-                Copy-Item -Path $from -Destination $to -Force
+                if (!$repair -or !(Test-Path $to -PathType Leaf)) { Copy-Item -Path $from -Destination $to -Force }
+                else { println "Skipping repairing: $to, already exists." }
             } else {
-                Copy-Item -Path $from -Destination $to -Recurse -Container -Force
+                if(!$repair) {
+                    Copy-Item -Path $from -Destination $to -Recurse -Container -Force
+                } else {
+                    repair_directories -Source $from -Destination $to
+                }
             }
         }
         'ren' {
@@ -138,6 +183,11 @@ if($isolated) {
     )
     foreach($path in $_ax_source_folders) {
         $source_path = Join-Path $env:AX_ROOT $path
+        $dest_path = Join-Path $_ax_root $path
+        if ($repair -and (Test-Path $dest_path)) {
+            println println "Skipping repairing: $dest_path, already exists."
+            continue
+        }
         if(Test-Path $source_path -PathType Container) {
             Copy-Item $source_path $_ax_root -Container -Recurse -Force
         } else {
@@ -147,7 +197,12 @@ if($isolated) {
 }
 
 # write .axproj
-$axprojInfo = "package_name=$packageName`nengine_version=$axmolVersion`nproject_type=$lang"
-Set-Content -Path "$projectDir/.axproj" -Value $axprojInfo
+$proj_file = Join-Path $projectDir '.axproj'
+if (!$repair -or !(Test-Path $proj_file -PathType Leaf)) {
+    $axprojInfo = "package_name=$packageName`nengine_version=$axmolVersion`nproject_type=$lang"
+    Set-Content -Path $proj_file -Value $axprojInfo
+} else {
+    println "Skipping repairing: $proj_file, already exists."
+}
 
 println "Create project $projectName done."

--- a/tools/cmdline/axmol_new.ps1
+++ b/tools/cmdline/axmol_new.ps1
@@ -3,7 +3,8 @@ param(
     $directory,
     $lang,
     [switch]$isolated,
-    [switch]$repair
+    [switch]$repair,
+    [switch]$forceOverwrite
 )
 
 $params = [System.Collections.ArrayList]$args
@@ -99,6 +100,10 @@ function repair_directories ($Source, $Destination) {
                 println "Repairing: $target"
                 Copy-Item $_.FullName -Destination $target -Force
             }
+            elseif($forceOverwrite) {
+                println "Overwriting: $target"
+                Copy-Item $_.FullName -Destination $target -Force
+            }
             else {
                 println "Skipping repairing: $target, already exists."
             }
@@ -138,12 +143,24 @@ function perform_action($actionParam) {
         }
         'cp' {
             $to = realpath $to
-            if (!$actionParam.is_dir) {
-                if (!$repair -or !(Test-Path $to -PathType Leaf)) { Copy-Item -Path $from -Destination $to -Force }
-                else { println "Skipping repairing: $to, already exists." }
-            } else {
-                if(!$repair) {
+            if(!$repair) {
+                if(!$actionParam.is_dir) {
+                    Copy-Item -Path $from -Destination $to -Force
+                }
+                else {
                     Copy-Item -Path $from -Destination $to -Recurse -Container -Force
+                }
+            } else {
+                if (!$actionParam.is_dir) {
+                    if (!(Test-Path $to -PathType Leaf)) { 
+                        println "Repairing: $to"
+                        Copy-Item -Path $from -Destination $to -Force 
+                    }
+                    elseif($forceOverwrite) {
+                        println "Overwriting: $to"
+                        Copy-Item -Path $from -Destination $to -Force
+                    }
+                    else { println "Skipping repairing: $to, already exists." }
                 } else {
                     repair_directories -Source $from -Destination $to
                 }


### PR DESCRIPTION
… common template files

## Describe your changes

- Add parameter `-r` for `axmol new` command

usage: `axmol new HelloCpp -r`

## Issue ticket number and link

#2591

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
