### PR TITLE
Rename GLView to RenderView

### DIFF
--- a/CMakeOptions.md
+++ b/CMakeOptions.md
@@ -41,7 +41,7 @@
   - win32: whether use ANGLE GLES backend
   - osx: whether use OpenGL instead Metal backend
   - ios/tvos: whether use GLES instead Metal backend
-- AX_CORE_PROFILE: whether strip deprecated features, default `FALSE`
+- AX_CORE_PROFILE: whether strip all deprecated features, default `FALSE`, it's useful to pre-upgrade your game project to adapte future axmol versions
 - AX_ISA_LEVEL: specifiy SIMD Instructions Acceleration Level: 0~4, 0: disabled, 1: SSE2, 2: SSE4.1/NEON, 3: SSE4.2, 4: AVX2, default: 2
 - AX_GLES_PROFILE: specify GLES profile version for GLES backend, valid value `200`, `300`
 - AX_WASM_THREADS: specify wasm thread count, valid value: number: `>=0` , string: must be: `auto` or `navigator.hardwareConcurrency`(default), 

--- a/core/2d/Camera.cpp
+++ b/core/2d/Camera.cpp
@@ -28,7 +28,7 @@
  ****************************************************************************/
 #include "2d/Camera.h"
 #include "2d/CameraBackgroundBrush.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #include "2d/Scene.h"
 #include "renderer/Renderer.h"
 #include "renderer/QuadCommand.h"

--- a/core/2d/ClippingRectangleNode.cpp
+++ b/core/2d/ClippingRectangleNode.cpp
@@ -25,7 +25,7 @@
 #include "base/Director.h"
 #include "renderer/Renderer.h"
 #include "math/Vec2.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 
 namespace ax
 {
@@ -79,8 +79,8 @@ void ClippingRectangleNode::onBeforeVisitScissor()
         }
 
         const Point pos = convertToWorldSpace(Point(_clippingRegion.origin.x, _clippingRegion.origin.y));
-        GLView* glView  = _director->getGLView();
-        glView->setScissorInPoints(pos.x, pos.y, _clippingRegion.size.width * scaleX,
+        RenderView* renderView  = _director->getRenderView();
+        renderView->setScissorInPoints(pos.x, pos.y, _clippingRegion.size.width * scaleX,
                                    _clippingRegion.size.height * scaleY);
     }
 }

--- a/core/2d/TextFieldTTF.cpp
+++ b/core/2d/TextFieldTTF.cpp
@@ -211,11 +211,9 @@ bool TextFieldTTF::attachWithIME()
     if (ret)
     {
         // open keyboard
-        auto pGlView = _director->getGLView();
-        if (pGlView)
-        {
-            pGlView->setIMEKeyboardState(true);
-        }
+        auto renderView = _director->getRenderView();
+        if (renderView)
+            renderView->setIMEKeyboardState(true);
     }
     return ret;
 }
@@ -226,11 +224,9 @@ bool TextFieldTTF::detachWithIME()
     if (ret)
     {
         // close keyboard
-        auto glView = _director->getGLView();
-        if (glView)
-        {
-            glView->setIMEKeyboardState(false);
-        }
+        auto renderView = _director->getRenderView();
+        if (renderView)
+            renderView->setIMEKeyboardState(false);
     }
     return ret;
 }

--- a/core/axmol.h
+++ b/core/axmol.h
@@ -186,47 +186,47 @@ THE SOFTWARE.
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
 #    include "platform/ios/Application-ios.h"
-#    include "platform/ios/GLViewImpl-ios.h"
+#    include "platform/ios/RenderViewImpl-ios.h"
 #    include "platform/ios/StdC-ios.h"
 #endif  // AX_TARGET_PLATFORM == AX_PLATFORM_IOS
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID)
 #    include "platform/android/Application-android.h"
-#    include "platform/android/GLViewImpl-android.h"
+#    include "platform/android/RenderViewImpl-android.h"
 #    include "platform/android/GL-android.h"
 #    include "platform/android/StdC-android.h"
 #endif  // AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
 #    include "platform/win32/Application-win32.h"
-#    include "platform/GLViewImpl.h"
+#    include "platform/RenderViewImpl.h"
 #    include "platform/win32/GL-win32.h"
 #    include "platform/win32/StdC-win32.h"
 #endif  // AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WINRT)
 #    include "platform/winrt/Application-winrt.h"
-#    include "platform/winrt/GLViewImpl-winrt.h"
+#    include "platform/winrt/RenderViewImpl-winrt.h"
 #    include "platform/winrt/GL-winrt.h"
 #    include "platform/winrt/StdC-winrt.h"
 #endif  // AX_TARGET_PLATFORM == AX_PLATFORM_WINRT
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-#    include "platform/GLViewImpl.h"
+#    include "platform/RenderViewImpl.h"
 #    include "platform/mac/Application-mac.h"
 #    include "platform/mac/StdC-mac.h"
 #endif  // AX_TARGET_PLATFORM == AX_PLATFORM_MAC
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
 #    include "platform/linux/Application-linux.h"
-#    include "platform/GLViewImpl.h"
+#    include "platform/RenderViewImpl.h"
 #    include "platform/linux/GL-linux.h"
 #    include "platform/linux/StdC-linux.h"
 #endif  // AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WASM)
     #include "platform/wasm/Application-wasm.h"
-    #include "platform/GLViewImpl.h"
+    #include "platform/RenderViewImpl.h"
     #include "platform/wasm/GL-wasm.h"
     #include "platform/wasm/StdC-wasm.h"
 #endif // AX_TARGET_PLATFORM == AX_PLATFORM_WASM

--- a/core/base/Console.cpp
+++ b/core/base/Console.cpp
@@ -1110,7 +1110,7 @@ void Console::commandResolution(socket_native_type /*fd*/, std::string_view args
 
     Scheduler* sched = Director::getInstance()->getScheduler();
     sched->runOnAxmolThread([=]() {
-        Director::getInstance()->getGLView()->setDesignResolutionSize(width, height,
+        Director::getInstance()->getRenderView()->setDesignResolutionSize(width, height,
                                                                       static_cast<ResolutionPolicy>(policy));
     });
 }
@@ -1120,10 +1120,10 @@ void Console::commandResolutionSubCommandEmpty(socket_native_type fd, std::strin
     auto director        = Director::getInstance();
     Vec2 points          = director->getWinSize();
     Vec2 pixels          = director->getWinSizeInPixels();
-    auto glView          = director->getGLView();
-    Vec2 design          = glView->getDesignResolutionSize();
-    ResolutionPolicy res = glView->getResolutionPolicy();
-    Rect visibleRect     = glView->getVisibleRect();
+    auto renderView          = director->getRenderView();
+    Vec2 design          = renderView->getDesignResolutionSize();
+    ResolutionPolicy res = renderView->getResolutionPolicy();
+    Rect visibleRect     = renderView->getVisibleRect();
 
     Console::Utility::mydprintf(fd,
                                 "Window size:\n"
@@ -1175,8 +1175,8 @@ void Console::commandTouchSubCommandTap(socket_native_type fd, std::string_view 
         _touchId         = rand();
         Scheduler* sched = Director::getInstance()->getScheduler();
         sched->runOnAxmolThread([&]() {
-            Director::getInstance()->getGLView()->handleTouchesBegin(1, &_touchId, &x, &y);
-            Director::getInstance()->getGLView()->handleTouchesEnd(1, &_touchId, &x, &y);
+            Director::getInstance()->getRenderView()->handleTouchesBegin(1, &_touchId, &x, &y);
+            Director::getInstance()->getRenderView()->handleTouchesEnd(1, &_touchId, &x, &y);
         });
     }
     else
@@ -1205,7 +1205,7 @@ void Console::commandTouchSubCommandSwipe(socket_native_type fd, std::string_vie
         Scheduler* sched = Director::getInstance()->getScheduler();
         sched->runOnAxmolThread([x1, y1, this]() {
             float tempx = x1, tempy = y1;
-            Director::getInstance()->getGLView()->handleTouchesBegin(1, &_touchId, &tempx, &tempy);
+            Director::getInstance()->getRenderView()->handleTouchesBegin(1, &_touchId, &tempx, &tempy);
         });
 
         float dx  = std::abs(x1 - x2);
@@ -1234,7 +1234,7 @@ void Console::commandTouchSubCommandSwipe(socket_native_type fd, std::string_vie
                 }
                 sched->runOnAxmolThread([_x_, _y_, this]() {
                     float tempx = _x_, tempy = _y_;
-                    Director::getInstance()->getGLView()->handleTouchesMove(1, &_touchId, &tempx, &tempy);
+                    Director::getInstance()->getRenderView()->handleTouchesMove(1, &_touchId, &tempx, &tempy);
                 });
                 dx -= 1;
             }
@@ -1261,7 +1261,7 @@ void Console::commandTouchSubCommandSwipe(socket_native_type fd, std::string_vie
                 }
                 sched->runOnAxmolThread([_x_, _y_, this]() {
                     float tempx = _x_, tempy = _y_;
-                    Director::getInstance()->getGLView()->handleTouchesMove(1, &_touchId, &tempx, &tempy);
+                    Director::getInstance()->getRenderView()->handleTouchesMove(1, &_touchId, &tempx, &tempy);
                 });
                 dy -= 1;
             }
@@ -1269,7 +1269,7 @@ void Console::commandTouchSubCommandSwipe(socket_native_type fd, std::string_vie
 
         sched->runOnAxmolThread([x2, y2, this]() {
             float tempx = x2, tempy = y2;
-            Director::getInstance()->getGLView()->handleTouchesEnd(1, &_touchId, &tempx, &tempy);
+            Director::getInstance()->getRenderView()->handleTouchesEnd(1, &_touchId, &tempx, &tempy);
         });
     }
     else

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -264,7 +264,7 @@ void Director::setDefaultValues()
 void Director::setGLDefaultValues()
 {
     // This method SHOULD be called only after glView_ was initialized
-    AXASSERT(_glView, "opengl view should not be null");
+    AXASSERT(_renderView, "opengl view should not be null");
 
     _renderer->setDepthTest(false);
     _renderer->setDepthCompareFunction(backend::CompareFunction::LESS_EQUAL);
@@ -279,9 +279,9 @@ void Director::drawScene()
     // calculate "global" dt
     calculateDeltaTime();
 
-    if (_glView)
+    if (_renderView)
     {
-        _glView->pollEvents();
+        _renderView->pollEvents();
     }
 
     // tick before glClear: issue #533
@@ -316,8 +316,8 @@ void Director::drawScene()
         _renderer->clearDrawStats();
 
         // render the scene
-        if (_glView)
-            _glView->renderScene(_runningScene, _renderer);
+        if (_renderView)
+            _renderView->renderScene(_runningScene, _renderer);
 
         _eventDispatcher->dispatchEvent(_eventAfterVisit);
     }
@@ -346,9 +346,9 @@ void Director::drawScene()
     _totalFrames++;
 
     // swap buffers
-    if (_glView)
+    if (_renderView)
     {
-        _glView->swapBuffers();
+        _renderView->swapBuffers();
     }
 
     _renderer->endFrame();
@@ -399,26 +399,26 @@ void Director::setRenderView(RenderView* renderView)
 {
     AXASSERT(renderView, "opengl view should not be null");
 
-    if (_glView != renderView)
+    if (_renderView != renderView)
     {
         // Configuration. Gather GPU info
         Configuration* conf = Configuration::getInstance();
         conf->gatherGPUInfo();
         AXLOGI("{}\n", conf->getInfo());
 
-        if (_glView)
-            _glView->release();
-        _glView = renderView;
-        _glView->retain();
+        if (_renderView)
+            _renderView->release();
+        _renderView = renderView;
+        _renderView->retain();
 
         // set size
-        _winSizeInPoints = _glView->getDesignResolutionSize();
+        _winSizeInPoints = _renderView->getDesignResolutionSize();
 
         _isStatusLabelUpdated = true;
 
         _renderer->init();
 
-        if (_glView)
+        if (_renderView)
         {
             setGLDefaultValues();
         }
@@ -451,9 +451,9 @@ void Director::destroyTextureCache()
 
 void Director::setViewport()
 {
-    if (_glView)
+    if (_renderView)
     {
-        _glView->setViewPortInPoints(0, 0, _winSizeInPoints.width, _winSizeInPoints.height);
+        _renderView->setViewPortInPoints(0, 0, _winSizeInPoints.width, _winSizeInPoints.height);
     }
 }
 
@@ -721,7 +721,7 @@ Vec2 Director::convertToGL(const Vec2& uiPoint)
     // Calculate z=0 using -> transform*[0, 0, 0, 1]/w
     float zClip = transform.m[14] / transform.m[15];
 
-    Vec2 glSize = _glView->getDesignResolutionSize();
+    Vec2 glSize = _renderView->getDesignResolutionSize();
     Vec4 clipCoord(2.0f * uiPoint.x / glSize.width - 1.0f, 1.0f - 2.0f * uiPoint.y / glSize.height, zClip, 1);
 
     Vec4 glCoord;
@@ -753,7 +753,7 @@ Vec2 Director::convertToUI(const Vec2& glPoint)
     clipCoord.y = clipCoord.y / clipCoord.w;
     clipCoord.z = clipCoord.z / clipCoord.w;
 
-    Vec2 glSize  = _glView->getDesignResolutionSize();
+    Vec2 glSize  = _renderView->getDesignResolutionSize();
     float factor = 1.0f / glCoord.w;
     return Vec2(glSize.width * (clipCoord.x * 0.5f + 0.5f) * factor,
                 glSize.height * (-clipCoord.y * 0.5f + 0.5f) * factor);
@@ -771,9 +771,9 @@ Vec2 Director::getWinSizeInPixels() const
 
 Vec2 Director::getVisibleSize() const
 {
-    if (_glView)
+    if (_renderView)
     {
-        return _glView->getVisibleSize();
+        return _renderView->getVisibleSize();
     }
     else
     {
@@ -783,9 +783,9 @@ Vec2 Director::getVisibleSize() const
 
 Vec2 Director::getVisibleOrigin() const
 {
-    if (_glView)
+    if (_renderView)
     {
-        return _glView->getVisibleOrigin();
+        return _renderView->getVisibleOrigin();
     }
     else
     {
@@ -795,9 +795,9 @@ Vec2 Director::getVisibleOrigin() const
 
 Rect Director::getSafeAreaRect() const
 {
-    if (_glView)
+    if (_renderView)
     {
-        return _glView->getSafeAreaRect();
+        return _renderView->getSafeAreaRect();
     }
     else
     {
@@ -1082,10 +1082,10 @@ void Director::cleanupDirector()
     backend::DriverBase::destroyInstance();
 
     // OpenGL view
-    if (_glView)
+    if (_renderView)
     {
-        _glView->end();
-        _glView = nullptr;
+        _renderView->end();
+        _renderView = nullptr;
     }
 
 #if AX_TARGET_PLATFORM == AX_PLATFORM_IOS || AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
@@ -1522,7 +1522,7 @@ void Director::queueOperation(AsyncOperation op, void* param)
 #if defined(AX_PLATFORM_PC)
     _operations.enqueue([=]() { op(param); });
 #else
-    _glView->queueOperation(op, param);
+    _renderView->queueOperation(op, param);
 #endif
 }
 

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -395,11 +395,11 @@ float Director::getDeltaTime() const
 {
     return _deltaTime;
 }
-void Director::setGLView(GLView* glView)
+void Director::setRenderView(RenderView* renderView)
 {
-    AXASSERT(glView, "opengl view should not be null");
+    AXASSERT(renderView, "opengl view should not be null");
 
-    if (_glView != glView)
+    if (_glView != renderView)
     {
         // Configuration. Gather GPU info
         Configuration* conf = Configuration::getInstance();
@@ -408,7 +408,7 @@ void Director::setGLView(GLView* glView)
 
         if (_glView)
             _glView->release();
-        _glView = glView;
+        _glView = renderView;
         _glView->retain();
 
         // set size
@@ -676,7 +676,7 @@ void Director::purgeCachedData()
     FontFNT::purgeCachedData();
     FontAtlasCache::purgeCachedData();
 
-    if (s_SharedDirector->getGLView())
+    if (s_SharedDirector->getRenderView())
     {
         SpriteFrameCache::getInstance()->removeUnusedSpriteFrames();
         _textureCache->removeUnusedTextures();

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -168,7 +168,7 @@ public:
      * Get the RenderView.
      * @lua NA
      */
-    RenderView* getRenderView() { return _glView; }
+    RenderView* getRenderView() { return _renderView; }
     /**
      * Sets the RenderView.
      * @lua NA
@@ -580,9 +580,9 @@ protected:
     float _deltaTime              = 0.0f;
     bool _deltaTimePassedByCaller = false;
 
-    /* The _glView, where everything is rendered, RenderView is a abstract class,cocos2d-x provide RenderViewImpl
+    /* The _renderView, where everything is rendered, RenderView is a abstract class,cocos2d-x provide RenderViewImpl
      which inherit from it as default renderer context,you can have your own by inherit from it*/
-    RenderView* _glView = nullptr;
+    RenderView* _renderView = nullptr;
 
     JobSystem* _jobSystem = nullptr;
 

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -37,7 +37,7 @@ THE SOFTWARE.
 #include "base/Vector.h"
 #include "2d/Scene.h"
 #include "math/Math.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #if defined(AX_PLATFORM_PC)
 #    include "concurrentqueue/concurrentqueue.h"
 #endif
@@ -57,7 +57,7 @@ namespace ax
 
 /* Forward declarations. */
 class LabelAtlas;
-// class GLView;
+// class RenderView;
 class DirectorDelegate;
 class Node;
 class Scheduler;
@@ -165,15 +165,15 @@ public:
     /** Sets the FPS value. */
 
     /**
-     * Get the GLView.
+     * Get the RenderView.
      * @lua NA
      */
-    GLView* getGLView() { return _glView; }
+    RenderView* getRenderView() { return _glView; }
     /**
-     * Sets the GLView.
+     * Sets the RenderView.
      * @lua NA
      */
-    void setGLView(GLView* glView);
+    void setRenderView(RenderView* renderView);
 
     /*
      * Gets singleton of TextureCache.
@@ -235,7 +235,7 @@ public:
 
     /**
      * Returns visible size of the OpenGL view in points.
-     * The value is equal to `Director::getWinSize()` if don't invoke `GLView::setDesignResolutionSize()`.
+     * The value is equal to `Director::getWinSize()` if don't invoke `RenderView::setDesignResolutionSize()`.
      */
     Vec2 getVisibleSize() const;
 
@@ -580,9 +580,9 @@ protected:
     float _deltaTime              = 0.0f;
     bool _deltaTimePassedByCaller = false;
 
-    /* The _glView, where everything is rendered, GLView is a abstract class,cocos2d-x provide GLViewImpl
+    /* The _glView, where everything is rendered, RenderView is a abstract class,cocos2d-x provide RenderViewImpl
      which inherit from it as default renderer context,you can have your own by inherit from it*/
-    GLView* _glView = nullptr;
+    RenderView* _glView = nullptr;
 
     JobSystem* _jobSystem = nullptr;
 
@@ -666,8 +666,8 @@ protected:
     EventListenerCustom* _rendererRecreatedListener = nullptr;
 #endif
 
-    // GLView will recreate stats labels to fit visible rect
-    friend class GLView;
+    // RenderView will recreate stats labels to fit visible rect
+    friend class RenderView;
 };
 
 // end of base group

--- a/core/base/EventTouch.h
+++ b/core/base/EventTouch.h
@@ -92,7 +92,7 @@ private:
     EventCode _eventCode;
     std::vector<Touch*> _touches;
 
-    friend class GLView;
+    friend class RenderView;
 };
 
 }

--- a/core/base/Macros.h
+++ b/core/base/Macros.h
@@ -108,7 +108,7 @@ default gl blend src function. Compatible with premultiplied alpha images.
 
 /** @def AX_DIRECTOR_END
  Stops and removes the director from memory.
- Removes the GLView from its parent
+ Removes the RenderView from its parent
 
  @since v0.99.4
  */

--- a/core/base/ScriptSupport.cpp
+++ b/core/base/ScriptSupport.cpp
@@ -59,7 +59,7 @@ ScriptHandlerEntry::~ScriptHandlerEntry()
     if (_handler != 0)
     {
         ScriptEngineManager::getInstance()->getScriptEngine()->removeScriptHandler(_handler);
-        AXLOGD("[LUA] Remove event handler: %d", _handler);
+        AXLOGD("[LUA] Remove event handler: {}", _handler);
         _handler = 0;
     }
 }

--- a/core/platform/ApplicationBase.h
+++ b/core/platform/ApplicationBase.h
@@ -98,12 +98,20 @@ public:
     /** Subclass override the function to set OpenGL context attribution instead of use default value.
      * And now can only set six attributions:redBits,greenBits,blueBits,alphaBits,depthBits,stencilBits.
      * Default value are(5,6,5,0,16,0), usually use as follows:
-     * void AppDelegate::initGLContextAttrs(){
-     *     GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8};
-     *     GLView::setGLContextAttrs(glContextAttrs);
+     * void AppDelegate::initGfxContextAttrs(){
+     *     GfxContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8};
+     *     RenderView::setGfxContextAttrs(gfxContextAttrs);
      * }
      */
-    virtual void initGLContextAttrs() {}
+#ifndef AX_CORE_PROFILE
+    AX_DEPRECATED(2.8) virtual void initGLContextAttrs() {}
+#endif
+    virtual void initGfxContextAttrs()
+    {
+#ifndef AX_CORE_PROFILE
+        initGLContextAttrs();
+#endif
+    }
 
     /**
     @brief Get current language config.

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -27,7 +27,7 @@ if(ANDROID)
   set(_AX_PLATFORM_SPECIFIC_SRC
     platform/android/Application-android.cpp
     platform/android/Common-android.cpp
-    platform/android/GLViewImpl-android.cpp
+    platform/android/RenderViewImpl-android.cpp
     platform/android/FileUtils-android.cpp
   )
 elseif(WINDOWS)
@@ -37,7 +37,7 @@ elseif(WINDOWS)
       platform/win32/GL-win32.h
       platform/win32/FileUtils-win32.h
       platform/win32/StdC-win32.h
-      platform/GLViewImpl.h
+      platform/RenderViewImpl.h
     )
     set(_AX_PLATFORM_SPECIFIC_SRC
       platform/win32/StdC-win32.cpp
@@ -45,7 +45,7 @@ elseif(WINDOWS)
       platform/win32/Common-win32.cpp
       platform/win32/Application-win32.cpp
       platform/win32/Device-win32.cpp
-      platform/GLViewImpl.cpp
+      platform/RenderViewImpl.cpp
     )
   else()
     file(GLOB _AX_PLATFORM_SPECIFIC_HEADER platform/winrt/*.h)
@@ -67,23 +67,23 @@ elseif(APPLE)
       ${_AX_PLATFORM_SPECIFIC_HEADER}
       platform/mac/StdC-mac.h
       platform/mac/Application-mac.h
-      platform/GLViewImpl.h
+      platform/RenderViewImpl.h
     )
     set(_AX_PLATFORM_SPECIFIC_SRC
       ${_AX_PLATFORM_SPECIFIC_SRC}
       platform/mac/Application-mac.mm
       platform/mac/Common-mac.mm
       platform/mac/Device-mac.mm
-      platform/GLViewImpl.cpp
+      platform/RenderViewImpl.cpp
     )
-    set_source_files_properties(platform/GLViewImpl.cpp PROPERTIES LANGUAGE OBJCXX)
+    set_source_files_properties(platform/RenderViewImpl.cpp PROPERTIES LANGUAGE OBJCXX)
   elseif(IOS)
     set(_AX_PLATFORM_SPECIFIC_HEADER
       ${_AX_PLATFORM_SPECIFIC_HEADER}
       platform/ios/Application-ios.h
       platform/ios/DirectorCaller-ios.h
-      platform/ios/EAGLView-ios.h
-      platform/ios/GLViewImpl-ios.h
+      platform/ios/EARenderView-ios.h
+      platform/ios/RenderViewImpl-ios.h
       platform/ios/StdC-ios.h
       platform/ios/InputView-ios.h
     )
@@ -93,8 +93,8 @@ elseif(APPLE)
       platform/ios/Common-ios.mm
       platform/ios/Device-ios.mm
       platform/ios/DirectorCaller-ios.mm
-      platform/ios/EAGLView-ios.mm
-      platform/ios/GLViewImpl-ios.mm
+      platform/ios/EARenderView-ios.mm
+      platform/ios/RenderViewImpl-ios.mm
       platform/ios/Image-ios.mm
       platform/ios/InputView-ios.mm
     )
@@ -128,14 +128,14 @@ elseif(LINUX)
     platform/linux/GL-linux.h
     platform/linux/StdC-linux.h
     platform/linux/FileUtils-linux.h
-    platform/GLViewImpl.h
+    platform/RenderViewImpl.h
   )
   set(_AX_PLATFORM_SPECIFIC_SRC
     platform/linux/FileUtils-linux.cpp
     platform/linux/Common-linux.cpp
     platform/linux/Application-linux.cpp
     platform/linux/Device-linux.cpp
-    platform/GLViewImpl.cpp
+    platform/RenderViewImpl.cpp
   )
 elseif(EMSCRIPTEN)
   include_directories(
@@ -147,14 +147,14 @@ elseif(EMSCRIPTEN)
     platform/wasm/GL-wasm.h
     platform/wasm/StdC-wasm.h
     platform/wasm/FileUtils-wasm.h
-    platform/GLViewImpl.h # wasm can share GLviewImpl-desktop based on GLFW
+    platform/RenderViewImpl.h # wasm can share GLviewImpl-desktop based on GLFW
   )
   set(_AX_PLATFORM_SPECIFIC_SRC
     platform/wasm/FileUtils-wasm.cpp
     platform/wasm/Common-wasm.cpp
     platform/wasm/Application-wasm.cpp
     platform/wasm/Device-wasm.cpp
-    platform/GLViewImpl.cpp
+    platform/RenderViewImpl.cpp
   )
 
   if(AX_WASM_ENABLE_DEVTOOLS)
@@ -170,7 +170,7 @@ set(_AX_PLATFORM_HEADER
   platform/Device.h
   platform/FileUtils.h
   platform/GL.h
-  platform/GLView.h
+  platform/RenderView.h
   platform/Image.h
   platform/PlatformConfig.h
   platform/PlatformDefine.h
@@ -184,7 +184,7 @@ set(_AX_PLATFORM_HEADER
 set(_AX_PLATFORM_SRC
   ${_AX_PLATFORM_SPECIFIC_SRC}
   platform/SAXParser.cpp
-  platform/GLView.cpp
+  platform/RenderView.cpp
   platform/FileUtils.cpp
   platform/Image.cpp
   platform/FileStream.cpp

--- a/core/platform/RenderView.cpp
+++ b/core/platform/RenderView.cpp
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 
 #include "base/Touch.h"
 #include "base/Director.h"
@@ -98,19 +98,19 @@ static void removeUsedIndexBit(int index)
 }  // namespace
 
 // default context attributions are set as follows
-GLContextAttrs GLView::_glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+GfxContextAttrs RenderView::_gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
 
-void GLView::setGLContextAttrs(GLContextAttrs& glContextAttrs)
+void RenderView::setGfxContextAttrs(GfxContextAttrs& gfxContextAttrs)
 {
-    _glContextAttrs = glContextAttrs;
+    _gfxContextAttrs = gfxContextAttrs;
 }
 
-GLContextAttrs GLView::getGLContextAttrs()
+GLContextAttrs& RenderView::getGfxContextAttrs()
 {
-    return _glContextAttrs;
+    return _gfxContextAttrs;
 }
 
-GLView::GLView()
+RenderView::RenderView()
     : _screenSize(0, 0)
     , _designResolutionSize(0, 0)
     , _scaleX(1.0f)
@@ -119,11 +119,11 @@ GLView::GLView()
     , _interactive(true)
 {}
 
-GLView::~GLView() {}
+RenderView::~RenderView() {}
 
-void GLView::pollEvents() {}
+void RenderView::pollEvents() {}
 
-void GLView::updateDesignResolutionSize()
+void RenderView::updateDesignResolutionSize()
 {
     if (_screenSize.width > 0 && _screenSize.height > 0 && _designResolutionSize.width > 0 &&
         _designResolutionSize.height > 0)
@@ -175,7 +175,7 @@ void GLView::updateDesignResolutionSize()
     }
 }
 
-void GLView::setDesignResolutionSize(float width, float height, ResolutionPolicy resolutionPolicy)
+void RenderView::setDesignResolutionSize(float width, float height, ResolutionPolicy resolutionPolicy)
 {
     AXASSERT(resolutionPolicy != ResolutionPolicy::UNKNOWN, "should set resolutionPolicy");
 
@@ -190,17 +190,17 @@ void GLView::setDesignResolutionSize(float width, float height, ResolutionPolicy
     updateDesignResolutionSize();
 }
 
-const Vec2& GLView::getDesignResolutionSize() const
+const Vec2& RenderView::getDesignResolutionSize() const
 {
     return _designResolutionSize;
 }
 
-Vec2 GLView::getFrameSize() const
+Vec2 RenderView::getFrameSize() const
 {
     return _screenSize;
 }
 
-void GLView::setFrameSize(float width, float height)
+void RenderView::setFrameSize(float width, float height)
 {
     _screenSize = Vec2(width, height);
 
@@ -210,7 +210,7 @@ void GLView::setFrameSize(float width, float height)
         _designResolutionSize = _screenSize;
 }
 
-Rect GLView::getVisibleRect() const
+Rect RenderView::getVisibleRect() const
 {
     Rect ret;
     ret.size   = getVisibleSize();
@@ -218,12 +218,12 @@ Rect GLView::getVisibleRect() const
     return ret;
 }
 
-Rect GLView::getSafeAreaRect() const
+Rect RenderView::getSafeAreaRect() const
 {
     return getVisibleRect();
 }
 
-Vec2 GLView::getVisibleSize() const
+Vec2 RenderView::getVisibleSize() const
 {
     if (_resolutionPolicy == ResolutionPolicy::NO_BORDER)
     {
@@ -235,7 +235,7 @@ Vec2 GLView::getVisibleSize() const
     }
 }
 
-Vec2 GLView::getVisibleOrigin() const
+Vec2 RenderView::getVisibleOrigin() const
 {
     if (_resolutionPolicy == ResolutionPolicy::NO_BORDER)
     {
@@ -248,7 +248,7 @@ Vec2 GLView::getVisibleOrigin() const
     }
 }
 
-void GLView::setViewPortInPoints(float x, float y, float w, float h)
+void RenderView::setViewPortInPoints(float x, float y, float w, float h)
 {
     Viewport vp;
     vp.x = (int)(x * _scaleX + _viewPortRect.origin.x);
@@ -258,20 +258,20 @@ void GLView::setViewPortInPoints(float x, float y, float w, float h)
     Camera::setDefaultViewport(vp);
 }
 
-void GLView::setScissorInPoints(float x, float y, float w, float h)
+void RenderView::setScissorInPoints(float x, float y, float w, float h)
 {
     auto renderer = Director::getInstance()->getRenderer();
     renderer->setScissorRect((int)(x * _scaleX + _viewPortRect.origin.x), (int)(y * _scaleY + _viewPortRect.origin.y),
                              (unsigned int)(w * _scaleX), (unsigned int)(h * _scaleY));
 }
 
-bool GLView::isScissorEnabled()
+bool RenderView::isScissorEnabled()
 {
     auto renderer = Director::getInstance()->getRenderer();
     return renderer->getScissorTest();
 }
 
-Rect GLView::getScissorRect() const
+Rect RenderView::getScissorRect() const
 {
     auto renderer = Director::getInstance()->getRenderer();
     auto& rect    = renderer->getScissorRect();
@@ -283,17 +283,17 @@ Rect GLView::getScissorRect() const
     return Rect(x, y, w, h);
 }
 
-void GLView::setViewName(std::string_view viewname)
+void RenderView::setViewName(std::string_view viewname)
 {
     _viewName = viewname;
 }
 
-std::string_view GLView::getViewName() const
+std::string_view RenderView::getViewName() const
 {
     return _viewName;
 }
 
-void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
+void RenderView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
 {
     if (!_interactive)
         return;
@@ -345,12 +345,12 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
     dispatcher->dispatchEvent(&touchEvent);
 }
 
-void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[])
+void RenderView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[])
 {
     handleTouchesMove(num, ids, xs, ys, nullptr, nullptr);
 }
 
-void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[], float ms[])
+void RenderView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[], float ms[])
 {
     if (!_interactive)
         return;
@@ -404,7 +404,7 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], 
     dispatcher->dispatchEvent(&touchEvent);
 }
 
-void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
+void RenderView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
                                         int num,
                                         intptr_t ids[],
                                         float xs[],
@@ -466,37 +466,37 @@ void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode,
     }
 }
 
-void GLView::handleTouchesEnd(int num, intptr_t ids[], float xs[], float ys[])
+void RenderView::handleTouchesEnd(int num, intptr_t ids[], float xs[], float ys[])
 {
     handleTouchesOfEndOrCancel(EventTouch::EventCode::ENDED, num, ids, xs, ys);
 }
 
-void GLView::handleTouchesCancel(int num, intptr_t ids[], float xs[], float ys[])
+void RenderView::handleTouchesCancel(int num, intptr_t ids[], float xs[], float ys[])
 {
     handleTouchesOfEndOrCancel(EventTouch::EventCode::CANCELLED, num, ids, xs, ys);
 }
 
-const Rect& GLView::getViewPortRect() const
+const Rect& RenderView::getViewPortRect() const
 {
     return _viewPortRect;
 }
 
-std::vector<Touch*> GLView::getAllTouches() const
+std::vector<Touch*> RenderView::getAllTouches() const
 {
     return getAllTouchesVector();
 }
 
-float GLView::getScaleX() const
+float RenderView::getScaleX() const
 {
     return _scaleX;
 }
 
-float GLView::getScaleY() const
+float RenderView::getScaleY() const
 {
     return _scaleY;
 }
 
-void GLView::renderScene(Scene* scene, Renderer* renderer)
+void RenderView::renderScene(Scene* scene, Renderer* renderer)
 {
     AXASSERT(scene, "Invalid Scene");
     AXASSERT(renderer, "Invalid Renderer");
@@ -504,11 +504,11 @@ void GLView::renderScene(Scene* scene, Renderer* renderer)
     scene->render(renderer, Mat4::IDENTITY, nullptr);
 }
 
-void GLView::queueOperation(AsyncOperation /*op*/, void* /*param*/)
+void RenderView::queueOperation(AsyncOperation /*op*/, void* /*param*/)
 {
 }
 
-void GLView::setInteractive(bool interactive)
+void RenderView::setInteractive(bool interactive)
 {
     if (_interactive && !interactive)
     {
@@ -518,7 +518,7 @@ void GLView::setInteractive(bool interactive)
     _interactive = interactive;
 }
 
-void GLView::cancelAllTouches()
+void RenderView::cancelAllTouches()
 {
     EventTouch touchEvent;
     touchEvent._touches = getAllTouchesVector();

--- a/core/platform/RenderViewImpl.cpp
+++ b/core/platform/RenderViewImpl.cpp
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "platform/GLViewImpl.h"
+#include "platform/RenderViewImpl.h"
 
 #include <cmath>
 #include <unordered_map>
@@ -167,7 +167,7 @@ public:
             _view->onGLFWWindowSizeCallback(window, width, height);
     }
 
-    static void setGLViewImpl(GLViewImpl* view) { _view = view; }
+    static void setRenderViewImpl(RenderViewImpl* view) { _view = view; }
 
     static void onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified)
     {
@@ -194,15 +194,15 @@ public:
     }
 
 private:
-    static GLViewImpl* _view;
+    static RenderViewImpl* _view;
 };
-GLViewImpl* GLFWEventHandler::_view = nullptr;
+RenderViewImpl* GLFWEventHandler::_view = nullptr;
 
-const std::string GLViewImpl::EVENT_WINDOW_POSITIONED = "glview_window_positioned";
-const std::string GLViewImpl::EVENT_WINDOW_RESIZED    = "glview_window_resized";
-const std::string GLViewImpl::EVENT_WINDOW_FOCUSED    = "glview_window_focused";
-const std::string GLViewImpl::EVENT_WINDOW_UNFOCUSED  = "glview_window_unfocused";
-const std::string GLViewImpl::EVENT_WINDOW_CLOSE      = "glview_window_close";
+const std::string RenderViewImpl::EVENT_WINDOW_POSITIONED = "glview_window_positioned";
+const std::string RenderViewImpl::EVENT_WINDOW_RESIZED    = "glview_window_resized";
+const std::string RenderViewImpl::EVENT_WINDOW_FOCUSED    = "glview_window_focused";
+const std::string RenderViewImpl::EVENT_WINDOW_UNFOCUSED  = "glview_window_unfocused";
+const std::string RenderViewImpl::EVENT_WINDOW_CLOSE      = "glview_window_close";
 
 ////////////////////////////////////////////////////
 
@@ -344,7 +344,7 @@ static keyCodeItem g_keyCodeStructArray[] = {
     {GLFW_KEY_LAST, EventKeyboard::KeyCode::KEY_NONE}};
 
 //////////////////////////////////////////////////////////////////////////
-// implement GLViewImpl
+// implement RenderViewImpl
 //////////////////////////////////////////////////////////////////////////
 
 static EventMouse::MouseButton checkMouseButton(GLFWwindow* window)
@@ -365,7 +365,7 @@ static EventMouse::MouseButton checkMouseButton(GLFWwindow* window)
     return mouseButton;
 }
 
-GLViewImpl::GLViewImpl(bool initglfw)
+RenderViewImpl::RenderViewImpl(bool initglfw)
     : _captured(false)
     , _isInRetinaMonitor(false)
     , _isRetinaEnabled(false)
@@ -383,7 +383,7 @@ GLViewImpl::GLViewImpl(bool initglfw)
         g_keyCodeMap[item.glfwKeyCode] = item.keyCode;
     }
 
-    GLFWEventHandler::setGLViewImpl(this);
+    GLFWEventHandler::setRenderViewImpl(this);
     if (initglfw)
     {
         glfwSetErrorCallback(GLFWEventHandler::onGLFWError);
@@ -391,60 +391,56 @@ GLViewImpl::GLViewImpl(bool initglfw)
     }
 }
 
-GLViewImpl::~GLViewImpl()
+RenderViewImpl::~RenderViewImpl()
 {
-    AXLOGD("deallocing GLViewImpl: {}", fmt::ptr(this));
-    GLFWEventHandler::setGLViewImpl(nullptr);
+    AXLOGD("deallocing RenderViewImpl: {}", fmt::ptr(this));
+    GLFWEventHandler::setRenderViewImpl(nullptr);
     glfwTerminate();
 }
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
-HWND GLViewImpl::getWin32Window()
+HWND RenderViewImpl::getWin32Window()
 {
     return glfwGetWin32Window(_mainWindow);
 }
-#endif /* (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32) */
-
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-void* GLViewImpl::getCocoaWindow()
+#elif (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
+void* RenderViewImpl::getCocoaWindow()
 {
     return (void*)glfwGetCocoaWindow(_mainWindow);
 }
-void* GLViewImpl::getNSGLContext()
+void* RenderViewImpl::getNSGLContext()
 {
     return (void*)glfwGetNSGLContext(_mainWindow);
 }  // stevetranby: added
-#endif  // #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
-void* GLViewImpl::getX11Window()
+#elif (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
+void* RenderViewImpl::getX11Window()
 {
     return (void*)glfwGetX11Window(_mainWindow);
 }
-void* GLViewImpl::getX11Display()
+void* RenderViewImpl::getX11Display()
 {
     return (void*)glfwGetX11Display();
 }
 /* TODO: Implement AX_PLATFORM_LINUX_WAYLAND
-void* GLViewImpl::getWaylandWindow()
+void* RenderViewImpl::getWaylandWindow()
 {
     return (void*)glfwGetWaylandWindow(_mainWindow);
 }
-void* GLViewImpl::getWaylandDisplay()
+void* RenderViewImpl::getWaylandDisplay()
 {
     return (void*)glfwGetWaylandDisplay();
 }
 */
 #endif  // #if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
 
-GLViewImpl* GLViewImpl::create(std::string_view viewName)
+RenderViewImpl* RenderViewImpl::create(std::string_view viewName)
 {
-    return GLViewImpl::create(viewName, false);
+    return RenderViewImpl::create(viewName, false);
 }
 
-GLViewImpl* GLViewImpl::create(std::string_view viewName, bool resizable)
+RenderViewImpl* RenderViewImpl::create(std::string_view viewName, bool resizable)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new RenderViewImpl;
     if (ret->initWithRect(viewName, ax::Rect(0, 0, 960, 640), 1.0f, resizable))
     {
         ret->autorelease();
@@ -454,12 +450,12 @@ GLViewImpl* GLViewImpl::create(std::string_view viewName, bool resizable)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithRect(std::string_view viewName,
+RenderViewImpl* RenderViewImpl::createWithRect(std::string_view viewName,
                                        const ax::Rect& rect,
                                        float frameZoomFactor,
                                        bool resizable)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new RenderViewImpl;
     if (ret->initWithRect(viewName, rect, frameZoomFactor, resizable))
     {
         ret->autorelease();
@@ -469,9 +465,9 @@ GLViewImpl* GLViewImpl::createWithRect(std::string_view viewName,
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName)
+RenderViewImpl* RenderViewImpl::createWithFullScreen(std::string_view viewName)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new RenderViewImpl();
     if (ret->initWithFullScreen(viewName))
     {
         ret->autorelease();
@@ -481,11 +477,11 @@ GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName,
+RenderViewImpl* RenderViewImpl::createWithFullScreen(std::string_view viewName,
                                              const GLFWvidmode& videoMode,
                                              GLFWmonitor* monitor)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new RenderViewImpl();
     if (ret->initWithFullscreen(viewName, videoMode, monitor))
     {
         ret->autorelease();
@@ -495,7 +491,7 @@ GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName,
     return nullptr;
 }
 
-bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, float frameZoomFactor, bool resizable)
+bool RenderViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, float frameZoomFactor, bool resizable)
 {
     setViewName(viewName);
 
@@ -515,17 +511,17 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
 #endif
 
     glfwWindowHint(GLFW_RESIZABLE, resizable ? GL_TRUE : GL_FALSE);
-    glfwWindowHint(GLFW_RED_BITS, _glContextAttrs.redBits);
-    glfwWindowHint(GLFW_GREEN_BITS, _glContextAttrs.greenBits);
-    glfwWindowHint(GLFW_BLUE_BITS, _glContextAttrs.blueBits);
-    glfwWindowHint(GLFW_ALPHA_BITS, _glContextAttrs.alphaBits);
-    glfwWindowHint(GLFW_DEPTH_BITS, _glContextAttrs.depthBits);
-    glfwWindowHint(GLFW_STENCIL_BITS, _glContextAttrs.stencilBits);
+    glfwWindowHint(GLFW_RED_BITS, _gfxContextAttrs.redBits);
+    glfwWindowHint(GLFW_GREEN_BITS, _gfxContextAttrs.greenBits);
+    glfwWindowHint(GLFW_BLUE_BITS, _gfxContextAttrs.blueBits);
+    glfwWindowHint(GLFW_ALPHA_BITS, _gfxContextAttrs.alphaBits);
+    glfwWindowHint(GLFW_DEPTH_BITS, _gfxContextAttrs.depthBits);
+    glfwWindowHint(GLFW_STENCIL_BITS, _gfxContextAttrs.stencilBits);
 
-    glfwWindowHint(GLFW_SAMPLES, _glContextAttrs.multisamplingCount);
+    glfwWindowHint(GLFW_SAMPLES, _gfxContextAttrs.multisamplingCount);
 
-    glfwWindowHint(GLFW_VISIBLE, _glContextAttrs.visible);
-    glfwWindowHint(GLFW_DECORATED, _glContextAttrs.decorated);
+    glfwWindowHint(GLFW_VISIBLE, _gfxContextAttrs.visible);
+    glfwWindowHint(GLFW_DECORATED, _gfxContextAttrs.decorated);
 
 #if defined(AX_USE_METAL)
     // Don't create gl context.
@@ -533,7 +529,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
 #endif
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
-    glfwWindowHintPointer(GLFW_WIN32_HWND_PARENT, _glContextAttrs.viewParent);
+    glfwWindowHintPointer(GLFW_WIN32_HWND_PARENT, _gfxContextAttrs.viewParent);
 #endif
 
     _mainWindow = glfwCreateWindow(static_cast<int>(windowSize.width), static_cast<int>(windowSize.height),
@@ -592,7 +588,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
     [layer setPixelFormat:MTLPixelFormatBGRA8Unorm];
     [layer setFramebufferOnly:YES];
     [layer setDrawableSize:size];
-    layer.displaySyncEnabled = _glContextAttrs.vsync;
+    layer.displaySyncEnabled = _gfxContextAttrs.vsync;
     [contentView setLayer:layer];
     backend::DriverMTL::setCAMetalLayer(layer);
 #endif
@@ -653,7 +649,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
 
 #if defined(AX_USE_GL)
 #    if !defined(__EMSCRIPTEN__)
-    glfwSwapInterval(_glContextAttrs.vsync ? 1 : 0);
+    glfwSwapInterval(_gfxContextAttrs.vsync ? 1 : 0);
 #    endif
     // Will cause OpenGL error 0x0500 when use ANGLE-GLES on desktop
 #    if !AX_GLES_PROFILE
@@ -663,7 +659,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
 #        else
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE_ARB);
 #        endif
-    if (_glContextAttrs.multisamplingCount > 0)
+    if (_gfxContextAttrs.multisamplingCount > 0)
         glEnable(GL_MULTISAMPLE);
 #    endif
     CHECK_GL_ERROR_DEBUG();
@@ -674,7 +670,7 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rect, f
     return true;
 }
 
-bool GLViewImpl::initWithFullScreen(std::string_view viewName)
+bool RenderViewImpl::initWithFullScreen(std::string_view viewName)
 {
     // Create fullscreen window on primary monitor at its current video mode.
     _monitor = glfwGetPrimaryMonitor();
@@ -694,7 +690,7 @@ bool GLViewImpl::initWithFullScreen(std::string_view viewName)
     return initWithRect(viewName, ax::Rect(0, 0, (float)videoMode->width, (float)videoMode->height), 1.0f, false);
 }
 
-bool GLViewImpl::initWithFullscreen(std::string_view viewname, const GLFWvidmode& videoMode, GLFWmonitor* monitor)
+bool RenderViewImpl::initWithFullscreen(std::string_view viewname, const GLFWvidmode& videoMode, GLFWmonitor* monitor)
 {
     // Create fullscreen on specified monitor at the specified video mode.
     _monitor = monitor;
@@ -712,23 +708,23 @@ bool GLViewImpl::initWithFullscreen(std::string_view viewname, const GLFWvidmode
     return initWithRect(viewname, ax::Rect(0, 0, (float)videoMode.width, (float)videoMode.height), 1.0f, false);
 }
 
-bool GLViewImpl::isOpenGLReady()
+bool RenderViewImpl::isGfxContextReady()
 {
     return nullptr != _mainWindow;
 }
 
-void GLViewImpl::end()
+void RenderViewImpl::end()
 {
     if (_mainWindow)
     {
         glfwSetWindowShouldClose(_mainWindow, 1);
         _mainWindow = nullptr;
     }
-    // Release self. Otherwise, GLViewImpl could not be freed.
+    // Release self. Otherwise, RenderViewImpl could not be freed.
     release();
 }
 
-void GLViewImpl::swapBuffers()
+void RenderViewImpl::swapBuffers()
 {
 #if defined(AX_USE_GL)
     if (_mainWindow)
@@ -736,7 +732,7 @@ void GLViewImpl::swapBuffers()
 #endif
 }
 
-bool GLViewImpl::windowShouldClose()
+bool RenderViewImpl::windowShouldClose()
 {
     if (_mainWindow)
         return glfwWindowShouldClose(_mainWindow) ? true : false;
@@ -744,12 +740,12 @@ bool GLViewImpl::windowShouldClose()
         return true;
 }
 
-void GLViewImpl::pollEvents()
+void RenderViewImpl::pollEvents()
 {
     glfwPollEvents();
 }
 
-void GLViewImpl::enableRetina(bool enabled)
+void RenderViewImpl::enableRetina(bool enabled)
 {
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
     _isRetinaEnabled = enabled;
@@ -757,15 +753,15 @@ void GLViewImpl::enableRetina(bool enabled)
 #endif
 }
 
-void GLViewImpl::setIMEKeyboardState(bool /*bOpen*/) {}
+void RenderViewImpl::setIMEKeyboardState(bool /*bOpen*/) {}
 
 #if AX_ICON_SET_SUPPORT
-void GLViewImpl::setIcon(std::string_view filename) const
+void RenderViewImpl::setIcon(std::string_view filename) const
 {
     this->setIcon(std::vector<std::string_view>{filename});
 }
 
-void GLViewImpl::setIcon(const std::vector<std::string_view>& filelist) const
+void RenderViewImpl::setIcon(const std::vector<std::string_view>& filelist) const
 {
     if (filelist.empty())
         return;
@@ -806,14 +802,14 @@ void GLViewImpl::setIcon(const std::vector<std::string_view>& filelist) const
     }
 }
 
-void GLViewImpl::setDefaultIcon() const
+void RenderViewImpl::setDefaultIcon() const
 {
     GLFWwindow* window = this->getWindow();
     glfwSetWindowIcon(window, 0, nullptr);
 }
 #endif /* AX_ICON_SET_SUPPORT */
 
-void GLViewImpl::setCursorVisible(bool isVisible)
+void RenderViewImpl::setCursorVisible(bool isVisible)
 {
     if (_mainWindow == NULL)
         return;
@@ -824,7 +820,7 @@ void GLViewImpl::setCursorVisible(bool isVisible)
         glfwSetInputMode(_mainWindow, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 }
 
-void GLViewImpl::setFrameZoomFactor(float zoomFactor)
+void RenderViewImpl::setFrameZoomFactor(float zoomFactor)
 {
     AXASSERT(zoomFactor > 0.0f, "zoomFactor must be larger than 0");
 
@@ -837,22 +833,22 @@ void GLViewImpl::setFrameZoomFactor(float zoomFactor)
     updateFrameSize();
 }
 
-float GLViewImpl::getFrameZoomFactor() const
+float RenderViewImpl::getFrameZoomFactor() const
 {
     return _frameZoomFactor;
 }
 
-bool GLViewImpl::isFullscreen() const
+bool RenderViewImpl::isFullscreen() const
 {
     return (_monitor != nullptr);
 }
 
-void GLViewImpl::setFullscreen()
+void RenderViewImpl::setFullscreen()
 {
     setFullscreen(-1, -1, -1);
 }
 
-void GLViewImpl::setFullscreen(int w, int h, int refreshRate)
+void RenderViewImpl::setFullscreen(int w, int h, int refreshRate)
 {
     auto monitor = glfwGetPrimaryMonitor();
     if (nullptr == monitor || monitor == _monitor)
@@ -862,12 +858,12 @@ void GLViewImpl::setFullscreen(int w, int h, int refreshRate)
     this->setFullscreen(monitor, w, h, refreshRate);
 }
 
-void GLViewImpl::setFullscreen(int monitorIndex)
+void RenderViewImpl::setFullscreen(int monitorIndex)
 {
     setFullscreen(monitorIndex, -1, -1, -1);
 }
 
-void GLViewImpl::setFullscreen(int monitorIndex, int w, int h, int refreshRate)
+void RenderViewImpl::setFullscreen(int monitorIndex, int w, int h, int refreshRate)
 {
     int count              = 0;
     GLFWmonitor** monitors = glfwGetMonitors(&count);
@@ -883,7 +879,7 @@ void GLViewImpl::setFullscreen(int monitorIndex, int w, int h, int refreshRate)
     this->setFullscreen(monitor, w, h, refreshRate);
 }
 
-void GLViewImpl::setFullscreen(GLFWmonitor* monitor, int w, int h, int refreshRate)
+void RenderViewImpl::setFullscreen(GLFWmonitor* monitor, int w, int h, int refreshRate)
 {
     _monitor = monitor;
 
@@ -898,7 +894,7 @@ void GLViewImpl::setFullscreen(GLFWmonitor* monitor, int w, int h, int refreshRa
     glfwSetWindowMonitor(_mainWindow, _monitor, 0, 0, w, h, refreshRate);
 }
 
-void GLViewImpl::setWindowed(int width, int height, bool borderless)
+void RenderViewImpl::setWindowed(int width, int height, bool borderless)
 {
     if (!this->isFullscreen())
     {
@@ -927,7 +923,7 @@ void GLViewImpl::setWindowed(int width, int height, bool borderless)
     }
 }
 
-void GLViewImpl::getWindowPosition(int* xpos, int* ypos)
+void RenderViewImpl::getWindowPosition(int* xpos, int* ypos)
 {
     if (_mainWindow != nullptr)
     {
@@ -935,7 +931,7 @@ void GLViewImpl::getWindowPosition(int* xpos, int* ypos)
     }
 }
 
-void GLViewImpl::getWindowSize(int* width, int* height)
+void RenderViewImpl::getWindowSize(int* width, int* height)
 {
     if (_mainWindow != nullptr)
     {
@@ -943,14 +939,14 @@ void GLViewImpl::getWindowSize(int* width, int* height)
     }
 }
 
-int GLViewImpl::getMonitorCount() const
+int RenderViewImpl::getMonitorCount() const
 {
     int count = 0;
     glfwGetMonitors(&count);
     return count;
 }
 
-Vec2 GLViewImpl::getMonitorSize() const
+Vec2 RenderViewImpl::getMonitorSize() const
 {
     GLFWmonitor* monitor = _monitor;
     if (nullptr == monitor)
@@ -971,7 +967,7 @@ Vec2 GLViewImpl::getMonitorSize() const
     return Vec2::ZERO;
 }
 
-void GLViewImpl::handleWindowSize(int w, int h)
+void RenderViewImpl::handleWindowSize(int w, int h)
 {
     /*
     * x-studio spec, fix view size incorrect when window size changed
@@ -987,7 +983,7 @@ void GLViewImpl::handleWindowSize(int w, int h)
       @remark:
       1. glfwSetWindowMonitor will fire window size change event in full screen mode
     */
-    GLView::setFrameSize(w / _frameZoomFactor, h / _frameZoomFactor);
+    RenderView::setFrameSize(w / _frameZoomFactor, h / _frameZoomFactor);
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
     // Fix #1787, update retina state when switch between fullscreen and windowed mode
     int fbWidth = 0, fbHeight = 0;
@@ -1001,7 +997,7 @@ void GLViewImpl::handleWindowSize(int w, int h)
     updateDesignResolutionSize();
 }
 
-void GLViewImpl::updateFrameSize()
+void RenderViewImpl::updateFrameSize()
 {
     if (_screenSize.width > 0 && _screenSize.height > 0)
     {
@@ -1027,13 +1023,13 @@ void GLViewImpl::updateFrameSize()
     }
 }
 
-void GLViewImpl::setFrameSize(float width, float height)
+void RenderViewImpl::setFrameSize(float width, float height)
 {
-    GLView::setFrameSize(width, height);
+    RenderView::setFrameSize(width, height);
     updateFrameSize();
 }
 
-void GLViewImpl::setViewPortInPoints(float x, float y, float w, float h)
+void RenderViewImpl::setViewPortInPoints(float x, float y, float w, float h)
 {
     Viewport vp;
     vp.x = (int)(x * _scaleX * _retinaFactor * _frameZoomFactor +
@@ -1045,7 +1041,7 @@ void GLViewImpl::setViewPortInPoints(float x, float y, float w, float h)
     Camera::setDefaultViewport(vp);
 }
 
-void GLViewImpl::setScissorInPoints(float x, float y, float w, float h)
+void RenderViewImpl::setScissorInPoints(float x, float y, float w, float h)
 {
     auto x1       = (int)(x * _scaleX * _retinaFactor * _frameZoomFactor +
                     _viewPortRect.origin.x * _retinaFactor * _frameZoomFactor);
@@ -1057,7 +1053,7 @@ void GLViewImpl::setScissorInPoints(float x, float y, float w, float h)
     renderer->setScissorRect(x1, y1, width1, height1);
 }
 
-ax::Rect GLViewImpl::getScissorRect() const
+ax::Rect RenderViewImpl::getScissorRect() const
 {
     auto renderer = Director::getInstance()->getRenderer();
     auto& rect    = renderer->getScissorRect();
@@ -1071,7 +1067,7 @@ ax::Rect GLViewImpl::getScissorRect() const
     return ax::Rect(x, y, w, h);
 }
 
-void GLViewImpl::onGLFWError(int errorID, const char* errorDesc)
+void RenderViewImpl::onGLFWError(int errorID, const char* errorDesc)
 {
     if (_mainWindow)
     {
@@ -1084,7 +1080,7 @@ void GLViewImpl::onGLFWError(int errorID, const char* errorDesc)
     AXLOGE("{}", _glfwError);
 }
 
-void GLViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int action, int /*modify*/)
+void RenderViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int action, int /*modify*/)
 {
     if (!_isTouchDevice)
     {
@@ -1129,7 +1125,7 @@ void GLViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int act
     }
 }
 
-void GLViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, double y)
+void RenderViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, double y)
 {
     _mouseX = (float)x;
     _mouseY = (float)y;
@@ -1165,7 +1161,7 @@ void GLViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, double y)
 }
 
 #if defined(__EMSCRIPTEN__)
-void GLViewImpl::onWebTouchCallback(int eventType, const EmscriptenTouchEvent* touchEvent)
+void RenderViewImpl::onWebTouchCallback(int eventType, const EmscriptenTouchEvent* touchEvent)
 {
     float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
     float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
@@ -1211,7 +1207,7 @@ void GLViewImpl::onWebTouchCallback(int eventType, const EmscriptenTouchEvent* t
     }
 }
 
-void GLViewImpl::onWebClickCallback()
+void RenderViewImpl::onWebClickCallback()
 {
     if (!_isTouchDevice)
     {
@@ -1225,7 +1221,7 @@ void GLViewImpl::onWebClickCallback()
 }
 #endif
 
-void GLViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double y)
+void RenderViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double y)
 {
     EventMouse event(EventMouse::MouseEventType::MOUSE_SCROLL);
     float cursorX = transformInputX(_mouseX);
@@ -1235,7 +1231,7 @@ void GLViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double 
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void GLViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/)
+void RenderViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/)
 {
     // x-studio spec, for repeat press key support.
     EventKeyboard event(g_keyCodeMap[key], action);
@@ -1265,7 +1261,7 @@ void GLViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scanco
     }
 }
 
-void GLViewImpl::onGLFWCharCallback(GLFWwindow* /*window*/, unsigned int charCode)
+void RenderViewImpl::onGLFWCharCallback(GLFWwindow* /*window*/, unsigned int charCode)
 {
     std::string utf8String;
     StringUtils::UTF32ToUTF8(std::u32string_view{(char32_t*)&charCode, (size_t)1}, utf8String);
@@ -1288,15 +1284,15 @@ void GLViewImpl::onGLFWCharCallback(GLFWwindow* /*window*/, unsigned int charCod
     }
 }
 
-void GLViewImpl::onGLFWWindowPosCallback(GLFWwindow* /*window*/, int x, int y)
+void RenderViewImpl::onGLFWWindowPosCallback(GLFWwindow* /*window*/, int x, int y)
 {
     Director::getInstance()->setViewport();
 
     Vec2 pos(x, y);
-    Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(GLViewImpl::EVENT_WINDOW_POSITIONED, &pos);
+    Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_POSITIONED, &pos);
 }
 
-void GLViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
+void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
 {
     if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
     {
@@ -1310,11 +1306,11 @@ void GLViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
 #endif
 
         Size size(w, h);
-        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(GLViewImpl::EVENT_WINDOW_RESIZED, &size);
+        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
     }
 }
 
-void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)
+void RenderViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)
 {
     if (iconified == GL_TRUE)
     {
@@ -1326,22 +1322,22 @@ void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconifi
     }
 }
 
-void GLViewImpl::onGLFWWindowFocusCallback(GLFWwindow* /*window*/, int focused)
+void RenderViewImpl::onGLFWWindowFocusCallback(GLFWwindow* /*window*/, int focused)
 {
     if (focused == GL_TRUE)
     {
-        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(GLViewImpl::EVENT_WINDOW_FOCUSED, nullptr);
+        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_FOCUSED, nullptr);
     }
     else
     {
-        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(GLViewImpl::EVENT_WINDOW_UNFOCUSED, nullptr);
+        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_UNFOCUSED, nullptr);
     }
 }
 
-void GLViewImpl::onGLFWWindowCloseCallback(GLFWwindow* window)
+void RenderViewImpl::onGLFWWindowCloseCallback(GLFWwindow* window)
 {
     bool isClose = true;
-    Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(GLViewImpl::EVENT_WINDOW_CLOSE, &isClose);
+    Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_CLOSE, &isClose);
     if (isClose == false)
     {
         glfwSetWindowShouldClose(window, 0);
@@ -1441,7 +1437,7 @@ static bool loadFboExtensions()
 }
 
 // helper
-bool GLViewImpl::loadGL()
+bool RenderViewImpl::loadGL()
 {
 #    if (AX_TARGET_PLATFORM != AX_PLATFORM_MAC)
 

--- a/core/platform/RenderViewImpl.h
+++ b/core/platform/RenderViewImpl.h
@@ -24,12 +24,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
-// Implement GLView based on GLFW for targets: win32,osx,web(wasm)
+// Implement RenderView based on GLFW for targets: win32,osx,web(wasm)
 #pragma once
 #include "platform/GL.h"
 #include "base/Object.h"
 #include "platform/Common.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #include "GLFW/glfw3.h"
 #if defined(__EMSCRIPTEN__)
 #    include "base/axstd.h"
@@ -41,19 +41,19 @@ namespace ax
 {
 
 class GLFWEventHandler;
-class AX_DLL GLViewImpl : public GLView
+class AX_DLL RenderViewImpl : public RenderView
 {
     friend class GLFWEventHandler;
 
 public:
-    static GLViewImpl* create(std::string_view viewName);
-    static GLViewImpl* create(std::string_view viewName, bool resizable);
-    static GLViewImpl* createWithRect(std::string_view viewName,
+    static RenderViewImpl* create(std::string_view viewName);
+    static RenderViewImpl* create(std::string_view viewName, bool resizable);
+    static RenderViewImpl* createWithRect(std::string_view viewName,
                                       const Rect& rect,
                                       float frameZoomFactor = 1.0f,
                                       bool resizable        = false);
-    static GLViewImpl* createWithFullScreen(std::string_view viewName);
-    static GLViewImpl* createWithFullScreen(std::string_view viewName,
+    static RenderViewImpl* createWithFullScreen(std::string_view viewName);
+    static RenderViewImpl* createWithFullScreen(std::string_view viewName,
                                             const GLFWvidmode& videoMode,
                                             GLFWmonitor* monitor);
 
@@ -66,9 +66,9 @@ public:
     float getFrameZoomFactor() const override;
     // void centerWindow();
 
-    virtual void setViewPortInPoints(float x, float y, float w, float h) override;
-    virtual void setScissorInPoints(float x, float y, float w, float h) override;
-    virtual Rect getScissorRect() const override;
+    void setViewPortInPoints(float x, float y, float w, float h) override;
+    void setScissorInPoints(float x, float y, float w, float h) override;
+    Rect getScissorRect() const override;
 
     bool windowShouldClose() override;
     void pollEvents() override;
@@ -103,16 +103,16 @@ public:
     Vec2 getMonitorSize() const;
 
     /* override functions */
-    virtual bool isOpenGLReady() override;
-    virtual void end() override;
-    virtual void swapBuffers() override;
-    virtual void setFrameSize(float width, float height) override;
-    virtual void setIMEKeyboardState(bool bOpen) override;
+    bool isGfxContextReady() override;
+    void end() override;
+    void swapBuffers() override;
+    void setFrameSize(float width, float height) override;
+    void setIMEKeyboardState(bool bOpen) override;
 
 #if AX_ICON_SET_SUPPORT
-    virtual void setIcon(std::string_view filename) const override;
-    virtual void setIcon(const std::vector<std::string_view>& filelist) const override;
-    virtual void setDefaultIcon() const override;
+    void setIcon(std::string_view filename) const override;
+    void setIcon(const std::vector<std::string_view>& filelist) const override;
+    void setDefaultIcon() const override;
 #endif /* AX_ICON_SET_SUPPORT */
 
     /*
@@ -122,7 +122,7 @@ public:
     /**
      * Hide or Show the mouse cursor if there is one.
      */
-    virtual void setCursorVisible(bool isVisible) override;
+    void setCursorVisible(bool isVisible) override;
     /** Retina support is disabled by default
      *  @note This method is only available on Mac.
      */
@@ -152,8 +152,8 @@ public:
 #endif // #if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
 
 protected:
-    GLViewImpl(bool initglfw = true);
-    virtual ~GLViewImpl();
+    RenderViewImpl(bool initglfw = true);
+    ~RenderViewImpl() override;
 
     bool initWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor, bool resizable);
     bool initWithFullScreen(std::string_view viewName);
@@ -216,7 +216,11 @@ public:
     static const std::string EVENT_WINDOW_CLOSE;
 
 private:
-    AX_DISALLOW_COPY_AND_ASSIGN(GLViewImpl);
+    AX_DISALLOW_COPY_AND_ASSIGN(RenderViewImpl);
 };
 
-}  // end of namespace   cocos2d
+#ifndef AX_CORE_PROFILE
+AX_DEPRECATED(2.8) typedef RenderViewImpl GLViewImpl;
+#endif
+
+}  // end of namespace ax

--- a/core/platform/android/RenderViewImpl-android.cpp
+++ b/core/platform/android/RenderViewImpl-android.cpp
@@ -24,7 +24,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
-#include "platform/android/GLViewImpl-android.h"
+#include "platform/android/RenderViewImpl-android.h"
 #include "base/Director.h"
 #include "base/Macros.h"
 #include "platform/android/jni/JniHelper.h"
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
 namespace ax
 {
-void GLViewImpl::loadGLES2()
+void RenderViewImpl::loadGLES2()
 {
     auto glesVer = gladLoaderLoadGLES2();
     if (glesVer)
@@ -48,9 +48,9 @@ void GLViewImpl::loadGLES2()
         throw std::runtime_error("Load GLES fail");
 }
 
-GLViewImpl* GLViewImpl::createWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor, bool resizable)
+RenderViewImpl* RenderViewImpl::createWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor, bool resizable)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new RenderViewImpl;
     if (ret && ret->initWithRect(viewName, rect, frameZoomFactor, resizable))
     {
         ret->autorelease();
@@ -60,9 +60,9 @@ GLViewImpl* GLViewImpl::createWithRect(std::string_view viewName, const Rect& re
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::create(std::string_view viewName)
+RenderViewImpl* RenderViewImpl::create(std::string_view viewName)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new RenderViewImpl;
     if (ret && ret->initWithFullScreen(viewName))
     {
         ret->autorelease();
@@ -72,9 +72,9 @@ GLViewImpl* GLViewImpl::create(std::string_view viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName)
+RenderViewImpl* RenderViewImpl::createWithFullScreen(std::string_view viewName)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new RenderViewImpl();
     if (ret && ret->initWithFullScreen(viewName))
     {
         ret->autorelease();
@@ -84,36 +84,36 @@ GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName)
     return nullptr;
 }
 
-GLViewImpl::GLViewImpl()
+RenderViewImpl::RenderViewImpl()
 {
 }
 
-GLViewImpl::~GLViewImpl() {}
+RenderViewImpl::~RenderViewImpl() {}
 
-bool GLViewImpl::initWithRect(std::string_view /*viewName*/, const Rect& /*rect*/, float /*frameZoomFactor*/, bool /*resizable*/)
-{
-    return true;
-}
-
-bool GLViewImpl::initWithFullScreen(std::string_view viewName)
+bool RenderViewImpl::initWithRect(std::string_view /*viewName*/, const Rect& /*rect*/, float /*frameZoomFactor*/, bool /*resizable*/)
 {
     return true;
 }
 
-bool GLViewImpl::isOpenGLReady()
+bool RenderViewImpl::initWithFullScreen(std::string_view viewName)
+{
+    return true;
+}
+
+bool RenderViewImpl::isGfxContextReady()
 {
     return (_screenSize.width != 0 && _screenSize.height != 0);
 }
 
-void GLViewImpl::end()
+void RenderViewImpl::end()
 {
     JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "onExit");
     release();
 }
 
-void GLViewImpl::swapBuffers() {}
+void RenderViewImpl::swapBuffers() {}
 
-void GLViewImpl::setIMEKeyboardState(bool bOpen)
+void RenderViewImpl::setIMEKeyboardState(bool bOpen)
 {
     if (bOpen)
     {
@@ -125,9 +125,9 @@ void GLViewImpl::setIMEKeyboardState(bool bOpen)
     }
 }
 
-Rect GLViewImpl::getSafeAreaRect() const
+Rect RenderViewImpl::getSafeAreaRect() const
 {
-    Rect safeAreaRect       = GLView::getSafeAreaRect();
+    Rect safeAreaRect       = RenderView::getSafeAreaRect();
     float deviceAspectRatio = 0;
     if (safeAreaRect.size.height > safeAreaRect.size.width)
     {
@@ -267,7 +267,7 @@ Rect GLViewImpl::getSafeAreaRect() const
     return safeAreaRect;
 }
 
-void GLViewImpl::queueOperation(void (*op)(void*), void* param)
+void RenderViewImpl::queueOperation(void (*op)(void*), void* param)
 {
     JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "queueOperation", (jlong)(uintptr_t)op,
                                     (jlong)(uintptr_t)param);

--- a/core/platform/android/RenderViewImpl-android.h
+++ b/core/platform/android/RenderViewImpl-android.h
@@ -28,21 +28,21 @@ THE SOFTWARE.
 
 #include "base/Object.h"
 #include "math/Math.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 
 namespace ax
 {
 
-class AX_DLL GLViewImpl : public GLView
+class AX_DLL RenderViewImpl : public RenderView
 {
 public:
     // static function
     static void loadGLES2();
-    static GLViewImpl* create(std::string_view viewname);
-    static GLViewImpl* createWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor = 1.0f, bool resizable = false);
-    static GLViewImpl* createWithFullScreen(std::string_view viewName);
+    static RenderViewImpl* create(std::string_view viewname);
+    static RenderViewImpl* createWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor = 1.0f, bool resizable = false);
+    static RenderViewImpl* createWithFullScreen(std::string_view viewName);
 
-    bool isOpenGLReady() override;
+    bool isGfxContextReady() override;
     void end() override;
     void swapBuffers() override;
     void setIMEKeyboardState(bool bOpen) override;
@@ -51,11 +51,15 @@ public:
     void queueOperation(void (*op)(void*), void* param) override;
 
 protected:
-    GLViewImpl();
-    virtual ~GLViewImpl();
+    RenderViewImpl();
+    virtual ~RenderViewImpl();
 
     bool initWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor, bool resizable = false);
     bool initWithFullScreen(std::string_view viewName);
 };
+
+#ifndef AX_CORE_PROFILE
+AX_DEPRECATED(2.8) typedef RenderViewImpl GLViewImpl;
+#endif
 
 }

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolActivity.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolActivity.java
@@ -188,7 +188,7 @@ public abstract class AxmolActivity extends Activity implements AxmolEngineListe
         this.setVolumeControlStream(AudioManager.STREAM_MUSIC);
     }
 
-    //native method,call GLViewImpl::getGLContextAttrs() to get the OpenGL ES context attributions
+    //native method,call RenderViewImpl::getGLContextAttrs() to get the OpenGL ES context attributions
     private static native int[] getGLContextAttrs();
 
     // ===========================================================

--- a/core/platform/android/java/src/dev/axmol/lib/AxmolEditBox.java
+++ b/core/platform/android/java/src/dev/axmol/lib/AxmolEditBox.java
@@ -160,11 +160,11 @@ public class AxmolEditBox extends EditText {
         this.setLayoutParams(layoutParams);
     }
 
-    public float getGLViewScaleX() {
+    public float getRenderViewScaleX() {
         return mScaleX;
     }
 
-    public void setGLViewScaleX(float mScaleX) {
+    public void setRenderViewScaleX(float mScaleX) {
         this.mScaleX = mScaleX;
     }
 

--- a/core/platform/android/java/src/dev/axmol/lib/EditBoxHelper.java
+++ b/core/platform/android/java/src/dev/axmol/lib/EditBoxHelper.java
@@ -99,7 +99,7 @@ public class EditBoxHelper {
                 editBox.setBackgroundColor(Color.TRANSPARENT);
                 editBox.setTextColor(Color.WHITE);
                 editBox.setSingleLine();
-                editBox.setGLViewScaleX(scaleX);
+                editBox.setRenderViewScaleX(scaleX);
                 editBox.setPadding(getPadding(scaleX), 0, 0, 0);
 
 

--- a/core/platform/android/javaactivity-android.cpp
+++ b/core/platform/android/javaactivity-android.cpp
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 #include "platform/android/Application-android.h"
-#include "platform/android/GLViewImpl-android.h"
+#include "platform/android/RenderViewImpl-android.h"
 #include "base/Director.h"
 #include "base/EventCustom.h"
 #include "base/EventType.h"
@@ -82,15 +82,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
 
 JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeInit(JNIEnv*, jclass, jint w, jint h)
 {
-    GLViewImpl::loadGLES2();
+    RenderViewImpl::loadGLES2();
 
     auto director = ax::Director::getInstance();
-    auto glView   = director->getGLView();
-    if (!glView)
+    auto renderView   = director->getRenderView();
+    if (!renderView)
     {
-        glView = ax::GLViewImpl::create("axmol2");
-        glView->setFrameSize(w, h);
-        director->setGLView(glView);
+        renderView = ax::RenderViewImpl::create("axmol2");
+        renderView->setFrameSize(w, h);
+        director->setRenderView(renderView);
 
         ax::Application::getInstance()->run();
     }
@@ -133,12 +133,12 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnContextLost(JNIE
 
 JNIEXPORT jintArray JNICALL Java_dev_axmol_lib_AxmolActivity_getGLContextAttrs(JNIEnv* env, jclass)
 {
-    ax::Application::getInstance()->initGLContextAttrs();
-    GLContextAttrs _glContextAttrs = GLView::getGLContextAttrs();
+    ax::Application::getInstance()->initGfxContextAttrs();
+    auto& _gfxContextAttrs = RenderView::getGfxContextAttrs();
 
-    int tmp[7] = {_glContextAttrs.redBits,           _glContextAttrs.greenBits, _glContextAttrs.blueBits,
-                  _glContextAttrs.alphaBits,         _glContextAttrs.depthBits, _glContextAttrs.stencilBits,
-                  _glContextAttrs.multisamplingCount};
+    int tmp[7] = {_gfxContextAttrs.redBits,           _gfxContextAttrs.greenBits, _gfxContextAttrs.blueBits,
+                  _gfxContextAttrs.alphaBits,         _gfxContextAttrs.depthBits, _gfxContextAttrs.stencilBits,
+                  _gfxContextAttrs.multisamplingCount};
 
     jintArray glContextAttrsJava = env->NewIntArray(7);
     env->SetIntArrayRegion(glContextAttrsJava, 0, 7, tmp);

--- a/core/platform/android/jni/Java_dev_axmol_lib_AxmolRenderer.cpp
+++ b/core/platform/android/jni/Java_dev_axmol_lib_AxmolRenderer.cpp
@@ -45,7 +45,7 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeRender(JNIEnv*, jc
 
 JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnPause(JNIEnv*, jclass)
 {
-    if (Director::getInstance()->getGLView())
+    if (Director::getInstance()->getRenderView())
     {
         Application::getInstance()->applicationDidEnterBackground();
         ax::EventCustom backgroundEvent(EVENT_COME_TO_BACKGROUND);
@@ -55,7 +55,7 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnPause(JNIEnv*, j
 
 JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnResume(JNIEnv*, jclass)
 {
-    if (Director::getInstance()->getGLView())
+    if (Director::getInstance()->getRenderView())
     {
         Application::getInstance()->applicationWillEnterForeground();
         ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);

--- a/core/platform/android/jni/TouchesJni.cpp
+++ b/core/platform/android/jni/TouchesJni.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "base/Director.h"
 #include "base/EventKeyboard.h"
 #include "base/EventDispatcher.h"
-#include "platform/android/GLViewImpl-android.h"
+#include "platform/android/RenderViewImpl-android.h"
 
 #include <android/log.h>
 #include <jni.h>
@@ -37,14 +37,14 @@ JNIEXPORT void JNICALL
 Java_dev_axmol_lib_AxmolRenderer_nativeTouchesBegin(JNIEnv*, jclass, jint id, jfloat x, jfloat y)
 {
     intptr_t idlong = id;
-    ax::Director::getInstance()->getGLView()->handleTouchesBegin(1, &idlong, &x, &y);
+    ax::Director::getInstance()->getRenderView()->handleTouchesBegin(1, &idlong, &x, &y);
 }
 
 JNIEXPORT void JNICALL
 Java_dev_axmol_lib_AxmolRenderer_nativeTouchesEnd(JNIEnv*, jclass, jint id, jfloat x, jfloat y)
 {
     intptr_t idlong = id;
-    ax::Director::getInstance()->getGLView()->handleTouchesEnd(1, &idlong, &x, &y);
+    ax::Director::getInstance()->getRenderView()->handleTouchesEnd(1, &idlong, &x, &y);
 }
 
 JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeTouchesMove(JNIEnv* env,
@@ -66,7 +66,7 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeTouchesMove(JNIEnv
     for (int i = 0; i < size; i++)
         idlong[i] = id[i];
 
-    ax::Director::getInstance()->getGLView()->handleTouchesMove(size, idlong, x, y);
+    ax::Director::getInstance()->getRenderView()->handleTouchesMove(size, idlong, x, y);
 }
 
 JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeTouchesCancel(JNIEnv* env,
@@ -88,7 +88,7 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeTouchesCancel(JNIE
     for (int i = 0; i < size; i++)
         idlong[i] = id[i];
 
-    ax::Director::getInstance()->getGLView()->handleTouchesCancel(size, idlong, x, y);
+    ax::Director::getInstance()->getRenderView()->handleTouchesCancel(size, idlong, x, y);
 }
 
 #define KEYCODE_BACK 0x04

--- a/core/platform/ios/DirectorCaller-ios.mm
+++ b/core/platform/ios/DirectorCaller-ios.mm
@@ -31,7 +31,7 @@
 #import <OpenGLES/EAGL.h>
 
 #import "base/Director.h"
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 
 static id s_sharedDirectorCaller;
 
@@ -139,7 +139,7 @@ static id s_sharedDirectorCaller;
     {
         ax::Director* director = ax::Director::getInstance();
 #if AX_GLES_PROFILE
-        EAGLContext* context = [(EAGLView*)director->getGLView()->getEAGLView() context];
+        EAGLContext* context = [(EARenderView*)director->getRenderView()->getEARenderView() context];
         if (context != [EAGLContext currentContext])
             glFlush();
 

--- a/core/platform/ios/EARenderView-ios.h
+++ b/core/platform/ios/EARenderView-ios.h
@@ -15,7 +15,7 @@ seeds.
 
 =====================
 
-File: EAGLView.h
+File: EARenderView.h
 Abstract: Convenience class that wraps the CAEAGLLayer from CoreAnimation into a
 UIView subclass.
 
@@ -75,12 +75,12 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 // CLASS INTERFACE:
 
-/** EAGLView Class.
+/** EARenderView Class.
  * This class wraps the CAEAGLLayer from CoreAnimation into a convenient UIView subclass.
  * The view content is basically an EAGL surface you render your OpenGL scene into.
  * Note that setting the view non-opaque will only work if the EAGL surface has an alpha channel.
  */
-@interface EAGLView : UIView {
+@interface EARenderView : UIView {
 #if AX_GLES_PROFILE
     id<ESRenderer> renderer_;
 #endif
@@ -92,13 +92,13 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     unsigned int requestedSamples_;
 }
 
-/** creates an initializes an EAGLView with a frame and 0-bit depth buffer, and a RGB565 color buffer */
+/** creates an initializes an EARenderView with a frame and 0-bit depth buffer, and a RGB565 color buffer */
 + (id)viewWithFrame:(CGRect)frame;
-/** creates an initializes an EAGLView with a frame, a color buffer format, and 0-bit depth buffer */
+/** creates an initializes an EARenderView with a frame, a color buffer format, and 0-bit depth buffer */
 + (id)viewWithFrame:(CGRect)frame pixelFormat:(int)format;
-/** creates an initializes an EAGLView with a frame, a color buffer format, and a depth buffer format */
+/** creates an initializes an EARenderView with a frame, a color buffer format, and a depth buffer format */
 + (id)viewWithFrame:(CGRect)frame pixelFormat:(int)format depthFormat:(int)depth;
-/** creates an initializes an EAGLView with a frame, a color buffer format, a depth buffer format, a sharegroup, and
+/** creates an initializes an EARenderView with a frame, a color buffer format, a depth buffer format, a sharegroup, and
  * multisampling */
 + (id)viewWithFrame:(CGRect)frame
            pixelFormat:(int)format
@@ -108,11 +108,11 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
          multiSampling:(BOOL)multisampling
        numberOfSamples:(unsigned int)samples;
 
-/** Initializes an EAGLView with a frame and 0-bit depth buffer, and a RGB565 color buffer */
+/** Initializes an EARenderView with a frame and 0-bit depth buffer, and a RGB565 color buffer */
 - (id)initWithFrame:(CGRect)frame;  // These also set the current context
-/** Initializes an EAGLView with a frame, a color buffer format, and 0-bit depth buffer */
+/** Initializes an EARenderView with a frame, a color buffer format, and 0-bit depth buffer */
 - (id)initWithFrame:(CGRect)frame pixelFormat:(int)format;
-/** Initializes an EAGLView with a frame, a color buffer format, a depth buffer format, a sharegroup and multisampling
+/** Initializes an EARenderView with a frame, a color buffer format, a depth buffer format, a sharegroup and multisampling
  * support */
 - (id)initWithFrame:(CGRect)frame
            pixelFormat:(int)format
@@ -138,7 +138,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 @property(nonatomic, readwrite) BOOL multiSampling;
 @property(nonatomic, readonly) BOOL isKeyboardShown;
 
-/** EAGLView uses double-buffer. This method swaps the buffers */
+/** EARenderView uses double-buffer. This method swaps the buffers */
 - (void)swapBuffers;
 
 - (CGRect)convertRectFromViewToSurface:(CGRect)rect;

--- a/core/platform/ios/EARenderView-ios.mm
+++ b/core/platform/ios/EARenderView-ios.mm
@@ -15,7 +15,7 @@ seeds.
 
 =====================
 
-File: EAGLView.m
+File: EARenderView.m
 Abstract: Convenience class that wraps the CAEAGLLayer from CoreAnimation into a
 UIView subclass.
 
@@ -60,7 +60,7 @@ APPLE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 */
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 
 #import <QuartzCore/QuartzCore.h>
 
@@ -74,7 +74,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #    import "renderer/backend/metal/DriverMTL.h"
 #    import "renderer/backend/metal/UtilsMTL.h"
 #else
-#    import "platform/ios/GLViewImpl-ios.h"
+#    import "platform/ios/RenderViewImpl-ios.h"
 #    import "platform/ios/ES3Renderer-ios.h"
 #    import "platform/ios/OpenGL_Internal-ios.h"
 #endif
@@ -83,14 +83,14 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #define IOS_MAX_TOUCHES_COUNT 10
 
-@interface EAGLView ()
+@interface EARenderView ()
 @property(nonatomic) TextInputView* textInputView;
 @property(nonatomic, readwrite, assign) BOOL isKeyboardShown;
 @property(nonatomic, copy) NSNotification* keyboardShowNotification;
 @property(nonatomic, assign) CGRect originalRect;
 @end
 
-@implementation EAGLView
+@implementation EARenderView
 
 @synthesize surfaceSize = size_;
 @synthesize pixelFormat = pixelformat_, depthFormat = depthFormat_;
@@ -412,7 +412,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 }
 #endif
 
-#pragma mark EAGLView - Point conversion
+#pragma mark EARenderView - Point conversion
 
 - (CGPoint)convertPointFromViewToSurface:(CGPoint)point
 {
@@ -439,7 +439,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 }
 
 // Pass the touches to the superview
-#pragma mark EAGLView - Touch Delegate
+#pragma mark EARenderView - Touch Delegate
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event
 {
     if (self.isKeyboardShown)
@@ -464,8 +464,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         ++i;
     }
 
-    auto glView = ax::Director::getInstance()->getGLView();
-    glView->handleTouchesBegin(i, (intptr_t*)ids, xs, ys);
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    renderView->handleTouchesBegin(i, (intptr_t*)ids, xs, ys);
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event
@@ -499,8 +499,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         ++i;
     }
 
-    auto glView = ax::Director::getInstance()->getGLView();
-    glView->handleTouchesMove(i, (intptr_t*)ids, xs, ys, fs, ms);
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    renderView->handleTouchesMove(i, (intptr_t*)ids, xs, ys, fs, ms);
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event
@@ -524,8 +524,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         ++i;
     }
 
-    auto glView = ax::Director::getInstance()->getGLView();
-    glView->handleTouchesEnd(i, (intptr_t*)ids, xs, ys);
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    renderView->handleTouchesEnd(i, (intptr_t*)ids, xs, ys);
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event
@@ -549,8 +549,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         ++i;
     }
 
-    auto glView = ax::Director::getInstance()->getGLView();
-    glView->handleTouchesCancel(i, (intptr_t*)ids, xs, ys);
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    renderView->handleTouchesCancel(i, (intptr_t*)ids, xs, ys);
 }
 
 - (void)showKeyboard
@@ -572,13 +572,13 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     [UIView setAnimationDuration:duration];
     [UIView setAnimationBeginsFromCurrentState:YES];
 
-    // NSLog(@"[animation] dis = %f, scale = %f \n", dis, ax::GLView::getInstance()->getScaleY());
+    // NSLog(@"[animation] dis = %f, scale = %f \n", dis, ax::RenderView::getInstance()->getScaleY());
 
     if (dis < 0.0f)
         dis = 0.0f;
 
-    auto glView = ax::Director::getInstance()->getGLView();
-    dis *= glView->getScaleY();
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    dis *= renderView->getScaleY();
 
     dis /= self.contentScaleFactor;
 
@@ -719,9 +719,9 @@ UIInterfaceOrientation getFixedOrientation(UIInterfaceOrientation statusBarOrien
         break;
     }
 
-    auto glView  = ax::Director::getInstance()->getGLView();
-    float scaleX = glView->getScaleX();
-    float scaleY = glView->getScaleY();
+    auto renderView  = ax::Director::getInstance()->getRenderView();
+    float scaleX = renderView->getScaleX();
+    float scaleY = renderView->getScaleY();
 
     // Convert to pixel coordinate
     begin = CGRectApplyAffineTransform(
@@ -729,7 +729,7 @@ UIInterfaceOrientation getFixedOrientation(UIInterfaceOrientation statusBarOrien
     end = CGRectApplyAffineTransform(
         end, CGAffineTransformScale(CGAffineTransformIdentity, self.contentScaleFactor, self.contentScaleFactor));
 
-    float offestY = glView->getViewPortRect().origin.y;
+    float offestY = renderView->getViewPortRect().origin.y;
     if (offestY < 0.0f)
     {
         begin.origin.y += offestY;

--- a/core/platform/ios/RenderViewImpl-ios.h
+++ b/core/platform/ios/RenderViewImpl-ios.h
@@ -27,32 +27,36 @@
 
 #include "base/Object.h"
 #include "platform/Common.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 
 namespace ax
 {
 
 /** Class that represent the OpenGL View
  */
-class AX_DLL GLViewImpl : public GLView
+class AX_DLL RenderViewImpl : public RenderView
 {
 public:
-    /** DEPRECATED creates a GLViewImpl with a objective-c CCEAGLViewImpl instance */
-    AX_DEPRECATED(2.8) static GLViewImpl* createWithEAGLView(void* eaGLView);
 
-    /** creates a GLViewImpl with a title name in fullscreen mode */
-    static GLViewImpl* create(std::string_view viewName);
+#ifndef AX_CORE_PROFILE
+    /** DEPRECATED creates a RenderViewImpl with a objective-c EARenderViewImpl instance */
+    AX_DEPRECATED(2.8) static RenderViewImpl* createWithEARenderView(void* viewHandle);
+#endif
 
-    /** creates a GLViewImpl with a title name, a rect and the zoom factor */
-    static GLViewImpl* createWithRect(std::string_view viewName,
+    /** creates a RenderViewImpl with a title name in fullscreen mode */
+    static RenderViewImpl* create(std::string_view viewName);
+
+    /** creates a RenderViewImpl with a title name, a rect and the zoom factor */
+    static RenderViewImpl* createWithRect(std::string_view viewName,
                                       const Rect& rect,
                                       float frameZoomFactor = 1.0f,
                                       bool resizable        = false);
 
-    /** creates a GLViewImpl with a name in fullscreen mode */
-    static GLViewImpl* createWithFullScreen(std::string_view viewName);
-
+    /** creates a RenderViewImpl with a name in fullscreen mode */
+    static RenderViewImpl* createWithFullScreen(std::string_view viewName);
+#ifndef AX_CORE_PROFILE
     AX_DEPRECATED(2.8) static void convertAttrs() { choosePixelFormats(); }
+#endif
     static void choosePixelFormats();
     static PixelFormat _pixelFormat;
     static PixelFormat _depthFormat;
@@ -64,41 +68,46 @@ public:
     void showWindow(void* viewController);
 
     /** sets the content scale factor */
-    virtual bool setContentScaleFactor(float contentScaleFactor) override;
+    bool setContentScaleFactor(float contentScaleFactor) override;
 
     /** returns the content scale factor */
-    virtual float getContentScaleFactor() const override;
+    float getContentScaleFactor() const override;
 
     /** returns whether or not the view is in Retina Display mode */
-    virtual bool isRetinaDisplay() const override { return getContentScaleFactor() == 2.0; }
+    bool isRetinaDisplay() const override { return getContentScaleFactor() == 2.0; }
 
-    /** returns the objective-c EAGLView instance */
-    virtual void* getEAGLView() const override { return _eaglView; }
-    
-    /** returns the objective-c UIWindow instance */
-    void* getUIWindow() const { return _uiWindow; }
+    /** @since axmol-2.8.0, returns the objective-c UIWindow instance */
+    void* getEAWindow() const override { return _eaWindowHandle; }
+
+    /** @since axmol-2.8.0, returns the objective-c EARenderView instance */
+    void* getEARenderView() const override { return _eaViewHandle; }
 
     // overrides
-    virtual bool isOpenGLReady() override;
-    virtual void end() override;
-    virtual void swapBuffers() override;
-    virtual void setIMEKeyboardState(bool bOpen) override;
+    bool isGfxContextReady() override;
+    void end() override;
+    void swapBuffers() override;
+    void setIMEKeyboardState(bool bOpen) override;
 
-    virtual Rect getSafeAreaRect() const override;
+    Rect getSafeAreaRect() const override;
 
     void queueOperation(void (*op)(void*), void* param) override;
 
 protected:
-    GLViewImpl();
-    virtual ~GLViewImpl();
-
-    bool initWithEAGLView(void* eaGLView);
+    RenderViewImpl();
+    ~RenderViewImpl() override;
+#ifndef AX_CORE_PROFILE
+    AX_DEPRECATED(2.8) bool initWithEARenderView(void* viewHandle);
+#endif
     bool initWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor, bool resizable = false);
     bool initWithFullScreen(std::string_view viewName);
 
-    // the objective-c EAGLView instance
-    void* _eaglView;
-    void* _uiWindow;
+    // the objective-c instance handles
+    void* _eaViewHandle;
+    void* _eaWindowHandle;
 };
+
+#ifndef AX_CORE_PROFILE
+AX_DEPRECATED(2.8) typedef RenderViewImpl GLViewImpl;
+#endif
 
 }

--- a/core/platform/linux/Application-linux.cpp
+++ b/core/platform/linux/Application-linux.cpp
@@ -52,7 +52,7 @@ Application::~Application()
 
 int Application::run()
 {
-    initGLContextAttrs();
+    initGfxContextAttrs();
     // Initialize instance and cocos2d.
     if (!applicationDidFinishLaunching())
     {
@@ -62,17 +62,17 @@ int Application::run()
     std::chrono::steady_clock::time_point lastTime{};
 
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto renderView   = director->getRenderView();
 
-    // Retain glView to avoid glView being released in the while loop
-    glView->retain();
+    // Retain renderView to avoid renderView being released in the while loop
+    renderView->retain();
 
-    while (!glView->windowShouldClose())
+    while (!renderView->windowShouldClose())
     {
         lastTime = std::chrono::steady_clock::now();
 
         director->mainLoop();
-        glView->pollEvents();
+        renderView->pollEvents();
 
         auto interval = std::chrono::steady_clock::now() - lastTime;
         if (interval < _animationInterval)
@@ -90,13 +90,13 @@ int Application::run()
      *  when we want to close the window, we should call Director::end();
      *  then call Director::mainLoop to do release of internal resources
      */
-    if (glView->isOpenGLReady())
+    if (renderView->isGfxContextReady())
     {
         director->end();
         director->mainLoop();
         director = nullptr;
     }
-    glView->release();
+    renderView->release();
     return EXIT_SUCCESS;
 }
 

--- a/core/platform/mac/Application-mac.mm
+++ b/core/platform/mac/Application-mac.mm
@@ -54,7 +54,7 @@ Application::~Application()
 
 int Application::run()
 {
-    initGLContextAttrs();
+    initGfxContextAttrs();
     if (!applicationDidFinishLaunching())
     {
         return 1;
@@ -65,17 +65,17 @@ int Application::run()
     constexpr std::chrono::nanoseconds _1ms{1000000};
 
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto renderView   = director->getRenderView();
 
-    // Retain glView to avoid glView being released in the while loop
-    glView->retain();
+    // Retain renderView to avoid renderView being released in the while loop
+    renderView->retain();
 
-    while (!glView->windowShouldClose())
+    while (!renderView->windowShouldClose())
     {
         lastTime = std::chrono::steady_clock::now();
 
         director->mainLoop();
-        glView->pollEvents();
+        renderView->pollEvents();
 
         auto interval = std::chrono::steady_clock::now() - lastTime;
         auto waitDuration = _animationInterval - interval - _1ms;
@@ -90,13 +90,13 @@ int Application::run()
      *  when we want to close the window, we should call Director::end();
      *  then call Director::mainLoop to do release of internal resources
      */
-    if (glView->isOpenGLReady())
+    if (renderView->isGfxContextReady())
     {
         director->end();
         director->mainLoop();
     }
 
-    glView->release();
+    renderView->release();
 
     return 0;
 }

--- a/core/platform/mac/Common-mac.mm
+++ b/core/platform/mac/Common-mac.mm
@@ -46,8 +46,8 @@ void messageBox(const char* msg, const char* title)
     [alert setInformativeText:tmpTitle];
     [alert setAlertStyle:NSAlertStyleWarning];
 
-    auto glView = Director::getInstance()->getGLView();
-    id window   = (id)glView->getCocoaWindow();
+    auto renderView = Director::getInstance()->getRenderView();
+    id window   = (id)renderView->getCocoaWindow();
     [alert beginSheetModalForWindow:window completionHandler:nil];
 }
 

--- a/core/platform/wasm/Application-wasm.cpp
+++ b/core/platform/wasm/Application-wasm.cpp
@@ -104,22 +104,22 @@ static int64_t mLastTickInNanoSeconds = 0;
 
 static void renderFrame() {
     auto director = __director;
-    auto glview   = director->getGLView();
+    auto renderView   = director->getRenderView();
 
     director->mainLoop();
-    glview->pollEvents();
+    renderView->pollEvents();
 
-    if (glview->windowShouldClose())
+    if (renderView->windowShouldClose())
     {
         AXLOGI("shuting down axmol wasm app ...");
         emscripten_cancel_main_loop();  // Cancel current loop and set the cleanup one.
 
-        if (glview->isOpenGLReady())
+        if (renderView->isGfxContextReady())
         {
             director->end();
             director->mainLoop();
         }
-        glview->release();
+        renderView->release();
 
         axmol_wasm_app_exit();
     }
@@ -176,7 +176,7 @@ Application::~Application()
 
 int Application::run()
 {
-    initGLContextAttrs();
+    initGfxContextAttrs();
     // Initialize instance and cocos2d.
     if (!applicationDidFinishLaunching())
     {
@@ -186,7 +186,7 @@ int Application::run()
     __director = Director::getInstance();
 
     // Retain glview to avoid glview being released in the while loop
-    __director->getGLView()->retain();
+    __director->getRenderView()->retain();
 
     /*
     The JavaScript environment will call that function at a specified number

--- a/core/platform/win32/Application-win32.cpp
+++ b/core/platform/win32/Application-win32.cpp
@@ -77,7 +77,7 @@ int Application::run()
 
     QueryPerformanceCounter(&nLast);
 
-    initGLContextAttrs();
+    initGfxContextAttrs();
 
     // Initialize instance and cocos2d.
     if (!applicationDidFinishLaunching())
@@ -86,10 +86,10 @@ int Application::run()
     }
 
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto renderView   = director->getRenderView();
 
-    // Retain glView to avoid glView being released in the while loop
-    glView->retain();
+    // Retain renderView to avoid renderView being released in the while loop
+    renderView->retain();
 
     LONGLONG interval = 0LL;
     LONG waitMS       = 0L;
@@ -97,7 +97,7 @@ int Application::run()
     LARGE_INTEGER freq;
     QueryPerformanceFrequency(&freq);
 
-    while (!glView->windowShouldClose())
+    while (!renderView->windowShouldClose())
     {
         QueryPerformanceCounter(&nNow);
         interval = nNow.QuadPart - nLast.QuadPart;
@@ -105,7 +105,7 @@ int Application::run()
         {
             nLast.QuadPart = nNow.QuadPart;
             director->mainLoop();
-            glView->pollEvents();
+            renderView->pollEvents();
         }
         else
         {
@@ -121,13 +121,13 @@ int Application::run()
     }
 
     // Director should still do a cleanup if the window was closed manually.
-    if (glView->isOpenGLReady())
+    if (renderView->isGfxContextReady())
     {
         director->end();
         director->mainLoop();
         director = nullptr;
     }
-    glView->release();
+    renderView->release();
 
 
     return 0;

--- a/core/platform/winrt/Application-winrt.cpp
+++ b/core/platform/winrt/Application-winrt.cpp
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 #include "platform/PlatformConfig.h"
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "base/Director.h"
 #include <algorithm>
 #include "platform/FileUtils.h"
@@ -83,7 +83,7 @@ int Application::run()
 
     QueryPerformanceCounter(&m_nLast);
 
-    GLViewImpl::sharedGLView()->Run();
+    RenderViewImpl::sharedRenderView()->Run();
     return 0;
 }
 
@@ -163,7 +163,7 @@ std::string Application::getVersion()
 
 bool Application::openURL(std::string_view url)
 {
-    auto dispatcher = ax::GLViewImpl::sharedGLView()->getDispatcher();
+    auto dispatcher = ax::RenderViewImpl::sharedRenderView()->getDispatcher();
     dispatcher.get().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, DispatchedHandler([url]() {
                                   auto uri = Windows::Foundation::Uri(PlatformStringFromString(url));
                                   Windows::System::Launcher::LaunchUriAsync(uri);

--- a/core/platform/winrt/Common-winrt.cpp
+++ b/core/platform/winrt/Common-winrt.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "platform/Common.h"
 #include "platform/StdC.h"
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "platform/winrt/WinRTUtils.h"
 
 #if defined(VLD_DEBUG_MEMORY)
@@ -40,7 +40,7 @@ void messageBox(const char * pszMsg, const char * pszTitle)
     // Create the message dialog and set its content
     auto message = PlatformStringFromString(pszMsg);
     auto title = PlatformStringFromString(pszTitle);
-    GLViewImpl::sharedGLView()->ShowMessageBox(title, message);
+    RenderViewImpl::sharedRenderView()->ShowMessageBox(title, message);
 }
 
 }

--- a/core/platform/winrt/Device-winrt.cpp
+++ b/core/platform/winrt/Device-winrt.cpp
@@ -38,7 +38,7 @@ THE SOFTWARE.
 #    include "platform/FileUtils.h"
 #    include "platform/winrt/WinRTUtils.h"
 #    include "platform/StdC.h"
-#    include "platform/winrt/GLViewImpl-winrt.h"
+#    include "platform/winrt/RenderViewImpl-winrt.h"
 
 #    include <winrt/Windows.Devices.Sensors.h>
 
@@ -363,7 +363,7 @@ static TextRenderer& sharedTextRenderer()
 
 int Device::getDPI()
 {
-    return ax::GLViewImpl::sharedGLView()->GetDPI();
+    return ax::RenderViewImpl::sharedRenderView()->GetDPI();
 }
 
 float Device::getPixelRatio()
@@ -415,7 +415,7 @@ void Device::setAccelerometerEnabled(bool isEnabled)
             acc.z         = reading.AccelerationZ();
             acc.timestamp = 0;
 
-            auto orientation = GLViewImpl::sharedGLView()->getDeviceOrientation();
+            auto orientation = RenderViewImpl::sharedRenderView()->getDeviceOrientation();
 
             if (isWindowsPhone())
             {
@@ -480,7 +480,7 @@ void Device::setAccelerometerEnabled(bool isEnabled)
             }
 
             std::shared_ptr<ax::InputEvent> event(new AccelerometerEvent(acc));
-            ax::GLViewImpl::sharedGLView()->QueueEvent(event);
+            ax::RenderViewImpl::sharedRenderView()->QueueEvent(event);
             });
     }
 }

--- a/core/platform/winrt/InputEvent.cpp
+++ b/core/platform/winrt/InputEvent.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "platform/winrt/InputEvent.h"
 #include "platform/winrt/WinRTUtils.h"
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "base/EventAcceleration.h"
 #include "base/Director.h"
 #include "base/EventDispatcher.h"
@@ -59,25 +59,25 @@ void PointerEvent::execute()
     switch(m_type)
     {
     case PointerEventType::PointerPressed:
-        GLViewImpl::sharedGLView()->OnPointerPressed(m_args);
+        RenderViewImpl::sharedRenderView()->OnPointerPressed(m_args);
         break;
     case PointerEventType::PointerMoved:
-        GLViewImpl::sharedGLView()->OnPointerMoved(m_args);
+        RenderViewImpl::sharedRenderView()->OnPointerMoved(m_args);
         break;
     case PointerEventType::PointerReleased:
-        GLViewImpl::sharedGLView()->OnPointerReleased(m_args);
+        RenderViewImpl::sharedRenderView()->OnPointerReleased(m_args);
         break;
     case ax::MousePressed:
-        GLViewImpl::sharedGLView()->OnMousePressed(m_args);
+        RenderViewImpl::sharedRenderView()->OnMousePressed(m_args);
         break;
     case ax::MouseMoved:
-        GLViewImpl::sharedGLView()->OnMouseMoved(m_args);
+        RenderViewImpl::sharedRenderView()->OnMouseMoved(m_args);
         break;
     case ax::MouseReleased:
-        GLViewImpl::sharedGLView()->OnMouseReleased(m_args);
+        RenderViewImpl::sharedRenderView()->OnMouseReleased(m_args);
         break;
     case ax::MouseWheelChanged:
-        GLViewImpl::sharedGLView()->OnMouseWheelChanged(m_args);
+        RenderViewImpl::sharedRenderView()->OnMouseWheelChanged(m_args);
         break;
     }
 }
@@ -131,7 +131,7 @@ WinRTKeyboardEvent::WinRTKeyboardEvent(WinRTKeyboardEventType type, const Window
 
 void WinRTKeyboardEvent::execute()
 {
-	GLViewImpl::sharedGLView()->OnWinRTKeyboardEvent(m_type, m_key);
+	RenderViewImpl::sharedRenderView()->OnWinRTKeyboardEvent(m_type, m_key);
 }
 
 BackButtonEvent::BackButtonEvent()
@@ -141,7 +141,7 @@ BackButtonEvent::BackButtonEvent()
 
 void BackButtonEvent::execute()
 {
-    GLViewImpl::sharedGLView()->OnBackKeyPress();
+    RenderViewImpl::sharedRenderView()->OnBackKeyPress();
 }
 
 CustomInputEvent::CustomInputEvent(const std::function<void()>& fun)

--- a/core/platform/winrt/Keyboard-winrt.cpp
+++ b/core/platform/winrt/Keyboard-winrt.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 #include "platform/winrt/Keyboard-winrt.h"
 #include "base/EventKeyboard.h"
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "base/IMEDispatcher.h"
 #include "base/Director.h"
 #include "base/EventDispatcher.h"
@@ -220,8 +220,8 @@ KeyBoardWinRT::~KeyBoardWinRT()
 
 void KeyBoardWinRT::ShowKeyboard(winrt::hstring const& text)
 {
-    auto panel = ax::GLViewImpl::sharedGLView()->getPanel();
-    auto dispatcher = ax::GLViewImpl::sharedGLView()->getDispatcher();
+    auto panel = ax::RenderViewImpl::sharedRenderView()->getPanel();
+    auto dispatcher = ax::RenderViewImpl::sharedRenderView()->getDispatcher();
 
     if (dispatcher && panel)
     {
@@ -252,8 +252,8 @@ void KeyBoardWinRT::ShowKeyboard(winrt::hstring const& text)
 
 void KeyBoardWinRT::HideKeyboard(winrt::hstring const& text)
 {
-    auto panel = ax::GLViewImpl::sharedGLView()->getPanel();
-    auto dispatcher = ax::GLViewImpl::sharedGLView()->getDispatcher();
+    auto panel = ax::RenderViewImpl::sharedRenderView()->getPanel();
+    auto dispatcher = ax::RenderViewImpl::sharedRenderView()->getDispatcher();
 
     if (dispatcher && panel)
     {
@@ -323,7 +323,7 @@ void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, KeyEventAr
     }
     else
     {
-        AXLOGW("GLViewImpl::OnWinRTKeyboardEvent Virtual Key Code {} not supported", key);
+        AXLOGW("RenderViewImpl::OnWinRTKeyboardEvent Virtual Key Code {} not supported", key);
     }
 }
 
@@ -336,7 +336,7 @@ void KeyBoardWinRT::OnTextChanged(const Windows::Foundation::IInspectable& sende
     if (!text.empty())
     {
         std::shared_ptr<ax::InputEvent> e(new ax::KeyboardEvent(AxmolKeyEvent::Text, text));
-        ax::GLViewImpl::sharedGLView()->QueueEvent(e);
+        ax::RenderViewImpl::sharedRenderView()->QueueEvent(e);
         m_textBox.Text(L"");
     }
 }
@@ -354,7 +354,7 @@ void KeyBoardWinRT::OnTextCompositionEnded(Windows::UI::Xaml::Controls::TextBox,
 	if (!text.empty())
 	{
 		std::shared_ptr<ax::InputEvent> e(new ax::KeyboardEvent(AxmolKeyEvent::Text, text));
-		ax::GLViewImpl::sharedGLView()->QueueEvent(e);
+		ax::RenderViewImpl::sharedRenderView()->QueueEvent(e);
 		m_textBox.Text(L"");
 	}
 }

--- a/core/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/core/platform/winrt/RenderViewImpl-winrt.cpp
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "base/Macros.h"
 #include "base/Director.h"
 #include "base/Touch.h"
@@ -44,7 +44,7 @@ THE SOFTWARE.
 namespace ax
 {
 
-static GLViewImpl* s_pEglView = nullptr;
+static RenderViewImpl* s_pEglView = nullptr;
 
 static EventMouse::MouseButton checkMouseButton(Windows::UI::Core::PointerEventArgs const& args)
 {
@@ -63,9 +63,9 @@ static EventMouse::MouseButton checkMouseButton(Windows::UI::Core::PointerEventA
     return EventMouse::MouseButton::BUTTON_UNSET;
 }
 
-GLViewImpl* GLViewImpl::create(std::string_view viewName)
+RenderViewImpl* RenderViewImpl::create(std::string_view viewName)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new RenderViewImpl;
     if (ret && ret->initWithFullScreen(viewName))
     {
         ret->autorelease();
@@ -75,10 +75,10 @@ GLViewImpl* GLViewImpl::create(std::string_view viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithRect(std::string_view viewName,
+RenderViewImpl* RenderViewImpl::createWithRect(std::string_view viewName,
                                        const Rect& rect, float frameZoomFactor, bool /*resizable*/)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new RenderViewImpl;
     if (ret && ret->initWithRect(viewName, rect, frameZoomFactor))
     {
         ret->autorelease();
@@ -88,9 +88,9 @@ GLViewImpl* GLViewImpl::createWithRect(std::string_view viewName,
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName)
+RenderViewImpl* RenderViewImpl::createWithFullScreen(std::string_view viewName)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new RenderViewImpl();
     if (ret->initWithFullScreen(viewName))
     {
         ret->autorelease();
@@ -100,7 +100,7 @@ GLViewImpl* GLViewImpl::createWithFullScreen(std::string_view viewName)
     return nullptr;
 }
 
-GLViewImpl::GLViewImpl()
+RenderViewImpl::RenderViewImpl()
     : _frameZoomFactor(1.0f)
     , _supportTouch(true)
     , _isRetina(false)
@@ -121,17 +121,17 @@ GLViewImpl::GLViewImpl()
     m_keyboard = KeyBoardWinRT();
 
     m_backButtonListener                = EventListenerKeyboard::create();
-    m_backButtonListener->onKeyReleased = AX_CALLBACK_2(GLViewImpl::BackButtonListener, this);
+    m_backButtonListener->onKeyReleased = AX_CALLBACK_2(RenderViewImpl::BackButtonListener, this);
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(m_backButtonListener, INT_MAX);
 }
 
-GLViewImpl::~GLViewImpl()
+RenderViewImpl::~RenderViewImpl()
 {
     AX_ASSERT(this == s_pEglView);
     s_pEglView = nullptr;
 }
 
-bool GLViewImpl::initWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor)
+bool RenderViewImpl::initWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor)
 {
     setViewName(viewName);
     setFrameSize(rect.size.width, rect.size.height);
@@ -140,33 +140,32 @@ bool GLViewImpl::initWithRect(std::string_view viewName, const Rect& rect, float
     return true;
 }
 
-bool GLViewImpl::initWithFullScreen(std::string_view viewName)
+bool RenderViewImpl::initWithFullScreen(std::string_view viewName)
 {
     return initWithRect(viewName, Rect(0, 0, m_width, m_height), 1.0f);
 }
 
-void ax::GLViewImpl::setCursorVisible(bool isVisible)
+void ax::RenderViewImpl::setCursorVisible(bool isVisible)
 {
     _isCursorVisible = isVisible;
 }
 
-void GLViewImpl::setDispatcher(winrt::agile_ref<Windows::UI::Core::CoreDispatcher> dispatcher)
+void RenderViewImpl::setDispatcher(winrt::agile_ref<Windows::UI::Core::CoreDispatcher> dispatcher)
 {
     m_dispatcher = dispatcher;
 }
 
-void GLViewImpl::setPanel(winrt::agile_ref<Windows::UI::Xaml::Controls::Panel> panel)
+void RenderViewImpl::setPanel(winrt::agile_ref<Windows::UI::Xaml::Controls::Panel> panel)
 {
     m_panel = panel;
 }
 
-void GLViewImpl::setIMEKeyboardState(bool bOpen)
+void RenderViewImpl::setIMEKeyboardState(bool bOpen)
 {
-    std::string str;
-    setIMEKeyboardState(bOpen, str);
+    setIMEKeyboardState(bOpen, "");
 }
 
-bool GLViewImpl::ShowMessageBox(const winrt::hstring& title, const winrt::hstring& message)
+bool RenderViewImpl::ShowMessageBox(const winrt::hstring& title, const winrt::hstring& message)
 {
     if (m_dispatcher)
     {
@@ -184,7 +183,7 @@ bool GLViewImpl::ShowMessageBox(const winrt::hstring& title, const winrt::hstrin
     return false;
 }
 
-void GLViewImpl::setIMEKeyboardState(bool bOpen, std::string_view str)
+void RenderViewImpl::setIMEKeyboardState(bool bOpen, std::string_view str)
 {
     if (bOpen)
     {
@@ -196,39 +195,39 @@ void GLViewImpl::setIMEKeyboardState(bool bOpen, std::string_view str)
     }
 }
 
-void GLViewImpl::swapBuffers() {}
+void RenderViewImpl::swapBuffers() {}
 
-bool GLViewImpl::isOpenGLReady()
+bool RenderViewImpl::isGfxContextReady()
 {
     return true;
 }
 
-void GLViewImpl::end()
+void RenderViewImpl::end()
 {
     m_windowClosed  = true;
     m_appShouldExit = true;
 }
 
-void GLViewImpl::OnSuspending(Windows::Foundation::IInspectable const& sender,
+void RenderViewImpl::OnSuspending(Windows::Foundation::IInspectable const& sender,
                               Windows::ApplicationModel::SuspendingEventArgs const& args)
 {}
 
-void GLViewImpl::OnResuming(Windows::Foundation::IInspectable const& sender) {}
+void RenderViewImpl::OnResuming(Windows::Foundation::IInspectable const& sender) {}
 
 // user pressed the Back Key on the phone
-void GLViewImpl::OnBackKeyPress()
+void RenderViewImpl::OnBackKeyPress()
 {
     ax::EventKeyboard::KeyCode cocos2dKey = EventKeyboard::KeyCode::KEY_ESCAPE;
     ax::EventKeyboard event(cocos2dKey, false);
     ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void GLViewImpl::BackButtonListener(EventKeyboard::KeyCode keyCode, Event* event)
+void RenderViewImpl::BackButtonListener(EventKeyboard::KeyCode keyCode, Event* event)
 {
     if (keyCode == EventKeyboard::KeyCode::KEY_ESCAPE)
     {
         AXLOGD("*********************************************************************");
-        AXLOGD("GLViewImpl::BackButtonListener: Exiting application!");
+        AXLOGD("RenderViewImpl::BackButtonListener: Exiting application!");
         AXLOGD("");
         AXLOGD("If you want to listen for Windows Phone back button events,");
         AXLOGD("add a listener for EventKeyboard::KeyCode::KEY_ESCAPE");
@@ -258,25 +257,25 @@ void GLViewImpl::BackButtonListener(EventKeyboard::KeyCode keyCode, Event* event
     }
 }
 
-bool GLViewImpl::AppShouldExit()
+bool RenderViewImpl::AppShouldExit()
 {
     return m_appShouldExit;
 }
 
-void GLViewImpl::OnPointerPressed(Windows::UI::Core::CoreWindow const& sender,
+void RenderViewImpl::OnPointerPressed(Windows::UI::Core::CoreWindow const& sender,
                                   Windows::UI::Core::PointerEventArgs const& args)
 {
     OnPointerPressed(args);
 }
 
-void GLViewImpl::OnPointerPressed(Windows::UI::Core::PointerEventArgs const& args)
+void RenderViewImpl::OnPointerPressed(Windows::UI::Core::PointerEventArgs const& args)
 {
     intptr_t id = args.CurrentPoint().PointerId();
     Vec2 pt     = GetPoint(args);
     handleTouchesBegin(1, &id, &pt.x, &pt.y);
 }
 
-void GLViewImpl::OnPointerWheelChanged(Windows::UI::Core::CoreWindow const& sender,
+void RenderViewImpl::OnPointerWheelChanged(Windows::UI::Core::CoreWindow const& sender,
                                        Windows::UI::Core::PointerEventArgs const& args)
 {
     float direction = (float)args.CurrentPoint().Properties().MouseWheelDelta();
@@ -288,25 +287,25 @@ void GLViewImpl::OnPointerWheelChanged(Windows::UI::Core::CoreWindow const& send
     handleTouchesEnd(1, &id, &p.x, &p.y);
 }
 
-void GLViewImpl::OnVisibilityChanged(Windows::UI::Core::CoreWindow const& sender,
+void RenderViewImpl::OnVisibilityChanged(Windows::UI::Core::CoreWindow const& sender,
                                      Windows::UI::Core::VisibilityChangedEventArgs const& args)
 {
     m_windowVisible = args.Visible();
 }
 
-void GLViewImpl::OnWindowClosed(Windows::UI::Core::CoreWindow const& sender,
+void RenderViewImpl::OnWindowClosed(Windows::UI::Core::CoreWindow const& sender,
                                 Windows::UI::Core::CoreWindowEventArgs const& args)
 {
     m_windowClosed = true;
 }
 
-void GLViewImpl::OnPointerMoved(Windows::UI::Core::CoreWindow const& sender,
+void RenderViewImpl::OnPointerMoved(Windows::UI::Core::CoreWindow const& sender,
                                 Windows::UI::Core::PointerEventArgs const& args)
 {
     OnPointerMoved(args);
 }
 
-void GLViewImpl::OnPointerMoved(Windows::UI::Core::PointerEventArgs const& args)
+void RenderViewImpl::OnPointerMoved(Windows::UI::Core::PointerEventArgs const& args)
 {
     auto currentPoint = args.CurrentPoint();
     if (currentPoint.IsInContact())
@@ -326,20 +325,20 @@ void GLViewImpl::OnPointerMoved(Windows::UI::Core::PointerEventArgs const& args)
     }
 }
 
-void GLViewImpl::OnPointerReleased(Windows::UI::Core::CoreWindow const& sender,
+void RenderViewImpl::OnPointerReleased(Windows::UI::Core::CoreWindow const& sender,
                                    Windows::UI::Core::PointerEventArgs const& args)
 {
     OnPointerReleased(args);
 }
 
-void GLViewImpl::OnPointerReleased(Windows::UI::Core::PointerEventArgs const& args)
+void RenderViewImpl::OnPointerReleased(Windows::UI::Core::PointerEventArgs const& args)
 {
     intptr_t id = args.CurrentPoint().PointerId();
     Vec2 pt     = GetPoint(args);
     handleTouchesEnd(1, &id, &pt.x, &pt.y);
 }
 
-void ax::GLViewImpl::OnMousePressed(Windows::UI::Core::PointerEventArgs const& args)
+void ax::RenderViewImpl::OnMousePressed(Windows::UI::Core::PointerEventArgs const& args)
 {
     Vec2 pt = GetPoint(args);
 
@@ -378,7 +377,7 @@ void ax::GLViewImpl::OnMousePressed(Windows::UI::Core::PointerEventArgs const& a
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void ax::GLViewImpl::OnMouseMoved(Windows::UI::Core::PointerEventArgs const& args)
+void ax::RenderViewImpl::OnMouseMoved(Windows::UI::Core::PointerEventArgs const& args)
 {
     Vec2 pt = GetPoint(args);
 
@@ -395,7 +394,7 @@ void ax::GLViewImpl::OnMouseMoved(Windows::UI::Core::PointerEventArgs const& arg
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void ax::GLViewImpl::OnMouseReleased(Windows::UI::Core::PointerEventArgs const& args)
+void ax::RenderViewImpl::OnMouseReleased(Windows::UI::Core::PointerEventArgs const& args)
 {
     Vec2 pt = GetPoint(args);
 
@@ -414,7 +413,7 @@ void ax::GLViewImpl::OnMouseReleased(Windows::UI::Core::PointerEventArgs const& 
     _lastMouseButtonPressed = EventMouse::MouseButton::BUTTON_UNSET;
 }
 
-void ax::GLViewImpl::OnMouseWheelChanged(Windows::UI::Core::PointerEventArgs const& args)
+void ax::RenderViewImpl::OnMouseWheelChanged(Windows::UI::Core::PointerEventArgs const& args)
 {
     Vec2 pt = GetPoint(args);
     EventMouse event(EventMouse::MouseEventType::MOUSE_SCROLL);
@@ -432,43 +431,43 @@ void ax::GLViewImpl::OnMouseWheelChanged(Windows::UI::Core::PointerEventArgs con
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void GLViewImpl::resize(int width, int height) {}
+void RenderViewImpl::resize(int width, int height) {}
 
-void GLViewImpl::setFrameZoomFactor(float fZoomFactor)
+void RenderViewImpl::setFrameZoomFactor(float fZoomFactor)
 {
     _frameZoomFactor = fZoomFactor;
     Director::getInstance()->setProjection(Director::getInstance()->getProjection());
     // resize(m_obScreenSize.width * fZoomFactor, m_obScreenSize.height * fZoomFactor);
 }
 
-float GLViewImpl::getFrameZoomFactor()
+float RenderViewImpl::getFrameZoomFactor()
 {
     return _frameZoomFactor;
 }
 
-void GLViewImpl::centerWindow()
+void RenderViewImpl::centerWindow()
 {
     // not implemented in WinRT. Window is always full screen
 }
 
-GLViewImpl* GLViewImpl::sharedGLView()
+RenderViewImpl* RenderViewImpl::sharedRenderView()
 {
     return s_pEglView;
 }
 
-int GLViewImpl::Run()
+int RenderViewImpl::Run()
 {
     // XAML version does not have a run loop
     m_running = true;
     return 0;
 };
 
-void GLViewImpl::Render()
+void RenderViewImpl::Render()
 {
     OnRendering();
 }
 
-void GLViewImpl::OnRendering()
+void RenderViewImpl::OnRendering()
 {
     if (m_running && m_initialized)
     {
@@ -477,7 +476,7 @@ void GLViewImpl::OnRendering()
 }
 
 // called by orientation change from WP8 XAML
-void GLViewImpl::UpdateOrientation(Windows::Graphics::Display::DisplayOrientations orientation)
+void RenderViewImpl::UpdateOrientation(Windows::Graphics::Display::DisplayOrientations orientation)
 {
     if (m_orientation != orientation)
     {
@@ -487,7 +486,7 @@ void GLViewImpl::UpdateOrientation(Windows::Graphics::Display::DisplayOrientatio
 }
 
 // called by size change from WP8 XAML
-void GLViewImpl::UpdateForWindowSizeChange(float width, float height)
+void RenderViewImpl::UpdateForWindowSizeChange(float width, float height)
 {
     if (width != m_width || height != m_height)
     {
@@ -497,7 +496,7 @@ void GLViewImpl::UpdateForWindowSizeChange(float width, float height)
     }
 }
 
-void GLViewImpl::UpdateWindowSize()
+void RenderViewImpl::UpdateWindowSize()
 {
     float width, height;
 
@@ -508,10 +507,10 @@ void GLViewImpl::UpdateWindowSize()
     if (!m_initialized)
     {
         m_initialized = true;
-        GLView::setFrameSize(width, height);
+        RenderView::setFrameSize(width, height);
     }
 
-    auto view = Director::getInstance()->getGLView();
+    auto view = Director::getInstance()->getRenderView();
     if (view && view->getResolutionPolicy() != ResolutionPolicy::UNKNOWN)
     {
         Size resSize               = view->getDesignResolutionSize();
@@ -524,7 +523,7 @@ void GLViewImpl::UpdateWindowSize()
     }
 }
 
-ax::Vec2 GLViewImpl::TransformToOrientation(Windows::Foundation::Point const& p)
+ax::Vec2 RenderViewImpl::TransformToOrientation(Windows::Foundation::Point const& p)
 {
     ax::Vec2 returnValue;
 
@@ -532,7 +531,7 @@ ax::Vec2 GLViewImpl::TransformToOrientation(Windows::Foundation::Point const& p)
     float y     = p.Y;
     returnValue = Vec2(x, y);
 
-    float zoomFactor = GLViewImpl::sharedGLView()->getFrameZoomFactor();
+    float zoomFactor = RenderViewImpl::sharedRenderView()->getFrameZoomFactor();
     if (zoomFactor > 0.0f)
     {
         returnValue.x /= zoomFactor;
@@ -544,40 +543,40 @@ ax::Vec2 GLViewImpl::TransformToOrientation(Windows::Foundation::Point const& p)
     return returnValue;
 }
 
-Vec2 GLViewImpl::GetPoint(Windows::UI::Core::PointerEventArgs const& args)
+Vec2 RenderViewImpl::GetPoint(Windows::UI::Core::PointerEventArgs const& args)
 {
     return TransformToOrientation(args.CurrentPoint().Position());
 }
 
-void GLViewImpl::QueueBackKeyPress()
+void RenderViewImpl::QueueBackKeyPress()
 {
     std::shared_ptr<BackButtonEvent> e(new BackButtonEvent());
     mInputEvents.push(e);
 }
 
-void GLViewImpl::QueuePointerEvent(PointerEventType type, Windows::UI::Core::PointerEventArgs const& args)
+void RenderViewImpl::QueuePointerEvent(PointerEventType type, Windows::UI::Core::PointerEventArgs const& args)
 {
     std::shared_ptr<PointerEvent> e(new PointerEvent(type, args));
     mInputEvents.push(e);
 }
 
-void GLViewImpl::QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
+void RenderViewImpl::QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
 {
     std::shared_ptr<WinRTKeyboardEvent> e(new WinRTKeyboardEvent(type, args));
     mInputEvents.push(e);
 }
 
-void GLViewImpl::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
+void RenderViewImpl::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
 {
     m_keyboard.OnWinRTKeyboardEvent(type, args);
 }
 
-void GLViewImpl::QueueEvent(std::shared_ptr<InputEvent>& event)
+void RenderViewImpl::QueueEvent(std::shared_ptr<InputEvent>& event)
 {
     mInputEvents.push(event);
 }
 
-void GLViewImpl::ProcessEvents()
+void RenderViewImpl::ProcessEvents()
 {
     std::shared_ptr<InputEvent> e;
     while (mInputEvents.try_pop(e))
@@ -586,12 +585,12 @@ void GLViewImpl::ProcessEvents()
     }
 }
 
-void GLViewImpl::SetQueueOperationCb(std::function<void(AsyncOperation, void*)> cb)
+void RenderViewImpl::SetQueueOperationCb(std::function<void(AsyncOperation, void*)> cb)
 {
     mQueueOperationCb = std::move(cb);
 }
 
-void GLViewImpl::queueOperation(AsyncOperation op, void* param)
+void RenderViewImpl::queueOperation(AsyncOperation op, void* param)
 {
     if (mQueueOperationCb)
         mQueueOperationCb(std::move(op), param);

--- a/core/platform/winrt/RenderViewImpl-winrt.h
+++ b/core/platform/winrt/RenderViewImpl-winrt.h
@@ -25,13 +25,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#ifndef __AX_EGLVIEWIMPL_WINRT_H__
-#define __AX_EGLVIEWIMPL_WINRT_H__
+#ifndef __AX_RENDERVIEWIMPL_WINRT_H__
+#define __AX_RENDERVIEWIMPL_WINRT_H__
 
 #include "platform/winrt/StdC-winrt.h"
 #include "platform/Common.h"
 #include "platform/winrt/Keyboard-winrt.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #include "base/EventKeyboard.h"
 #include "base/EventMouse.h"
 
@@ -47,25 +47,25 @@ using namespace winrt;
 namespace ax
 {
 
-class GLViewImpl;
+class RenderViewImpl;
 
-class AX_DLL GLViewImpl : public GLView
+class AX_DLL RenderViewImpl : public RenderView
 {
 public:
-    static GLViewImpl* create(std::string_view viewName);
-    static GLViewImpl* createWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor = 1.0f, bool resizable = false);
-    static GLViewImpl* createWithFullScreen(std::string_view viewName);
+    static RenderViewImpl* create(std::string_view viewName);
+    static RenderViewImpl* createWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor = 1.0f, bool resizable = false);
+    static RenderViewImpl* createWithFullScreen(std::string_view viewName);
 
     /* override functions */
-    virtual bool isOpenGLReady();
-    virtual void end();
-    virtual void swapBuffers();
+    bool isGfxContextReady() override;
+    void end() override;
+    void swapBuffers() override;
 
     Windows::Graphics::Display::DisplayOrientations getDeviceOrientation() { return m_orientation; };
     Size getRenerTargetSize() const { return Size(m_width, m_height); }
 
-    virtual void setIMEKeyboardState(bool bOpen) override;
-    virtual void setIMEKeyboardState(bool bOpen, std::string_view str);
+    void setIMEKeyboardState(bool bOpen) override;
+    void setIMEKeyboardState(bool bOpen, std::string_view str);
 
     /**
      * Hide or Show the mouse cursor if there is one.
@@ -133,7 +133,7 @@ public:
     /**
     @brief    get the shared main open gl window
     */
-    static GLViewImpl* sharedGLView();
+    static RenderViewImpl* sharedRenderView();
 
     void ProcessEvents();
 
@@ -142,8 +142,8 @@ public:
     void SetQueueOperationCb(std::function<void(AsyncOperation, void*)> cb);
 
 protected:
-    GLViewImpl();
-    virtual ~GLViewImpl();
+    RenderViewImpl();
+    ~RenderViewImpl() override;
 
     bool initWithRect(std::string_view viewName, const Rect& rect, float frameZoomFactor);
     bool initWithFullScreen(std::string_view viewName);
@@ -161,7 +161,7 @@ protected:
     bool _isCursorVisible;
 
 private:
-    AX_DISALLOW_COPY_AND_ASSIGN(GLViewImpl);
+    AX_DISALLOW_COPY_AND_ASSIGN(RenderViewImpl);
 
     void OnRendering();
     void UpdateWindowSize();
@@ -200,6 +200,10 @@ private:
 
     ax::EventListenerKeyboard* m_backButtonListener;
 };
+
+#ifndef AX_CORE_PROFILE
+AX_DEPRECATED(2.8) typedef RenderViewImpl GLViewImpl;
+#endif
 
 }
 

--- a/core/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/core/platform/winrt/xaml/AxmolRenderer.cpp
@@ -19,7 +19,7 @@
 
 #include "AxmolRenderer.h"
 #include "AppDelegate.h"
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "platform/Application.h"
 #include "renderer/TextureCache.h"
 
@@ -54,17 +54,17 @@ AxmolRenderer::~AxmolRenderer() {}
 void AxmolRenderer::Resume()
 {
     auto director = ax::Director::getInstance();
-    auto glview   = director->getGLView();
+    auto glview   = director->getRenderView();
 
     if (!glview)
     {
-        GLViewImpl* glview = GLViewImpl::createWithRect(
+        RenderViewImpl* glview = RenderViewImpl::createWithRect(
             "axmol2", ax::Rect{0, 0, static_cast<float>(m_width), static_cast<float>(m_height)});
         glview->UpdateOrientation(m_orientation);
         glview->SetDPI(m_dpi);
         glview->setDispatcher(m_dispatcher);
         glview->setPanel(m_panel);
-        director->setGLView(glview);
+        director->setRenderView(glview);
         Application::getInstance()->run();
     }
     else
@@ -77,7 +77,7 @@ void AxmolRenderer::Resume()
 
 void AxmolRenderer::Pause()
 {
-    if (Director::getInstance()->getGLView())
+    if (Director::getInstance()->getRenderView())
     {
         Application::getInstance()->applicationDidEnterBackground();
         ax::EventCustom backgroundEvent(EVENT_COME_TO_BACKGROUND);
@@ -87,7 +87,7 @@ void AxmolRenderer::Pause()
 
 bool AxmolRenderer::AppShouldExit()
 {
-    return GLViewImpl::sharedGLView()->AppShouldExit();
+    return RenderViewImpl::sharedRenderView()->AppShouldExit();
 }
 
 void AxmolRenderer::DeviceLost()
@@ -95,7 +95,7 @@ void AxmolRenderer::DeviceLost()
     Pause();
 
     auto director = ax::Director::getInstance();
-    if (director->getGLView())
+    if (director->getRenderView())
     {
         backend::DriverBase::getInstance()->resetState();
         ax::Director::getInstance()->resetMatrixStack();
@@ -114,47 +114,47 @@ void AxmolRenderer::DeviceLost()
 
 void AxmolRenderer::SetQueueOperationCb(std::function<void(AsyncOperation, void*)> cb)
 {
-    GLViewImpl::sharedGLView()->SetQueueOperationCb(std::move(cb));
+    RenderViewImpl::sharedRenderView()->SetQueueOperationCb(std::move(cb));
 }
 
 void AxmolRenderer::Draw(size_t width, size_t height, float dpi, DisplayOrientations orientation)
 {
-    auto glView = GLViewImpl::sharedGLView();
+    auto renderView = RenderViewImpl::sharedRenderView();
 
     if (orientation != m_orientation)
     {
         m_orientation = orientation;
-        glView->UpdateOrientation(orientation);
+        renderView->UpdateOrientation(orientation);
     }
 
     if (width != m_width || height != m_height)
     {
         m_width  = width;
         m_height = height;
-        glView->UpdateForWindowSizeChange(static_cast<float>(width), static_cast<float>(height));
+        renderView->UpdateForWindowSizeChange(static_cast<float>(width), static_cast<float>(height));
     }
 
     if (dpi != m_dpi)
     {
         m_dpi = dpi;
-        glView->SetDPI(m_dpi);
+        renderView->SetDPI(m_dpi);
     }
 
-    glView->ProcessEvents();
-    glView->Render();
+    renderView->ProcessEvents();
+    renderView->Render();
 }
 
 void AxmolRenderer::QueuePointerEvent(ax::PointerEventType type, Windows::UI::Core::PointerEventArgs const& args)
 {
-    GLViewImpl::sharedGLView()->QueuePointerEvent(type, args);
+    RenderViewImpl::sharedRenderView()->QueuePointerEvent(type, args);
 }
 
 void AxmolRenderer::QueueBackButtonEvent()
 {
-    GLViewImpl::sharedGLView()->QueueBackKeyPress();
+    RenderViewImpl::sharedRenderView()->QueueBackKeyPress();
 }
 
 void AxmolRenderer::QueueKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
 {
-    GLViewImpl::sharedGLView()->QueueWinRTKeyboardEvent(type, args);
+    RenderViewImpl::sharedRenderView()->QueueWinRTKeyboardEvent(type, args);
 }

--- a/core/platform/winrt/xaml/OpenGLESPage.cpp
+++ b/core/platform/winrt/xaml/OpenGLESPage.cpp
@@ -20,7 +20,7 @@
 #include "OpenGLESPage.h"
 #include "OpenGLESPage.g.cpp"
 
-#include "platform/winrt/GLViewImpl-winrt.h"
+#include "platform/winrt/RenderViewImpl-winrt.h"
 #include "platform/Application.h"
 
 #include "yasio/wtimer_hres.hpp"
@@ -113,7 +113,7 @@ void OpenGLESPage::CreateInput()
         mCoreInput.PointerReleased({this, &OpenGLESPage::_OnPointerReleased});
         mCoreInput.PointerWheelChanged({this, &OpenGLESPage::_OnPointerWheelChanged});
 
-        if (GLViewImpl::sharedGLView() && !GLViewImpl::sharedGLView()->isCursorVisible())
+        if (RenderViewImpl::sharedRenderView() && !RenderViewImpl::sharedRenderView()->isCursorVisible())
         {
             mCoreInput.PointerCursor(nullptr);
         }
@@ -275,10 +275,10 @@ void OpenGLESPage::StartRenderLoop()
             mRenderer->Draw(panelWidth, panelHeight, mDpi, mOrientation);
 
             // Recreate input dispatch
-            if (GLViewImpl::sharedGLView() && mCursorVisible != GLViewImpl::sharedGLView()->isCursorVisible())
+            if (RenderViewImpl::sharedRenderView() && mCursorVisible != RenderViewImpl::sharedRenderView()->isCursorVisible())
             {
                 CreateInput();
-                mCursorVisible = GLViewImpl::sharedGLView()->isCursorVisible();
+                mCursorVisible = RenderViewImpl::sharedRenderView()->isCursorVisible();
             }
 
             if (mRenderer->AppShouldExit())

--- a/core/renderer/Renderer.h
+++ b/core/renderer/Renderer.h
@@ -146,7 +146,7 @@ public:
     /**Destructor.*/
     ~Renderer();
 
-    // TODO: manage GLView inside Render itself
+    // TODO: manage RenderView inside Render itself
     void init();
 
     void addCallbackCommand(std::function<void()> func, float globalZOrder = 0.0f);
@@ -169,7 +169,7 @@ public:
     /** Creates a render queue and returns its Id */
     int createRenderQueue();
 
-    /** Renders into the GLView all the queued `RenderCommand` objects */
+    /** Renders into the RenderView all the queued `RenderCommand` objects */
     void render();
 
     /** Cleans all `RenderCommand`s in the queue */

--- a/core/ui/LayoutHelper.cpp
+++ b/core/ui/LayoutHelper.cpp
@@ -14,8 +14,8 @@ void LayoutHelper::setDesignSizeFixedEdge(const Vec2& designSize)
     LayoutHelper::s_designSize = designSize;
 
     // Set the design resolution//分辨率的大小
-    GLView* pEGLView      = Director::getInstance()->getGLView();
-    const Vec2& frameSize = pEGLView->getFrameSize();
+    RenderView* pERenderView      = Director::getInstance()->getRenderView();
+    const Vec2& frameSize = pERenderView->getFrameSize();
 
     // Vec2 lsSize = lsaSize;
 
@@ -25,11 +25,11 @@ void LayoutHelper::setDesignSizeFixedEdge(const Vec2& designSize)
     // adjustedScale = 0.0f; // MAX(scaleX, scaleY);
     if (scaleX < scaleY)
     {
-        pEGLView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::FIXED_WIDTH);
+        pERenderView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::FIXED_WIDTH);
     }
     else
     {
-        pEGLView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::FIXED_HEIGHT);
+        pERenderView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::FIXED_HEIGHT);
     }
 }
 
@@ -39,8 +39,8 @@ void LayoutHelper::setDesignSizeNoBorder(const Vec2& designSize)
     LayoutHelper::s_designSize = designSize;
 
     // Set the design resolution//分辨率的大小
-    GLView* pEGLView      = Director::getInstance()->getGLView();
-    const Vec2& frameSize = pEGLView->getFrameSize();
+    RenderView* pERenderView      = Director::getInstance()->getRenderView();
+    const Vec2& frameSize = pERenderView->getFrameSize();
 
     // Vec2 lsSize = lsaSize;
 
@@ -59,13 +59,13 @@ void LayoutHelper::setDesignSizeNoBorder(const Vec2& designSize)
 
     AXLOGD("x: {}; y: {}; scale: {}", scaleX, scaleY, s_adjustedScale);
 
-    pEGLView->setDesignResolutionSize(LayoutHelper::s_designSize.width * s_adjustedScale,
+    pERenderView->setDesignResolutionSize(LayoutHelper::s_designSize.width * s_adjustedScale,
                                       LayoutHelper::s_designSize.height * s_adjustedScale, ResolutionPolicy::NO_BORDER);
 }
 
 ax::Vec2 LayoutHelper::getVisibleOrigin(void)
 {
-    const auto& adjustedDesignSize = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    const auto& adjustedDesignSize = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     return ax::Vec2((adjustedDesignSize.width - LayoutHelper::s_designSize.width) * .5f,
                          (adjustedDesignSize.height - LayoutHelper::s_designSize.height) * .5f);
 }
@@ -908,9 +908,9 @@ void LayoutHelper::VisibleRect::lazyInit()
     if (s_ScreenVisibleRect.size.width == 0.0f && s_ScreenVisibleRect.size.height == 0.0f)
     {
         auto director = Director::getInstance();
-        auto glView   = director->getGLView();
+        auto renderView   = director->getRenderView();
 
-        if (glView->getResolutionPolicy() == ResolutionPolicy::NO_BORDER)
+        if (renderView->getResolutionPolicy() == ResolutionPolicy::NO_BORDER)
         {
             s_ScreenVisibleRect.origin = director->getVisibleOrigin();
             s_ScreenVisibleRect.size   = director->getVisibleSize();
@@ -1032,7 +1032,7 @@ float LayoutHelper::VisibleRect::getNodeTop(Node* pNode)
 void LayoutHelper::VisibleRect::setNodeLeft(Node* pNode, float left)
 {
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(0, scrSize.height) - LayoutHelper::VisibleRect::leftTop();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1047,7 +1047,7 @@ void LayoutHelper::VisibleRect::setNodeLeft(Node* pNode, float left)
 void LayoutHelper::VisibleRect::setNodeTop(Node* pNode, float top)
 {
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(0, scrSize.height) - LayoutHelper::VisibleRect::leftTop();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1062,7 +1062,7 @@ void LayoutHelper::VisibleRect::setNodeTop(Node* pNode, float top)
 void LayoutHelper::VisibleRect::setNodeRight(Node* pNode, float right)
 {
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(scrSize.width, 0) - LayoutHelper::VisibleRect::rightBottom();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1077,7 +1077,7 @@ void LayoutHelper::VisibleRect::setNodeRight(Node* pNode, float right)
 void LayoutHelper::VisibleRect::setNodeBottom(Node* pNode, float bottom)
 {
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(scrSize.width, 0) - LayoutHelper::VisibleRect::rightBottom();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1093,7 +1093,7 @@ void LayoutHelper::VisibleRect::setNodeBottom(Node* pNode, float bottom)
 void LayoutHelper::VisibleRect::setNodeLT(Node* pNode, const ax::Point& p)
 {
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(0, scrSize.height) - LayoutHelper::VisibleRect::leftTop();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1110,7 +1110,7 @@ void LayoutHelper::VisibleRect::setNodeLT(Node* pNode, const ax::Point& p)
 void LayoutHelper::VisibleRect::setNodeRT(Node* pNode, const ax::Point& p)
 {  // right top
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(scrSize.width, scrSize.height) - LayoutHelper::VisibleRect::rightTop();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1126,7 +1126,7 @@ void LayoutHelper::VisibleRect::setNodeRT(Node* pNode, const ax::Point& p)
 void LayoutHelper::VisibleRect::setNodeLB(Node* pNode, const ax::Point& p)
 {  // left bottom
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(0, 0) - LayoutHelper::VisibleRect::leftBottom();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1142,7 +1142,7 @@ void LayoutHelper::VisibleRect::setNodeLB(Node* pNode, const ax::Point& p)
 void LayoutHelper::VisibleRect::setNodeRB(Node* pNode, const ax::Point& p)
 {  // right bottom
     AX_ASSERT(pNode);
-    Vec2 scrSize              = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize              = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta      = ax::Vec2(scrSize.width, 0) - LayoutHelper::VisibleRect::rightBottom();
     Vec2 size                 = pNode->getContentSize() * getScale2D(pNode);
     ax::Point achorPoint = Vec2::ZERO;
@@ -1162,7 +1162,7 @@ void LayoutHelper::VisibleRect::setNodeNormalizedLT(Node* pNode, const ax::Point
 {
     AX_ASSERT(pNode);
 
-    Vec2 scrSize         = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize         = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta = ax::Vec2(0, scrSize.height) - LayoutHelper::VisibleRect::leftTop();
 
     Vec2 vscrSize    = LayoutHelper::VisibleRect::size();
@@ -1183,7 +1183,7 @@ void LayoutHelper::VisibleRect::setNodeNormalizedLT(Node* pNode, const ax::Point
 void LayoutHelper::VisibleRect::setNodeNormalizedRT(Node* pNode, const ax::Point& ratio)
 {  // right top
     AX_ASSERT(pNode);
-    Vec2 scrSize         = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize         = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta = ax::Vec2(scrSize.width, scrSize.height) - LayoutHelper::VisibleRect::rightTop();
 
     Vec2 vscrSize    = LayoutHelper::VisibleRect::size();
@@ -1204,7 +1204,7 @@ void LayoutHelper::VisibleRect::setNodeNormalizedRT(Node* pNode, const ax::Point
 void LayoutHelper::VisibleRect::setNodeNormalizedLB(Node* pNode, const ax::Point& ratio)
 {  // left bottom
     AX_ASSERT(pNode);
-    Vec2 scrSize         = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize         = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta = ax::Vec2(0, 0) - LayoutHelper::VisibleRect::leftBottom();
 
     Vec2 vscrSize    = LayoutHelper::VisibleRect::size();
@@ -1225,7 +1225,7 @@ void LayoutHelper::VisibleRect::setNodeNormalizedLB(Node* pNode, const ax::Point
 void LayoutHelper::VisibleRect::setNodeNormalizedRB(Node* pNode, const ax::Point& ratio)
 {  // right bottom
     AX_ASSERT(pNode);
-    Vec2 scrSize         = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize         = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta = ax::Vec2(scrSize.width, 0) - LayoutHelper::VisibleRect::rightBottom();
 
     Vec2 vscrSize    = LayoutHelper::VisibleRect::size();
@@ -1247,7 +1247,7 @@ void LayoutHelper::VisibleRect::setNodeNormalizedRB(Node* pNode, const ax::Point
 void LayoutHelper::VisibleRect::setNodeNormalizedTop(Node* pNode, const float ratioTop)
 {  // right top
     AX_ASSERT(pNode);
-    Vec2 scrSize         = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    Vec2 scrSize         = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     ax::Point delta = ax::Vec2(scrSize.width, scrSize.height) - LayoutHelper::VisibleRect::rightTop();
 
     Vec2 vscrSize = LayoutHelper::VisibleRect::size();

--- a/core/ui/UIEditBox/Mac/UIEditBoxMac.mm
+++ b/core/ui/UIEditBox/Mac/UIEditBoxMac.mm
@@ -131,8 +131,8 @@
 
 - (NSWindow*)window
 {
-    auto glView = ax::Director::getInstance()->getGLView();
-    return (NSWindow*)glView->getCocoaWindow();
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    return (NSWindow*)renderView->getCocoaWindow();
 }
 
 - (void)openKeyboard

--- a/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -97,8 +97,8 @@ EditBoxImplAndroid::~EditBoxImplAndroid()
 void EditBoxImplAndroid::createNativeControl(const Rect& frame)
 {
     auto director  = ax::Director::getInstance();
-    auto glView    = director->getGLView();
-    auto frameSize = glView->getFrameSize();
+    auto renderView    = director->getRenderView();
+    auto frameSize = renderView->getFrameSize();
 
     auto winSize    = director->getWinSize();
     auto leftBottom = _editBox->convertToWorldSpace(Point::ZERO);
@@ -106,20 +106,20 @@ void EditBoxImplAndroid::createNativeControl(const Rect& frame)
     auto contentSize = frame.size;
     auto rightTop    = _editBox->convertToWorldSpace(Point(contentSize.width, contentSize.height));
 
-    auto uiLeft   = frameSize.width / 2 + (leftBottom.x - winSize.width / 2) * glView->getScaleX();
-    auto uiTop    = frameSize.height / 2 - (rightTop.y - winSize.height / 2) * glView->getScaleY();
-    auto uiWidth  = (rightTop.x - leftBottom.x) * glView->getScaleX();
-    auto uiHeight = (rightTop.y - leftBottom.y) * glView->getScaleY();
-    LOGD("scaleX = %f", glView->getScaleX());
+    auto uiLeft   = frameSize.width / 2 + (leftBottom.x - winSize.width / 2) * renderView->getScaleX();
+    auto uiTop    = frameSize.height / 2 - (rightTop.y - winSize.height / 2) * renderView->getScaleY();
+    auto uiWidth  = (rightTop.x - leftBottom.x) * renderView->getScaleX();
+    auto uiHeight = (rightTop.y - leftBottom.y) * renderView->getScaleY();
+    LOGD("scaleX = %f", renderView->getScaleX());
     _editBoxIndex = JniHelper::callStaticIntMethod(editBoxClassName, "createEditBox", (int)uiLeft, (int)uiTop,
-                                                   (int)uiWidth, (int)uiHeight, (float)glView->getScaleX());
+                                                   (int)uiWidth, (int)uiHeight, (float)renderView->getScaleX());
     s_allEditBoxes[_editBoxIndex] = this;
 }
 
 void EditBoxImplAndroid::setNativeFont(const char* pFontName, int fontSize)
 {
     auto director            = ax::Director::getInstance();
-    auto glView              = director->getGLView();
+    auto renderView              = director->getRenderView();
     auto isFontFileExists    = ax::FileUtils::getInstance()->isFileExist(pFontName);
     std::string realFontPath = pFontName;
     if (isFontFileExists)
@@ -132,7 +132,7 @@ void EditBoxImplAndroid::setNativeFont(const char* pFontName, int fontSize)
         }
     }
     JniHelper::callStaticVoidMethod(editBoxClassName, "setFont", _editBoxIndex, realFontPath,
-                                    (float)fontSize * glView->getScaleX());
+                                    (float)fontSize * renderView->getScaleX());
 }
 
 void EditBoxImplAndroid::setNativeFontColor(const Color4B& color)

--- a/core/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/core/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -34,7 +34,7 @@
 #    include "ui/UIEditBox/UIEditBox.h"
 #    include "base/Director.h"
 #    include "2d/Label.h"
-#    import "platform/ios/EAGLView-ios.h"
+#    import "platform/ios/EARenderView-ios.h"
 
 #    import <Foundation/Foundation.h>
 #    import <UIKit/UIKit.h>
@@ -64,9 +64,9 @@ EditBoxImplIOS::~EditBoxImplIOS()
 
 void EditBoxImplIOS::createNativeControl(const Rect& frame)
 {
-    auto glView = ax::Director::getInstance()->getGLView();
+    auto renderView = ax::Director::getInstance()->getRenderView();
 
-    Rect rect(0, 0, frame.size.width * glView->getScaleX(), frame.size.height * glView->getScaleY());
+    Rect rect(0, 0, frame.size.width * renderView->getScaleX(), frame.size.height * renderView->getScaleY());
 
     float factor = ax::Director::getInstance()->getContentScaleFactor();
 
@@ -181,8 +181,8 @@ void EditBoxImplIOS::setNativeVisible(bool visible)
 
 void EditBoxImplIOS::updateNativeFrame(const Rect& rect)
 {
-    auto glView          = ax::Director::getInstance()->getGLView();
-    EAGLView* eaglView = (EAGLView*)glView->getEAGLView();
+    auto renderView          = ax::Director::getInstance()->getRenderView();
+    EARenderView* eaglView = (EARenderView*)renderView->getEARenderView();
 
     float factor = eaglView.contentScaleFactor;
 
@@ -210,14 +210,14 @@ void EditBoxImplIOS::nativeCloseKeyboard()
 UIFont* EditBoxImplIOS::constructFont(const char* fontName, int fontSize)
 {
     AXASSERT(fontName != nullptr, "fontName can't be nullptr");
-    EAGLView* eaglView = static_cast<EAGLView*>(ax::Director::getInstance()->getGLView()->getEAGLView());
+    EARenderView* eaglView = static_cast<EARenderView*>(ax::Director::getInstance()->getRenderView()->getEARenderView());
     float retinaFactor   = eaglView.contentScaleFactor;
     NSString* fntName    = [NSString stringWithUTF8String:fontName];
 
     fntName = [[fntName lastPathComponent] stringByDeletingPathExtension];
 
-    auto glView       = ax::Director::getInstance()->getGLView();
-    float scaleFactor = glView->getScaleX();
+    auto renderView       = ax::Director::getInstance()->getRenderView();
+    float scaleFactor = renderView->getScaleX();
 
     if (fontSize == -1)
     {

--- a/core/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/core/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -48,7 +48,7 @@ EditBoxImpl* __createSystemEditBox(EditBox* pEditBox)
 EditBoxImplMac::EditBoxImplMac(EditBox* pEditText) : EditBoxImplCommon(pEditText), _sysEdit(nullptr)
 {
     //! TODO: Retina on Mac
-    //! _inRetinaMode = [[EAGLView sharedEGLView] contentScaleFactor] == 2.0f ? true : false;
+    //! _inRetinaMode = [[EARenderView sharedERenderView] contentScaleFactor] == 2.0f ? true : false;
     _inRetinaMode = false;
 }
 
@@ -59,9 +59,9 @@ EditBoxImplMac::~EditBoxImplMac()
 
 void EditBoxImplMac::createNativeControl(const ax::Rect& frame)
 {
-    auto glView = ax::Director::getInstance()->getGLView();
+    auto renderView = ax::Director::getInstance()->getRenderView();
     Size size   = frame.size;
-    NSRect rect = NSMakeRect(0, 0, size.width * glView->getScaleX(), size.height * glView->getScaleY());
+    NSRect rect = NSMakeRect(0, 0, size.width * renderView->getScaleX(), size.height * renderView->getScaleY());
 
     float factor = ax::Director::getInstance()->getContentScaleFactor();
 
@@ -77,8 +77,8 @@ NSFont* EditBoxImplMac::constructFont(const char* fontName, int fontSize)
     NSString* fntName  = [NSString stringWithUTF8String:fontName];
     fntName            = [[fntName lastPathComponent] stringByDeletingPathExtension];
     float retinaFactor = _inRetinaMode ? 2.0f : 1.0f;
-    auto glView        = ax::Director::getInstance()->getGLView();
-    float scaleFactor  = glView->getScaleX();
+    auto renderView        = ax::Director::getInstance()->getRenderView();
+    float scaleFactor  = renderView->getScaleX();
 
     if (fontSize == -1)
     {
@@ -195,7 +195,7 @@ void EditBoxImplMac::setNativeVisible(bool visible)
 
 void EditBoxImplMac::updateNativeFrame(const ax::Rect& rect)
 {
-    GLView* eglView = Director::getInstance()->getGLView();
+    RenderView* eglView = Director::getInstance()->getRenderView();
     auto frameSize  = eglView->getFrameSize();
     // Coordinate System on OSX has its origin at the lower left corner.
     //    https://developer.apple.com/library/ios/documentation/General/Conceptual/Devpedia-CocoaApp/CoordinateSystem.html

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -55,7 +55,7 @@ HWND EditBoxImplWin::s_hwndCocos           = 0;
 
 void EditBoxImplWin::lazyInit()
 {
-    s_hwndCocos = ax::Director::getInstance()->getGLView()->getWin32Window();
+    s_hwndCocos = ax::Director::getInstance()->getRenderView()->getWin32Window();
     LONG style  = ::GetWindowLongW(s_hwndCocos, GWL_STYLE);
     ::SetWindowLongW(s_hwndCocos, GWL_STYLE, style | WS_CLIPCHILDREN);
     s_isInitialized    = true;
@@ -142,8 +142,8 @@ void EditBoxImplWin::createNativeControl(const Rect& frame)
 
 void EditBoxImplWin::setNativeFont(const char* pFontName, int fontSize)
 {
-    auto glView = Director::getInstance()->getGLView();
-    HFONT hFont = ::CreateFontW(static_cast<int>(fontSize * glView->getScaleX()), 0, 0, 0, FW_NORMAL, FALSE, FALSE,
+    auto renderView = Director::getInstance()->getRenderView();
+    HFONT hFont = ::CreateFontW(static_cast<int>(fontSize * renderView->getScaleX()), 0, 0, 0, FW_NORMAL, FALSE, FALSE,
                                 FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS, CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY,
                                 VARIABLE_PITCH, L"Arial");
 

--- a/core/ui/UIEditBox/iOS/UIEditBoxIOS.mm
+++ b/core/ui/UIEditBox/iOS/UIEditBoxIOS.mm
@@ -30,7 +30,7 @@
 #import "ui/UIEditBox/iOS/UISingleLineTextField.h"
 #import "ui/UIEditBox/iOS/UIMultilineTextField.h"
 
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 #include "base/Director.h"
 
 #define getEditBoxImplIOS() ((ax::ui::EditBoxImplIOS*)_editBox)
@@ -319,8 +319,8 @@
 
 - (void)doAnimationWhenKeyboardMoveWithDuration:(float)duration distance:(float)distance
 {
-    auto view            = ax::Director::getInstance()->getGLView();
-    EAGLView* eaglView = (EAGLView*)view->getEAGLView();
+    auto view            = ax::Director::getInstance()->getRenderView();
+    EARenderView* eaglView = (EARenderView*)view->getEARenderView();
 
     [eaglView doAnimationWhenKeyboardMoveWithDuration:duration distance:distance];
 }
@@ -336,8 +336,8 @@
 
 - (void)openKeyboard
 {
-    auto view            = ax::Director::getInstance()->getGLView();
-    EAGLView* eaglView = (EAGLView*)view->getEAGLView();
+    auto view            = ax::Director::getInstance()->getRenderView();
+    EARenderView* eaglView = (EARenderView*)view->getEARenderView();
 
     [eaglView addSubview:self.textInput];
     [self.textInput becomeFirstResponder];
@@ -361,8 +361,8 @@
 
 - (void)animationSelector
 {
-    auto view            = ax::Director::getInstance()->getGLView();
-    EAGLView* eaglView = (EAGLView*)view->getEAGLView();
+    auto view            = ax::Director::getInstance()->getRenderView();
+    EARenderView* eaglView = (EARenderView*)view->getEARenderView();
 
     [eaglView doAnimationWhenAnotherEditBeClicked];
 }
@@ -375,8 +375,8 @@
     _editState     = YES;
     _returnPressed = NO;
 
-    auto view            = ax::Director::getInstance()->getGLView();
-    EAGLView* eaglView = (EAGLView*)view->getEAGLView();
+    auto view            = ax::Director::getInstance()->getRenderView();
+    EARenderView* eaglView = (EARenderView*)view->getEARenderView();
 
     if ([eaglView isKeyboardShown])
     {
@@ -468,8 +468,8 @@
     _editState     = YES;
     _returnPressed = NO;
 
-    auto view            = ax::Director::getInstance()->getGLView();
-    EAGLView* eaglView = (EAGLView*)view->getEAGLView();
+    auto view            = ax::Director::getInstance()->getRenderView();
+    EARenderView* eaglView = (EARenderView*)view->getEARenderView();
 
     if ([eaglView isKeyboardShown])
     {

--- a/core/ui/UIEditBox/iOS/UIMultilineTextField.mm
+++ b/core/ui/UIEditBox/iOS/UIMultilineTextField.mm
@@ -84,8 +84,8 @@ CGFloat const UI_PLACEHOLDER_TEXT_CHANGED_ANIMATION_DURATION = 0.25;
 {
     if (_placeHolderLabel == nil)
     {
-        auto glView   = ax::Director::getInstance()->getGLView();
-        float padding = AX_EDIT_BOX_PADDING * glView->getScaleX() / glView->getContentScaleFactor();
+        auto renderView   = ax::Director::getInstance()->getRenderView();
+        float padding = AX_EDIT_BOX_PADDING * renderView->getScaleX() / renderView->getContentScaleFactor();
 
         _placeHolderLabel =
             [[UILabel alloc] initWithFrame:CGRectMake(padding, padding, self.bounds.size.width - padding * 2, 0)];
@@ -106,9 +106,9 @@ CGFloat const UI_PLACEHOLDER_TEXT_CHANGED_ANIMATION_DURATION = 0.25;
 
 - (CGRect)textRectForBounds:(CGRect)bounds
 {
-    auto glView = ax::Director::getInstance()->getGLView();
+    auto renderView = ax::Director::getInstance()->getRenderView();
 
-    float padding = AX_EDIT_BOX_PADDING * glView->getScaleX() / glView->getContentScaleFactor();
+    float padding = AX_EDIT_BOX_PADDING * renderView->getScaleX() / renderView->getContentScaleFactor();
     return CGRectInset(bounds, padding, padding);
 }
 

--- a/core/ui/UIEditBox/iOS/UISingleLineTextField.mm
+++ b/core/ui/UIEditBox/iOS/UISingleLineTextField.mm
@@ -76,9 +76,9 @@
 
 - (CGRect)textRectForBounds:(CGRect)bounds
 {
-    auto glView = ax::Director::getInstance()->getGLView();
+    auto renderView = ax::Director::getInstance()->getRenderView();
 
-    float padding = AX_EDIT_BOX_PADDING * glView->getScaleX() / glView->getContentScaleFactor();
+    float padding = AX_EDIT_BOX_PADDING * renderView->getScaleX() / renderView->getContentScaleFactor();
     return CGRectInset(bounds, padding, padding);
 }
 

--- a/core/ui/UIHelper.cpp
+++ b/core/ui/UIHelper.cpp
@@ -189,8 +189,8 @@ Rect Helper::restrictCapInsetRect(const ax::Rect& capInsets, const Vec2& texture
 Rect Helper::convertBoundingBoxToScreen(Node* node)
 {
     auto director  = Director::getInstance();
-    auto glView    = director->getGLView();
-    auto frameSize = glView->getFrameSize();
+    auto renderView    = director->getRenderView();
+    auto frameSize = renderView->getFrameSize();
 
     auto winSize    = director->getWinSize();
     auto leftBottom = node->convertToWorldSpace(Point::ZERO);
@@ -198,10 +198,10 @@ Rect Helper::convertBoundingBoxToScreen(Node* node)
     auto contentSize = node->getContentSize();
     auto rightTop    = node->convertToWorldSpace(Point(contentSize.width, contentSize.height));
 
-    auto uiLeft   = frameSize.width / 2 + (leftBottom.x - winSize.width / 2) * glView->getScaleX();
-    auto uiTop    = frameSize.height / 2 - (rightTop.y - winSize.height / 2) * glView->getScaleY();
-    auto uiWidth  = (rightTop.x - leftBottom.x) * glView->getScaleX();
-    auto uiHeight = (rightTop.y - leftBottom.y) * glView->getScaleY();
+    auto uiLeft   = frameSize.width / 2 + (leftBottom.x - winSize.width / 2) * renderView->getScaleX();
+    auto uiTop    = frameSize.height / 2 - (rightTop.y - winSize.height / 2) * renderView->getScaleY();
+    auto uiWidth  = (rightTop.x - leftBottom.x) * renderView->getScaleX();
+    auto uiHeight = (rightTop.y - leftBottom.y) * renderView->getScaleY();
 
     return Rect(uiLeft, uiTop, uiWidth, uiHeight);
 }

--- a/core/ui/UILayout.cpp
+++ b/core/ui/UILayout.cpp
@@ -321,9 +321,9 @@ void Layout::stencilClippingVisit(Renderer* renderer, const Mat4& parentTransfor
 
 void Layout::onBeforeVisitScissor()
 {
-    auto glView = _director->getGLView();
+    auto renderView = _director->getRenderView();
     // apply scissor test
-    _scissorOldState = glView->isScissorEnabled();
+    _scissorOldState = renderView->isScissorEnabled();
     if (false == _scissorOldState)
     {
         auto renderer = _director->getRenderer();
@@ -332,10 +332,10 @@ void Layout::onBeforeVisitScissor()
 
     // apply scissor box
     Rect clippingRect = getClippingRect();
-    _clippingOldRect  = glView->getScissorRect();
+    _clippingOldRect  = renderView->getScissorRect();
     if (false == _clippingOldRect.equals(clippingRect))
     {
-        glView->setScissorInPoints(clippingRect.origin.x, clippingRect.origin.y, clippingRect.size.width,
+        renderView->setScissorInPoints(clippingRect.origin.x, clippingRect.origin.y, clippingRect.size.width,
                                    clippingRect.size.height);
     }
 }
@@ -347,8 +347,8 @@ void Layout::onAfterVisitScissor()
         // revert scissor box
         if (false == _clippingOldRect.equals(_clippingRect))
         {
-            auto glView = _director->getGLView();
-            glView->setScissorInPoints(_clippingOldRect.origin.x, _clippingOldRect.origin.y,
+            auto renderView = _director->getRenderView();
+            renderView->setScissorInPoints(_clippingOldRect.origin.x, _clippingOldRect.origin.y,
                                        _clippingOldRect.size.width, _clippingOldRect.size.height);
         }
     }

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -650,7 +650,7 @@ void BasicMediaController::createControls()
     }
 
     const auto& contentSize = getContentSize();
-    auto scale              = Director::getInstance()->getGLView()->getScaleY();
+    auto scale              = Director::getInstance()->getRenderView()->getScaleY();
 
     _mediaOverlay = Layout::create();
     _mediaOverlay->setBackGroundColor(Color3B::BLACK);
@@ -854,7 +854,7 @@ void BasicMediaController::updateControlsForContentSize(const Vec2& contentSize)
     _mediaOverlay->setContentSize(contentSize);
     _controlPanel->setContentSize(contentSize);
 
-    auto scale = Director::getInstance()->getGLView()->getScaleY();
+    auto scale = Director::getInstance()->getRenderView()->getScaleY();
     _primaryButtonPanel->setScale(1 / scale);
     _timelineTotal->setContentSize(Size(contentSize.width - 40, _timelineBarHeight / scale));
     _timelineSelector->setContentSize(Size(_timelineBarHeight, _timelineBarHeight) * 1.5f / scale);
@@ -1216,7 +1216,7 @@ void MediaPlayer::setFullScreenEnabled(bool enabled)
         _fullScreenEnabled = enabled;
 
         auto pvd               = reinterpret_cast<PrivateVideoDescriptor*>(_videoContext);
-        const auto contentSize = enabled ? _director->getGLView()->getDesignResolutionSize() : pvd->_originalViewSize;
+        const auto contentSize = enabled ? _director->getRenderView()->getDesignResolutionSize() : pvd->_originalViewSize;
         Widget::setContentSize(contentSize);
 
         sendEvent((int)EventType::FULLSCREEN_SWITCH);

--- a/core/ui/UIScrollView.cpp
+++ b/core/ui/UIScrollView.cpp
@@ -43,9 +43,9 @@ constexpr float BOUNCE_BACK_DURATION                    = 1.0f;
 
 float convertDistanceFromPointToInch(const Vec2& dis)
 {
-    auto glView    = Director::getInstance()->getGLView();
+    auto renderView    = Director::getInstance()->getRenderView();
     int dpi        = Device::getDPI();
-    float distance = Vec2(dis.x * glView->getScaleX() / dpi, dis.y * glView->getScaleY() / dpi).getLength();
+    float distance = Vec2(dis.x * renderView->getScaleX() / dpi, dis.y * renderView->getScaleY() / dpi).getLength();
     return distance;
 }
 }  // namespace

--- a/core/ui/UITextFieldEx.cpp
+++ b/core/ui/UITextFieldEx.cpp
@@ -487,11 +487,9 @@ bool TextFieldEx::attachWithIME()
     if (ret)
     {
         // open keyboard
-        GLView* pGlView = _director->getGLView();
-        if (pGlView)
-        {
-            pGlView->setIMEKeyboardState(true);
-        }
+        RenderView* renderView = _director->getRenderView();
+        if (renderView)
+            renderView->setIMEKeyboardState(true);
     }
     return ret;
 }
@@ -502,11 +500,9 @@ bool TextFieldEx::detachWithIME()
     if (ret)
     {
         // close keyboard
-        GLView* glView = _director->getGLView();
-        if (glView)
-        {
-            glView->setIMEKeyboardState(false);
-        }
+        RenderView* renderView = _director->getRenderView();
+        if (renderView)
+            renderView->setIMEKeyboardState(false);
     }
     return ret;
 }

--- a/core/ui/UIWebView/UIWebView-inl.h
+++ b/core/ui/UIWebView/UIWebView-inl.h
@@ -32,7 +32,7 @@
      AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
 
 #include "ui/UIWebView/UIWebView.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #include "base/Director.h"
 #include "platform/FileUtils.h"
 

--- a/core/ui/UIWebView/UIWebViewImpl-android.cpp
+++ b/core/ui/UIWebView/UIWebViewImpl-android.cpp
@@ -31,7 +31,7 @@
 #include "platform/android/jni/JniHelper.h"
 
 #include "ui/UIWebView/UIWebView.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #include "base/Director.h"
 #include "platform/FileUtils.h"
 #include "ui/UIHelper.h"

--- a/core/ui/UIWebView/UIWebViewImpl-ios.mm
+++ b/core/ui/UIWebView/UIWebViewImpl-ios.mm
@@ -31,8 +31,8 @@
 #include "ui/UIWebView/UIWebView.h"
 #include "renderer/Renderer.h"
 #include "base/Director.h"
-#include "platform/GLView.h"
-#include "platform/ios/EAGLView-ios.h"
+#include "platform/RenderView.h"
+#include "platform/ios/EARenderView-ios.h"
 #include "platform/FileUtils.h"
 
 @interface UIWebViewWrapper : NSObject
@@ -132,8 +132,8 @@
     }
     if (!self.wkWebView.superview)
     {
-        auto view     = ax::Director::getInstance()->getGLView();
-        auto eaglView = (EAGLView*)view->getEAGLView();
+        auto view     = ax::Director::getInstance()->getRenderView();
+        auto eaglView = (EARenderView*)view->getEARenderView();
         [eaglView addSubview:self.wkWebView];
     }
 }
@@ -500,10 +500,10 @@ void WebViewImpl::draw(ax::Renderer* renderer, ax::Mat4 const& transform, uint32
     {
 
         auto director  = ax::Director::getInstance();
-        auto glView    = director->getGLView();
-        auto frameSize = glView->getFrameSize();
+        auto renderView    = director->getRenderView();
+        auto frameSize = renderView->getFrameSize();
 
-        auto scaleFactor = [static_cast<EAGLView*>(glView->getEAGLView()) contentScaleFactor];
+        auto scaleFactor = [static_cast<EARenderView*>(renderView->getEARenderView()) contentScaleFactor];
 
         auto winSize = director->getWinSize();
 
@@ -511,10 +511,10 @@ void WebViewImpl::draw(ax::Renderer* renderer, ax::Mat4 const& transform, uint32
         auto rightTop   = this->_webView->convertToWorldSpace(
               ax::Vec2(this->_webView->getContentSize().width, this->_webView->getContentSize().height));
 
-        auto x      = (frameSize.width / 2 + (leftBottom.x - winSize.width / 2) * glView->getScaleX()) / scaleFactor;
-        auto y      = (frameSize.height / 2 - (rightTop.y - winSize.height / 2) * glView->getScaleY()) / scaleFactor;
-        auto width  = (rightTop.x - leftBottom.x) * glView->getScaleX() / scaleFactor;
-        auto height = (rightTop.y - leftBottom.y) * glView->getScaleY() / scaleFactor;
+        auto x      = (frameSize.width / 2 + (leftBottom.x - winSize.width / 2) * renderView->getScaleX()) / scaleFactor;
+        auto y      = (frameSize.height / 2 - (rightTop.y - winSize.height / 2) * renderView->getScaleY()) / scaleFactor;
+        auto width  = (rightTop.x - leftBottom.x) * renderView->getScaleX() / scaleFactor;
+        auto height = (rightTop.y - leftBottom.y) * renderView->getScaleY() / scaleFactor;
 
         [_uiWebViewWrapper setFrameWithX:x y:y width:width height:height];
     }

--- a/core/ui/UIWebView/UIWebViewImpl-linux.cpp
+++ b/core/ui/UIWebView/UIWebViewImpl-linux.cpp
@@ -37,7 +37,7 @@
 #    include "UIWebView.h"
 #    include "base/Director.h"
 #    include "platform/FileUtils.h"
-#    include "platform/GLView.h"
+#    include "platform/RenderView.h"
 #    include "ui/UIHelper.h"
 #    include "UIWebViewCommon.h"
 
@@ -284,8 +284,8 @@ class GTKWebKit
 public:
     GTKWebKit() : isXwayland(webkit_dmabuf::is_wayland_display())
     {
-        m_X11Display      = static_cast<Display*>(ax::Director::getInstance()->getGLView()->getX11Display());
-        m_ParentX11Window = reinterpret_cast<Window>(ax::Director::getInstance()->getGLView()->getX11Window());
+        m_X11Display      = static_cast<Display*>(ax::Director::getInstance()->getRenderView()->getX11Display());
+        m_ParentX11Window = reinterpret_cast<Window>(ax::Director::getInstance()->getRenderView()->getX11Window());
 
         init_gtk_platform_with_display(m_X11Display);
 

--- a/core/ui/UIWebView/UIWebViewImpl-win32.cpp
+++ b/core/ui/UIWebView/UIWebViewImpl-win32.cpp
@@ -32,7 +32,7 @@
 #    include "UIWebViewCommon.h"
 #    include "base/Director.h"
 #    include "platform/FileUtils.h"
-#    include "platform/GLView.h"
+#    include "platform/RenderView.h"
 #    include "ui/UIHelper.h"
 #    include "rapidjson/document.h"
 #    include "rapidjson/stringbuffer.h"
@@ -680,7 +680,7 @@ void Win32WebControl::lazyInit()
 {
 #    if AX_TARGET_PLATFORM != AX_PLATFORM_WINRT
     // reset the main windows style so that its drawing does not cover the webview sub window
-    auto hwnd        = ax::Director::getInstance()->getGLView()->getWin32Window();
+    auto hwnd        = ax::Director::getInstance()->getRenderView()->getWin32Window();
     const auto style = GetWindowLong(hwnd, GWL_STYLE);
     SetWindowLong(hwnd, GWL_STYLE, style | WS_CLIPCHILDREN);
 
@@ -705,7 +705,7 @@ bool Win32WebControl::createWebView(const std::function<bool(std::string_view)>&
 #    if AX_TARGET_PLATFORM != AX_PLATFORM_WINRT
     do
     {
-        HWND hwnd           = ax::Director::getInstance()->getGLView()->getWin32Window();
+        HWND hwnd           = ax::Director::getInstance()->getRenderView()->getWin32Window();
         HINSTANCE hInstance = GetModuleHandle(nullptr);
         WNDCLASSEX wc;
         ZeroMemory(&wc, sizeof(WNDCLASSEX));

--- a/extensions/GUI/src/GUI/ScrollView/ScrollView.cpp
+++ b/extensions/GUI/src/GUI/ScrollView/ScrollView.cpp
@@ -46,8 +46,8 @@ NS_AX_EXT_BEGIN
 
 static float convertDistanceFromPointToInch(float pointDis)
 {
-    auto glView  = Director::getInstance()->getGLView();
-    float factor = (glView->getScaleX() + glView->getScaleY()) / 2;
+    auto renderView = Director::getInstance()->getRenderView();
+    float factor    = (renderView->getScaleX() + renderView->getScaleY()) / 2;
     return pointDis * factor / Device::getDPI();
 }
 
@@ -583,24 +583,24 @@ void ScrollView::onBeforeDraw()
     {
         _scissorRestored = false;
         Rect frame = getViewRect();
-        auto glview = Director::getInstance()->getGLView();
+        auto renderView = Director::getInstance()->getRenderView();
 
-            if (glview->isScissorEnabled()) {
+            if (renderView->isScissorEnabled()) {
                 _scissorRestored = true;
-                _parentScissorRect = glview->getScissorRect();
+                _parentScissorRect = renderView->getScissorRect();
                 //set the intersection of _parentScissorRect and frame as the new scissor rect
                 if (frame.intersectsRect(_parentScissorRect)) {
                     float x = MAX(frame.origin.x, _parentScissorRect.origin.x);
                     float y = MAX(frame.origin.y, _parentScissorRect.origin.y);
                     float xx = MIN(frame.origin.x + frame.size.width, _parentScissorRect.origin.x + _parentScissorRect.size.width);
                     float yy = MIN(frame.origin.y + frame.size.height, _parentScissorRect.origin.y + _parentScissorRect.size.height);
-                    glview->setScissorInPoints(x, y, xx - x, yy - y);
+                    renderView->setScissorInPoints(x, y, xx - x, yy - y);
                 }
             }
             else {
 
                   Director::getInstance()->getRenderer()->setScissorTest(true);
-                glview->setScissorInPoints(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+                renderView->setScissorInPoints(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
             }
 
     }
@@ -622,10 +622,10 @@ void ScrollView::onAfterDraw()
 
     if (_clippingToBounds)
     {
-        auto glview = Director::getInstance()->getGLView();
+        auto renderView = Director::getInstance()->getRenderView();
         
         if (_scissorRestored) {//restore the parent's scissor rect
-            glview->setScissorInPoints(_parentScissorRect.origin.x, _parentScissorRect.origin.y, _parentScissorRect.size.width, _parentScissorRect.size.height);
+            renderView->setScissorInPoints(_parentScissorRect.origin.x, _parentScissorRect.origin.y, _parentScissorRect.size.width, _parentScissorRect.size.height);
         }
         else {
             Director::getInstance()->getRenderer()->setScissorTest(false);

--- a/extensions/ImGui/src/ImGui/ImGuiPresenter.cpp
+++ b/extensions/ImGui/src/ImGui/ImGuiPresenter.cpp
@@ -329,9 +329,9 @@ void ImGuiPresenter::init()
     }
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID)
-    ImGui_ImplAndroid_InitForAxmol(Director::getInstance()->getGLView(), true);
+    ImGui_ImplAndroid_InitForAxmol(Director::getInstance()->getRenderView(), true);
 #else
-    auto window = static_cast<GLViewImpl*>(Director::getInstance()->getGLView())->getWindow();
+    auto window = static_cast<RenderViewImpl*>(Director::getInstance()->getRenderView())->getWindow();
     ImGui_ImplGlfw_InitForAxmol(window, true);
 #endif
     ImGui_ImplAxmol_Init();

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_android.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_android.cpp
@@ -60,7 +60,7 @@ protected:
 
 struct ImGui_ImplAndroid_Data
 {
-    GLView*          Window{nullptr};
+    RenderView*      Window{nullptr};
     double           Time{0};
     bool             InstalledCallbacks{false};
 
@@ -92,7 +92,7 @@ static ax::Vec2 convertToUICoordinates(const Vec2& pos)
 }
 
 // Functions
-bool ImGui_ImplAndroid_InitForAxmol(GLView* window, bool install_callbacks)
+bool ImGui_ImplAndroid_InitForAxmol(RenderView* window, bool install_callbacks)
 {
     ImGuiIO& io = ImGui::GetIO();
     IM_ASSERT(io.BackendPlatformUserData == nullptr && "Already initialized a platform backend!");
@@ -235,7 +235,7 @@ void ImGui_ImplAndroid_NewFrame()
 // Helper structure we store in the void* RenderUserData field of each ImGuiViewport to easily retrieve our backend data.
 struct ImGui_ImplAndroid_ViewportData
 {
-    GLView* Window;
+    RenderView* Window;
     bool        WindowOwned;
     int         IgnoreWindowPosEventFrame;
     int         IgnoreWindowSizeEventFrame;
@@ -244,7 +244,7 @@ struct ImGui_ImplAndroid_ViewportData
     ~ImGui_ImplAndroid_ViewportData() { IM_ASSERT(Window == nullptr); }
 };
 
-static void ImGui_ImplAndroid_WindowCloseCallback(GLView* window)
+static void ImGui_ImplAndroid_WindowCloseCallback(RenderView* window)
 {
     if (ImGuiViewport* viewport = ImGui::FindViewportByPlatformHandle(window))
         viewport->PlatformRequestClose = true;

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_android.h
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_android.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "imgui.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 
 struct ANativeWindow;
 struct AInputEvent;
@@ -8,7 +8,7 @@ struct AInputEvent;
 typedef void (*ImGuiImplCocos2dxLoadFontFun)(void* userdata);
 
 /// ImGui glfw APIs
-IMGUI_IMPL_API bool ImGui_ImplAndroid_InitForAxmol(ax::GLView* window, bool install_callbacks);
+IMGUI_IMPL_API bool ImGui_ImplAndroid_InitForAxmol(ax::RenderView* window, bool install_callbacks);
 IMGUI_IMPL_API void ImGui_ImplAndroid_Shutdown();
 IMGUI_IMPL_API void ImGui_ImplAndroid_NewFrame();
 

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -3,7 +3,7 @@
 #include "base/Director.h"
 #include "base/Data.h"
 #if !defined(__ANDROID__)
-#    include "platform/GLViewImpl.h"
+#    include "platform/RenderViewImpl.h"
 #endif
 #include "renderer/backend/Program.h"
 #include "renderer/backend/ProgramState.h"
@@ -512,7 +512,7 @@ static void ImGui_ImplAxmol_ShutdownMultiViewportSupport()
 IMGUI_IMPL_API void ImGui_ImplAxmol_SetViewResolution(float width, float height)
 {
     // Resize (expand) window
-    auto* view = (ax::GLViewImpl*)ax::Director::getInstance()->getGLView();
+    auto* view = (ax::RenderViewImpl*)ax::Director::getInstance()->getRenderView();
     view->setWindowed(width, height);
 }
 #endif

--- a/extensions/fairygui/src/fairygui/GRoot.cpp
+++ b/extensions/fairygui/src/fairygui/GRoot.cpp
@@ -561,7 +561,7 @@ bool GRoot::initWithScene(ax::Scene* scene, int zOrder)
     _inputProcessor->setCaptureCallback(AX_CALLBACK_1(GRoot::onTouchEvent, this));
 
 #if defined(AX_PLATFORM_PC) && AX_TARGET_PLATFORM != AX_PLATFORM_WINRT
-    _windowSizeListener = Director::getInstance()->getEventDispatcher()->addCustomEventListener(GLViewImpl::EVENT_WINDOW_RESIZED, AX_CALLBACK_0(GRoot::onWindowSizeChanged, this));
+    _windowSizeListener = Director::getInstance()->getEventDispatcher()->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_RESIZED, AX_CALLBACK_0(GRoot::onWindowSizeChanged, this));
 #endif
     onWindowSizeChanged();
 
@@ -572,7 +572,7 @@ bool GRoot::initWithScene(ax::Scene* scene, int zOrder)
 
 void GRoot::onWindowSizeChanged()
 {
-    const ax::Size& rs = Director::getInstance()->getGLView()->getDesignResolutionSize();
+    const ax::Size& rs = Director::getInstance()->getRenderView()->getDesignResolutionSize();
     setSize(rs.width, rs.height);
 
     updateContentScaleLevel();

--- a/extensions/fairygui/src/fairygui/display/FUIContainer.cpp
+++ b/extensions/fairygui/src/fairygui/display/FUIContainer.cpp
@@ -310,8 +310,8 @@ void FUIContainer::restoreAllProgramStates()
 
 void FUIContainer::onBeforeVisitScissor()
 {
-    auto glView = Director::getInstance()->getGLView();
-    _rectClippingSupport->_scissorOldState = glView->isScissorEnabled();
+    auto renderView                        = Director::getInstance()->getRenderView();
+    _rectClippingSupport->_scissorOldState = renderView->isScissorEnabled();
     Rect clippingRect = getClippingRect();
     if (false == _rectClippingSupport->_scissorOldState)
     {
@@ -323,11 +323,11 @@ void FUIContainer::onBeforeVisitScissor()
     }
     else
     {
-        _rectClippingSupport->_clippingOldRect = glView->getScissorRect();
+        _rectClippingSupport->_clippingOldRect = renderView->getScissorRect();
         clippingRect = ToolSet::intersection(clippingRect, _rectClippingSupport->_clippingOldRect);
     }
 
-    glView->setScissorInPoints(clippingRect.origin.x,
+    renderView->setScissorInPoints(clippingRect.origin.x,
         clippingRect.origin.y,
         clippingRect.size.width,
         clippingRect.size.height);
@@ -337,8 +337,9 @@ void FUIContainer::onAfterVisitScissor()
 {
     if (_rectClippingSupport->_scissorOldState)
     {
-        auto glView = Director::getInstance()->getGLView();
-        glView->setScissorInPoints(_rectClippingSupport->_clippingOldRect.origin.x,
+        auto renderView = Director::getInstance()->getRenderView();
+        renderView->setScissorInPoints(
+            _rectClippingSupport->_clippingOldRect.origin.x,
             _rectClippingSupport->_clippingOldRect.origin.y,
             _rectClippingSupport->_clippingOldRect.size.width,
             _rectClippingSupport->_clippingOldRect.size.height);

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -12554,10 +12554,10 @@ int lua_register_ax_base_Scene(lua_State* tolua_S)
     return 1;
 }
 
-int lua_ax_base_GLView_end(lua_State* tolua_S)
+int lua_ax_base_RenderView_end(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12566,15 +12566,15 @@ int lua_ax_base_GLView_end(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_end'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_end'", nullptr);
         return 0;
     }
 #endif
@@ -12584,27 +12584,27 @@ int lua_ax_base_GLView_end(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_end'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_end'", nullptr);
             return 0;
         }
         cobj->end();
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:end",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:end",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_end'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_end'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_isOpenGLReady(lua_State* tolua_S)
+int lua_ax_base_RenderView_isGfxContextReady(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12613,15 +12613,15 @@ int lua_ax_base_GLView_isOpenGLReady(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_isOpenGLReady'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_isGfxContextReady'", nullptr);
         return 0;
     }
 #endif
@@ -12631,27 +12631,27 @@ int lua_ax_base_GLView_isOpenGLReady(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_isOpenGLReady'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_isGfxContextReady'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->isOpenGLReady();
+        auto&& ret = cobj->isGfxContextReady();
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:isOpenGLReady",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:isGfxContextReady",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_isOpenGLReady'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_isGfxContextReady'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_swapBuffers(lua_State* tolua_S)
+int lua_ax_base_RenderView_swapBuffers(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12660,15 +12660,15 @@ int lua_ax_base_GLView_swapBuffers(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_swapBuffers'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_swapBuffers'", nullptr);
         return 0;
     }
 #endif
@@ -12678,27 +12678,27 @@ int lua_ax_base_GLView_swapBuffers(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_swapBuffers'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_swapBuffers'", nullptr);
             return 0;
         }
         cobj->swapBuffers();
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:swapBuffers",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:swapBuffers",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_swapBuffers'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_swapBuffers'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setIMEKeyboardState(lua_State* tolua_S)
+int lua_ax_base_RenderView_setIMEKeyboardState(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12707,15 +12707,15 @@ int lua_ax_base_GLView_setIMEKeyboardState(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setIMEKeyboardState'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setIMEKeyboardState'", nullptr);
         return 0;
     }
 #endif
@@ -12725,30 +12725,30 @@ int lua_ax_base_GLView_setIMEKeyboardState(lua_State* tolua_S)
     {
         bool arg0;
 
-        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.GLView:setIMEKeyboardState");
+        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.RenderView:setIMEKeyboardState");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setIMEKeyboardState'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setIMEKeyboardState'", nullptr);
             return 0;
         }
         cobj->setIMEKeyboardState(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setIMEKeyboardState",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setIMEKeyboardState",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setIMEKeyboardState'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setIMEKeyboardState'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_windowShouldClose(lua_State* tolua_S)
+int lua_ax_base_RenderView_windowShouldClose(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12757,15 +12757,15 @@ int lua_ax_base_GLView_windowShouldClose(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_windowShouldClose'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_windowShouldClose'", nullptr);
         return 0;
     }
 #endif
@@ -12775,27 +12775,27 @@ int lua_ax_base_GLView_windowShouldClose(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_windowShouldClose'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_windowShouldClose'", nullptr);
             return 0;
         }
         auto&& ret = cobj->windowShouldClose();
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:windowShouldClose",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:windowShouldClose",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_windowShouldClose'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_windowShouldClose'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_pollEvents(lua_State* tolua_S)
+int lua_ax_base_RenderView_pollEvents(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12804,15 +12804,15 @@ int lua_ax_base_GLView_pollEvents(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_pollEvents'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_pollEvents'", nullptr);
         return 0;
     }
 #endif
@@ -12822,27 +12822,27 @@ int lua_ax_base_GLView_pollEvents(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_pollEvents'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_pollEvents'", nullptr);
             return 0;
         }
         cobj->pollEvents();
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:pollEvents",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:pollEvents",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_pollEvents'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_pollEvents'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getFrameSize(lua_State* tolua_S)
+int lua_ax_base_RenderView_getFrameSize(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12851,15 +12851,15 @@ int lua_ax_base_GLView_getFrameSize(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getFrameSize'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getFrameSize'", nullptr);
         return 0;
     }
 #endif
@@ -12869,27 +12869,27 @@ int lua_ax_base_GLView_getFrameSize(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getFrameSize'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getFrameSize'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getFrameSize();
         vec2_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getFrameSize",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getFrameSize",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getFrameSize'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getFrameSize'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setFrameSize(lua_State* tolua_S)
+int lua_ax_base_RenderView_setFrameSize(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12898,15 +12898,15 @@ int lua_ax_base_GLView_setFrameSize(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setFrameSize'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setFrameSize'", nullptr);
         return 0;
     }
 #endif
@@ -12917,32 +12917,32 @@ int lua_ax_base_GLView_setFrameSize(lua_State* tolua_S)
         double arg0;
         double arg1;
 
-        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.GLView:setFrameSize");
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.RenderView:setFrameSize");
 
-        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.GLView:setFrameSize");
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.RenderView:setFrameSize");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setFrameSize'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setFrameSize'", nullptr);
             return 0;
         }
         cobj->setFrameSize(arg0, arg1);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setFrameSize",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setFrameSize",argc, 2);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setFrameSize'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setFrameSize'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setFrameZoomFactor(lua_State* tolua_S)
+int lua_ax_base_RenderView_setFrameZoomFactor(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -12951,15 +12951,15 @@ int lua_ax_base_GLView_setFrameZoomFactor(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setFrameZoomFactor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setFrameZoomFactor'", nullptr);
         return 0;
     }
 #endif
@@ -12969,30 +12969,30 @@ int lua_ax_base_GLView_setFrameZoomFactor(lua_State* tolua_S)
     {
         double arg0;
 
-        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.GLView:setFrameZoomFactor");
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.RenderView:setFrameZoomFactor");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setFrameZoomFactor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setFrameZoomFactor'", nullptr);
             return 0;
         }
         cobj->setFrameZoomFactor(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setFrameZoomFactor",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setFrameZoomFactor",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setFrameZoomFactor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setFrameZoomFactor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getFrameZoomFactor(lua_State* tolua_S)
+int lua_ax_base_RenderView_getFrameZoomFactor(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13001,15 +13001,15 @@ int lua_ax_base_GLView_getFrameZoomFactor(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getFrameZoomFactor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getFrameZoomFactor'", nullptr);
         return 0;
     }
 #endif
@@ -13019,27 +13019,27 @@ int lua_ax_base_GLView_getFrameZoomFactor(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getFrameZoomFactor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getFrameZoomFactor'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getFrameZoomFactor();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getFrameZoomFactor",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getFrameZoomFactor",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getFrameZoomFactor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getFrameZoomFactor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setCursorVisible(lua_State* tolua_S)
+int lua_ax_base_RenderView_setCursorVisible(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13048,15 +13048,15 @@ int lua_ax_base_GLView_setCursorVisible(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setCursorVisible'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setCursorVisible'", nullptr);
         return 0;
     }
 #endif
@@ -13066,30 +13066,30 @@ int lua_ax_base_GLView_setCursorVisible(lua_State* tolua_S)
     {
         bool arg0;
 
-        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.GLView:setCursorVisible");
+        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.RenderView:setCursorVisible");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setCursorVisible'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setCursorVisible'", nullptr);
             return 0;
         }
         cobj->setCursorVisible(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setCursorVisible",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setCursorVisible",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setCursorVisible'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setCursorVisible'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getRetinaFactor(lua_State* tolua_S)
+int lua_ax_base_RenderView_getRetinaFactor(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13098,15 +13098,15 @@ int lua_ax_base_GLView_getRetinaFactor(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getRetinaFactor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getRetinaFactor'", nullptr);
         return 0;
     }
 #endif
@@ -13116,27 +13116,27 @@ int lua_ax_base_GLView_getRetinaFactor(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getRetinaFactor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getRetinaFactor'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getRetinaFactor();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getRetinaFactor",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getRetinaFactor",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getRetinaFactor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getRetinaFactor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setContentScaleFactor(lua_State* tolua_S)
+int lua_ax_base_RenderView_setContentScaleFactor(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13145,15 +13145,15 @@ int lua_ax_base_GLView_setContentScaleFactor(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setContentScaleFactor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setContentScaleFactor'", nullptr);
         return 0;
     }
 #endif
@@ -13163,30 +13163,30 @@ int lua_ax_base_GLView_setContentScaleFactor(lua_State* tolua_S)
     {
         double arg0;
 
-        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.GLView:setContentScaleFactor");
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.RenderView:setContentScaleFactor");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setContentScaleFactor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setContentScaleFactor'", nullptr);
             return 0;
         }
         auto&& ret = cobj->setContentScaleFactor(arg0);
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setContentScaleFactor",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setContentScaleFactor",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setContentScaleFactor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setContentScaleFactor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getContentScaleFactor(lua_State* tolua_S)
+int lua_ax_base_RenderView_getContentScaleFactor(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13195,15 +13195,15 @@ int lua_ax_base_GLView_getContentScaleFactor(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getContentScaleFactor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getContentScaleFactor'", nullptr);
         return 0;
     }
 #endif
@@ -13213,27 +13213,27 @@ int lua_ax_base_GLView_getContentScaleFactor(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getContentScaleFactor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getContentScaleFactor'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getContentScaleFactor();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getContentScaleFactor",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getContentScaleFactor",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getContentScaleFactor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getContentScaleFactor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_isRetinaDisplay(lua_State* tolua_S)
+int lua_ax_base_RenderView_isRetinaDisplay(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13242,15 +13242,15 @@ int lua_ax_base_GLView_isRetinaDisplay(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_isRetinaDisplay'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_isRetinaDisplay'", nullptr);
         return 0;
     }
 #endif
@@ -13260,27 +13260,27 @@ int lua_ax_base_GLView_isRetinaDisplay(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_isRetinaDisplay'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_isRetinaDisplay'", nullptr);
             return 0;
         }
         auto&& ret = cobj->isRetinaDisplay();
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:isRetinaDisplay",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:isRetinaDisplay",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_isRetinaDisplay'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_isRetinaDisplay'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getVisibleSize(lua_State* tolua_S)
+int lua_ax_base_RenderView_getVisibleSize(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13289,15 +13289,15 @@ int lua_ax_base_GLView_getVisibleSize(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getVisibleSize'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getVisibleSize'", nullptr);
         return 0;
     }
 #endif
@@ -13307,27 +13307,27 @@ int lua_ax_base_GLView_getVisibleSize(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getVisibleSize'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getVisibleSize'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getVisibleSize();
         vec2_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getVisibleSize",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getVisibleSize",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getVisibleSize'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getVisibleSize'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getVisibleOrigin(lua_State* tolua_S)
+int lua_ax_base_RenderView_getVisibleOrigin(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13336,15 +13336,15 @@ int lua_ax_base_GLView_getVisibleOrigin(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getVisibleOrigin'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getVisibleOrigin'", nullptr);
         return 0;
     }
 #endif
@@ -13354,27 +13354,27 @@ int lua_ax_base_GLView_getVisibleOrigin(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getVisibleOrigin'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getVisibleOrigin'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getVisibleOrigin();
         vec2_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getVisibleOrigin",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getVisibleOrigin",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getVisibleOrigin'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getVisibleOrigin'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getVisibleRect(lua_State* tolua_S)
+int lua_ax_base_RenderView_getVisibleRect(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13383,15 +13383,15 @@ int lua_ax_base_GLView_getVisibleRect(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getVisibleRect'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getVisibleRect'", nullptr);
         return 0;
     }
 #endif
@@ -13401,27 +13401,27 @@ int lua_ax_base_GLView_getVisibleRect(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getVisibleRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getVisibleRect'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getVisibleRect();
         rect_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getVisibleRect",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getVisibleRect",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getVisibleRect'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getVisibleRect'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getSafeAreaRect(lua_State* tolua_S)
+int lua_ax_base_RenderView_getSafeAreaRect(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13430,15 +13430,15 @@ int lua_ax_base_GLView_getSafeAreaRect(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getSafeAreaRect'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getSafeAreaRect'", nullptr);
         return 0;
     }
 #endif
@@ -13448,27 +13448,27 @@ int lua_ax_base_GLView_getSafeAreaRect(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getSafeAreaRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getSafeAreaRect'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getSafeAreaRect();
         rect_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getSafeAreaRect",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getSafeAreaRect",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getSafeAreaRect'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getSafeAreaRect'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setDesignResolutionSize(lua_State* tolua_S)
+int lua_ax_base_RenderView_setDesignResolutionSize(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13477,15 +13477,15 @@ int lua_ax_base_GLView_setDesignResolutionSize(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setDesignResolutionSize'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setDesignResolutionSize'", nullptr);
         return 0;
     }
 #endif
@@ -13497,34 +13497,34 @@ int lua_ax_base_GLView_setDesignResolutionSize(lua_State* tolua_S)
         double arg1;
         ResolutionPolicy arg2;
 
-        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.GLView:setDesignResolutionSize");
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.RenderView:setDesignResolutionSize");
 
-        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.GLView:setDesignResolutionSize");
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.RenderView:setDesignResolutionSize");
 
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.GLView:setDesignResolutionSize");
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.RenderView:setDesignResolutionSize");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setDesignResolutionSize'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setDesignResolutionSize'", nullptr);
             return 0;
         }
         cobj->setDesignResolutionSize(arg0, arg1, arg2);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setDesignResolutionSize",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setDesignResolutionSize",argc, 3);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setDesignResolutionSize'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setDesignResolutionSize'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getDesignResolutionSize(lua_State* tolua_S)
+int lua_ax_base_RenderView_getDesignResolutionSize(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13533,15 +13533,15 @@ int lua_ax_base_GLView_getDesignResolutionSize(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getDesignResolutionSize'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getDesignResolutionSize'", nullptr);
         return 0;
     }
 #endif
@@ -13551,27 +13551,27 @@ int lua_ax_base_GLView_getDesignResolutionSize(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getDesignResolutionSize'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getDesignResolutionSize'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getDesignResolutionSize();
         vec2_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getDesignResolutionSize",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getDesignResolutionSize",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getDesignResolutionSize'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getDesignResolutionSize'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setViewPortInPoints(lua_State* tolua_S)
+int lua_ax_base_RenderView_setViewPortInPoints(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13580,15 +13580,15 @@ int lua_ax_base_GLView_setViewPortInPoints(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setViewPortInPoints'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setViewPortInPoints'", nullptr);
         return 0;
     }
 #endif
@@ -13601,36 +13601,36 @@ int lua_ax_base_GLView_setViewPortInPoints(lua_State* tolua_S)
         double arg2;
         double arg3;
 
-        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.GLView:setViewPortInPoints");
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.RenderView:setViewPortInPoints");
 
-        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.GLView:setViewPortInPoints");
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.RenderView:setViewPortInPoints");
 
-        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.GLView:setViewPortInPoints");
+        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.RenderView:setViewPortInPoints");
 
-        ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.GLView:setViewPortInPoints");
+        ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.RenderView:setViewPortInPoints");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setViewPortInPoints'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setViewPortInPoints'", nullptr);
             return 0;
         }
         cobj->setViewPortInPoints(arg0, arg1, arg2, arg3);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setViewPortInPoints",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setViewPortInPoints",argc, 4);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setViewPortInPoints'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setViewPortInPoints'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setScissorInPoints(lua_State* tolua_S)
+int lua_ax_base_RenderView_setScissorInPoints(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13639,15 +13639,15 @@ int lua_ax_base_GLView_setScissorInPoints(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setScissorInPoints'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setScissorInPoints'", nullptr);
         return 0;
     }
 #endif
@@ -13660,36 +13660,36 @@ int lua_ax_base_GLView_setScissorInPoints(lua_State* tolua_S)
         double arg2;
         double arg3;
 
-        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.GLView:setScissorInPoints");
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "ax.RenderView:setScissorInPoints");
 
-        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.GLView:setScissorInPoints");
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.RenderView:setScissorInPoints");
 
-        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.GLView:setScissorInPoints");
+        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.RenderView:setScissorInPoints");
 
-        ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.GLView:setScissorInPoints");
+        ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.RenderView:setScissorInPoints");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setScissorInPoints'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setScissorInPoints'", nullptr);
             return 0;
         }
         cobj->setScissorInPoints(arg0, arg1, arg2, arg3);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setScissorInPoints",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setScissorInPoints",argc, 4);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setScissorInPoints'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setScissorInPoints'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_isScissorEnabled(lua_State* tolua_S)
+int lua_ax_base_RenderView_isScissorEnabled(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13698,15 +13698,15 @@ int lua_ax_base_GLView_isScissorEnabled(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_isScissorEnabled'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_isScissorEnabled'", nullptr);
         return 0;
     }
 #endif
@@ -13716,27 +13716,27 @@ int lua_ax_base_GLView_isScissorEnabled(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_isScissorEnabled'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_isScissorEnabled'", nullptr);
             return 0;
         }
         auto&& ret = cobj->isScissorEnabled();
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:isScissorEnabled",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:isScissorEnabled",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_isScissorEnabled'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_isScissorEnabled'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getScissorRect(lua_State* tolua_S)
+int lua_ax_base_RenderView_getScissorRect(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13745,15 +13745,15 @@ int lua_ax_base_GLView_getScissorRect(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getScissorRect'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getScissorRect'", nullptr);
         return 0;
     }
 #endif
@@ -13763,27 +13763,27 @@ int lua_ax_base_GLView_getScissorRect(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getScissorRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getScissorRect'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getScissorRect();
         rect_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getScissorRect",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getScissorRect",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getScissorRect'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getScissorRect'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setViewName(lua_State* tolua_S)
+int lua_ax_base_RenderView_setViewName(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13792,15 +13792,15 @@ int lua_ax_base_GLView_setViewName(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setViewName'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setViewName'", nullptr);
         return 0;
     }
 #endif
@@ -13810,30 +13810,30 @@ int lua_ax_base_GLView_setViewName(lua_State* tolua_S)
     {
         std::string_view arg0;
 
-        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLView:setViewName");
+        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderView:setViewName");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setViewName'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setViewName'", nullptr);
             return 0;
         }
         cobj->setViewName(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setViewName",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setViewName",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setViewName'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setViewName'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getViewName(lua_State* tolua_S)
+int lua_ax_base_RenderView_getViewName(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13842,15 +13842,15 @@ int lua_ax_base_GLView_getViewName(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getViewName'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getViewName'", nullptr);
         return 0;
     }
 #endif
@@ -13860,40 +13860,40 @@ int lua_ax_base_GLView_getViewName(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getViewName'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getViewName'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getViewName();
         lua_pushlstring(tolua_S,ret.data(),ret.length());
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getViewName",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getViewName",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getViewName'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getViewName'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setIcon(lua_State* tolua_S)
+int lua_ax_base_RenderView_setIcon(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 #if _AX_DEBUG >= 1
     tolua_Error tolua_err;
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setIcon'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setIcon'", nullptr);
         return 0;
     }
 #endif
@@ -13901,7 +13901,7 @@ int lua_ax_base_GLView_setIcon(lua_State* tolua_S)
     do{
         if (argc == 1) {
             std::vector<std::string_view> arg0;
-            ok &= luaval_to_std_vector_string_view(tolua_S, 2, &arg0, "ax.GLView:setIcon");
+            ok &= luaval_to_std_vector_string_view(tolua_S, 2, &arg0, "ax.RenderView:setIcon");
 
             if (!ok) { break; }
             cobj->setIcon(arg0);
@@ -13913,7 +13913,7 @@ int lua_ax_base_GLView_setIcon(lua_State* tolua_S)
     do{
         if (argc == 1) {
             std::string_view arg0;
-            ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLView:setIcon");
+            ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderView:setIcon");
 
             if (!ok) { break; }
             cobj->setIcon(arg0);
@@ -13922,20 +13922,20 @@ int lua_ax_base_GLView_setIcon(lua_State* tolua_S)
         }
     }while(0);
     ok  = true;
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.GLView:setIcon",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.RenderView:setIcon",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setIcon'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setIcon'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setDefaultIcon(lua_State* tolua_S)
+int lua_ax_base_RenderView_setDefaultIcon(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13944,15 +13944,15 @@ int lua_ax_base_GLView_setDefaultIcon(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setDefaultIcon'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setDefaultIcon'", nullptr);
         return 0;
     }
 #endif
@@ -13962,27 +13962,27 @@ int lua_ax_base_GLView_setDefaultIcon(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setDefaultIcon'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setDefaultIcon'", nullptr);
             return 0;
         }
         cobj->setDefaultIcon();
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setDefaultIcon",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setDefaultIcon",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setDefaultIcon'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setDefaultIcon'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getViewPortRect(lua_State* tolua_S)
+int lua_ax_base_RenderView_getViewPortRect(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -13991,15 +13991,15 @@ int lua_ax_base_GLView_getViewPortRect(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getViewPortRect'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getViewPortRect'", nullptr);
         return 0;
     }
 #endif
@@ -14009,27 +14009,27 @@ int lua_ax_base_GLView_getViewPortRect(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getViewPortRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getViewPortRect'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getViewPortRect();
         rect_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getViewPortRect",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getViewPortRect",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getViewPortRect'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getViewPortRect'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getScaleX(lua_State* tolua_S)
+int lua_ax_base_RenderView_getScaleX(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -14038,15 +14038,15 @@ int lua_ax_base_GLView_getScaleX(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getScaleX'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getScaleX'", nullptr);
         return 0;
     }
 #endif
@@ -14056,27 +14056,27 @@ int lua_ax_base_GLView_getScaleX(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getScaleX'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getScaleX'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getScaleX();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getScaleX",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getScaleX",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getScaleX'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getScaleX'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getScaleY(lua_State* tolua_S)
+int lua_ax_base_RenderView_getScaleY(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -14085,15 +14085,15 @@ int lua_ax_base_GLView_getScaleY(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getScaleY'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getScaleY'", nullptr);
         return 0;
     }
 #endif
@@ -14103,27 +14103,27 @@ int lua_ax_base_GLView_getScaleY(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getScaleY'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getScaleY'", nullptr);
             return 0;
         }
         auto&& ret = cobj->getScaleY();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getScaleY",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getScaleY",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getScaleY'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getScaleY'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_getResolutionPolicy(lua_State* tolua_S)
+int lua_ax_base_RenderView_getResolutionPolicy(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -14132,15 +14132,15 @@ int lua_ax_base_GLView_getResolutionPolicy(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_getResolutionPolicy'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_getResolutionPolicy'", nullptr);
         return 0;
     }
 #endif
@@ -14150,27 +14150,27 @@ int lua_ax_base_GLView_getResolutionPolicy(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getResolutionPolicy'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getResolutionPolicy'", nullptr);
             return 0;
         }
         int ret = (int)cobj->getResolutionPolicy();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getResolutionPolicy",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getResolutionPolicy",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getResolutionPolicy'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getResolutionPolicy'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_renderScene(lua_State* tolua_S)
+int lua_ax_base_RenderView_renderScene(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -14179,15 +14179,15 @@ int lua_ax_base_GLView_renderScene(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_renderScene'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_renderScene'", nullptr);
         return 0;
     }
 #endif
@@ -14198,32 +14198,32 @@ int lua_ax_base_GLView_renderScene(lua_State* tolua_S)
         ax::Scene* arg0;
         ax::Renderer* arg1;
 
-        ok &= luaval_to_object<ax::Scene>(tolua_S, 2, "ax.Scene",&arg0, "ax.GLView:renderScene");
+        ok &= luaval_to_object<ax::Scene>(tolua_S, 2, "ax.Scene",&arg0, "ax.RenderView:renderScene");
 
-        ok &= luaval_to_object<ax::Renderer>(tolua_S, 3, "ax.Renderer",&arg1, "ax.GLView:renderScene");
+        ok &= luaval_to_object<ax::Renderer>(tolua_S, 3, "ax.Renderer",&arg1, "ax.RenderView:renderScene");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_renderScene'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_renderScene'", nullptr);
             return 0;
         }
         cobj->renderScene(arg0, arg1);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:renderScene",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:renderScene",argc, 2);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_renderScene'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_renderScene'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setInteractive(lua_State* tolua_S)
+int lua_ax_base_RenderView_setInteractive(lua_State* tolua_S)
 {
     int argc = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok  = true;
 
 #if _AX_DEBUG >= 1
@@ -14232,15 +14232,15 @@ int lua_ax_base_GLView_setInteractive(lua_State* tolua_S)
 
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S,1,0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_GLView_setInteractive'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_setInteractive'", nullptr);
         return 0;
     }
 #endif
@@ -14250,27 +14250,27 @@ int lua_ax_base_GLView_setInteractive(lua_State* tolua_S)
     {
         bool arg0;
 
-        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.GLView:setInteractive");
+        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.RenderView:setInteractive");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setInteractive'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setInteractive'", nullptr);
             return 0;
         }
         cobj->setInteractive(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:setInteractive",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:setInteractive",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setInteractive'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setInteractive'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_GLView_setGLContextAttrs(lua_State* tolua_S)
+int lua_ax_base_RenderView_setGfxContextAttrs(lua_State* tolua_S)
 {
     int argc = 0;
     bool ok  = true;
@@ -14280,34 +14280,34 @@ int lua_ax_base_GLView_setGLContextAttrs(lua_State* tolua_S)
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertable(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
     argc = lua_gettop(tolua_S) - 1;
 
     if (argc == 1)
     {
-        GLContextAttrs arg0;
-        #pragma warning NO CONVERSION TO NATIVE FOR GLContextAttrs
+        GfxContextAttrs arg0;
+        #pragma warning NO CONVERSION TO NATIVE FOR GfxContextAttrs
 		ok = false;
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_setGLContextAttrs'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_setGfxContextAttrs'", nullptr);
             return 0;
         }
-        ax::GLView::setGLContextAttrs(arg0);
+        ax::RenderView::setGfxContextAttrs(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.GLView:setGLContextAttrs",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.RenderView:setGfxContextAttrs",argc, 1);
     return 0;
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_setGLContextAttrs'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_setGfxContextAttrs'.",&tolua_err);
 #endif
     return 0;
 }
-int lua_ax_base_GLView_getGLContextAttrs(lua_State* tolua_S)
+int lua_ax_base_RenderView_getGfxContextAttrs(lua_State* tolua_S)
 {
     int argc = 0;
     bool ok  = true;
@@ -14317,7 +14317,7 @@ int lua_ax_base_GLView_getGLContextAttrs(lua_State* tolua_S)
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.GLView",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertable(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
 #endif
 
     argc = lua_gettop(tolua_S) - 1;
@@ -14326,74 +14326,74 @@ int lua_ax_base_GLView_getGLContextAttrs(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLView_getGLContextAttrs'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_getGfxContextAttrs'", nullptr);
             return 0;
         }
-        auto&& ret = ax::GLView::getGLContextAttrs();
-        #pragma warning NO CONVERSION FROM NATIVE FOR GLContextAttrs;
+        auto&& ret = ax::RenderView::getGfxContextAttrs();
+        #pragma warning NO CONVERSION FROM NATIVE FOR GfxContextAttrs;
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.GLView:getGLContextAttrs",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.RenderView:getGfxContextAttrs",argc, 0);
     return 0;
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLView_getGLContextAttrs'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_getGfxContextAttrs'.",&tolua_err);
 #endif
     return 0;
 }
-static int lua_ax_base_GLView_finalize(lua_State* tolua_S)
+static int lua_ax_base_RenderView_finalize(lua_State* tolua_S)
 {
-    AXLOGV("luabindings: finalizing LUA object (GLView)");
+    AXLOGV("luabindings: finalizing LUA object (RenderView)");
     return 0;
 }
 
-int lua_register_ax_base_GLView(lua_State* tolua_S)
+int lua_register_ax_base_RenderView(lua_State* tolua_S)
 {
-    tolua_usertype(tolua_S,"ax.GLView");
-    tolua_cclass(tolua_S,"GLView","ax.GLView","ax.Object",nullptr);
+    tolua_usertype(tolua_S,"ax.RenderView");
+    tolua_cclass(tolua_S,"RenderView","ax.RenderView","ax.Object",nullptr);
 
-    tolua_beginmodule(tolua_S,"GLView");
-        tolua_function(tolua_S,"endToLua",lua_ax_base_GLView_end);
-        tolua_function(tolua_S,"isOpenGLReady",lua_ax_base_GLView_isOpenGLReady);
-        tolua_function(tolua_S,"swapBuffers",lua_ax_base_GLView_swapBuffers);
-        tolua_function(tolua_S,"setIMEKeyboardState",lua_ax_base_GLView_setIMEKeyboardState);
-        tolua_function(tolua_S,"windowShouldClose",lua_ax_base_GLView_windowShouldClose);
-        tolua_function(tolua_S,"pollEvents",lua_ax_base_GLView_pollEvents);
-        tolua_function(tolua_S,"getFrameSize",lua_ax_base_GLView_getFrameSize);
-        tolua_function(tolua_S,"setFrameSize",lua_ax_base_GLView_setFrameSize);
-        tolua_function(tolua_S,"setFrameZoomFactor",lua_ax_base_GLView_setFrameZoomFactor);
-        tolua_function(tolua_S,"getFrameZoomFactor",lua_ax_base_GLView_getFrameZoomFactor);
-        tolua_function(tolua_S,"setCursorVisible",lua_ax_base_GLView_setCursorVisible);
-        tolua_function(tolua_S,"getRetinaFactor",lua_ax_base_GLView_getRetinaFactor);
-        tolua_function(tolua_S,"setContentScaleFactor",lua_ax_base_GLView_setContentScaleFactor);
-        tolua_function(tolua_S,"getContentScaleFactor",lua_ax_base_GLView_getContentScaleFactor);
-        tolua_function(tolua_S,"isRetinaDisplay",lua_ax_base_GLView_isRetinaDisplay);
-        tolua_function(tolua_S,"getVisibleSize",lua_ax_base_GLView_getVisibleSize);
-        tolua_function(tolua_S,"getVisibleOrigin",lua_ax_base_GLView_getVisibleOrigin);
-        tolua_function(tolua_S,"getVisibleRect",lua_ax_base_GLView_getVisibleRect);
-        tolua_function(tolua_S,"getSafeAreaRect",lua_ax_base_GLView_getSafeAreaRect);
-        tolua_function(tolua_S,"setDesignResolutionSize",lua_ax_base_GLView_setDesignResolutionSize);
-        tolua_function(tolua_S,"getDesignResolutionSize",lua_ax_base_GLView_getDesignResolutionSize);
-        tolua_function(tolua_S,"setViewPortInPoints",lua_ax_base_GLView_setViewPortInPoints);
-        tolua_function(tolua_S,"setScissorInPoints",lua_ax_base_GLView_setScissorInPoints);
-        tolua_function(tolua_S,"isScissorEnabled",lua_ax_base_GLView_isScissorEnabled);
-        tolua_function(tolua_S,"getScissorRect",lua_ax_base_GLView_getScissorRect);
-        tolua_function(tolua_S,"setViewName",lua_ax_base_GLView_setViewName);
-        tolua_function(tolua_S,"getViewName",lua_ax_base_GLView_getViewName);
-        tolua_function(tolua_S,"setIcon",lua_ax_base_GLView_setIcon);
-        tolua_function(tolua_S,"setDefaultIcon",lua_ax_base_GLView_setDefaultIcon);
-        tolua_function(tolua_S,"getViewPortRect",lua_ax_base_GLView_getViewPortRect);
-        tolua_function(tolua_S,"getScaleX",lua_ax_base_GLView_getScaleX);
-        tolua_function(tolua_S,"getScaleY",lua_ax_base_GLView_getScaleY);
-        tolua_function(tolua_S,"getResolutionPolicy",lua_ax_base_GLView_getResolutionPolicy);
-        tolua_function(tolua_S,"renderScene",lua_ax_base_GLView_renderScene);
-        tolua_function(tolua_S,"setInteractive",lua_ax_base_GLView_setInteractive);
-        tolua_function(tolua_S,"setGLContextAttrs", lua_ax_base_GLView_setGLContextAttrs);
-        tolua_function(tolua_S,"getGLContextAttrs", lua_ax_base_GLView_getGLContextAttrs);
+    tolua_beginmodule(tolua_S,"RenderView");
+        tolua_function(tolua_S,"endToLua",lua_ax_base_RenderView_end);
+        tolua_function(tolua_S,"isGfxContextReady",lua_ax_base_RenderView_isGfxContextReady);
+        tolua_function(tolua_S,"swapBuffers",lua_ax_base_RenderView_swapBuffers);
+        tolua_function(tolua_S,"setIMEKeyboardState",lua_ax_base_RenderView_setIMEKeyboardState);
+        tolua_function(tolua_S,"windowShouldClose",lua_ax_base_RenderView_windowShouldClose);
+        tolua_function(tolua_S,"pollEvents",lua_ax_base_RenderView_pollEvents);
+        tolua_function(tolua_S,"getFrameSize",lua_ax_base_RenderView_getFrameSize);
+        tolua_function(tolua_S,"setFrameSize",lua_ax_base_RenderView_setFrameSize);
+        tolua_function(tolua_S,"setFrameZoomFactor",lua_ax_base_RenderView_setFrameZoomFactor);
+        tolua_function(tolua_S,"getFrameZoomFactor",lua_ax_base_RenderView_getFrameZoomFactor);
+        tolua_function(tolua_S,"setCursorVisible",lua_ax_base_RenderView_setCursorVisible);
+        tolua_function(tolua_S,"getRetinaFactor",lua_ax_base_RenderView_getRetinaFactor);
+        tolua_function(tolua_S,"setContentScaleFactor",lua_ax_base_RenderView_setContentScaleFactor);
+        tolua_function(tolua_S,"getContentScaleFactor",lua_ax_base_RenderView_getContentScaleFactor);
+        tolua_function(tolua_S,"isRetinaDisplay",lua_ax_base_RenderView_isRetinaDisplay);
+        tolua_function(tolua_S,"getVisibleSize",lua_ax_base_RenderView_getVisibleSize);
+        tolua_function(tolua_S,"getVisibleOrigin",lua_ax_base_RenderView_getVisibleOrigin);
+        tolua_function(tolua_S,"getVisibleRect",lua_ax_base_RenderView_getVisibleRect);
+        tolua_function(tolua_S,"getSafeAreaRect",lua_ax_base_RenderView_getSafeAreaRect);
+        tolua_function(tolua_S,"setDesignResolutionSize",lua_ax_base_RenderView_setDesignResolutionSize);
+        tolua_function(tolua_S,"getDesignResolutionSize",lua_ax_base_RenderView_getDesignResolutionSize);
+        tolua_function(tolua_S,"setViewPortInPoints",lua_ax_base_RenderView_setViewPortInPoints);
+        tolua_function(tolua_S,"setScissorInPoints",lua_ax_base_RenderView_setScissorInPoints);
+        tolua_function(tolua_S,"isScissorEnabled",lua_ax_base_RenderView_isScissorEnabled);
+        tolua_function(tolua_S,"getScissorRect",lua_ax_base_RenderView_getScissorRect);
+        tolua_function(tolua_S,"setViewName",lua_ax_base_RenderView_setViewName);
+        tolua_function(tolua_S,"getViewName",lua_ax_base_RenderView_getViewName);
+        tolua_function(tolua_S,"setIcon",lua_ax_base_RenderView_setIcon);
+        tolua_function(tolua_S,"setDefaultIcon",lua_ax_base_RenderView_setDefaultIcon);
+        tolua_function(tolua_S,"getViewPortRect",lua_ax_base_RenderView_getViewPortRect);
+        tolua_function(tolua_S,"getScaleX",lua_ax_base_RenderView_getScaleX);
+        tolua_function(tolua_S,"getScaleY",lua_ax_base_RenderView_getScaleY);
+        tolua_function(tolua_S,"getResolutionPolicy",lua_ax_base_RenderView_getResolutionPolicy);
+        tolua_function(tolua_S,"renderScene",lua_ax_base_RenderView_renderScene);
+        tolua_function(tolua_S,"setInteractive",lua_ax_base_RenderView_setInteractive);
+        tolua_function(tolua_S,"setGfxContextAttrs", lua_ax_base_RenderView_setGfxContextAttrs);
+        tolua_function(tolua_S,"getGfxContextAttrs", lua_ax_base_RenderView_getGfxContextAttrs);
     tolua_endmodule(tolua_S);
-    auto typeName = typeid(ax::GLView).name(); // rtti is literal storage
-    g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.GLView";
-    g_typeCast[typeName] = "ax.GLView";
+    auto typeName = typeid(ax::RenderView).name(); // rtti is literal storage
+    g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.RenderView";
+    g_typeCast[typeName] = "ax.RenderView";
     return 1;
 }
 
@@ -14840,7 +14840,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Director_getGLView(lua_State* tolua_S)
+int lua_ax_base_Director_getRenderView(lua_State* tolua_S)
 {
     int argc = 0;
     ax::Director* cobj = nullptr;
@@ -14860,7 +14860,7 @@ int lua_ax_base_Director_getGLView(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Director_getGLView'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Director_getRenderView'", nullptr);
         return 0;
     }
 #endif
@@ -14870,24 +14870,24 @@ int lua_ax_base_Director_getGLView(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Director_getGLView'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Director_getRenderView'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->getGLView();
-        object_to_luaval<ax::GLView>(tolua_S, "ax.GLView",(ax::GLView*)ret);
+        auto&& ret = cobj->getRenderView();
+        object_to_luaval<ax::RenderView>(tolua_S, "ax.RenderView",(ax::RenderView*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Director:getGLView",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Director:getRenderView",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_getGLView'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_getRenderView'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_ax_base_Director_setGLView(lua_State* tolua_S)
+int lua_ax_base_Director_setRenderView(lua_State* tolua_S)
 {
     int argc = 0;
     ax::Director* cobj = nullptr;
@@ -14907,7 +14907,7 @@ int lua_ax_base_Director_setGLView(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Director_setGLView'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Director_setRenderView'", nullptr);
         return 0;
     }
 #endif
@@ -14915,24 +14915,24 @@ int lua_ax_base_Director_setGLView(lua_State* tolua_S)
     argc = lua_gettop(tolua_S)-1;
     if (argc == 1) 
     {
-        ax::GLView* arg0;
+        ax::RenderView* arg0;
 
-        ok &= luaval_to_object<ax::GLView>(tolua_S, 2, "ax.GLView",&arg0, "ax.Director:setGLView");
+        ok &= luaval_to_object<ax::RenderView>(tolua_S, 2, "ax.RenderView",&arg0, "ax.Director:setRenderView");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Director_setGLView'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Director_setRenderView'", nullptr);
             return 0;
         }
-        cobj->setGLView(arg0);
+        cobj->setRenderView(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Director:setGLView",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Director:setRenderView",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_setGLView'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_setRenderView'.",&tolua_err);
 #endif
 
     return 0;
@@ -17825,8 +17825,8 @@ int lua_register_ax_base_Director(lua_State* tolua_S)
         tolua_function(tolua_S,"setStatsDisplay",lua_ax_base_Director_setStatsDisplay);
         tolua_function(tolua_S,"getSecondsPerFrame",lua_ax_base_Director_getSecondsPerFrame);
         tolua_function(tolua_S,"setStatsAnchor",lua_ax_base_Director_setStatsAnchor);
-        tolua_function(tolua_S,"getGLView",lua_ax_base_Director_getGLView);
-        tolua_function(tolua_S,"setGLView",lua_ax_base_Director_setGLView);
+        tolua_function(tolua_S,"getRenderView",lua_ax_base_Director_getRenderView);
+        tolua_function(tolua_S,"setRenderView",lua_ax_base_Director_setRenderView);
         tolua_function(tolua_S,"getTextureCache",lua_ax_base_Director_getTextureCache);
         tolua_function(tolua_S,"isNextDeltaTimeZero",lua_ax_base_Director_isNextDeltaTimeZero);
         tolua_function(tolua_S,"setNextDeltaTimeZero",lua_ax_base_Director_setNextDeltaTimeZero);
@@ -103535,7 +103535,7 @@ int lua_register_ax_base_Application(lua_State* tolua_S)
     return 1;
 }
 
-int lua_ax_base_GLViewImpl_create(lua_State* tolua_S)
+int lua_ax_base_RenderViewImpl_create(lua_State* tolua_S)
 {
     int argc = 0;
     bool ok  = true;
@@ -103545,7 +103545,7 @@ int lua_ax_base_GLViewImpl_create(lua_State* tolua_S)
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.GLViewImpl",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertable(tolua_S,1,"ax.RenderViewImpl",0,&tolua_err)) goto tolua_lerror;
 #endif
 
     argc = lua_gettop(tolua_S) - 1;
@@ -103553,25 +103553,25 @@ int lua_ax_base_GLViewImpl_create(lua_State* tolua_S)
     if (argc == 1)
     {
         std::string_view arg0;
-        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLViewImpl:create");
+        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderViewImpl:create");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLViewImpl_create'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderViewImpl_create'", nullptr);
             return 0;
         }
-        auto&& ret = ax::GLViewImpl::create(arg0);
-        object_to_luaval<ax::GLViewImpl>(tolua_S, "ax.GLViewImpl",(ax::GLViewImpl*)ret);
+        auto&& ret = ax::RenderViewImpl::create(arg0);
+        object_to_luaval<ax::RenderViewImpl>(tolua_S, "ax.RenderViewImpl",(ax::RenderViewImpl*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.GLViewImpl:create",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.RenderViewImpl:create",argc, 1);
     return 0;
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLViewImpl_create'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderViewImpl_create'.",&tolua_err);
 #endif
     return 0;
 }
-int lua_ax_base_GLViewImpl_createWithRect(lua_State* tolua_S)
+int lua_ax_base_RenderViewImpl_createWithRect(lua_State* tolua_S)
 {
     int argc = 0;
     bool ok  = true;
@@ -103581,7 +103581,7 @@ int lua_ax_base_GLViewImpl_createWithRect(lua_State* tolua_S)
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.GLViewImpl",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertable(tolua_S,1,"ax.RenderViewImpl",0,&tolua_err)) goto tolua_lerror;
 #endif
 
     argc = lua_gettop(tolua_S) - 1;
@@ -103590,15 +103590,15 @@ int lua_ax_base_GLViewImpl_createWithRect(lua_State* tolua_S)
     {
         std::string_view arg0;
         ax::Rect arg1;
-        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLViewImpl:createWithRect");
-        ok &= luaval_to_rect(tolua_S, 3, &arg1, "ax.GLViewImpl:createWithRect");
+        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderViewImpl:createWithRect");
+        ok &= luaval_to_rect(tolua_S, 3, &arg1, "ax.RenderViewImpl:createWithRect");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLViewImpl_createWithRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderViewImpl_createWithRect'", nullptr);
             return 0;
         }
-        auto&& ret = ax::GLViewImpl::createWithRect(arg0, arg1);
-        object_to_luaval<ax::GLViewImpl>(tolua_S, "ax.GLViewImpl",(ax::GLViewImpl*)ret);
+        auto&& ret = ax::RenderViewImpl::createWithRect(arg0, arg1);
+        object_to_luaval<ax::RenderViewImpl>(tolua_S, "ax.RenderViewImpl",(ax::RenderViewImpl*)ret);
         return 1;
     }
     if (argc == 3)
@@ -103606,16 +103606,16 @@ int lua_ax_base_GLViewImpl_createWithRect(lua_State* tolua_S)
         std::string_view arg0;
         ax::Rect arg1;
         double arg2;
-        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLViewImpl:createWithRect");
-        ok &= luaval_to_rect(tolua_S, 3, &arg1, "ax.GLViewImpl:createWithRect");
-        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.GLViewImpl:createWithRect");
+        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderViewImpl:createWithRect");
+        ok &= luaval_to_rect(tolua_S, 3, &arg1, "ax.RenderViewImpl:createWithRect");
+        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.RenderViewImpl:createWithRect");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLViewImpl_createWithRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderViewImpl_createWithRect'", nullptr);
             return 0;
         }
-        auto&& ret = ax::GLViewImpl::createWithRect(arg0, arg1, arg2);
-        object_to_luaval<ax::GLViewImpl>(tolua_S, "ax.GLViewImpl",(ax::GLViewImpl*)ret);
+        auto&& ret = ax::RenderViewImpl::createWithRect(arg0, arg1, arg2);
+        object_to_luaval<ax::RenderViewImpl>(tolua_S, "ax.RenderViewImpl",(ax::RenderViewImpl*)ret);
         return 1;
     }
     if (argc == 4)
@@ -103624,28 +103624,28 @@ int lua_ax_base_GLViewImpl_createWithRect(lua_State* tolua_S)
         ax::Rect arg1;
         double arg2;
         bool arg3;
-        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLViewImpl:createWithRect");
-        ok &= luaval_to_rect(tolua_S, 3, &arg1, "ax.GLViewImpl:createWithRect");
-        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.GLViewImpl:createWithRect");
-        ok &= luaval_to_boolean(tolua_S, 5,&arg3, "ax.GLViewImpl:createWithRect");
+        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderViewImpl:createWithRect");
+        ok &= luaval_to_rect(tolua_S, 3, &arg1, "ax.RenderViewImpl:createWithRect");
+        ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.RenderViewImpl:createWithRect");
+        ok &= luaval_to_boolean(tolua_S, 5,&arg3, "ax.RenderViewImpl:createWithRect");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLViewImpl_createWithRect'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderViewImpl_createWithRect'", nullptr);
             return 0;
         }
-        auto&& ret = ax::GLViewImpl::createWithRect(arg0, arg1, arg2, arg3);
-        object_to_luaval<ax::GLViewImpl>(tolua_S, "ax.GLViewImpl",(ax::GLViewImpl*)ret);
+        auto&& ret = ax::RenderViewImpl::createWithRect(arg0, arg1, arg2, arg3);
+        object_to_luaval<ax::RenderViewImpl>(tolua_S, "ax.RenderViewImpl",(ax::RenderViewImpl*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.GLViewImpl:createWithRect",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.RenderViewImpl:createWithRect",argc, 2);
     return 0;
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLViewImpl_createWithRect'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderViewImpl_createWithRect'.",&tolua_err);
 #endif
     return 0;
 }
-int lua_ax_base_GLViewImpl_createWithFullScreen(lua_State* tolua_S)
+int lua_ax_base_RenderViewImpl_createWithFullScreen(lua_State* tolua_S)
 {
     int argc = 0;
     bool ok  = true;
@@ -103655,7 +103655,7 @@ int lua_ax_base_GLViewImpl_createWithFullScreen(lua_State* tolua_S)
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.GLViewImpl",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertable(tolua_S,1,"ax.RenderViewImpl",0,&tolua_err)) goto tolua_lerror;
 #endif
 
     argc = lua_gettop(tolua_S) - 1;
@@ -103663,43 +103663,43 @@ int lua_ax_base_GLViewImpl_createWithFullScreen(lua_State* tolua_S)
     if (argc == 1)
     {
         std::string_view arg0;
-        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.GLViewImpl:createWithFullScreen");
+        ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.RenderViewImpl:createWithFullScreen");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GLViewImpl_createWithFullScreen'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderViewImpl_createWithFullScreen'", nullptr);
             return 0;
         }
-        auto&& ret = ax::GLViewImpl::createWithFullScreen(arg0);
-        object_to_luaval<ax::GLViewImpl>(tolua_S, "ax.GLViewImpl",(ax::GLViewImpl*)ret);
+        auto&& ret = ax::RenderViewImpl::createWithFullScreen(arg0);
+        object_to_luaval<ax::RenderViewImpl>(tolua_S, "ax.RenderViewImpl",(ax::RenderViewImpl*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.GLViewImpl:createWithFullScreen",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.RenderViewImpl:createWithFullScreen",argc, 1);
     return 0;
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_GLViewImpl_createWithFullScreen'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderViewImpl_createWithFullScreen'.",&tolua_err);
 #endif
     return 0;
 }
-static int lua_ax_base_GLViewImpl_finalize(lua_State* tolua_S)
+static int lua_ax_base_RenderViewImpl_finalize(lua_State* tolua_S)
 {
-    AXLOGV("luabindings: finalizing LUA object (GLViewImpl)");
+    AXLOGV("luabindings: finalizing LUA object (RenderViewImpl)");
     return 0;
 }
 
-int lua_register_ax_base_GLViewImpl(lua_State* tolua_S)
+int lua_register_ax_base_RenderViewImpl(lua_State* tolua_S)
 {
-    tolua_usertype(tolua_S,"ax.GLViewImpl");
-    tolua_cclass(tolua_S,"GLViewImpl","ax.GLViewImpl","ax.GLView",nullptr);
+    tolua_usertype(tolua_S,"ax.RenderViewImpl");
+    tolua_cclass(tolua_S,"RenderViewImpl","ax.RenderViewImpl","ax.RenderView",nullptr);
 
-    tolua_beginmodule(tolua_S,"GLViewImpl");
-        tolua_function(tolua_S,"create", lua_ax_base_GLViewImpl_create);
-        tolua_function(tolua_S,"createWithRect", lua_ax_base_GLViewImpl_createWithRect);
-        tolua_function(tolua_S,"createWithFullScreen", lua_ax_base_GLViewImpl_createWithFullScreen);
+    tolua_beginmodule(tolua_S,"RenderViewImpl");
+        tolua_function(tolua_S,"create", lua_ax_base_RenderViewImpl_create);
+        tolua_function(tolua_S,"createWithRect", lua_ax_base_RenderViewImpl_createWithRect);
+        tolua_function(tolua_S,"createWithFullScreen", lua_ax_base_RenderViewImpl_createWithFullScreen);
     tolua_endmodule(tolua_S);
-    auto typeName = typeid(ax::GLViewImpl).name(); // rtti is literal storage
-    g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.GLViewImpl";
-    g_typeCast[typeName] = "ax.GLViewImpl";
+    auto typeName = typeid(ax::RenderViewImpl).name(); // rtti is literal storage
+    g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.RenderViewImpl";
+    g_typeCast[typeName] = "ax.RenderViewImpl";
     return 1;
 }
 
@@ -112952,7 +112952,7 @@ TOLUA_API int register_all_ax_base(lua_State* tolua_S)
 	lua_register_ax_base_Component(tolua_S);
 	lua_register_ax_base_Node(tolua_S);
 	lua_register_ax_base_Scene(tolua_S);
-	lua_register_ax_base_GLView(tolua_S);
+	lua_register_ax_base_RenderView(tolua_S);
 	lua_register_ax_base_Director(tolua_S);
 	lua_register_ax_base_Timer(tolua_S);
 	lua_register_ax_base_Scheduler(tolua_S);
@@ -113195,7 +113195,7 @@ TOLUA_API int register_all_ax_base(lua_State* tolua_S)
 	lua_register_ax_base_TextureCache(tolua_S);
 	lua_register_ax_base_Device(tolua_S);
 	lua_register_ax_base_Application(tolua_S);
-	lua_register_ax_base_GLViewImpl(tolua_S);
+	lua_register_ax_base_RenderViewImpl(tolua_S);
 	lua_register_ax_base_AnimationCache(tolua_S);
 	lua_register_ax_base_SpriteBatchNode(tolua_S);
 	lua_register_ax_base_ParallaxNode(tolua_S);

--- a/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
+++ b/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
@@ -61,7 +61,7 @@
 #include "platform/Application.h"
 #include "platform/Device.h"
 #include "platform/FileUtils.h"
-#include "platform/GLView.h"
+#include "platform/RenderView.h"
 #include "renderer/TextureCache.h"
 #include "renderer/Shaders.h"
 
@@ -6457,10 +6457,10 @@ static void extendTextureCache(lua_State* tolua_S)
     lua_pop(tolua_S, 1);
 }
 
-int axlua_GLView_getAllTouches(lua_State* tolua_S)
+int axlua_RenderView_getAllTouches(lua_State* tolua_S)
 {
     int argc              = 0;
-    ax::GLView* cobj = nullptr;
+    ax::RenderView* cobj = nullptr;
     bool ok               = true;
 
 #if _AX_DEBUG >= 1
@@ -6468,16 +6468,16 @@ int axlua_GLView_getAllTouches(lua_State* tolua_S)
 #endif
 
 #if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S, 1, "ax.GLView", 0, &tolua_err))
+    if (!tolua_isusertype(tolua_S, 1, "ax.RenderView", 0, &tolua_err))
         goto tolua_lerror;
 #endif
 
-    cobj = (ax::GLView*)tolua_tousertype(tolua_S, 1, 0);
+    cobj = (ax::RenderView*)tolua_tousertype(tolua_S, 1, 0);
 
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S, "invalid 'cobj' in function 'axlua_GLView_getAllTouches'", nullptr);
+        tolua_error(tolua_S, "invalid 'cobj' in function 'axlua_RenderView_getAllTouches'", nullptr);
         return 0;
     }
 #endif
@@ -6509,25 +6509,25 @@ int axlua_GLView_getAllTouches(lua_State* tolua_S)
 
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GLView:getAllTouches", argc,
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:getAllTouches", argc,
                0);
     return 0;
 
 #if _AX_DEBUG >= 1
 tolua_lerror:
-    tolua_error(tolua_S, "#ferror in function 'axlua_GLView_getAllTouches'.", &tolua_err);
+    tolua_error(tolua_S, "#ferror in function 'axlua_RenderView_getAllTouches'.", &tolua_err);
 #endif
 
     return 0;
 }
 
-static void extendGLView(lua_State* tolua_S)
+static void extendRenderView(lua_State* tolua_S)
 {
-    lua_pushstring(tolua_S, "ax.GLView");
+    lua_pushstring(tolua_S, "ax.RenderView");
     lua_rawget(tolua_S, LUA_REGISTRYINDEX);
     if (lua_istable(tolua_S, -1))
     {
-        tolua_function(tolua_S, "getAllTouches", axlua_GLView_getAllTouches);
+        tolua_function(tolua_S, "getAllTouches", axlua_RenderView_getAllTouches);
     }
     lua_pop(tolua_S, 1);
 }
@@ -7260,7 +7260,7 @@ int register_all_ax_manual(lua_State* tolua_S)
     extendFastTMXLayer(tolua_S);
     extendApplication(tolua_S);
     extendTextureCache(tolua_S);
-    extendGLView(tolua_S);
+    extendRenderView(tolua_S);
     extendCamera(tolua_S);
     extendProperties(tolua_S);
     extendAutoPolygon(tolua_S);

--- a/extensions/scripting/lua-bindings/script/framework/device.lua
+++ b/extensions/scripting/lua-bindings/script/framework/device.lua
@@ -42,7 +42,7 @@ elseif target == cc.PLATFORM_ANDROID then
 elseif target == cc.PLATFORM_IOS then
     device.platform = "ios"
     local director = cc.Director:getInstance()
-    local view = director:getGLView()
+    local view = director:getRenderView()
     local framesize = view:getFrameSize()
     local w, h = framesize.width, framesize.height
     if w == 640 and h == 960 then

--- a/extensions/scripting/lua-bindings/script/framework/display.lua
+++ b/extensions/scripting/lua-bindings/script/framework/display.lua
@@ -25,7 +25,7 @@ THE SOFTWARE.
 local display = {}
 
 local director = cc.Director:getInstance()
-local view = director:getGLView()
+local view = director:getRenderView()
 
 if not view then
     local width = 960
@@ -38,8 +38,8 @@ if not view then
             height = AX_DESIGN_RESOLUTION.height
         end
     end
-    view = cc.GLViewImpl:createWithRect("Axmol-Lua", cc.rect(0, 0, width, height))
-    director:setGLView(view)
+    view = cc.RenderViewImpl:createWithRect("Axmol-Lua", cc.rect(0, 0, width, height))
+    director:setRenderView(view)
 end
 
 local framesize = view:getFrameSize()

--- a/templates/common/proj.ios_mac/ios/AppController.mm
+++ b/templates/common/proj.ios_mac/ios/AppController.mm
@@ -43,12 +43,12 @@ static AppDelegate s_sharedApplication;
 
     ax::Application* app = ax::Application::getInstance();
 
-    // Initialize the GLView attributes
-    app->initGLContextAttrs();
+    // Initialize the RenderView attributes
+    app->initGfxContextAttrs();
 
     // Override point for customization after application launch.
 
-    auto renderView = ax::GLViewImpl::createWithFullScreen("axmol2");
+    auto renderView = ax::RenderViewImpl::createWithFullScreen("axmol2");
     _viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
 
     // uncumment if you want disable multiple touches
@@ -56,8 +56,8 @@ static AppDelegate s_sharedApplication;
 
     renderView->showWindow(_viewController);
 
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    ax::Director::getInstance()->setGLView(renderView);
+    // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
+    ax::Director::getInstance()->setRenderView(renderView);
 
     // run the axmol game scene
     app->run();

--- a/templates/common/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/common/proj.ios_mac/ios/RootViewController.mm
@@ -27,7 +27,7 @@
 
 #import "RootViewController.h"
 #import "axmol.h"
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 
 @implementation RootViewController
 
@@ -80,11 +80,11 @@ customization that is not appropriate for viewDidLoad.
 {
     [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
 
-    auto glView = ax::Director::getInstance()->getGLView();
+    auto glView = ax::Director::getInstance()->getRenderView();
 
     if (glView)
     {
-        EAGLView* eaglView = (__bridge EAGLView*)glView->getEAGLView();
+        EARenderView* eaglView = (__bridge EARenderView*)glView->getEARenderView();
 
         if (eaglView)
         {

--- a/templates/cpp/Source/AppDelegate.cpp
+++ b/templates/cpp/Source/AppDelegate.cpp
@@ -40,33 +40,33 @@ AppDelegate::AppDelegate() {}
 
 AppDelegate::~AppDelegate() {}
 
-// if you want a different context, modify the value of glContextAttrs
+// if you want a different context, modify the value of gfxContextAttrs
 // it will affect all platforms
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil,multisamplesCount
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GLContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
     // since axmol-2.2 vsync was enabled in engine by default
-    // glContextAttrs.vsync = false;
+    // gfxContextAttrs.vsync = false;
 
-    GLView::setGLContextAttrs(glContextAttrs);
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 bool AppDelegate::applicationDidFinishLaunching()
 {
     // initialize director
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto glView   = director->getRenderView();
     if (!glView)
     {
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_MAC) || \
     (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
-        glView = GLViewImpl::createWithRect(
+        glView = RenderViewImpl::createWithRect(
             "Dummy", ax::Rect(0, 0, designResolutionSize.width, designResolutionSize.height));
 #else
-        glView = GLViewImpl::create("Dummy");
+        glView = RenderViewImpl::create("Dummy");
 #endif
-        director->setGLView(glView);
+        director->setRenderView(glView);
     }
 
     // turn on display FPS

--- a/templates/cpp/Source/AppDelegate.h
+++ b/templates/cpp/Source/AppDelegate.h
@@ -39,7 +39,7 @@ public:
     AppDelegate();
     ~AppDelegate() override;
 
-    void initGLContextAttrs() override;
+    void initGfxContextAttrs() override;
 
     /**
     @brief    Implement Director and Scene init code here.

--- a/templates/lua/Source/AppDelegate.cpp
+++ b/templates/lua/Source/AppDelegate.cpp
@@ -40,14 +40,14 @@ AppDelegate::AppDelegate() {}
 
 AppDelegate::~AppDelegate() {}
 
-// if you want a different context, modify the value of glContextAttrs
+// if you want a different context, modify the value of gfxContextAttrs
 // it will affect all platforms
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil,multisamplesCount
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
-    // glContextAttrs.vsync = false
-    GLView::setGLContextAttrs(glContextAttrs);
+    GLContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    // gfxContextAttrs.vsync = false
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 bool AppDelegate::applicationDidFinishLaunching()

--- a/templates/lua/Source/AppDelegate.h
+++ b/templates/lua/Source/AppDelegate.h
@@ -38,7 +38,7 @@ public:
     AppDelegate();
     ~AppDelegate() override;
 
-    void initGLContextAttrs() override;
+    void initGfxContextAttrs() override;
 
     /**
     @brief    Implement Director and Scene init code here.

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -45,14 +45,14 @@ AppDelegate::~AppDelegate()
     //  cocostudio::ArmatureDataManager::destroyInstance();
 }
 
-// if you want a different context, modify the value of glContextAttrs
+// if you want a different context, modify the value of gfxContextAttrs
 // it will affect all platforms
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GfxContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
 
-    GLView::setGLContextAttrs(glContextAttrs);
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 bool AppDelegate::applicationDidFinishLaunching()
@@ -70,7 +70,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
     // initialize director
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto glView   = director->getRenderView();
     if (!glView)
     {
         std::string title = "Cpp Tests";
@@ -78,11 +78,11 @@ bool AppDelegate::applicationDidFinishLaunching()
         title += " *Debug*",
 #endif
 #ifdef AX_PLATFORM_PC
-        glView = GLViewImpl::createWithRect(title, Rect(0, 0, g_resourceSize.width, g_resourceSize.height), 1.0F, true);
+        glView = RenderViewImpl::createWithRect(title, Rect(0, 0, g_resourceSize.width, g_resourceSize.height), 1.0F, true);
 #else
-        glView = GLViewImpl::createWithRect(title, Rect(0, 0, g_resourceSize.width, g_resourceSize.height));
+        glView = RenderViewImpl::createWithRect(title, Rect(0, 0, g_resourceSize.width, g_resourceSize.height));
 #endif
-        director->setGLView(glView);
+        director->setRenderView(glView);
     }
 
     director->setStatsDisplay(true);

--- a/tests/cpp-tests/Source/AppDelegate.h
+++ b/tests/cpp-tests/Source/AppDelegate.h
@@ -41,7 +41,7 @@ public:
     AppDelegate();
     virtual ~AppDelegate();
 
-    virtual void initGLContextAttrs();
+    virtual void initGfxContextAttrs();
 
     /**
     @brief    Implement Director and ax::Scene* init code here.

--- a/tests/cpp-tests/Source/BaseTest.cpp
+++ b/tests/cpp-tests/Source/BaseTest.cpp
@@ -164,7 +164,7 @@ void TestList::runThisTest()
      * otherwise, the layout will incorrect
      */
 
-    GLViewImpl* glView = (GLViewImpl*)Director::getInstance()->getGLView();
+    RenderViewImpl* glView = (RenderViewImpl*)Director::getInstance()->getRenderView();
 #if defined(AX_PLATFORM_PC) || defined(__EMSCRIPTEN__)
     glView->setWindowed(g_resourceSize.width, g_resourceSize.height);
 #endif

--- a/tests/cpp-tests/Source/BugsTest/Bug-14327.cpp
+++ b/tests/cpp-tests/Source/BugsTest/Bug-14327.cpp
@@ -41,7 +41,7 @@ bool Bug14327Layer::init()
 {
     if (BugsTestBase::init())
     {
-        auto glView        = Director::getInstance()->getGLView();
+        auto glView        = Director::getInstance()->getRenderView();
         auto visibleOrigin = glView->getVisibleOrigin();
         auto visibleSize   = glView->getVisibleSize();
 

--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
@@ -309,7 +309,7 @@ ChipmunkTestBed::ChipmunkTestBed()
     // halx99: since axmol init scene default camera at 'initWithXXX' function, only change design size at scene
     // construct is ok see also: https://github.com/axmolengine/axmol/commit/581a7921554c09746616759d5a5ca6ce9d3eaa22
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto glView   = director->getRenderView();
     Size designSize(g_designSize.width * 0.85, g_designSize.height * 0.85);
     glView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::SHOW_ALL);
 

--- a/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.cpp
+++ b/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.cpp
@@ -76,7 +76,7 @@ bool EffekseerTest::init()
         return false;
 
 
-    auto rsize = _director->getGLView()->getDesignResolutionSize();
+    auto rsize = _director->getRenderView()->getDesignResolutionSize();
 
 	//auto sprite = Sprite::create("HelloWorld.png");
 	//sprite->setPosition(Vec2(320, 200));

--- a/tests/cpp-tests/Source/InputTest/MouseTest.cpp
+++ b/tests/cpp-tests/Source/InputTest/MouseTest.cpp
@@ -133,12 +133,12 @@ HideMouseTest::HideMouseTest()
 
     _lis              = EventListenerMouse::create();
     _lis->onMouseDown = [](Event* e) -> bool {
-        Director::getInstance()->getGLView()->setCursorVisible(false);
+        Director::getInstance()->getRenderView()->setCursorVisible(false);
         return true;
     };
 
     _lis->onMouseUp = [](Event* e) -> bool {
-        Director::getInstance()->getGLView()->setCursorVisible(true);
+        Director::getInstance()->getRenderView()->setCursorVisible(true);
         return true;
     };
 

--- a/tests/cpp-tests/Source/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Source/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -1667,13 +1667,13 @@ WindowEventsTest::WindowEventsTest()
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX) || \
     (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
     auto dispatcher = Director::getInstance()->getEventDispatcher();
-    dispatcher->addCustomEventListener(GLViewImpl::EVENT_WINDOW_RESIZED, [](EventCustom* event) {
+    dispatcher->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_RESIZED, [](EventCustom* event) {
         // TODO: need to create resizeable window
         AXLOGD("<<< WINDOW RESIZED! >>> ");
     });
-    dispatcher->addCustomEventListener(GLViewImpl::EVENT_WINDOW_FOCUSED,
+    dispatcher->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_FOCUSED,
                                        [](EventCustom* event) { AXLOGD("<<< WINDOW FOCUSED! >>> "); });
-    dispatcher->addCustomEventListener(GLViewImpl::EVENT_WINDOW_UNFOCUSED,
+    dispatcher->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_UNFOCUSED,
                                        [](EventCustom* event) { AXLOGD("<<< WINDOW BLURRED! >>> "); });
 #endif
 }

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
@@ -144,9 +144,9 @@ void ShaderNode::setPosition(const Vec2& newPosition)
 {
     Node::setPosition(newPosition);
     auto position     = getPosition();
-    auto frameSize    = Director::getInstance()->getGLView()->getFrameSize();
+    auto frameSize    = Director::getInstance()->getRenderView()->getFrameSize();
     auto visibleSize  = Director::getInstance()->getVisibleSize();
-    auto retinaFactor = Director::getInstance()->getGLView()->getRetinaFactor();
+    auto retinaFactor = Director::getInstance()->getRenderView()->getRetinaFactor();
     _center           = Vec2(position.x * frameSize.width / visibleSize.width * retinaFactor,
                              position.y * frameSize.height / visibleSize.height * retinaFactor);
 }
@@ -189,8 +189,8 @@ void ShaderNode::updateUniforms()
     _locCosTime    = _programState->getUniformLocation("u_CosTime");
     _locScreenSize = _programState->getUniformLocation("u_screenSize");
 
-    const Vec2& frameSize   = Director::getInstance()->getGLView()->getFrameSize();
-    float retinaFactor      = Director::getInstance()->getGLView()->getRetinaFactor();
+    const Vec2& frameSize   = Director::getInstance()->getRenderView()->getFrameSize();
+    float retinaFactor      = Director::getInstance()->getRenderView()->getRetinaFactor();
     auto screenSizeInPixels = frameSize * retinaFactor;
     _programState->setUniform(_locScreenSize, &screenSizeInPixels, sizeof(screenSizeInPixels));
 }
@@ -570,8 +570,8 @@ bool ShaderRetroEffect::init()
         auto p        = new backend::ProgramState(program);
         auto director = Director::getInstance();
         const auto& screenSizeLocation = p->getUniformLocation("u_screenSize");
-        const auto& frameSize          = director->getGLView()->getFrameSize();
-        float retinaFactor             = director->getGLView()->getRetinaFactor();
+        const auto& frameSize          = director->getRenderView()->getFrameSize();
+        float retinaFactor             = director->getRenderView()->getRetinaFactor();
         auto screenSizeInPixels        = frameSize * retinaFactor;
         p->setUniform(screenSizeLocation, &screenSizeInPixels, sizeof(screenSizeInPixels));
 

--- a/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -44,7 +44,7 @@ bool UIEditBoxTest::init()
 {
     if (UIScene::init())
     {
-        auto glView        = Director::getInstance()->getGLView();
+        auto glView        = Director::getInstance()->getRenderView();
         auto visibleOrigin = glView->getVisibleOrigin();
         auto visibleSize   = glView->getVisibleSize();
 
@@ -178,7 +178,7 @@ bool UIEditBoxTestToggleVisibility::init()
 {
     if (UIScene::init())
     {
-        auto glView        = Director::getInstance()->getGLView();
+        auto glView        = Director::getInstance()->getRenderView();
         auto visibleOrigin = glView->getVisibleOrigin();
         auto visibleSize   = glView->getVisibleSize();
 
@@ -307,7 +307,7 @@ bool UIEditBoxTestTextHorizontalAlignment::init()
         return false;
     }
 
-    const auto glView        = Director::getInstance()->getGLView();
+    const auto glView        = Director::getInstance()->getRenderView();
     const auto visibleOrigin = glView->getVisibleOrigin();
     const auto visibleSize   = glView->getVisibleSize();
     const auto editBoxSize   = Size(visibleSize.width - 100, visibleSize.height * 0.1f);
@@ -343,7 +343,7 @@ bool UIEditBoxTestPressedAndDisabled::init()
         return false;
     }
 
-    auto glView            = Director::getInstance()->getGLView();
+    auto glView            = Director::getInstance()->getRenderView();
     auto visibleOrigin     = glView->getVisibleOrigin();
     auto visibleSize       = glView->getVisibleSize();
     const auto editBoxSize = Size(visibleSize.width - 100, visibleSize.height * 0.1f);

--- a/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIVideoPlayerTest/UIVideoPlayerTest.cpp
+++ b/tests/cpp-tests/Source/UITest/CocoStudioGUITest/UIVideoPlayerTest/UIVideoPlayerTest.cpp
@@ -50,7 +50,7 @@ bool VideoPlayerTest::init()
         return false;
     }
 
-    _visibleRect = Director::getInstance()->getGLView()->getVisibleRect();
+    _visibleRect = Director::getInstance()->getRenderView()->getVisibleRect();
 
     MenuItemFont::setFontSize(16);
 
@@ -345,7 +345,7 @@ bool SimpleVideoPlayerTest::init()
         return false;
     }
 
-    _visibleRect = Director::getInstance()->getGLView()->getVisibleRect();
+    _visibleRect = Director::getInstance()->getRenderView()->getVisibleRect();
 
     MenuItemFont::setFontSize(16);
 

--- a/tests/cpp-tests/Source/VRTest/VRTest.cpp
+++ b/tests/cpp-tests/Source/VRTest/VRTest.cpp
@@ -48,7 +48,7 @@ VRTest1::VRTest1()
     addChild(image);
 
     auto button = MenuItemFont::create("Enable / Disable VR", [](Object* ref) {
-        auto glView = Director::getInstance()->getGLView();
+        auto glView = Director::getInstance()->getRenderView();
         auto vrimpl = glView->getVR();
         if (vrimpl)
         {

--- a/tests/cpp-tests/Source/VisibleRect.cpp
+++ b/tests/cpp-tests/Source/VisibleRect.cpp
@@ -33,7 +33,7 @@ void VisibleRect::lazyInit()
 {
     // no lazy init
     // Useful if we change the resolution in runtime
-    s_visibleRect = Director::getInstance()->getGLView()->getVisibleRect();
+    s_visibleRect = Director::getInstance()->getRenderView()->getVisibleRect();
 }
 
 Rect VisibleRect::getVisibleRect()

--- a/tests/cpp-tests/Source/WindowTest/WindowTest.cpp
+++ b/tests/cpp-tests/Source/WindowTest/WindowTest.cpp
@@ -47,7 +47,7 @@ std::string WindowTest::title() const
 void WindowTestWindowed1::onEnter()
 {
     WindowTest::onEnter();
-    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getGLView();
+    RenderViewImpl* view = (RenderViewImpl*)Director::getInstance()->getRenderView();
     view->setWindowed(480, 320);
 }
 
@@ -59,7 +59,7 @@ std::string WindowTestWindowed1::subtitle() const
 void WindowTestWindowed2::onEnter()
 {
     WindowTest::onEnter();
-    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getGLView();
+    RenderViewImpl* view = (RenderViewImpl*)Director::getInstance()->getRenderView();
     view->setWindowed(960, 640);
 }
 
@@ -72,7 +72,7 @@ bool WindowTestFullscreen1::init()
 {
     // @remark: Set full screen before layout renderer elements to ensure VisibleRect is
     // correct with full screen window size
-    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getGLView();
+    RenderViewImpl* view = (RenderViewImpl*)Director::getInstance()->getRenderView();
     view->setFullscreen();
     return WindowTest::init();
 }
@@ -84,7 +84,7 @@ std::string WindowTestFullscreen1::subtitle() const
 
 bool WindowTestFullscreen2::init()
 {
-    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getGLView();
+    RenderViewImpl* view = (RenderViewImpl*)Director::getInstance()->getRenderView();
     view->setFullscreen(1);
     return WindowTest::init();
 }
@@ -96,7 +96,7 @@ std::string WindowTestFullscreen2::subtitle() const
 
 bool WindowTestFullscreen3::init()
 {
-    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getGLView();
+    RenderViewImpl* view = (RenderViewImpl*)Director::getInstance()->getRenderView();
     view->setFullscreen(2);
     return WindowTest::init();
 }
@@ -111,7 +111,7 @@ void WindowTestResizedAndPositioned::onEnter()
     WindowTest::onEnter();
 
     auto s = _director->getWinSize();
-    auto glView = static_cast<GLViewImpl*>(_director->getGLView());
+    auto glView = static_cast<RenderViewImpl*>(_director->getRenderView());
 
     int x = 0;
     int y = 0;
@@ -129,18 +129,18 @@ void WindowTestResizedAndPositioned::onEnter()
     addChild(label2);
 
     _director->getEventDispatcher()->addCustomEventListener(
-        GLViewImpl::EVENT_WINDOW_POSITIONED,
+        RenderViewImpl::EVENT_WINDOW_POSITIONED,
         AX_CALLBACK_1(WindowTestResizedAndPositioned::onWindowPositioned, this));
     _director->getEventDispatcher()->addCustomEventListener(
-        GLViewImpl::EVENT_WINDOW_RESIZED,
+        RenderViewImpl::EVENT_WINDOW_RESIZED,
         AX_CALLBACK_1(WindowTestResizedAndPositioned::onWindowResized, this));
 }
 
 void WindowTestResizedAndPositioned::onExit()
 {
     WindowTest::onExit();
-    _director->getEventDispatcher()->removeCustomEventListeners(GLViewImpl::EVENT_WINDOW_POSITIONED);
-    _director->getEventDispatcher()->removeCustomEventListeners(GLViewImpl::EVENT_WINDOW_RESIZED);
+    _director->getEventDispatcher()->removeCustomEventListeners(RenderViewImpl::EVENT_WINDOW_POSITIONED);
+    _director->getEventDispatcher()->removeCustomEventListeners(RenderViewImpl::EVENT_WINDOW_RESIZED);
 }
 
 std::string WindowTestResizedAndPositioned::subtitle() const
@@ -172,14 +172,14 @@ void WindowTestClose::onEnter()
 
     label = nullptr;
 
-    _director->getEventDispatcher()->addCustomEventListener(GLViewImpl::EVENT_WINDOW_CLOSE,
+    _director->getEventDispatcher()->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_CLOSE,
                                                             AX_CALLBACK_1(WindowTestClose::onWindowClose, this));
 }
 
 void WindowTestClose::onExit()
 {
     WindowTest::onExit();
-    _director->getEventDispatcher()->removeCustomEventListeners(GLViewImpl::EVENT_WINDOW_CLOSE);
+    _director->getEventDispatcher()->removeCustomEventListeners(RenderViewImpl::EVENT_WINDOW_CLOSE);
 }
 
 std::string WindowTestClose::subtitle() const

--- a/tests/cpp-tests/proj.ios/Source/testsAppDelegate.mm
+++ b/tests/cpp-tests/proj.ios/Source/testsAppDelegate.mm
@@ -26,7 +26,7 @@
 
 #import "testsAppDelegate.h"
 
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 #import "axmol.h"
 #import "AppDelegate.h"
 #import "RootViewController.h"
@@ -43,19 +43,19 @@ static AppDelegate s_sharedApplication;
 {
 
     ax::Application* app = ax::Application::getInstance();
-    app->initGLContextAttrs();
+    app->initGfxContextAttrs();
 
     // Override point for customization after application launch.
 
-    auto renderView = ax::GLViewImpl::createWithFullScreen("axmol2");
+    auto renderView = ax::RenderViewImpl::createWithFullScreen("axmol2");
     
-    // Use RootViewController manage EAGLView and UIWindow
+    // Use RootViewController manage EARenderView and UIWindow
     viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
     
     renderView->showWindow(viewController);
 
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    ax::Director::getInstance()->setGLView(renderView);
+    // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
+    ax::Director::getInstance()->setRenderView(renderView);
 
     app->run();
 

--- a/tests/fairygui-tests/Source/AppDelegate.cpp
+++ b/tests/fairygui-tests/Source/AppDelegate.cpp
@@ -19,14 +19,14 @@ AppDelegate::~AppDelegate()
     AudioEngine::end();
 }
 
-// if you want a different context, modify the value of glContextAttrs
+// if you want a different context, modify the value of gfxContextAttrs
 // it will affect all platforms
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil
-    GLContextAttrs glContextAttrs = { 8, 8, 8, 8, 24, 8 };
+    GfxContextAttrs gfxContextAttrs = { 8, 8, 8, 8, 24, 8 };
 
-    GLView::setGLContextAttrs(glContextAttrs);
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 // if you want to use the package manager to install more packages,
@@ -39,14 +39,14 @@ static int register_all_packages()
 bool AppDelegate::applicationDidFinishLaunching() {
     // initialize director
     auto director = Director::getInstance();
-    auto glView = director->getGLView();
+    auto glView = director->getRenderView();
     if (!glView) {
 #if defined(AX_PLATFORM_PC) || (AX_TARGET_PLATFORM == AX_PLATFORM_WASM)
-        glView = GLViewImpl::createWithRect("Examples", ax::Rect(0, 0, 1280, 720));
+        glView = RenderViewImpl::createWithRect("Examples", ax::Rect(0, 0, 1280, 720));
 #else
-        glView = GLViewImpl::create("Examples");
+        glView = RenderViewImpl::create("Examples");
 #endif
-        director->setGLView(glView);
+        director->setRenderView(glView);
     }
 
     // turn on display FPS

--- a/tests/fairygui-tests/Source/AppDelegate.h
+++ b/tests/fairygui-tests/Source/AppDelegate.h
@@ -14,7 +14,7 @@ public:
     AppDelegate();
     virtual ~AppDelegate();
 
-    virtual void initGLContextAttrs();
+    virtual void initGfxContextAttrs();
 
     /**
     @brief    Implement Director and Scene init code here.

--- a/tests/fairygui-tests/proj.ios/AppController.mm
+++ b/tests/fairygui-tests/proj.ios/AppController.mm
@@ -25,7 +25,6 @@
 #import <UIKit/UIKit.h>
 #import "AppController.h"
 #import "axmol.h"
-#import "platform/ios/EAGLView-ios.h"
 #import "AppDelegate.h"
 #import "RootViewController.h"
 
@@ -40,17 +39,17 @@ static AppDelegate s_sharedApplication;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     ax::Application *app = ax::Application::getInstance();
-    app->initGLContextAttrs();
+    app->initGfxContextAttrs();
 
     // Override point for customization after application launch.
 
-    auto renderView = ax::GLViewImpl::createWithFullScreen("axmol2");
+    auto renderView = ax::RenderViewImpl::createWithFullScreen("axmol2");
 
     viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
     renderView->showWindow(viewController);
 
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    ax::Director::getInstance()->setGLView(renderView);
+    // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
+    ax::Director::getInstance()->setRenderView(renderView);
 
     app->run();
     return YES;

--- a/tests/live2d-tests/Source/AppDelegate.cpp
+++ b/tests/live2d-tests/Source/AppDelegate.cpp
@@ -47,14 +47,14 @@ AppDelegate::~AppDelegate()
 #endif
 }
 
-// if you want a different context, modify the value of glContextAttrs
+// if you want a different context, modify the value of gfxContextAttrs
 // it will affect all platforms
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil,multisamplesCount
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GfxContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
 
-    GLView::setGLContextAttrs(glContextAttrs);
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 // if you want to use the package manager to install more packages,
@@ -68,15 +68,15 @@ bool AppDelegate::applicationDidFinishLaunching()
 {
     // initialize director
     auto director = Director::getInstance();
-    auto glView = director->getGLView();
+    auto glView = director->getRenderView();
     if(!glView)
     {
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_MAC) || (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
-        glView = GLViewImpl::createWithRect("Demo", ax::Rect(0, 0, designResolutionSize.width, designResolutionSize.height));
+        glView = RenderViewImpl::createWithRect("Demo", ax::Rect(0, 0, designResolutionSize.width, designResolutionSize.height));
 #else
-        glView = GLViewImpl::create("Demo");
+        glView = RenderViewImpl::create("Demo");
 #endif
-        director->setGLView(glView);
+        director->setRenderView(glView);
     }
 
     // turn on display FPS

--- a/tests/live2d-tests/Source/AppDelegate.h
+++ b/tests/live2d-tests/Source/AppDelegate.h
@@ -26,7 +26,7 @@ public:
     AppDelegate();
     virtual ~AppDelegate();
 
-    virtual void initGLContextAttrs();
+    virtual void initGfxContextAttrs();
 
     /**
     @brief    Implement Director and Scene init code here.

--- a/tests/live2d-tests/Source/AppMacros.h
+++ b/tests/live2d-tests/Source/AppMacros.h
@@ -11,7 +11,7 @@
      We check current device frame size to decide which resource need to be selected.
      So if you want to test this situation which said in title '[Situation 1]',
      you should change ios simulator to different device(e.g. iphone, iphone-retina3.5, iphone-retina4.0, ipad, ipad-retina),
-     or change the window size in "proj.XXX/main.cpp" by "CCEGLView::setFrameSize" if you are using win32 or linux plaform
+     or change the window size in "proj.XXX/main.cpp" by "CCERenderView::setFrameSize" if you are using win32 or linux plaform
      and modify "proj.mac/AppController.mm" by changing the window rectangle.
 
    [Situation 2] Using one resource to match different design resolutions.
@@ -51,6 +51,6 @@ static ax::CCSize designResolutionSize = ax::CCSizeMake(2048, 1536);
 #endif
 
 // The font size 24 is designed for small resolution, so we should change it to fit for current design resolution
-#define TITLE_FONT_SIZE  (ax::CCEGLView::sharedGLView()->getDesignResolutionSize().width / smallResource.size.width * 24)
+#define TITLE_FONT_SIZE  (ax::CCERenderView::sharedRenderView()->getDesignResolutionSize().width / smallResource.size.width * 24)
 
 #endif /* __APPMACROS_H__ */

--- a/tests/live2d-tests/Source/LAppLive2DManager.cpp
+++ b/tests/live2d-tests/Source/LAppLive2DManager.cpp
@@ -74,8 +74,8 @@ LAppLive2DManager::LAppLive2DManager()
 
     CreateShader();
 
-    int width = static_cast<int>(ax::Director::getInstance()->getGLView()->getFrameSize().width);
-    int height = static_cast<int>(ax::Director::getInstance()->getGLView()->getFrameSize().height);
+    int width = static_cast<int>(ax::Director::getInstance()->getRenderView()->getFrameSize().width);
+    int height = static_cast<int>(ax::Director::getInstance()->getRenderView()->getFrameSize().height);
 
     // 画面全体を覆うサイズ
     _sprite = new LAppSprite(_program);
@@ -89,7 +89,7 @@ LAppLive2DManager::LAppLive2DManager()
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
         // Retina対策でこっちからとる
-        GLViewImpl *glimpl = (GLViewImpl *)Director::getInstance()->getGLView();
+        RenderViewImpl *glimpl = (RenderViewImpl *)Director::getInstance()->getRenderView();
         glfwGetFramebufferSize(glimpl->getWindow(), &width, &height);
 #endif
 

--- a/tests/live2d-tests/Source/LAppModel.cpp
+++ b/tests/live2d-tests/Source/LAppModel.cpp
@@ -758,11 +758,11 @@ void LAppModel::MakeRenderingTarget()
     if (!_renderSprite && !_renderBuffer->IsValid())
     {
         float aspectFactor = 1.0f;
-        int frameW = Director::getInstance()->getGLView()->getFrameSize().width, frameH = Director::getInstance()->getGLView()->getFrameSize().height;
+        int frameW = Director::getInstance()->getRenderView()->getFrameSize().width, frameH = Director::getInstance()->getRenderView()->getFrameSize().height;
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
         // Retina対策でこっちからとる
-        GLViewImpl *glimpl = (GLViewImpl *)Director::getInstance()->getGLView();
+        RenderViewImpl *glimpl = (RenderViewImpl *)Director::getInstance()->getRenderView();
         int renderW = frameW;
         int renderH = frameH;
         glfwGetFramebufferSize(glimpl->getWindow(), &frameW, &frameH);

--- a/tests/live2d-tests/proj.ios/AppController.mm
+++ b/tests/live2d-tests/proj.ios/AppController.mm
@@ -25,7 +25,7 @@
 #import <UIKit/UIKit.h>
 #import "AppController.h"
 #import "axmol.h"
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 #import "AppDelegate.h"
 #import "RootViewController.h"
 
@@ -40,19 +40,19 @@ static AppDelegate s_sharedApplication;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     ax::Application *app = ax::Application::getInstance();
-    app->initGLContextAttrs();
+    app->initGfxContextAttrs();
 
     // Override point for customization after application launch.
 
-    auto renderView = ax::GLViewImpl::createWithFullScreen("axmol2");
+    auto renderView = ax::RenderViewImpl::createWithFullScreen("axmol2");
 
     // Add the view controller's view to the window and display.
     viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
 
     renderView->showWindow(viewController);
 
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    ax::Director::getInstance()->setGLView(renderView);
+    // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
+    ax::Director::getInstance()->setRenderView(renderView);
 
     app->run();
     return YES;

--- a/tests/lua-tests/Content/src/OpenGLTest/OpenGLTest.lua
+++ b/tests/lua-tests/Content/src/OpenGLTest/OpenGLTest.lua
@@ -204,9 +204,9 @@ local function OpenGLTestMainLayer()
 
         local resolution = cc.p(256, 256)
         local director = cc.Director:getInstance()
-        local frameSize = director:getGLView():getFrameSize()
+        local frameSize = director:getRenderView():getFrameSize()
         local visibleSize = director:getVisibleSize()
-        local retinaFactor = director:getGLView():getRetinaFactor()
+        local retinaFactor = director:getRenderView():getRetinaFactor()
         local center = cc.p( size.width / 2 * frameSize.width / visibleSize.width * retinaFactor, size.height / 2 * frameSize.height / visibleSize.height * retinaFactor)
 
         local function initBuffers()

--- a/tests/lua-tests/Content/src/VideoPlayerTest/VideoPlayerTest.lua
+++ b/tests/lua-tests/Content/src/VideoPlayerTest/VideoPlayerTest.lua
@@ -1,4 +1,4 @@
-local visibleRect = cc.Director:getInstance():getGLView():getVisibleRect()
+local visibleRect = cc.Director:getInstance():getRenderView():getVisibleRect()
 local centerPos   = cc.p(visibleRect.x + visibleRect.width / 2,visibleRect.y + visibleRect.height /2)
 
 axui.VideoPlayer = axui.MediaPlayer

--- a/tests/lua-tests/Content/src/controller.lua
+++ b/tests/lua-tests/Content/src/controller.lua
@@ -13,10 +13,10 @@ AX_USE_DEPRECATED_API = true
 require "axmol.init"
 
 local director = cc.Director:getInstance()
-local glView   = director:getGLView()
-if nil == glView then
-    glView = cc.GLViewImpl:createWithRect("Lua Tests", cc.rect(0,0,960,640), 1.0, true)
-    director:setGLView(glView)
+local renderView   = director:getRenderView()
+if nil == renderView then
+    renderView = ax.RenderViewImpl:createWithRect("Lua Tests", cc.rect(0,0,960,640), 1.0, true)
+    director:setRenderView(renderView)
 end
 
 --turn on display FPS
@@ -25,7 +25,7 @@ director:setDisplayStats(true)
 --set FPS. the default value is 1.0/60 if you don't call this
 director:setAnimationInterval(1.0 / 60)
 
-local screenSize = glView:getFrameSize()
+local screenSize = renderView:getFrameSize()
 
 local designSize = {width = 480, height = 320}
 
@@ -34,7 +34,7 @@ if screenSize.height > 320 then
     cc.Director:getInstance():setContentScaleFactor(resourceSize.height/designSize.height)
 end
 
-glView:setDesignResolutionSize(designSize.width, designSize.height, cc.ResolutionPolicy.SHOW_ALL)
+renderView:setDesignResolutionSize(designSize.width, designSize.height, cc.ResolutionPolicy.SHOW_ALL)
 
 local fileUtils = cc.FileUtils:getInstance()
 local function addSearchPath(resPrefix, height)

--- a/tests/lua-tests/Content/src/helper.lua
+++ b/tests/lua-tests/Content/src/helper.lua
@@ -76,7 +76,7 @@ end
 function Helper.initWithLayer(layer)
     Helper.currentLayer = layer
 
-    local size = cc.Director:getInstance():getGLView():getVisibleRect()
+    local size = cc.Director:getInstance():getRenderView():getVisibleRect()
     Helper.titleLabel = cc.Label:createWithTTF("", s_arialPath, 28)
     Helper.titleLabel:setAnchorPoint(cc.p(0.5, 0.5))
     layer:addChild(Helper.titleLabel, 1)
@@ -126,7 +126,7 @@ function CreateBackMenuItem()
     local MenuItem = cc.MenuItemLabel:create(label)
     MenuItem:registerScriptTapHandler(MainMenuCallback)
 
-    local s = cc.Director:getInstance():getGLView():getVisibleRect()
+    local s = cc.Director:getInstance():getRenderView():getVisibleRect()
     local Menu = cc.Menu:create()
     Menu:addChild(MenuItem)
     Menu:setPosition(0, 0)

--- a/tests/lua-tests/Source/AppDelegate.cpp
+++ b/tests/lua-tests/Source/AppDelegate.cpp
@@ -36,11 +36,11 @@ AppDelegate::AppDelegate() {}
 
 AppDelegate::~AppDelegate() {}
 
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GLContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
 
-    GLView::setGLContextAttrs(glContextAttrs);
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 bool AppDelegate::applicationDidFinishLaunching()

--- a/tests/lua-tests/Source/AppDelegate.h
+++ b/tests/lua-tests/Source/AppDelegate.h
@@ -38,7 +38,7 @@ public:
     AppDelegate();
     virtual ~AppDelegate();
 
-    void initGLContextAttrs();
+    void initGfxContextAttrs();
     /**
     @brief    Implement Director and Scene init code here.
     @return true    Initialize success, app continue.

--- a/tests/lua-tests/proj.ios_mac/ios/AppController.mm
+++ b/tests/lua-tests/proj.ios_mac/ios/AppController.mm
@@ -25,7 +25,7 @@
 #import <UIKit/UIKit.h>
 #import "AppController.h"
 #import "axmol.h"
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 #import "AppDelegate.h"
 
 #import "RootViewController.h"
@@ -42,18 +42,18 @@ static AppDelegate s_sharedApplication;
 {
 
     ax::Application* app = ax::Application::getInstance();
-    app->initGLContextAttrs();
+    app->initGfxContextAttrs();
     
     // Override point for customization after application launch.
 
-    auto renderView = ax::GLViewImpl::createWithFullScreen("axmol2");
+    auto renderView = ax::RenderViewImpl::createWithFullScreen("axmol2");
 
-    // Use RootViewController manage EAGLView
+    // Use RootViewController manage EARenderView
     viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
     renderView->showWindow(viewController);
 
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    ax::Director::getInstance()->setGLView(renderView);
+    // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
+    ax::Director::getInstance()->setRenderView(renderView);
 
     app->run();
     return YES;

--- a/tests/unit-tests/Source/AppDelegate.cpp
+++ b/tests/unit-tests/Source/AppDelegate.cpp
@@ -35,12 +35,12 @@ static Vec2 gWindowSize = Vec2(1024, 768);
 
 
 
-void AppDelegate::initGLContextAttrs()
+void AppDelegate::initGfxContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GfxContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
 
-    GLView::setGLContextAttrs(glContextAttrs);
+    RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
 
@@ -54,16 +54,16 @@ bool AppDelegate::applicationDidFinishLaunching()
 
     // initialize director
     auto director = Director::getInstance();
-    auto glView   = director->getGLView();
+    auto glView   = director->getRenderView();
     if (!glView)
     {
         std::string title = "Unit Tests";
         #ifdef AX_PLATFORM_PC
-            glView = GLViewImpl::createWithRect(title, Rect(0, 0, gWindowSize.x, gWindowSize.y), 1.0F, true);
+            glView = RenderViewImpl::createWithRect(title, Rect(0, 0, gWindowSize.x, gWindowSize.y), 1.0F, true);
         #else
-            glView = GLViewImpl::createWithRect(title, Rect(0, 0, gWindowSize.x, gWindowSize.y));
+            glView = RenderViewImpl::createWithRect(title, Rect(0, 0, gWindowSize.x, gWindowSize.y));
         #endif
-        director->setGLView(glView);
+        director->setRenderView(glView);
     }
 
     director->setStatsDisplay(true);

--- a/tests/unit-tests/Source/AppDelegate.h
+++ b/tests/unit-tests/Source/AppDelegate.h
@@ -35,7 +35,7 @@ class TestController;
 class AppDelegate : private ax::Application
 {
 public:
-    virtual void initGLContextAttrs();
+    virtual void initGfxContextAttrs();
 
     virtual bool applicationDidFinishLaunching();
     virtual void applicationDidEnterBackground();

--- a/tests/unit-tests/proj.ios/Source/testsAppDelegate.mm
+++ b/tests/unit-tests/proj.ios/Source/testsAppDelegate.mm
@@ -26,7 +26,7 @@
 
 #import "testsAppDelegate.h"
 
-#import "platform/ios/EAGLView-ios.h"
+#import "platform/ios/EARenderView-ios.h"
 #import "axmol.h"
 #import "AppDelegate.h"
 #import "RootViewController.h"
@@ -43,16 +43,16 @@ static AppDelegate s_sharedApplication;
 {
 
     ax::Application* app = ax::Application::getInstance();
-    app->initGLContextAttrs();
+    app->initGfxContextAttrs();
 
     // Override point for customization after application launch.
 
-    auto renderView = ax::GLViewImpl::createWithFullScreen("axmol2");
+    auto renderView = ax::RenderViewImpl::createWithFullScreen("axmol2");
     viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
     renderView->showWindow(viewController);
 
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    ax::Director::getInstance()->setGLView(renderView);
+    // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
+    ax::Director::getInstance()->setRenderView(renderView);
 
     app->run();
 

--- a/tools/tolua/ax_base.ini
+++ b/tools/tolua/ax_base.ini
@@ -18,7 +18,7 @@ headers = %(axdir)s/core/axmol.h %(axdir)s/core/2d/ProtectedNode.h %(axdir)s/ext
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".
-classes = New.* Sprite.* Scene Node.* Director Layer.* Menu.* Touch .*Action.* Move.* Rotate.* Blink.* Tint.* Sequence Repeat.* Fade.* Ease.* Scale.* Transition.* Spawn Animat.* Flip.* Delay.* Skew.* Jump.* Place.* Show.* Progress.* PointArray ToggleVisibility.* RemoveSelf Hide Particle.* Label.* Atlas.* TextureCache.* Texture2D Cardinal.* CatmullRom.* ParallaxNode TileMap.* .*TMX.* CallFunc RenderTexture GridAction Grid3DAction GridBase$ .+Grid Shaky3D Waves3D FlipX3D FlipY3D Speed ActionManager Set Scheduler Timer Orbit.* Follow.* Bezier.* CardinalSpline.* Camera.* DrawNode .*3D$ Liquid$ Waves$ ShuffleTiles$ TurnOffTiles$ Split.* Twirl$ FileUtils$ GLProgram ShaderCache Application ClippingNode MotionStreak ^Object$ UserDefault GLViewImpl GLView Image Event(?!.*(Physics).*).* Component ProtectedNode Console Device ClippingRectangleNode .*Light$ RenderState Material Properties Technique Pass PolygonInfo AutoPolygon BoneNode SkeletonNode ComponentLua PipelineDescriptor Renderer FastTMXLayer FastTMXTiledMap
+classes = New.* Sprite.* Scene Node.* Director Layer.* Menu.* Touch .*Action.* Move.* Rotate.* Blink.* Tint.* Sequence Repeat.* Fade.* Ease.* Scale.* Transition.* Spawn Animat.* Flip.* Delay.* Skew.* Jump.* Place.* Show.* Progress.* PointArray ToggleVisibility.* RemoveSelf Hide Particle.* Label.* Atlas.* TextureCache.* Texture2D Cardinal.* CatmullRom.* ParallaxNode TileMap.* .*TMX.* CallFunc RenderTexture GridAction Grid3DAction GridBase$ .+Grid Shaky3D Waves3D FlipX3D FlipY3D Speed ActionManager Set Scheduler Timer Orbit.* Follow.* Bezier.* CardinalSpline.* Camera.* DrawNode .*3D$ Liquid$ Waves$ ShuffleTiles$ TurnOffTiles$ Split.* Twirl$ FileUtils$ GLProgram ShaderCache Application ClippingNode MotionStreak ^Object$ UserDefault RenderViewImpl RenderView Image Event(?!.*(Physics).*).* Component ProtectedNode Console Device ClippingRectangleNode .*Light$ RenderState Material Properties Technique Pass PolygonInfo AutoPolygon BoneNode SkeletonNode ComponentLua PipelineDescriptor Renderer FastTMXLayer FastTMXTiledMap
 
 # what should we skip? in the format ClassName::[function function]
 # ClassName is a regular expression, but will be used like this: "^ClassName$" functions are also
@@ -101,8 +101,8 @@ skip = Node::[setGLServerState description _setLocalZOrder getUserObject .*UserD
         ccFontDefinition::[*],
         Object::[autorelease isEqual acceptVisitor update],
         UserDefault::[getInstance (s|g)etDataForKey encrypt],
-        GLView::[setTouchDelegate getAllTouches],
-        GLViewImpl::[end swapBuffers loadGLES2],
+        RenderView::[setTouchDelegate getAllTouches],
+        RenderViewImpl::[end swapBuffers loadGLES2],
         NewTextureAtlas::[*],
         DisplayLinkDirector::[mainLoop setAnimationInterval startAnimation stopAnimation],
         RenderTexture::[listenToBackground listenToForeground newImage],
@@ -156,7 +156,7 @@ rename_functions = SpriteFrameCache::[addSpriteFramesWithFile=addSpriteFrames ge
     Touch::[getID=getId],
     FileUtils::[loadFilenameLookupDictionaryFromFile=loadFilenameLookup],
     Director::[end=endToLua],
-    GLView::[end=endToLua],
+    RenderView::[end=endToLua],
     RenderTexture::[end=endToLua]
 
 rename_classes = ParticleSystemQuad::ParticleSystem
@@ -172,7 +172,7 @@ base_classes_to_skip = Clonable
 
 # classes that create no constructor
 # Set is special and we will use a hand-written constructor
-abstract_classes = Action FiniteTimeAction ActionInterval ActionEase EaseRateAction EaseElastic EaseBounce ActionInstant GridAction Grid3DAction TiledGrid3DAction Director SpriteFrameCache TransitionEaseScene Set FileUtils Application ClippingNode Label GLViewImpl GLView EventAcceleration DisplayLinkDirector Component Console EventListener BaseLight
+abstract_classes = Action FiniteTimeAction ActionInterval ActionEase EaseRateAction EaseElastic EaseBounce ActionInstant GridAction Grid3DAction TiledGrid3DAction Director SpriteFrameCache TransitionEaseScene Set FileUtils Application ClippingNode Label RenderViewImpl RenderView EventAcceleration DisplayLinkDirector Component Console EventListener BaseLight
 
 # Determining whether to use script object(js object) to control the lifecycle of native(cpp) object or the other way around. Supported values are 'yes' or 'no'.
 script_control_cpp = no


### PR DESCRIPTION
## Describe your changes

- Rename GLView to RenderView
- Rename RenderView method: isOpenGLReady to isGfxContextReady
- Rename struct `GLContextAttrs` to `GfxContextAttrs`
- Rename RenderView method: `setGLContextAttrs` to `setGfxContextAttrs`
- Rename RenderView method: `getGLContextAttrs` to `getGfxContextAttrs`
- All renamed stub has compatible typedef like: `AX_DEPRECATED(2.8) typedef NewName OldName;`

## Affects

- User can upgrade from axmol-2.7 without game code changes, but will encouter some deprecated warnings

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.
