### PR TITLE
Fix incorrect FontAtlas when switching label rendering mode from normal to SDF

### DIFF
--- a/core/2d/FontAtlasCache.cpp
+++ b/core/2d/FontAtlasCache.cpp
@@ -58,23 +58,20 @@ void FontAtlasCache::preloadFontAtlas(std::string_view fontatlasFile)
     FontAtlas::loadFontAtlas(fontatlasFile, _atlasMap);
 }
 
-FontAtlas* FontAtlasCache::getFontAtlasTTF(_ttfConfig* config)
+FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
 {
     auto& realFontFilename = config->fontFilePath;
     bool useDistanceField  = config->distanceFieldEnabled;
     int outlineSize        = useDistanceField ? 0 : config->outlineSize;
 
     // underlaying font engine (freetype2) only support int type, so convert to int avoid precision issue
-    if (!config->distanceFieldEnabled)
-        config->faceSize = static_cast<int>(config->fontSize);
+    const int faceSize = config->distanceFieldEnabled ? config->faceSize : static_cast<int>(config->fontSize);
+    auto scaledFaceSize = static_cast<int>(faceSize * AX_CONTENT_SCALE_FACTOR());
 
-    auto scaledFaceSize = static_cast<int>(config->faceSize * AX_CONTENT_SCALE_FACTOR());
-
-    std::string atlasName =
-        config->distanceFieldEnabled
+    std::string atlasName = config->distanceFieldEnabled
                                 ? fmt::format("df {} {}", scaledFaceSize, realFontFilename)
                                 : fmt::format("{} {} {}", scaledFaceSize, outlineSize, realFontFilename);
-    auto it = _atlasMap.find(atlasName);
+    auto it               = _atlasMap.find(atlasName);
 
     if (it == _atlasMap.end())
     {

--- a/core/2d/FontAtlasCache.h
+++ b/core/2d/FontAtlasCache.h
@@ -46,7 +46,7 @@ public:
      * since axmol-2.1.0, must call before creating any Label
      */
     static void preloadFontAtlas(std::string_view fontatlasFile);
-    static FontAtlas* getFontAtlasTTF(_ttfConfig* config);
+    static FontAtlas* getFontAtlasTTF(const _ttfConfig* config);
 
     static FontAtlas* getFontAtlasFNT(std::string_view fontFileName);
     static FontAtlas* getFontAtlasFNT(std::string_view fontFileName, std::string_view subTextureKey);

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -55,7 +55,7 @@ typedef struct _ttfConfig
 
     GlyphCollection glyphs;
     float fontSize; // The desired render font size
-    int faceSize; // The original face size of font
+    int faceSize; // The original face size of font, used when distanceFieldEnabled == true
     int outlineSize;
 
     bool distanceFieldEnabled;


### PR DESCRIPTION
shouldn't modify config->faceSize inside getFontAtlasTTF

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
