### PR TITLE
[RHI] Add sampler2DArray support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,5 @@ tests/*-tests/build_*
 
 .gitee
 release_note_draft.txt
+
+*.hprof

--- a/1k/build.profiles
+++ b/1k/build.profiles
@@ -5,9 +5,7 @@
 
 # --- region platfom:common
 
-# The axmol shader compiler,
-# before axmol-2.3.0, it's 'glslcc'
-# before axmol-3.0.0, it's 'axslcc'
+# The axmol shader compiler, legacy name is 'glslcc' before axmol-2.3.0
 axslcc=1.11.0+
 
 # The cmake, @gradle @axmol-cmdline

--- a/axmol/2d/AnchoredSprite.cpp
+++ b/axmol/2d/AnchoredSprite.cpp
@@ -72,7 +72,7 @@ AnchoredSprite* AnchoredSprite::createWithTexture(Texture2D* texture, const Rect
 
 AnchoredSprite* AnchoredSprite::create(std::string_view filename)
 {
-    return AnchoredSprite::create(filename, PixelFormat::NONE);
+    return AnchoredSprite::create(filename, PixelFormat::AUTO);
 }
 
 AnchoredSprite* AnchoredSprite::create(std::string_view filename, PixelFormat format)

--- a/axmol/2d/AnchoredSprite.cpp
+++ b/axmol/2d/AnchoredSprite.cpp
@@ -72,7 +72,7 @@ AnchoredSprite* AnchoredSprite::createWithTexture(Texture2D* texture, const Rect
 
 AnchoredSprite* AnchoredSprite::create(std::string_view filename)
 {
-    return AnchoredSprite::create(filename, PixelFormat::AUTO);
+    return AnchoredSprite::create(filename, PixelFormat::NONE);
 }
 
 AnchoredSprite* AnchoredSprite::create(std::string_view filename, PixelFormat format)

--- a/axmol/2d/CameraBackgroundBrush.cpp
+++ b/axmol/2d/CameraBackgroundBrush.cpp
@@ -418,7 +418,7 @@ void CameraBackgroundSkyBoxBrush::setTexture(TextureCube* texture)
     AX_SAFE_RETAIN(texture);
     AX_SAFE_RELEASE(_texture);
     _texture = texture;
-    _programState->setTexture(_uniformEnvLoc, 0, _texture->getBackendTexture());
+    _programState->setTexture(_uniformEnvLoc, 0, _texture->getRHITexture());
 }
 
 bool CameraBackgroundSkyBoxBrush::isActived() const

--- a/axmol/2d/CameraBackgroundBrush.cpp
+++ b/axmol/2d/CameraBackgroundBrush.cpp
@@ -36,7 +36,7 @@
 #include "axmol/renderer/TextureCube.h"
 #include "axmol/renderer/Shaders.h"
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 #    include "axmol/base/EventCustom.h"
 #    include "axmol/base/EventListenerCustom.h"
 #    include "axmol/base/EventType.h"
@@ -87,11 +87,11 @@ CameraBackgroundSkyBoxBrush* CameraBackgroundBrush::createSkyboxBrush(std::strin
 CameraBackgroundDepthBrush::CameraBackgroundDepthBrush()
     : _depth(0.f)
     , _clearColor(false)
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     , _backToForegroundListener(nullptr)
 #endif
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener =
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { initBuffer(); });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
@@ -99,7 +99,7 @@ CameraBackgroundDepthBrush::CameraBackgroundDepthBrush()
 }
 CameraBackgroundDepthBrush::~CameraBackgroundDepthBrush()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 }
@@ -264,11 +264,11 @@ CameraBackgroundSkyBoxBrush::CameraBackgroundSkyBoxBrush()
     : _texture(nullptr)
     , _actived(true)
     , _textureValid(true)
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     , _backToForegroundListener(nullptr)
 #endif
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener =
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { initBuffer(); });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
@@ -278,7 +278,7 @@ CameraBackgroundSkyBoxBrush::CameraBackgroundSkyBoxBrush()
 CameraBackgroundSkyBoxBrush::~CameraBackgroundSkyBoxBrush()
 {
     AX_SAFE_RELEASE(_texture);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 }

--- a/axmol/2d/CameraBackgroundBrush.h
+++ b/axmol/2d/CameraBackgroundBrush.h
@@ -169,7 +169,7 @@ private:
     void onAfterDraw();
 
 protected:
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener;
 #endif
     void initBuffer();
@@ -299,7 +299,7 @@ protected:
 
     TextureCube* _texture;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener;
 #endif
 

--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -85,7 +85,7 @@ DrawNode::DrawNode()
 
     properties.setDefaultValues();
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // TODO new-renderer: interface setupBuffer removal
 
     // Need to listen the event only when not use batchnode, because it will use VBO

--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -469,7 +469,7 @@ void FastTMXLayer::updatePrimitives()
 
             _mvpMatrixLocaiton = pipelineDesc.programState->getUniformLocation("u_MVPMatrix");
             _textureLocation   = pipelineDesc.programState->getUniformLocation("u_tex0");
-            pipelineDesc.programState->setTexture(_textureLocation, 0, _texture->getBackendTexture());
+            pipelineDesc.programState->setTexture(_textureLocation, 0, _texture->getRHITexture());
             command->init(_globalZOrder, blendfunc);
 
             _customCommands[iter.first] = command;

--- a/axmol/2d/FontAtlas.cpp
+++ b/axmol/2d/FontAtlas.cpp
@@ -48,7 +48,6 @@ namespace ax
 {
 const int FontAtlas::CacheTextureWidth     = 512;
 const int FontAtlas::CacheTextureHeight    = 512;
-const char* FontAtlas::CMD_PURGE_FONTATLAS = "__ax_PURGE_FONTATLAS";
 const char* FontAtlas::CMD_RESET_FONTATLAS = "__ax_RESET_FONTATLAS";
 
 void FontAtlas::loadFontAtlas(std::string_view fontatlasFile, hlookup::string_map<FontAtlas*>& outAtlasMap)
@@ -161,7 +160,7 @@ FontAtlas::FontAtlas(Font* theFont, int atlasWidth, int atlasHeight, float scale
             _letterPadding += 2 * FontFreeType::DistanceMapSpread;
         }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         auto eventDispatcher = Director::getInstance()->getEventDispatcher();
 
         _rendererRecreatedListener = EventListenerCustom::create(
@@ -182,7 +181,7 @@ void FontAtlas::reinit()
 
 FontAtlas::~FontAtlas()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     if (_fontFreeType && _rendererRecreatedListener)
     {
         auto eventDispatcher = Director::getInstance()->getEventDispatcher();
@@ -210,7 +209,7 @@ void FontAtlas::initWithSettings(void* opaque /*simdjson::ondemand::document*/)
     {
         auto comprData   = utils::base64Decode(page);
         auto uncomprData = ZipUtils::decompressGZ(std::span{comprData}, _currentPageDataSize);
-        addNewPageWithData(uncomprData.data(), uncomprData.size());
+        ensureNextPage(uncomprData.data(), uncomprData.size());
     }
 
     _currentPageOrigX = static_cast<float>(settings["pageX"].get_double());
@@ -247,39 +246,41 @@ void FontAtlas::initWithSettings(void* opaque /*simdjson::ondemand::document*/)
 
 void FontAtlas::reset()
 {
-    releaseTextures();
+    for (auto& [_, texture] : _atlasTextures)
+    {
+        texture->invalidate();
+    }
 
     _currLineHeight   = 0;
     _currentPageOrigX = 0;
     _currentPageOrigY = 0;
     _letterDefinitions.clear();
 
-    reinit();
+     reinit();
 }
 
 void FontAtlas::releaseTextures()
 {
-    for (auto&& item : _atlasTextures)
+    for (auto&& [_, texture] : _atlasTextures)
     {
-        item.second->release();
+        texture->release();
     }
     _atlasTextures.clear();
 }
 
-void FontAtlas::purgeTexturesAtlas()
+void FontAtlas::clearTexturesAtlas()
 {
     if (_fontFreeType)
     {
         reset();
         auto eventDispatcher = Director::getInstance()->getEventDispatcher();
-        eventDispatcher->dispatchCustomEvent(CMD_PURGE_FONTATLAS, this);
         eventDispatcher->dispatchCustomEvent(CMD_RESET_FONTATLAS, this);
     }
 }
 
 void FontAtlas::listenRendererRecreated(EventCustom* /*event*/)
 {
-    purgeTexturesAtlas();
+    clearTexturesAtlas();
 }
 
 void FontAtlas::addLetterDefinition(char32_t utf32Char, const FontLetterDefinition& letterDefinition)
@@ -470,25 +471,33 @@ void FontAtlas::updateTextureContent(rhi::PixelFormat format, int startY)
 void FontAtlas::addNewPage()
 {
     memset(_currentPageData, 0, _currentPageDataSize);
-    addNewPageWithData(_currentPageData, _currentPageDataSize);
+    ensureNextPage(_currentPageData, _currentPageDataSize);
 
     _currentPageOrigY = 0;
 }
 
-void FontAtlas::addNewPageWithData(const uint8_t* data, size_t size)
+void FontAtlas::ensureNextPage(const uint8_t* data, size_t size)
 {
     assert(_currentPageDataSize == size);
 
-    auto texture = new Texture2D();
-    texture->initWithData(data, _currentPageDataSize, _pixelFormat, _width, _height);
+    ++_currentPage;
+    auto texture = _atlasTextures[_currentPage];
+
+    if (!texture)
+    {
+        texture = new Texture2D();
+        texture->initWithData(data, _currentPageDataSize, _pixelFormat, _width, _height);
+        _atlasTextures[_currentPage] = texture;
+    }
+    else
+    {
+        texture->updateData(data, _width, _height);
+    }
 
     if (_antialiasEnabled)
         texture->setAntiAliasTexParameters();
     else
         texture->setAliasTexParameters();
-
-    setTexture(++_currentPage, texture);
-    texture->release();
 }
 
 void FontAtlas::setTexture(unsigned int slot, Texture2D* texture)

--- a/axmol/2d/FontAtlas.cpp
+++ b/axmol/2d/FontAtlas.cpp
@@ -463,7 +463,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
 void FontAtlas::updateTextureContent(rhi::PixelFormat format, int startY)
 {
     auto data = _currentPageData + (_width * (int)startY << _strideShift);
-    _atlasTextures[_currentPage]->updateWithSubData(data, 0, startY, _width,
+    _atlasTextures[_currentPage]->updateSubData(data, 0, startY, _width,
                                                     (std::min)((int)_currentPageOrigY - startY + _currLineHeight, _height));
 }
 

--- a/axmol/2d/FontAtlas.h
+++ b/axmol/2d/FontAtlas.h
@@ -67,7 +67,6 @@ class AX_DLL FontAtlas : public Object
 public:
     static const int CacheTextureWidth;
     static const int CacheTextureHeight;
-    static const char* CMD_PURGE_FONTATLAS;
     static const char* CMD_RESET_FONTATLAS;
     static void loadFontAtlas(std::string_view fontatlasFile, hlookup::string_map<FontAtlas*>& outAtlasMap);
     /**
@@ -90,7 +89,7 @@ public:
 
     virtual void addNewPage();
 
-    void addNewPageWithData(const uint8_t* data, size_t size);
+    void ensureNextPage(const uint8_t* data, size_t size);
 
     void setTexture(unsigned int slot, Texture2D* texture);
     Texture2D* getTexture(int slot);
@@ -107,10 +106,10 @@ public:
      */
     void listenRendererRecreated(EventCustom* event);
 
-    /** Removes textures atlas.
-     It will purge the textures atlas and if multiple texture exist in the FontAtlas.
+    /** Clear textures atlas.
+     It will clear the textures atlas and if multiple texture exist in the FontAtlas.
      */
-    void purgeTexturesAtlas();
+    void clearTexturesAtlas();
 
     /** sets font texture parameters:
      - GL_TEXTURE_MIN_FILTER = GL_LINEAR

--- a/axmol/2d/FontAtlas.h
+++ b/axmol/2d/FontAtlas.h
@@ -161,7 +161,7 @@ protected:
 
     // Dynamic GlyphCollection related stuff
     int _currentPage                  = -1;
-    rhi::PixelFormat _pixelFormat = rhi::PixelFormat::AUTO;
+    rhi::PixelFormat _pixelFormat = rhi::PixelFormat::NONE;
     int _strideShift                  = 0;
     uint8_t* _currentPageData         = nullptr;
     int _currentPageDataSize          = 0;

--- a/axmol/2d/FontAtlas.h
+++ b/axmol/2d/FontAtlas.h
@@ -161,7 +161,7 @@ protected:
 
     // Dynamic GlyphCollection related stuff
     int _currentPage                  = -1;
-    rhi::PixelFormat _pixelFormat = rhi::PixelFormat::NONE;
+    rhi::PixelFormat _pixelFormat = rhi::PixelFormat::AUTO;
     int _strideShift                  = 0;
     uint8_t* _currentPageData         = nullptr;
     int _currentPageDataSize          = 0;

--- a/axmol/2d/FontAtlasCache.cpp
+++ b/axmol/2d/FontAtlasCache.cpp
@@ -166,7 +166,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(std::string_view plistFile)
 
 FontAtlas* FontAtlasCache::getFontAtlasCharMap(Texture2D* texture, int itemWidth, int itemHeight, int startCharMap)
 {
-    auto atlasName = fmt::format("name:{}_{}_{}_{}", reinterpret_cast<uintptr_t>(texture->getBackendTexture()), itemWidth, itemHeight, startCharMap);
+    auto atlasName = fmt::format("name:{}_{}_{}_{}", reinterpret_cast<uintptr_t>(texture->getRHITexture()), itemWidth, itemHeight, startCharMap);
 
     auto it = _atlasMap.find(atlasName);
     if (it == _atlasMap.end())

--- a/axmol/2d/FontAtlasCache.cpp
+++ b/axmol/2d/FontAtlasCache.cpp
@@ -42,13 +42,11 @@ hlookup::string_map<FontAtlas*> FontAtlasCache::_atlasMap;
 
 void FontAtlasCache::purgeCachedData()
 {
-    auto atlasMapCopy = _atlasMap;
-    for (auto&& atlas : atlasMapCopy)
+    for(auto& [_, atlas] : _atlasMap)
     {
-        auto refCount = atlas.second->getReferenceCount();
-        atlas.second->release();
-        if (refCount != 1)
-            atlas.second->purgeTexturesAtlas();
+        if(atlas->getReferenceCount() > 1)
+            atlas->clearTexturesAtlas();
+        atlas->release();
     }
     _atlasMap.clear();
 }

--- a/axmol/2d/FontAtlasCache.cpp
+++ b/axmol/2d/FontAtlasCache.cpp
@@ -211,24 +211,22 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(std::string_view charMapFile,
 
 bool FontAtlasCache::releaseFontAtlas(FontAtlas* atlas)
 {
-    if (nullptr != atlas)
+    if (!atlas) [[unlikely]]
+        return false;
+
+    if (atlas->getReferenceCount() == 1)
     {
-        if (atlas->getReferenceCount() == 1)
+        for (auto it = _atlasMap.begin(); it != _atlasMap.end(); ++it)
         {
-            for (auto&& item : _atlasMap)
+            if (it->second == atlas)
             {
-                if (item.second == atlas)
-                {
-                    _atlasMap.erase(item.first);
-                    break;
-                }
+                _atlasMap.erase(it);
+                break;
             }
         }
-        atlas->release();
-        return true;
     }
-
-    return false;
+    atlas->release();
+    return true;
 }
 
 void FontAtlasCache::reloadFontAtlasFNT(std::string_view fontFileName, const Rect& imageRect, bool imageRotated)

--- a/axmol/2d/Grid.cpp
+++ b/axmol/2d/Grid.cpp
@@ -61,7 +61,7 @@ bool GridBase::initWithSize(const Vec2& gridSize, const ax::Rect& rect)
     descriptor.width         = POTWide;
     descriptor.height        = POTHigh;
     descriptor.textureUsage  = rhi::TextureUsage::RENDER_TARGET;
-    descriptor.textureFormat = rhi::PixelFormat::RGBA8;
+    descriptor.pixelFormat = rhi::PixelFormat::RGBA8;
     texture->updateTextureDesc(descriptor);
 
     initWithSize(gridSize, texture, false, rect);

--- a/axmol/2d/Grid.cpp
+++ b/axmol/2d/Grid.cpp
@@ -57,12 +57,12 @@ bool GridBase::initWithSize(const Vec2& gridSize, const ax::Rect& rect)
 
     Texture2D* texture = new Texture2D();
 
-    rhi::TextureDesc descriptor;
-    descriptor.width         = POTWide;
-    descriptor.height        = POTHigh;
-    descriptor.textureUsage  = rhi::TextureUsage::RENDER_TARGET;
-    descriptor.pixelFormat = rhi::PixelFormat::RGBA8;
-    texture->updateTextureDesc(descriptor);
+    rhi::TextureDesc desc;
+    desc.width         = POTWide;
+    desc.height        = POTHigh;
+    desc.textureUsage  = rhi::TextureUsage::RENDER_TARGET;
+    desc.pixelFormat   = rhi::PixelFormat::RGBA8;
+    texture->initWithSpec(desc, {});
 
     initWithSize(gridSize, texture, false, rect);
 

--- a/axmol/2d/Grid.cpp
+++ b/axmol/2d/Grid.cpp
@@ -220,7 +220,7 @@ void GridBase::beforeDraw()
         _oldRenderTarget = renderer->getRenderTarget();
         AX_SAFE_RELEASE(_renderTarget);
         _renderTarget =
-            rhi::DriverBase::getInstance()->createRenderTarget(_texture->getBackendTexture());
+            rhi::DriverBase::getInstance()->createRenderTarget(_texture->getRHITexture());
         renderer->setRenderTarget(_renderTarget);
     };
     renderer->addCallbackCommand(beforeDrawCommandFunc);
@@ -385,7 +385,7 @@ void Grid3D::blit()
     ax::Mat4 projectionMat = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     auto programState           = _drawCommand.getPipelineDesc().programState;
     programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));
-    programState->setTexture(_textureLocation, 0, _texture->getBackendTexture());
+    programState->setTexture(_textureLocation, 0, _texture->getRHITexture());
 }
 
 void Grid3D::calculateVertexPoints()
@@ -635,7 +635,7 @@ void TiledGrid3D::blit()
     ax::Mat4 projectionMat = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     auto programState           = _drawCommand.getPipelineDesc().programState;
     programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));
-    programState->setTexture(_textureLocation, 0, _texture->getBackendTexture());
+    programState->setTexture(_textureLocation, 0, _texture->getRHITexture());
 }
 
 void TiledGrid3D::calculateVertexPoints()

--- a/axmol/2d/Label.cpp
+++ b/axmol/2d/Label.cpp
@@ -2059,7 +2059,7 @@ void Label::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
             auto texture       = textureAtlas->getTexture();
             auto& pipelineQuad = _quadCommand.getPipelineDesc();
             pipelineQuad.programState->setUniform(_mvpMatrixLocation, matrixProjection.m, sizeof(matrixProjection.m));
-            pipelineQuad.programState->setTexture(texture->getBackendTexture());
+            pipelineQuad.programState->setTexture(texture->getRHITexture());
             _quadCommand.init(_globalZOrder, texture, _blendFunc, textureAtlas->getQuads(),
                               textureAtlas->getTotalQuads(), transform, flags);
             renderer->addCommand(&_quadCommand);
@@ -2093,7 +2093,7 @@ void Label::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
                 {
                     auto* programState = command->getPipelineDesc().programState;
                     programState->setUniform(_textColorLocation, &_textColor, sizeof(_textColor));
-                    programState->setTexture(textureAtlas->getTexture()->getBackendTexture());
+                    programState->setTexture(textureAtlas->getTexture()->getRHITexture());
                 }
                 batch.textCommand.getPipelineDesc().programState->setUniform(_mvpMatrixLocation, matrixMVP.m,
                                                                                    sizeof(matrixMVP.m));

--- a/axmol/2d/Label.cpp
+++ b/axmol/2d/Label.cpp
@@ -502,7 +502,7 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
     AX_SAFE_RETAIN(_debugDrawNode);
 #endif
 
-    _purgeTextureListener = EventListenerCustom::create(FontAtlas::CMD_PURGE_FONTATLAS, [this](EventCustom* event) {
+    _resetTextureListener = EventListenerCustom::create(FontAtlas::CMD_RESET_FONTATLAS, [this](EventCustom* event) {
         if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
         {
             for (auto&& it : _letters)
@@ -515,15 +515,9 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
             if (_fontAtlas)
             {
                 FontAtlasCache::releaseFontAtlas(_fontAtlas);
+                _fontAtlas      = nullptr;
             }
-        }
-    });
-    _eventDispatcher->addEventListenerWithFixedPriority(_purgeTextureListener, 1);
 
-    _resetTextureListener = EventListenerCustom::create(FontAtlas::CMD_RESET_FONTATLAS, [this](EventCustom* event) {
-        if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
-        {
-            _fontAtlas      = nullptr;
             auto lineHeight = _lineHeight;
             this->setTTFConfig(_fontConfig);
             if (_currentLabelType != LabelType::STRING_TEXTURE)
@@ -536,7 +530,7 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
             }
         }
     });
-    _eventDispatcher->addEventListenerWithFixedPriority(_resetTextureListener, 2);
+    _eventDispatcher->addEventListenerWithFixedPriority(_resetTextureListener, 1);
 }
 
 Label::~Label()
@@ -551,7 +545,6 @@ Label::~Label()
         FontAtlasCache::releaseFontAtlas(_fontAtlas);
     }
     _batchCommands.clear();
-    _eventDispatcher->removeEventListener(_purgeTextureListener);
     _eventDispatcher->removeEventListener(_resetTextureListener);
 
     AX_SAFE_RELEASE_NULL(_textSprite);

--- a/axmol/2d/Label.h
+++ b/axmol/2d/Label.h
@@ -904,7 +904,6 @@ protected:
 
     std::unordered_map<int, Sprite*> _letters;
 
-    EventListenerCustom* _purgeTextureListener;
     EventListenerCustom* _resetTextureListener;
 
 #if AX_LABEL_DEBUG_DRAW

--- a/axmol/2d/Node.cpp
+++ b/axmol/2d/Node.cpp
@@ -2271,10 +2271,10 @@ rhi::ProgramState* Node::setProgramStateByProgramId(uint64_t programId)
 
 void Node::updateProgramStateTexture(Texture2D* texture)
 {
-    if (texture == nullptr || texture->getBackendTexture() == nullptr || _programState == nullptr)
+    if (texture == nullptr || texture->getRHITexture() == nullptr || _programState == nullptr)
         return;
 
-    _programState->setTexture(texture->getBackendTexture());
+    _programState->setTexture(texture->getRHITexture());
 }
 
 rhi::ProgramState* Node::getProgramState() const

--- a/axmol/2d/ParticleBatchNode.cpp
+++ b/axmol/2d/ParticleBatchNode.cpp
@@ -166,7 +166,7 @@ void ParticleBatchNode::addChild(Node* aChild, int zOrder, int tag)
     AXASSERT(dynamic_cast<ParticleSystem*>(aChild) != nullptr,
              "CCParticleBatchNode only supports QuadParticleSystems as children");
     ParticleSystem* child = static_cast<ParticleSystem*>(aChild);
-    AXASSERT(child->getTexture()->getBackendTexture() == _textureAtlas->getTexture()->getBackendTexture(),
+    AXASSERT(child->getTexture()->getRHITexture() == _textureAtlas->getTexture()->getRHITexture(),
              "CCParticleSystem is not using the same texture id");
 
     addChildByTagOrName(child, zOrder, tag, "", true);
@@ -178,7 +178,7 @@ void ParticleBatchNode::addChild(Node* aChild, int zOrder, std::string_view name
     AXASSERT(dynamic_cast<ParticleSystem*>(aChild) != nullptr,
              "CCParticleBatchNode only supports QuadParticleSystems as children");
     ParticleSystem* child = static_cast<ParticleSystem*>(aChild);
-    AXASSERT(child->getTexture()->getBackendTexture() == _textureAtlas->getTexture()->getBackendTexture(),
+    AXASSERT(child->getTexture()->getRHITexture() == _textureAtlas->getTexture()->getRHITexture(),
              "CCParticleSystem is not using the same texture id");
 
     addChildByTagOrName(child, zOrder, 0, name, false);
@@ -541,7 +541,7 @@ void ParticleBatchNode::updateProgramStateTexture()
     if (!texture)
         return;
     auto programState = _customCommand.getPipelineDesc().programState;
-    programState->setTexture(texture->getBackendTexture());
+    programState->setTexture(texture->getRHITexture());
     // If the new texture has No premultiplied alpha, AND the blendFunc hasn't been changed, then update it
     if (!texture->hasPremultipliedAlpha() && (_blendFunc.src == AX_BLEND_SRC && _blendFunc.dst == AX_BLEND_DST))
         _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;

--- a/axmol/2d/ParticleSystemQuad.cpp
+++ b/axmol/2d/ParticleSystemQuad.cpp
@@ -223,11 +223,11 @@ void ParticleSystemQuad::setTextureWithRect(Texture2D* texture, const Rect& rect
     }
 
     // Only update the texture if is different from the current one
-    if (!_texture || texture->getBackendTexture() != _texture->getBackendTexture())
+    if (!_texture || texture->getRHITexture() != _texture->getRHITexture())
     {
         ParticleSystem::setTexture(texture);
 
-        _programState->setTexture(_texture->getBackendTexture());
+        _programState->setTexture(_texture->getRHITexture());
     }
 
     this->initTexCoordsWithRect(rect);

--- a/axmol/2d/ParticleSystemQuad.cpp
+++ b/axmol/2d/ParticleSystemQuad.cpp
@@ -121,7 +121,7 @@ bool ParticleSystemQuad::initWithTotalParticles(int numberOfParticles)
         initIndices();
         //        setupVBO();
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         // Need to listen the event only when not use batchnode, because it will use VBO
         auto listener = EventListenerCustom::create(EVENT_RENDERER_RECREATED,
                                                     AX_CALLBACK_1(ParticleSystemQuad::listenRendererRecreated, this));

--- a/axmol/2d/ProgressTimer.cpp
+++ b/axmol/2d/ProgressTimer.cpp
@@ -635,7 +635,7 @@ void ProgressTimer::draw(Renderer* renderer, const Mat4& transform, uint32_t fla
     const ax::Mat4& projectionMat = _director->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     Mat4 finalMat                      = projectionMat * transform;
     _programState->setUniform(_locMVP1, finalMat.m, sizeof(finalMat.m));
-    _programState->setTexture(_locTex1, 0, _sprite->getTexture()->getBackendTexture());
+    _programState->setTexture(_locTex1, 0, _sprite->getTexture()->getRHITexture());
 
     if (_type == Type::BAR)
     {
@@ -651,7 +651,7 @@ void ProgressTimer::draw(Renderer* renderer, const Mat4& transform, uint32_t fla
 
             _customCommand2.init(_globalZOrder, _sprite->getBlendFunc());
             _programState2->setUniform(_locMVP2, finalMat.m, sizeof(finalMat.m));
-            _programState2->setTexture(_locTex2, 0, _sprite->getTexture()->getBackendTexture());
+            _programState2->setTexture(_locTex2, 0, _sprite->getTexture()->getRHITexture());
             renderer->addCommand(&_customCommand2);
         }
     }

--- a/axmol/2d/RenderTexture.cpp
+++ b/axmol/2d/RenderTexture.cpp
@@ -138,7 +138,7 @@ RenderTexture* RenderTexture::create(int w, int h, bool sharedRenderTarget)
 {
     RenderTexture* ret = new RenderTexture();
 
-    if (ret->initWithWidthAndHeight(w, h, rhi::PixelFormat::RGBA8, PixelFormat::AUTO, sharedRenderTarget))
+    if (ret->initWithWidthAndHeight(w, h, rhi::PixelFormat::RGBA8, PixelFormat::NONE, sharedRenderTarget))
     {
         ret->autorelease();
         return ret;
@@ -149,7 +149,7 @@ RenderTexture* RenderTexture::create(int w, int h, bool sharedRenderTarget)
 
 bool RenderTexture::initWithWidthAndHeight(int w, int h, rhi::PixelFormat eFormat, bool sharedRenderTarget)
 {
-    return initWithWidthAndHeight(w, h, eFormat, PixelFormat::AUTO, sharedRenderTarget);
+    return initWithWidthAndHeight(w, h, eFormat, PixelFormat::NONE, sharedRenderTarget);
 }
 
 bool RenderTexture::initWithWidthAndHeight(int w,
@@ -214,13 +214,13 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         else
         {
             _renderTarget = rhi::DriverBase::getInstance()->createRenderTarget(
-                _texture2D ? _texture2D->getBackendTexture() : nullptr,
-                _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr);
+                _texture2D ? _texture2D->getRHITexture() : nullptr,
+                _depthStencilTexture ? _depthStencilTexture->getRHITexture() : nullptr);
         }
 
-        _renderTarget->setColorAttachment(_texture2D ? _texture2D->getBackendTexture() : nullptr);
+        _renderTarget->setColorAttachment(_texture2D ? _texture2D->getRHITexture() : nullptr);
 
-        auto depthStencilTexture = _depthStencilTexture ? _depthStencilTexture->getBackendTexture() : nullptr;
+        auto depthStencilTexture = _depthStencilTexture ? _depthStencilTexture->getRHITexture() : nullptr;
         _renderTarget->setDepthStencilAttachment(depthStencilTexture);
 
         clearColorAttachment();

--- a/axmol/2d/RenderTexture.cpp
+++ b/axmol/2d/RenderTexture.cpp
@@ -138,7 +138,7 @@ RenderTexture* RenderTexture::create(int w, int h, bool sharedRenderTarget)
 {
     RenderTexture* ret = new RenderTexture();
 
-    if (ret->initWithWidthAndHeight(w, h, rhi::PixelFormat::RGBA8, PixelFormat::NONE, sharedRenderTarget))
+    if (ret->initWithWidthAndHeight(w, h, rhi::PixelFormat::RGBA8, PixelFormat::AUTO, sharedRenderTarget))
     {
         ret->autorelease();
         return ret;
@@ -149,7 +149,7 @@ RenderTexture* RenderTexture::create(int w, int h, bool sharedRenderTarget)
 
 bool RenderTexture::initWithWidthAndHeight(int w, int h, rhi::PixelFormat eFormat, bool sharedRenderTarget)
 {
-    return initWithWidthAndHeight(w, h, eFormat, PixelFormat::NONE, sharedRenderTarget);
+    return initWithWidthAndHeight(w, h, eFormat, PixelFormat::AUTO, sharedRenderTarget);
 }
 
 bool RenderTexture::initWithWidthAndHeight(int w,
@@ -190,13 +190,13 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         descriptor.width         = powW;
         descriptor.height        = powH;
         descriptor.textureUsage  = TextureUsage::RENDER_TARGET;
-        descriptor.textureFormat = PixelFormat::RGBA8;
+        descriptor.pixelFormat = PixelFormat::RGBA8;
         _texture2D               = new Texture2D();
         _texture2D->updateTextureDesc(descriptor, !!AX_ENABLE_PREMULTIPLIED_ALPHA);
 
         if (PixelFormat::D24S8 == depthStencilFormat || sharedRenderTarget)
         {
-            descriptor.textureFormat = PixelFormat::D24S8;
+            descriptor.pixelFormat = PixelFormat::D24S8;
 
             AX_SAFE_RELEASE(_depthStencilTexture);
 

--- a/axmol/2d/RenderTexture.cpp
+++ b/axmol/2d/RenderTexture.cpp
@@ -50,7 +50,7 @@ namespace ax
 // implementation RenderTexture
 RenderTexture::RenderTexture()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // Listen this event to save render texture before come to background.
     // Then it can be restored after coming to foreground on Android.
     auto toBackgroundListener =
@@ -60,13 +60,30 @@ RenderTexture::RenderTexture()
     auto toForegroundListener =
         EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, AX_CALLBACK_1(RenderTexture::listenToForeground, this));
     _eventDispatcher->addEventListenerWithSceneGraphPriority(toForegroundListener, this);
+
+     // Listen this event to restored texture id after coming to foreground on GLES.
+    _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
+        TextureSliceData emptyData[] = {TextureSliceData{}};
+        // Invalidate _depthStencilTexture contents and reinitializing GPU resources (e.g., after context loss)
+        // Note: VolatileTextureMgr is responsible for resetting _colorTexture
+        if(_depthStencilTexture) {
+            _depthStencilTexture->invalidate();
+            _depthStencilTexture->updateData(emptyData);
+        }
+    });
+    _eventDispatcher->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
 }
 
 RenderTexture::~RenderTexture()
 {
+#    if AX_ENABLE_CONTEXT_LOSS_RECOVERY
+    _eventDispatcher->removeEventListener(_rendererRecreatedListener);
+#endif
+
     AX_SAFE_RELEASE(_renderTarget);
     AX_SAFE_RELEASE(_sprite);
+    AX_SAFE_RELEASE(_colorTexture);
     AX_SAFE_RELEASE(_depthStencilTexture);
 }
 
@@ -74,7 +91,7 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
 {
     // We have not found a way to dispatch the enter background message before the texture data are destroyed.
     // So we disable this pair of message handler at present.
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     if (!_cachedTextureDirty)
         return;
     _cachedTextureDirty = false;
@@ -83,8 +100,8 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
         if (uiTextureImage)
         {
             _UITextureImage = uiTextureImage;
-            const Vec2& s   = _texture2D->getContentSizeInPixels();
-            VolatileTextureMgr::addDataTexture(_texture2D, uiTextureImage->getData(), s.width * s.height * 4,
+            const Vec2& s   = _colorTexture->getContentSizeInPixels();
+            VolatileTextureMgr::addDataTexture(_colorTexture, uiTextureImage->getData(), s.width * s.height * 4,
                                                rhi::PixelFormat::RGBA8, s);
         }
         else
@@ -99,8 +116,8 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
 
 void RenderTexture::listenToForeground(EventCustom* /*event*/)
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    _texture2D->setAntiAliasTexParameters();
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
+    _colorTexture->setAntiAliasTexParameters();
 #endif
 }
 
@@ -191,8 +208,9 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         desc.height        = powH;
         desc.textureUsage  = TextureUsage::RENDER_TARGET;
         desc.pixelFormat = PixelFormat::RGBA8;
-        _texture2D               = new Texture2D();
-        _texture2D->initWithSpec(desc, {}, PixelFormat::NONE, !!AX_ENABLE_PREMULTIPLIED_ALPHA);
+        _colorTexture                = new Texture2D();
+        TextureSliceData emptyData[] = {TextureSliceData{}};
+        _colorTexture->initWithSpec(desc, emptyData, PixelFormat::NONE, !!AX_ENABLE_PREMULTIPLIED_ALPHA);
 
         if (PixelFormat::D24S8 == depthStencilFormat || sharedRenderTarget)
         {
@@ -201,7 +219,7 @@ bool RenderTexture::initWithWidthAndHeight(int w,
             AX_SAFE_RELEASE(_depthStencilTexture);
 
             _depthStencilTexture = new Texture2D();
-            _depthStencilTexture->initWithSpec(desc, {});
+            _depthStencilTexture->initWithSpec(desc, emptyData);
         }
 
         AX_SAFE_RELEASE(_renderTarget);
@@ -214,21 +232,21 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         else
         {
             _renderTarget = rhi::DriverBase::getInstance()->createRenderTarget(
-                _texture2D ? _texture2D->getRHITexture() : nullptr,
+                _colorTexture ? _colorTexture->getRHITexture() : nullptr,
                 _depthStencilTexture ? _depthStencilTexture->getRHITexture() : nullptr);
         }
 
-        _renderTarget->setColorAttachment(_texture2D ? _texture2D->getRHITexture() : nullptr);
+        _renderTarget->setColorAttachment(_colorTexture ? _colorTexture->getRHITexture() : nullptr);
 
         auto depthStencilTexture = _depthStencilTexture ? _depthStencilTexture->getRHITexture() : nullptr;
         _renderTarget->setDepthStencilAttachment(depthStencilTexture);
 
         clearColorAttachment();
 
-        _texture2D->setAntiAliasTexParameters();
+        _colorTexture->setAntiAliasTexParameters();
 
         // retained
-        setSprite(Sprite::createWithTexture(_texture2D));
+        setSprite(Sprite::createWithTexture(_colorTexture));
 
         _sprite->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
         _sprite->setPosition(Vec2(w, h) / 2);
@@ -237,7 +255,7 @@ bool RenderTexture::initWithWidthAndHeight(int w,
         _sprite->setFlippedY(true);
 #endif
 
-        if (_texture2D->hasPremultipliedAlpha())
+        if (_colorTexture->hasPremultipliedAlpha())
         {
             _sprite->setBlendFunc(BlendFunc::ALPHA_PREMULTIPLIED);
             _sprite->setOpacityModifyRGB(true);
@@ -247,8 +265,6 @@ bool RenderTexture::initWithWidthAndHeight(int w,
             _sprite->setBlendFunc(BlendFunc::ALPHA_NON_PREMULTIPLIED);
             _sprite->setOpacityModifyRGB(false);
         }
-
-        _texture2D->release();
 
         // Disabled by default.
         _autoDraw = false;
@@ -527,19 +543,17 @@ void RenderTexture::newImage(std::function<void(RefPtr<Image>)> imageCallback, b
 {
     AXASSERT(_pixelFormat == rhi::PixelFormat::RGBA8, "only RGBA8888 can be saved as image");
 
-    if ((nullptr == _texture2D))
-    {
+    if ((nullptr == _colorTexture))
         return;
-    }
 
-    const Vec2& s = _texture2D->getContentSizeInPixels();
+    const Vec2& s = _colorTexture->getContentSizeInPixels();
 
     // to get the image size to save
     //        if the saving image domain exceeds the buffer texture domain,
     //        it should be cut
     int savedBufferWidth       = (int)s.width;
     int savedBufferHeight      = (int)s.height;
-    bool hasPremultipliedAlpha = _texture2D->hasPremultipliedAlpha();
+    bool hasPremultipliedAlpha = _colorTexture->hasPremultipliedAlpha();
 
     auto callback = [hasPremultipliedAlpha, imageCallback](const rhi::PixelBufferDesc& pbd) {
         if (pbd)
@@ -606,7 +620,7 @@ void RenderTexture::onBegin()
     if (!_keepMatrix)
     {
         _director->setProjection(_director->getProjection());
-        const Vec2& texSize = _texture2D->getContentSizeInPixels();
+        const Vec2& texSize = _colorTexture->getContentSizeInPixels();
 
         // Calculate the adjustment ratios based on the old and new projections
         Vec2 size         = _director->getWinSizeInPixels();
@@ -659,7 +673,7 @@ void RenderTexture::begin()
     {
         _director->setProjection(_director->getProjection());
 
-        const Vec2& texSize = _texture2D->getContentSizeInPixels();
+        const Vec2& texSize = _colorTexture->getContentSizeInPixels();
 
         // Calculate the adjustment ratios based on the old and new projections
         Vec2 size = _director->getWinSizeInPixels();
@@ -683,7 +697,7 @@ void RenderTexture::begin()
     beginCommand->init(_globalZOrder);
     beginCommand->func = AX_CALLBACK_0(RenderTexture::onBegin, this);
     renderer->addCommand(beginCommand);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _cachedTextureDirty = true;
 #endif
 }

--- a/axmol/2d/RenderTexture.cpp
+++ b/axmol/2d/RenderTexture.cpp
@@ -186,22 +186,22 @@ bool RenderTexture::initWithWidthAndHeight(int w,
             powH = utils::nextPOT(h);
         }
 
-        rhi::TextureDesc descriptor;
-        descriptor.width         = powW;
-        descriptor.height        = powH;
-        descriptor.textureUsage  = TextureUsage::RENDER_TARGET;
-        descriptor.pixelFormat = PixelFormat::RGBA8;
+        rhi::TextureDesc desc;
+        desc.width         = powW;
+        desc.height        = powH;
+        desc.textureUsage  = TextureUsage::RENDER_TARGET;
+        desc.pixelFormat = PixelFormat::RGBA8;
         _texture2D               = new Texture2D();
-        _texture2D->updateTextureDesc(descriptor, !!AX_ENABLE_PREMULTIPLIED_ALPHA);
+        _texture2D->initWithSpec(desc, {}, PixelFormat::NONE, !!AX_ENABLE_PREMULTIPLIED_ALPHA);
 
         if (PixelFormat::D24S8 == depthStencilFormat || sharedRenderTarget)
         {
-            descriptor.pixelFormat = PixelFormat::D24S8;
+            desc.pixelFormat = PixelFormat::D24S8;
 
             AX_SAFE_RELEASE(_depthStencilTexture);
 
             _depthStencilTexture = new Texture2D();
-            _depthStencilTexture->updateTextureDesc(descriptor);
+            _depthStencilTexture->initWithSpec(desc, {});
         }
 
         AX_SAFE_RELEASE(_renderTarget);

--- a/axmol/2d/RenderTexture.h
+++ b/axmol/2d/RenderTexture.h
@@ -401,8 +401,9 @@ protected:
     void clearColorAttachment();
 
     void onSaveToFile(std::string fileName, bool isRGBA = true, bool forceNonPMA = false);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     bool _cachedTextureDirty = false;
+    EventListener* _rendererRecreatedListener = nullptr;
 #endif
     bool _keepMatrix = false;
     Rect _rtTextureRect;
@@ -411,7 +412,7 @@ protected:
 
     Viewport _oldViewport;
 
-    Texture2D* _texture2D           = nullptr;
+    Texture2D* _colorTexture        = nullptr;
     Texture2D* _depthStencilTexture = nullptr;
 
     rhi::RenderTarget* _renderTarget    = nullptr;

--- a/axmol/2d/Sprite.cpp
+++ b/axmol/2d/Sprite.cpp
@@ -75,7 +75,7 @@ Sprite* Sprite::createWithTexture(Texture2D* texture, const Rect& rect, bool rot
 
 Sprite* Sprite::create(std::string_view filename)
 {
-    return Sprite::create(filename, PixelFormat::AUTO);
+    return Sprite::create(filename, PixelFormat::NONE);
 }
 
 Sprite* Sprite::create(std::string_view filename, PixelFormat format)
@@ -187,7 +187,7 @@ bool Sprite::initWithTexture(Texture2D* texture, const Rect& rect)
 
 bool Sprite::initWithFile(std::string_view filename)
 {
-    return initWithFile(filename, PixelFormat::AUTO);
+    return initWithFile(filename, PixelFormat::NONE);
 }
 
 bool Sprite::initWithFile(std::string_view filename, PixelFormat format)
@@ -1066,7 +1066,7 @@ void Sprite::updateTransform()
 // draw
 void Sprite::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
 {
-    if (_texture == nullptr || _texture->getBackendTexture() == nullptr)
+    if (_texture == nullptr || _texture->getRHITexture() == nullptr)
         return;
 
     // TODO: arnold: current camera can be a non-default one.
@@ -1699,10 +1699,10 @@ std::string Sprite::getDescription() const
     std::string_view desc;
     if (_renderMode == RenderMode::QUAD_BATCHNODE)
         desc = fmt::format_to_z(buf, "<Sprite | Tag = {}, TextureID = {}>", _tag,
-                 fmt::ptr(_batchNode->getTextureAtlas()->getTexture()->getBackendTexture()));
+                 fmt::ptr(_batchNode->getTextureAtlas()->getTexture()->getRHITexture()));
     else
         desc = fmt::format_to_z(buf, "<Sprite | Tag = {}, TextureID = {}>", _tag,
-                 fmt::ptr(_texture->getBackendTexture()));
+                 fmt::ptr(_texture->getRHITexture()));
 
     return std::string{desc};
 }

--- a/axmol/2d/Sprite.cpp
+++ b/axmol/2d/Sprite.cpp
@@ -75,7 +75,7 @@ Sprite* Sprite::createWithTexture(Texture2D* texture, const Rect& rect, bool rot
 
 Sprite* Sprite::create(std::string_view filename)
 {
-    return Sprite::create(filename, PixelFormat::NONE);
+    return Sprite::create(filename, PixelFormat::AUTO);
 }
 
 Sprite* Sprite::create(std::string_view filename, PixelFormat format)
@@ -187,7 +187,7 @@ bool Sprite::initWithTexture(Texture2D* texture, const Rect& rect)
 
 bool Sprite::initWithFile(std::string_view filename)
 {
-    return initWithFile(filename, PixelFormat::NONE);
+    return initWithFile(filename, PixelFormat::AUTO);
 }
 
 bool Sprite::initWithFile(std::string_view filename, PixelFormat format)

--- a/axmol/2d/SpriteBatchNode.cpp
+++ b/axmol/2d/SpriteBatchNode.cpp
@@ -213,7 +213,7 @@ void SpriteBatchNode::addChild(Node* child, int zOrder, int tag)
     AXASSERT(dynamic_cast<Sprite*>(child) != nullptr, "CCSpriteBatchNode only supports Sprites as children");
     Sprite* sprite = static_cast<Sprite*>(child);
     // check Sprite is using the same texture id
-    AXASSERT(sprite->getTexture()->getBackendTexture() == _textureAtlas->getTexture()->getBackendTexture(),
+    AXASSERT(sprite->getTexture()->getRHITexture() == _textureAtlas->getTexture()->getRHITexture(),
              "CCSprite is not using the same texture id");
 
     Node::addChild(child, zOrder, tag);

--- a/axmol/3d/Mesh.cpp
+++ b/axmol/3d/Mesh.cpp
@@ -332,7 +332,7 @@ void Mesh::setTexture(Texture2D* tex, NTextureData::Usage usage, bool cacheFileN
             auto technique = _material->_currentTechnique;
             for (auto&& pass : technique->_passes)
             {
-                pass->setUniformTexture(0, tex->getBackendTexture());
+                pass->setUniformTexture(0, tex->getRHITexture());
             }
         }
 
@@ -347,7 +347,7 @@ void Mesh::setTexture(Texture2D* tex, NTextureData::Usage usage, bool cacheFileN
             auto technique = _material->_currentTechnique;
             for (auto&& pass : technique->_passes)
             {
-                pass->setUniformNormTexture(1, tex->getBackendTexture());
+                pass->setUniformNormTexture(1, tex->getRHITexture());
             }
         }
     }

--- a/axmol/3d/MeshMaterial.cpp
+++ b/axmol/3d/MeshMaterial.cpp
@@ -325,7 +325,7 @@ void MeshMaterial::setTexture(Texture2D* tex, NTextureData::Usage usage)
     const auto& passes = getTechnique()->getPasses();
     for (auto&& pass : passes)
     {
-        pass->setUniformTexture(0, tex->getBackendTexture());
+        pass->setUniformTexture(0, tex->getRHITexture());
     }
 }
 

--- a/axmol/3d/MeshVertexIndexData.cpp
+++ b/axmol/3d/MeshVertexIndexData.cpp
@@ -74,7 +74,7 @@ rhi::Buffer* MeshIndexData::getVertexBuffer() const
 
 MeshIndexData::MeshIndexData()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
         _indexBuffer->updateData((void*)_indexData.data(), _indexData.bsize());
     });
@@ -84,7 +84,7 @@ MeshIndexData::MeshIndexData()
 
 void MeshIndexData::setIndexData(const ax::MeshData::IndexArray& indexdata)
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     if (!_indexData.empty())
         return;
     _indexData = indexdata;
@@ -95,14 +95,14 @@ MeshIndexData::~MeshIndexData()
 {
     AX_SAFE_RELEASE(_indexBuffer);
     _indexData.clear();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 }
 
 void MeshVertexData::setVertexData(const std::vector<float>& vertexData)
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     if (!_vertexData.empty())
         return;
     _vertexData = vertexData;
@@ -122,7 +122,7 @@ MeshVertexData* MeshVertexData::create(const MeshData& meshdata, CustomCommand::
 
     if (vertexdata->_vertexBuffer)
     {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         vertexdata->setVertexData(meshdata.vertex);
         vertexdata->_vertexBuffer->usingDefaultStoredData(false);
 #endif
@@ -137,7 +137,7 @@ MeshVertexData* MeshVertexData::create(const MeshData& meshdata, CustomCommand::
         auto indexBuffer = rhi::DriverBase::getInstance()->createBuffer(
             indices.bsize(), rhi::BufferType::INDEX, rhi::BufferUsage::STATIC);
         indexBuffer->autorelease();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         indexBuffer->usingDefaultStoredData(false);
 #endif
         indexBuffer->updateData((void*)indices.data(), indices.bsize());
@@ -151,7 +151,7 @@ MeshVertexData* MeshVertexData::create(const MeshData& meshdata, CustomCommand::
         }
         else
             indexdata = MeshIndexData::create(id, vertexdata, indexBuffer, meshdata.subMeshAABB[i]);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         indexdata->setIndexData(indices);
 #endif
         vertexdata->_indices.pushBack(indexdata);
@@ -183,7 +183,7 @@ bool MeshVertexData::hasVertexAttrib(shaderinfos::VertexKey attrib) const
 
 MeshVertexData::MeshVertexData()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
         _vertexBuffer->updateData((void*)_vertexData.data(), _vertexData.size() * sizeof(_vertexData[0]));
     });
@@ -196,7 +196,7 @@ MeshVertexData::~MeshVertexData()
     AX_SAFE_RELEASE(_vertexBuffer);
     _indices.clear();
     _vertexData.clear();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 }

--- a/axmol/3d/MeshVertexIndexData.h
+++ b/axmol/3d/MeshVertexIndexData.h
@@ -96,7 +96,7 @@ protected:
 
     friend class MeshVertexData;
     friend class MeshRenderer;
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener = nullptr;
 #endif
 };
@@ -149,7 +149,7 @@ protected:
 
     int _vertexCount = 0;  // vertex count
     std::vector<float> _vertexData;
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener = nullptr;
 #endif
 };

--- a/axmol/3d/MotionStreak3D.cpp
+++ b/axmol/3d/MotionStreak3D.cpp
@@ -258,7 +258,7 @@ void MotionStreak3D::setTexture(Texture2D* texture)
         AX_SAFE_RETAIN(texture);
         AX_SAFE_RELEASE(_texture);
         _texture = texture;
-        _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
+        _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
     }
 }
 

--- a/axmol/3d/Skybox.cpp
+++ b/axmol/3d/Skybox.cpp
@@ -163,7 +163,7 @@ void Skybox::setTexture(TextureCube* texture)
     AX_SAFE_RELEASE_NULL(_texture);
     texture->retain();
     _texture = texture;
-    _programState->setTexture(_uniformEnvLoc, 0, _texture->getBackendTexture());
+    _programState->setTexture(_uniformEnvLoc, 0, _texture->getRHITexture());
 }
 
 void Skybox::reload()

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -256,11 +256,11 @@ Terrain::Terrain()
     : _alphaMap(nullptr)
     , _lightMap(nullptr)
     , _lightDir(-1.f, -1.f, 0.f)
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     , _backToForegroundListener(nullptr)
 #endif
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener =
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { reload(); });
     _director->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, 1);
@@ -489,7 +489,7 @@ Terrain::~Terrain()
         }
     }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _director->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 }

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -135,7 +135,7 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
     _programState->setUniform(_lightDirLocation, &_lightDir, sizeof(_lightDir));
     if (!_alphaMap)
     {
-        _programState->setTexture(_detailMapLocation[0], 0, _detailMapTextures[0]->getBackendTexture());
+        _programState->setTexture(_detailMapLocation[0], 0, _detailMapTextures[0]->getRHITexture());
         int hasAlphaMap = 0;
         _programState->setUniform(_alphaIsHasAlphaMapLocation, &hasAlphaMap, sizeof(hasAlphaMap));
     }
@@ -144,27 +144,27 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
         float detailMapSize[4] = {0.0f, 0.0f, 0.0f, 0.0f};
         for (int i = 0; i < _maxDetailMapValue; ++i)
         {
-            _programState->setTexture(_detailMapLocation[i], i, _detailMapTextures[i]->getBackendTexture());
+            _programState->setTexture(_detailMapLocation[i], i, _detailMapTextures[i]->getRHITexture());
             detailMapSize[i] = _terrainData._detailMaps[i]._detailMapSize;
         }
         _programState->setUniform(_detailMapSizeLocation, detailMapSize, sizeof(detailMapSize));
 
         int hasAlphaMap = 1;
         _programState->setUniform(_alphaIsHasAlphaMapLocation, &hasAlphaMap, sizeof(hasAlphaMap));
-        _programState->setTexture(_alphaMapLocation, 4, _alphaMap->getBackendTexture());
+        _programState->setTexture(_alphaMapLocation, 4, _alphaMap->getRHITexture());
     }
     if (_lightMap)
     {
         int hasLightMap = 1;
         _programState->setUniform(_lightMapCheckLocation, &hasLightMap, sizeof(hasLightMap));
-        _programState->setTexture(_lightMapLocation, 5, _lightMap->getBackendTexture());
+        _programState->setTexture(_lightMapLocation, 5, _lightMap->getRHITexture());
     }
     else
     {
         int hasLightMap = 0;
         _programState->setUniform(_lightMapCheckLocation, &hasLightMap, sizeof(hasLightMap));
 #if AX_RENDER_API == AX_RENDER_API_MTL || AX_RENDER_API == AX_RENDER_API_D3D
-        _programState->setTexture(_lightMapLocation, 5, _dummyTexture->getBackendTexture());
+        _programState->setTexture(_lightMapLocation, 5, _detailMapTextures[0]->getRHITexture());
 #endif
     }
     auto camera = Camera::getVisitingCamera();
@@ -836,46 +836,58 @@ bool Terrain::initTextures()
         _detailMapTextures[i] = nullptr;
     }
 
-    Texture2D::TexParams texParam{};
-
+    rhi::TextureDesc texDesc;
     if (_terrainData._alphaMapSrc.empty())
     {
-        texParam.sAddressMode = rhi::SamplerAddressMode::REPEAT;
-        texParam.tAddressMode = rhi::SamplerAddressMode::REPEAT;
-        auto textImage = new Image();
-        textImage->initWithImageFile(_terrainData._detailMaps[0]._detailMapSrc);
-        auto texture = new Texture2D();
-        texture->initWithImage(textImage);
-        texture->generateMipmap();
+        texDesc.samplerDesc.sAddressMode = rhi::SamplerAddressMode::REPEAT;
+        texDesc.samplerDesc.tAddressMode = rhi::SamplerAddressMode::REPEAT;
+        auto image                       = new Image();
+        image->initWithImageFile(_terrainData._detailMaps[0]._detailMapSrc);
+
+        TextureSliceData subDatas[] = {
+            TextureSliceData{.data = image->getData(), .dataSize = static_cast<unsigned int>(image->getDataSize())}};
+        texDesc.mipLevels = 0;  // request rhi to generate mipmaps automatically
+        texDesc.width     = image->getWidth();
+        texDesc.height    = image->getHeight();
+        texDesc.pixelFormat = image->getPixelFormat();
+        auto texture      = new Texture2D();
+
+        texture->initWithSpec(texDesc, subDatas);
         _detailMapTextures[0] = texture;
-        texture->setTexParameters(texParam);
-        delete textImage;
+        image->release();
     }
     else
     {
         // alpha map
         auto image = new Image();
         image->initWithImageFile(_terrainData._alphaMapSrc);
-        _alphaMap = new Texture2D();
-        _alphaMap->initWithImage(image);
-        texParam.sAddressMode = rhi::SamplerAddressMode::CLAMP;
-        texParam.tAddressMode = rhi::SamplerAddressMode::CLAMP;
-        _alphaMap->setTexParameters(texParam);
-        delete image;
 
-        texParam.sAddressMode = rhi::SamplerAddressMode::REPEAT;
-        texParam.tAddressMode = rhi::SamplerAddressMode::REPEAT;
+        _alphaMap = new Texture2D();
+        _alphaMap->initWithImage(image, PixelFormat::NONE, true);
+        image->release();
+
+        texDesc.samplerDesc.sAddressMode = rhi::SamplerAddressMode::REPEAT;
+        texDesc.samplerDesc.tAddressMode = rhi::SamplerAddressMode::REPEAT;
+
+        // request rhi to generate mipmaps automatically
+        texDesc.mipLevels             = 0;
         for (int i = 0; i < _terrainData._detailMapAmount; ++i)
         {
-            auto textImage = new Image();
-            textImage->initWithImageFile(_terrainData._detailMaps[i]._detailMapSrc);
+            image = new Image();
+            image->initWithImageFile(_terrainData._detailMaps[i]._detailMapSrc);
+
+            texDesc.width       = image->getWidth();
+            texDesc.height      = image->getHeight();
+            texDesc.pixelFormat = image->getPixelFormat();
+
+            TextureSliceData subDatas[] = {TextureSliceData{
+                .data = image->getData(), .dataSize = static_cast<unsigned int>(image->getDataSize())}};
+
             auto texture = new Texture2D();
-            texture->initWithImage(textImage);
-            delete textImage;
-            texture->generateMipmap();
+            texture->initWithSpec(texDesc, subDatas);
             _detailMapTextures[i] = texture;
 
-            texture->setTexParameters(texParam);
+            image->release();
         }
     }
     setMaxDetailMapAmount(_terrainData._detailMapAmount);

--- a/axmol/3d/Terrain.h
+++ b/axmol/3d/Terrain.h
@@ -570,7 +570,7 @@ private:
     rhi::UniformLocation _lightDirLocation;
 
     rhi::UniformLocation _mvpMatrixLocation;
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener;
 #endif
 };

--- a/axmol/base/Config.h
+++ b/axmol/base/Config.h
@@ -318,10 +318,6 @@ THE SOFTWARE.
 #    define AX_REDUCE_PAUSED_CPU_USAGE 0
 #endif
 
-#ifndef AX_META_TEXTURES
-#    define AX_META_TEXTURES 2
-#endif
-
 /// @name namespace ax
 /// @{
 #ifdef __cplusplus

--- a/axmol/base/Director.cpp
+++ b/axmol/base/Director.cpp
@@ -153,10 +153,11 @@ bool Director::init()
 
     _renderer = new Renderer;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // listen the event that renderer was recreated on Android/WP8
     _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
         _isStatusLabelUpdated = true;  // Force recreation of textures
+        rhi::SamplerCache::getInstance()->invalidateAll();
     });
 
     _eventDispatcher->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
@@ -169,7 +170,7 @@ Director::~Director()
 {
     AXLOGD("deallocing Director: {}", fmt::ptr(this));
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _eventDispatcher->removeEventListener(_rendererRecreatedListener);
     _rendererRecreatedListener = nullptr;
 #endif
@@ -1106,7 +1107,7 @@ void Director::restartDirector()
 
     setGLDefaultValues();
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // listen the event that renderer was recreated on Android/WP8
     _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
         _isStatusLabelUpdated = true;  // Force recreation of textures

--- a/axmol/base/Director.h
+++ b/axmol/base/Director.h
@@ -662,7 +662,7 @@ protected:
     moodycamel::ConcurrentQueue<std::function<void()>> _operations;
 #endif
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _rendererRecreatedListener = nullptr;
 #endif
 

--- a/axmol/base/Types.h
+++ b/axmol/base/Types.h
@@ -81,7 +81,6 @@ struct TextureFlag
         NONE               = 0,
         ANTIALIAS_ENABLED  = 1 << 1,
         PREMULTIPLIEDALPHA = 1 << 2,
-        RENDERTARGET       = 1 << 3,
     };
 };
 

--- a/axmol/base/Utils.h
+++ b/axmol/base/Utils.h
@@ -56,6 +56,11 @@ enum class DigestPresent
     Binary,
 };
 
+inline unsigned int isPOT(unsigned int value)
+{
+    return (((value) & (value - 1)) == 0);
+}
+
 /** Returns the Next Power of Two value.
 
 Examples:

--- a/axmol/platform/Image.cpp
+++ b/axmol/platform/Image.cpp
@@ -567,7 +567,7 @@ Image::Image()
     , _height(0)
     , _unpack(false)
     , _fileType(Format::UNKNOWN)
-    , _pixelFormat(rhi::PixelFormat::AUTO)
+    , _pixelFormat(rhi::PixelFormat::NONE)
     , _numberOfMipmaps(0)
     , _hasPremultipliedAlpha(false)
 {}
@@ -1871,9 +1871,9 @@ bool Image::initWithETCData(uint8_t* data, ssize_t dataLen, bool ownData)
     else if (Configuration::getInstance()->supportsETC2())
         compressedFormat = rhi::PixelFormat::ETC2_RGB;
     else
-        compressedFormat = rhi::PixelFormat::AUTO;
+        compressedFormat = rhi::PixelFormat::NONE;
 
-    if (compressedFormat != rhi::PixelFormat::AUTO)
+    if (compressedFormat != rhi::PixelFormat::NONE)
     {
         _pixelFormat = compressedFormat;
         forwardPixels(data, dataLen, pixelOffset, ownData);

--- a/axmol/platform/Image.cpp
+++ b/axmol/platform/Image.cpp
@@ -476,9 +476,7 @@ static rhi::PixelFormat getDevicePVRPixelFormat(rhi::PixelFormat format)
         else
             return rhi::PixelFormat::RGBA8;
     case rhi::PixelFormat::ETC1:
-        if (Configuration::getInstance()->supportsETC1())
-            return format;
-        else if (Configuration::getInstance()->supportsETC2())
+        if (Configuration::getInstance()->supportsETC2())
             return rhi::PixelFormat::ETC2_RGB;
         else
             return rhi::PixelFormat::RGBA8;
@@ -1766,7 +1764,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
             heightBlocks = height / 4;
             break;
         case PVR3TexturePixelFormat::ETC1:
-            if (!Configuration::getInstance()->supportsETC1())
+            if (!Configuration::getInstance()->supportsETC2())
             {
                 AXLOGW("Hardware ETC1 decoder not present. Using software decoder");
                 const int bytePerPixel = 4;
@@ -1865,17 +1863,10 @@ bool Image::initWithETCData(uint8_t* data, ssize_t dataLen, bool ownData)
 
     // GL_ETC1_RGB8_OES is not available in any desktop GL extension but the compression
     // format is forwards compatible so just use the ETC2 format.
-    rhi::PixelFormat compressedFormat;
-    if (Configuration::getInstance()->supportsETC1())
-        compressedFormat = rhi::PixelFormat::ETC1;
-    else if (Configuration::getInstance()->supportsETC2())
-        compressedFormat = rhi::PixelFormat::ETC2_RGB;
-    else
-        compressedFormat = rhi::PixelFormat::NONE;
-
-    if (compressedFormat != rhi::PixelFormat::NONE)
+    // @Note axmol-3.0, ETC1 not support sampler2DArray, so preferred ETC2
+    if (Configuration::getInstance()->supportsETC2())
     {
-        _pixelFormat = compressedFormat;
+        _pixelFormat = rhi::PixelFormat::ETC2_RGB;
         forwardPixels(data, dataLen, pixelOffset, ownData);
         return true;
     }

--- a/axmol/platform/Image.cpp
+++ b/axmol/platform/Image.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "axmol/platform/Image.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 
 #include <string>
 #include <ctype.h>
@@ -561,13 +561,13 @@ bool Image::isCompressedImageHavePMA(uint32_t target)
 
 Image::Image()
     : _data(nullptr)
-    , _dataLen(0)
+    , _dataSize(0)
     , _offset(0)
     , _width(0)
     , _height(0)
     , _unpack(false)
     , _fileType(Format::UNKNOWN)
-    , _pixelFormat(rhi::PixelFormat::NONE)
+    , _pixelFormat(rhi::PixelFormat::AUTO)
     , _numberOfMipmaps(0)
     , _hasPremultipliedAlpha(false)
 {}
@@ -581,7 +581,7 @@ Image::~Image()
     else
     {
         for (int i = 0; i < _numberOfMipmaps; ++i)
-            AX_SAFE_FREE(_mipmaps[i].address);
+            AX_SAFE_FREE(_mipmaps[i].data);
     }
 }
 
@@ -737,10 +737,10 @@ bool Image::initWithRawData(const uint8_t* data,
 
         // only RGBA8888 supported
         int bytesPerComponent = 4;
-        _dataLen              = height * width * bytesPerComponent;
-        _data                 = static_cast<uint8_t*>(malloc(_dataLen));
+        _dataSize              = height * width * bytesPerComponent;
+        _data                 = static_cast<uint8_t*>(malloc(_dataSize));
         AX_BREAK_IF(!_data);
-        memcpy(_data, data, _dataLen);
+        memcpy(_data, data, _dataSize);
 
         ret = true;
     } while (0);
@@ -924,17 +924,17 @@ Image::Format Image::detectFormat(const uint8_t* data, ssize_t dataLen)
 
 int Image::getBitPerPixel()
 {
-    return rhi::PixelFormatUtils::getFormatDesc(_pixelFormat).bpp;
+    return rhi::RHIUtils::getFormatDesc(_pixelFormat).bpp;
 }
 
 bool Image::hasAlpha()
 {
-    return rhi::PixelFormatUtils::getFormatDesc(_pixelFormat).alpha;
+    return rhi::RHIUtils::getFormatDesc(_pixelFormat).alpha;
 }
 
 bool Image::isCompressed()
 {
-    return rhi::PixelFormatUtils::isCompressed(_pixelFormat);
+    return rhi::RHIUtils::isCompressed(_pixelFormat);
 }
 
 #if AX_USE_WIC
@@ -975,12 +975,12 @@ bool Image::decodeWithWIC(const unsigned char* data, ssize_t dataLen)
             _pixelFormat = rhi::PixelFormat::BGRA8;
         }
 
-        _dataLen = img.getImageDataSize();
+        _dataSize = img.getImageDataSize();
 
-        AXASSERT(_dataLen > 0, "Image: Decompressed data length is invalid");
+        AXASSERT(_dataSize > 0, "Image: Decompressed data length is invalid");
 
-        _data = new (std::nothrow) unsigned char[_dataLen];
-        bRet  = (img.getImageData(_data, _dataLen) > 0);
+        _data = new unsigned char[_dataSize];
+        bRet  = (img.getImageData(_data, _dataSize) > 0);
 
         if (_pixelFormat == rhi::PixelFormat::RGBA8)
         {
@@ -996,17 +996,17 @@ bool Image::encodeWithWIC(std::string_view filePath, bool isToRGB, GUID containe
     // Save formats supported by WIC
     WICPixelFormatGUID targetFormat = isToRGB ? GUID_WICPixelFormat24bppBGR : GUID_WICPixelFormat32bppBGRA;
     unsigned char* pSaveData        = nullptr;
-    int saveLen                     = _dataLen;
+    int saveLen                     = _dataSize;
     int bpp                         = 4;
 
     if (targetFormat == GUID_WICPixelFormat24bppBGR && _pixelFormat == rhi::PixelFormat::RGBA8)
     {
         bpp       = 3;
         saveLen   = _width * _height * bpp;
-        pSaveData = new (std::nothrow) unsigned char[saveLen];
+        pSaveData = new unsigned char[saveLen];
         int indL = 0, indR = 0;
 
-        while (indL < saveLen && indR < _dataLen)
+        while (indL < saveLen && indR < _dataSize)
         {
             memcpy(&pSaveData[indL], &_data[indR], 3);
             indL += 3;
@@ -1015,7 +1015,7 @@ bool Image::encodeWithWIC(std::string_view filePath, bool isToRGB, GUID containe
     }
     else
     {
-        pSaveData = new (std::nothrow) unsigned char[saveLen];
+        pSaveData = new unsigned char[saveLen];
         memcpy(pSaveData, _data, saveLen);
     }
 
@@ -1157,8 +1157,8 @@ bool Image::initWithJpgData(uint8_t* data, ssize_t dataLen)
         _width  = cinfo.output_width;
         _height = cinfo.output_height;
 
-        _dataLen = cinfo.output_width * cinfo.output_height * cinfo.output_components;
-        _data    = static_cast<uint8_t*>(malloc(_dataLen));
+        _dataSize = cinfo.output_width * cinfo.output_height * cinfo.output_components;
+        _data    = static_cast<uint8_t*>(malloc(_dataSize));
         AX_BREAK_IF(!_data);
 
         /* now actually read the jpeg into the raw buffer */
@@ -1294,8 +1294,8 @@ bool Image::initWithPngData(uint8_t* data, ssize_t dataLen)
 
         rowbytes = png_get_rowbytes(png_ptr, info_ptr);
 
-        _dataLen = rowbytes * _height;
-        _data    = static_cast<uint8_t*>(malloc(_dataLen));
+        _dataSize = rowbytes * _height;
+        _data    = static_cast<uint8_t*>(malloc(_dataSize));
         if (!_data)
         {
             if (row_pointers != nullptr)
@@ -1354,7 +1354,7 @@ bool Image::initWithBmpData(uint8_t* data, ssize_t dataLen)
     _data = stbi_load_from_memory(data, static_cast<int>(dataLen), &_width, &_height, nullptr, nrChannels);
     if (_data)
     {
-        _dataLen     = _width * _height * nrChannels;
+        _dataSize     = _width * _height * nrChannels;
         _fileType    = Format::BMP;
         _pixelFormat = rhi::PixelFormat::RGBA8;
         return true;
@@ -1385,12 +1385,12 @@ bool Image::initWithWebpData(uint8_t* data, ssize_t dataLen)
         // we ask webp to give data with premultiplied alpha
         _hasPremultipliedAlpha = (config.input.has_alpha != 0);
 
-        _dataLen = _width * _height * (config.input.has_alpha ? 4 : 3);
-        _data    = static_cast<uint8_t*>(malloc(_dataLen));
+        _dataSize = _width * _height * (config.input.has_alpha ? 4 : 3);
+        _data    = static_cast<uint8_t*>(malloc(_dataSize));
 
         config.output.u.RGBA.rgba        = static_cast<uint8_t*>(_data);
         config.output.u.RGBA.stride      = _width * (config.input.has_alpha ? 4 : 3);
-        config.output.u.RGBA.size        = _dataLen;
+        config.output.u.RGBA.size        = _dataSize;
         config.output.is_external_memory = 1;
 
         if (WebPDecode(static_cast<const uint8_t*>(data), dataLen, &config) != VP8_STATUS_OK)
@@ -1458,7 +1458,7 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
         _width    = tgaData->width;
         _height   = tgaData->height;
         _data     = tgaData->imageData;
-        _dataLen  = _width * _height * tgaData->pixelDepth / 8;
+        _dataSize  = _width * _height * tgaData->pixelDepth / 8;
         _fileType = Format::TGA;
 
         ret = true;
@@ -1535,7 +1535,7 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
     }
 
     auto pixelFormat = getDevicePVRPixelFormat(v2_pixel_formathash.at(formatFlags));
-    auto& info       = rhi::PixelFormatUtils::getFormatDesc(pixelFormat);
+    auto& info       = rhi::RHIUtils::getFormatDesc(pixelFormat);
     int bpp          = info.bpp;
     if (!bpp)
     {
@@ -1571,9 +1571,10 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
             {
                 AXLOGD("Hardware PVR decoder not present. Using software decoder");
                 _unpack                            = true;
-                _mipmaps[_numberOfMipmaps].len     = width * height * 4;
-                _mipmaps[_numberOfMipmaps].address = (uint8_t*)malloc(width * height * 4);
-                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[_numberOfMipmaps].address, true);
+                _mipmaps[_numberOfMipmaps].dataSize     = width * height * 4;
+                _mipmaps[_numberOfMipmaps].data = (uint8_t*)malloc(width * height * 4);
+                _mipmaps[_numberOfMipmaps].mipLevel     = _numberOfMipmaps;
+                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[_numberOfMipmaps].data, true);
                 bpp = 2;
             }
             blockSize    = 8 * 4;  // Pixel by pixel block size for 2bpp
@@ -1584,10 +1585,11 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
             if (!Configuration::getInstance()->supportsPVRTC())
             {
                 AXLOGD("Hardware PVR decoder not present. Using software decoder");
-                _unpack                            = true;
-                _mipmaps[_numberOfMipmaps].len     = width * height * 4;
-                _mipmaps[_numberOfMipmaps].address = (uint8_t*)malloc(width * height * 4);
-                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[_numberOfMipmaps].address, false);
+                _unpack                             = true;
+                _mipmaps[_numberOfMipmaps].dataSize = width * height * 4;
+                _mipmaps[_numberOfMipmaps].data = (uint8_t*)malloc(width * height * 4);
+                _mipmaps[_numberOfMipmaps].mipLevel = _numberOfMipmaps;
+                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[_numberOfMipmaps].data, false);
                 bpp = 4;
             }
             blockSize    = 4 * 4;  // Pixel by pixel block size for 4bpp
@@ -1624,8 +1626,9 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
         // Make record to the mipmaps array and increment counter
         if (!_unpack)
         {
-            _mipmaps[_numberOfMipmaps].address = pixelData + dataOffset;
-            _mipmaps[_numberOfMipmaps].len     = packetLength;
+            _mipmaps[_numberOfMipmaps].data     = pixelData + dataOffset;
+            _mipmaps[_numberOfMipmaps].dataSize = packetLength;
+            _mipmaps[_numberOfMipmaps].mipLevel = _numberOfMipmaps;
         }
         _numberOfMipmaps++;
 
@@ -1642,8 +1645,8 @@ bool Image::initWithPVRv2Data(uint8_t* data, ssize_t dataLen, bool ownData)
     }
     else
     {
-        _data    = _mipmaps[0].address;
-        _dataLen = _mipmaps[0].len;
+        _data     = (uint8_t*)_mipmaps[0].data;
+        _dataSize = _mipmaps[0].dataSize;
     }
 
     return true;
@@ -1687,7 +1690,7 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
     }
 
     auto finalPixelFormat = getDevicePVRPixelFormat(v3_pixel_formathash.at(pixelFormat));
-    auto& info            = rhi::PixelFormatUtils::getFormatDesc(finalPixelFormat);
+    auto& info            = rhi::RHIUtils::getFormatDesc(finalPixelFormat);
     int bpp               = info.bpp;
     if (!info.bpp)
     {
@@ -1735,10 +1738,11 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
             if (!Configuration::getInstance()->supportsPVRTC())
             {
                 AXLOGW("Hardware PVR decoder not present. Using software decoder");
-                _unpack             = true;
-                _mipmaps[i].len     = width * height * 4;
-                _mipmaps[i].address = (uint8_t*)malloc(width * height * 4);
-                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[i].address, true);
+                _unpack              = true;
+                _mipmaps[i].dataSize = width * height * 4;
+                _mipmaps[i].data     = (uint8_t*)malloc(width * height * 4);
+                _mipmaps[i].mipLevel = i;
+                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[i].data, true);
                 bpp = 2;
             }
             blockSize    = 8 * 4;  // Pixel by pixel block size for 2bpp
@@ -1751,9 +1755,10 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
             {
                 AXLOGW("Hardware PVR decoder not present. Using software decoder");
                 _unpack             = true;
-                _mipmaps[i].len     = width * height * 4;
-                _mipmaps[i].address = (uint8_t*)malloc(width * height * 4);
-                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[i].address, false);
+                _mipmaps[i].dataSize = width * height * 4;
+                _mipmaps[i].data     = (uint8_t*)malloc(width * height * 4);
+                _mipmaps[i].mipLevel = i;
+                PVRTDecompressPVRTC(pixelData + dataOffset, width, height, _mipmaps[i].data, false);
                 bpp = 4;
             }
             blockSize    = 4 * 4;  // Pixel by pixel block size for 4bpp
@@ -1766,10 +1771,11 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
                 AXLOGW("Hardware ETC1 decoder not present. Using software decoder");
                 const int bytePerPixel = 4;
                 _unpack                = true;
-                _mipmaps[i].len        = width * height * bytePerPixel;
-                _mipmaps[i].address    = (uint8_t*)malloc(width * height * bytePerPixel);
+                _mipmaps[i].dataSize   = width * height * bytePerPixel;
+                _mipmaps[i].data       = (uint8_t*)malloc(width * height * bytePerPixel);
+                _mipmaps[i].mipLevel   = i;
                 if (etc2_decode_image(ETC2_RGB_NO_MIPMAPS, pixelData + dataOffset,
-                                      static_cast<etc1_byte*>(_mipmaps[i].address), width, height) != 0)
+                                      static_cast<etc1_byte*>(_mipmaps[i].data), width, height) != 0)
                 {
                     return false;
                 }
@@ -1807,8 +1813,9 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
 
         if (!_unpack)
         {
-            _mipmaps[i].address = pixelData + dataOffset;
-            _mipmaps[i].len     = static_cast<int>(packetLength);
+            _mipmaps[i].data     = pixelData + dataOffset;
+            _mipmaps[i].dataSize = static_cast<int>(packetLength);
+            _mipmaps[i].mipLevel = i;
         }
 
         dataOffset += packetLength;
@@ -1824,8 +1831,8 @@ bool Image::initWithPVRv3Data(uint8_t* data, ssize_t dataLen, bool ownData)
     }
     else
     {
-        _data    = _mipmaps[0].address;
-        _dataLen = _mipmaps[0].len;
+        _data     = static_cast<uint8_t*>(_mipmaps[0].data);
+        _dataSize = _mipmaps[0].dataSize;
     }
 
     return true;
@@ -1864,9 +1871,9 @@ bool Image::initWithETCData(uint8_t* data, ssize_t dataLen, bool ownData)
     else if (Configuration::getInstance()->supportsETC2())
         compressedFormat = rhi::PixelFormat::ETC2_RGB;
     else
-        compressedFormat = rhi::PixelFormat::NONE;
+        compressedFormat = rhi::PixelFormat::AUTO;
 
-    if (compressedFormat != rhi::PixelFormat::NONE)
+    if (compressedFormat != rhi::PixelFormat::AUTO)
     {
         _pixelFormat = compressedFormat;
         forwardPixels(data, dataLen, pixelOffset, ownData);
@@ -1876,8 +1883,8 @@ bool Image::initWithETCData(uint8_t* data, ssize_t dataLen, bool ownData)
     {
         AXLOGW("Hardware ETC1 decoder not present. Using software decoder");
 
-        _dataLen = _width * _height * 4;
-        _data    = static_cast<uint8_t*>(malloc(_dataLen));
+        _dataSize = _width * _height * 4;
+        _data    = static_cast<uint8_t*>(malloc(_dataSize));
         if (etc2_decode_image(ETC2_RGB_NO_MIPMAPS, static_cast<const uint8_t*>(data) + pixelOffset,
                               static_cast<etc2_byte*>(_data), _width, _height) == 0)
         {  // if it is not gles or device do not support ETC1, decode texture by software
@@ -1888,7 +1895,7 @@ bool Image::initWithETCData(uint8_t* data, ssize_t dataLen, bool ownData)
 
         // software decode fail, release pixels data
         AX_SAFE_FREE(_data);
-        _dataLen = 0;
+        _dataSize = 0;
         return false;
     }
 }
@@ -1943,14 +1950,14 @@ bool Image::initWithETC2Data(uint8_t* data, ssize_t dataLen, bool ownData)
 
             // if device do not support ETC2, decode texture by software
             // etc2_decode_image always decode to RGBA8888
-            _dataLen = _width * _height * 4;
-            _data    = static_cast<uint8_t*>(malloc(_dataLen));
+            _dataSize = _width * _height * 4;
+            _data    = static_cast<uint8_t*>(malloc(_dataSize));
             if (AX_UNLIKELY(etc2_decode_image(format, static_cast<const uint8_t*>(data) + pixelOffset,
                                                  static_cast<etc2_byte*>(_data), _width, _height) != 0))
             {
                 // software decode fail, release pixels data
                 AX_SAFE_FREE(_data);
-                _dataLen = 0;
+                _dataSize = 0;
                 break;
             }
             _pixelFormat = rhi::PixelFormat::RGBA8;
@@ -2028,14 +2035,14 @@ bool Image::initWithASTCData(uint8_t* data, ssize_t dataLen, bool ownData)
         {
             AXLOGW("Hardware ASTC decoder not present. Using software decoder");
 
-            _dataLen = _width * _height * 4;
-            _data    = static_cast<uint8_t*>(malloc(_dataLen));
+            _dataSize = _width * _height * 4;
+            _data    = static_cast<uint8_t*>(malloc(_dataSize));
             if (AX_UNLIKELY(astc_decompress_image(static_cast<const uint8_t*>(data) + ASTC_HEAD_SIZE,
                                                      static_cast<uint32_t>(dataLen) - ASTC_HEAD_SIZE, _data, _width,
                                                      _height, block_x, block_y) != 0))
             {
                 AX_SAFE_FREE(_data);
-                _dataLen = 0;
+                _dataSize = 0;
                 break;
             }
 
@@ -2065,7 +2072,7 @@ bool Image::initWithS3TCData(uint8_t* data, ssize_t dataLen, bool ownData)
         1,
         header->ddsd.DUMMYUNIONNAMEN2
             .mipMapCount);  // if dds header reports 0 mipmaps, set to 1 to force correct software decoding (if needed).
-    _dataLen      = 0;
+    _dataSize      = 0;
     int blockSize = (FOURCC_DXT1 == header->ddsd.DUMMYUNIONNAMEN4.ddpfPixelFormat.fourCC) ? 8 : 16;
 
     /* calculate the dataLen */
@@ -2106,12 +2113,12 @@ bool Image::initWithS3TCData(uint8_t* data, ssize_t dataLen, bool ownData)
             if (height == 0)
                 height = 1;
 
-            _dataLen += (height * width * 4);
+            _dataSize += (height * width * 4);
 
             width >>= 1;
             height >>= 1;
         }
-        _data = static_cast<uint8_t*>(malloc(_dataLen));
+        _data = static_cast<uint8_t*>(malloc(_dataSize));
     }
 
     /* load the mipmaps */
@@ -2131,8 +2138,9 @@ bool Image::initWithS3TCData(uint8_t* data, ssize_t dataLen, bool ownData)
 
         if (Configuration::getInstance()->supportsS3TC())
         {  // decode texture through hardware
-            _mipmaps[i].address = (uint8_t*)pixelData + encodeOffset;
-            _mipmaps[i].len     = size;
+            _mipmaps[i].data = (uint8_t*)pixelData + encodeOffset;
+            _mipmaps[i].dataSize = size;
+            _mipmaps[i].mipLevel = i;
         }
         else
         {  // if it is not gles or device do not support S3TC, decode texture by software
@@ -2156,9 +2164,10 @@ bool Image::initWithS3TCData(uint8_t* data, ssize_t dataLen, bool ownData)
                 s3tc_decode(pixelData + encodeOffset, &decodeImageData[0], width, height, S3TCDecodeFlag::DXT5);
             }
 
-            _mipmaps[i].address = (uint8_t*)_data + decodeOffset;
-            _mipmaps[i].len     = (stride * height);
-            memcpy((void*)_mipmaps[i].address, (void*)&decodeImageData[0], _mipmaps[i].len);
+            _mipmaps[i].data = (uint8_t*)_data + decodeOffset;
+            _mipmaps[i].dataSize = (stride * height);
+            _mipmaps[i].mipLevel = i;
+            memcpy((void*)_mipmaps[i].data, (void*)&decodeImageData[0], _mipmaps[i].dataSize);
             decodeOffset += stride * height;
         }
 
@@ -2243,12 +2252,12 @@ bool Image::initWithATITCData(uint8_t* data, ssize_t dataLen, bool ownData)
             if (height == 0)
                 height = 1;
 
-            _dataLen += (height * width * 4);
+            _dataSize += (height * width * 4);
 
             width >>= 1;
             height >>= 1;
         }
-        _data = static_cast<uint8_t*>(malloc(_dataLen));
+        _data = static_cast<uint8_t*>(malloc(_dataSize));
     }
 
     /* load the mipmaps */
@@ -2269,8 +2278,9 @@ bool Image::initWithATITCData(uint8_t* data, ssize_t dataLen, bool ownData)
         if (hardware)
         {
             /* decode texture through hardware */
-            _mipmaps[i].address = (uint8_t*)pixelData + encodeOffset;
-            _mipmaps[i].len     = size;
+            _mipmaps[i].data = (uint8_t*)pixelData + encodeOffset;
+            _mipmaps[i].dataSize = size;
+            _mipmaps[i].mipLevel = i;
         }
         else
         {
@@ -2295,9 +2305,10 @@ bool Image::initWithATITCData(uint8_t* data, ssize_t dataLen, bool ownData)
                 break;
             }
 
-            _mipmaps[i].address = (uint8_t*)_data + decodeOffset;
-            _mipmaps[i].len     = (stride * height);
-            memcpy((void*)_mipmaps[i].address, (void*)&decodeImageData[0], _mipmaps[i].len);
+            _mipmaps[i].data = (uint8_t*)_data + decodeOffset;
+            _mipmaps[i].dataSize = (stride * height);
+            _mipmaps[i].mipLevel = i;
+            memcpy((void*)_mipmaps[i].data, (void*)&decodeImageData[0], _mipmaps[i].dataSize);
             decodeOffset += stride * height;
         }
 
@@ -2325,14 +2336,14 @@ void Image::forwardPixels(uint8_t* data, ssize_t dataLen, int offset, bool ownDa
     if (ownData)
     {
         _data    = data;
-        _dataLen = dataLen;
+        _dataSize = dataLen;
         _offset  = offset;
     }
     else
     {
-        _dataLen = dataLen - offset;
-        _data    = (uint8_t*)malloc(_dataLen);
-        memcpy(_data, data + offset, _dataLen);
+        _dataSize = dataLen - offset;
+        _data    = (uint8_t*)malloc(_dataSize);
+        memcpy(_data, data + offset, _dataSize);
     }
 }
 

--- a/axmol/platform/Image.h
+++ b/axmol/platform/Image.h
@@ -52,16 +52,6 @@ namespace ax
  * @{
  */
 
-/**
- @brief Structure which can tell where mipmap begins and how long is it
- */
-typedef struct _MipmapInfo
-{
-    uint8_t* address;
-    int len;
-    _MipmapInfo() : address(NULL), len(0) {}
-} MipmapInfo;
-
 /** The Image class for loading all images supported by axmol . */
 class AX_DLL Image : public Object
 {
@@ -168,13 +158,13 @@ public:
 
     // Getters
     uint8_t* getData() { return _data + _offset; }
-    ssize_t getDataLen() { return _dataLen - _offset; }
+    ssize_t getDataSize() { return _dataSize - _offset; }
     Format getFileType() { return _fileType; }
     rhi::PixelFormat getPixelFormat() { return _pixelFormat; }
     int getWidth() { return _width; }
     int getHeight() { return _height; }
     int getNumberOfMipmaps() { return _numberOfMipmaps; }
-    MipmapInfo* getMipmaps() { return _mipmaps; }
+    std::span<MipmapInfo> getMipmaps() { return std::span<MipmapInfo>(&_mipmaps[0], &_mipmaps[0] + _numberOfMipmaps); }
     bool hasPremultipliedAlpha() { return _hasPremultipliedAlpha; }
     std::string getFilePath() const { return _filePath; }
 
@@ -233,7 +223,7 @@ protected:
     static uint32_t COMPRESSED_IMAGE_PMA_FLAGS;
 
     uint8_t* _data;
-    ssize_t _dataLen;
+    ssize_t _dataSize;
     ssize_t _offset;  // useful for hardware decoder present to hold data without copy
     int _width;
     int _height;

--- a/axmol/platform/PlatformMacros.h
+++ b/axmol/platform/PlatformMacros.h
@@ -80,26 +80,26 @@ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
         }                                           \
     }
 
-/** @def AX_ENABLE_CACHE_TEXTURE_DATA
+/** @def AX_ENABLE_CONTEXT_LOSS_RECOVERY
  * Enable it if you want to cache the texture data.
  * to be different from other platforms unless there's a good reason.
  *
  * @since v0.99.5
  */
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID) || (AX_TARGET_PLATFORM == AX_PLATFORM_WASM)
-#    if !defined(AX_ENABLE_CACHE_TEXTURE_DATA)
-#        define AX_ENABLE_CACHE_TEXTURE_DATA 1
+#    if !defined(AX_ENABLE_CONTEXT_LOSS_RECOVERY)
+#        define AX_ENABLE_CONTEXT_LOSS_RECOVERY 1
 #    endif
 #else
-#    undef AX_ENABLE_CACHE_TEXTURE_DATA
-#    define AX_ENABLE_CACHE_TEXTURE_DATA 0
+#    undef AX_ENABLE_CONTEXT_LOSS_RECOVERY
+#    define AX_ENABLE_CONTEXT_LOSS_RECOVERY 0
 #endif
 
 /** @def AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST
  * Enable this if application should be restarted after the OpenGL context is lost
  *
  */
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID && !AX_ENABLE_CACHE_TEXTURE_DATA)
+#if (AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID && !AX_ENABLE_CONTEXT_LOSS_RECOVERY)
 #    if !defined(AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST)
 #        define AX_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST 1
 #    endif

--- a/axmol/platform/android/javaactivity-android.cpp
+++ b/axmol/platform/android/javaactivity-android.cpp
@@ -101,7 +101,7 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeInit(JNIEnv*, jcla
         ax::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
         director->getEventDispatcher()->dispatchEvent(&recreatedEvent, true);
         director->setGLDefaultValues();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         ax::VolatileTextureMgr::reloadAllTextures();
 #endif
     }

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -101,7 +101,7 @@ void RenderViewImpl::choosePixelFormats()
     }
     else if (_gfxContextAttrs.depthBits == 0 && _gfxContextAttrs.stencilBits == 0)
     {
-        _depthFormat = PixelFormat::AUTO;
+        _depthFormat = PixelFormat::NONE;
     }
     else
     {

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -101,7 +101,7 @@ void RenderViewImpl::choosePixelFormats()
     }
     else if (_gfxContextAttrs.depthBits == 0 && _gfxContextAttrs.stencilBits == 0)
     {
-        _depthFormat = PixelFormat::NONE;
+        _depthFormat = PixelFormat::AUTO;
     }
     else
     {

--- a/axmol/platform/wasm/Application-wasm.cpp
+++ b/axmol/platform/wasm/Application-wasm.cpp
@@ -66,7 +66,7 @@ void axmol_webglcontextrestored()
     ax::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
     director->getEventDispatcher()->dispatchEvent(&recreatedEvent, true);
     director->setGLDefaultValues();
-#    if AX_ENABLE_CACHE_TEXTURE_DATA
+#    if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     ax::VolatileTextureMgr::reloadAllTextures();
 #    endif
 }

--- a/axmol/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/axmol/platform/winrt/xaml/AxmolRenderer.cpp
@@ -102,7 +102,7 @@ void AxmolRenderer::DeviceLost()
         ax::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
         director->getEventDispatcher()->dispatchEvent(&recreatedEvent, true);
         director->setGLDefaultValues();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         ax::VolatileTextureMgr::reloadAllTextures();
 #endif
 

--- a/axmol/renderer/Material.cpp
+++ b/axmol/renderer/Material.cpp
@@ -261,10 +261,18 @@ bool Material::parseSampler(rhi::ProgramState* programState, Properties* sampler
 {
     AXASSERT(!samplerProperties->getId().empty(), "Sampler must have an id. The id is the uniform name");
 
+    // mipmap
+    bool usemipmap     = false;
+    const char* mipmap = getOptionalString(samplerProperties, "mipmap", "false");
+    if (mipmap && strcasecmp(mipmap, "true") == 0)
+    {
+        usemipmap = true;
+    }
+
     // required
     auto filename = samplerProperties->getString("path");
 
-    auto texture = Director::getInstance()->getTextureCache()->addImage(filename);
+    auto texture = Director::getInstance()->getTextureCache()->addImage(filename, usemipmap);
     if (!texture)
     {
         AXLOGW("Invalid filepath");
@@ -274,15 +282,6 @@ bool Material::parseSampler(rhi::ProgramState* programState, Properties* sampler
     // optionals
     {
         Texture2D::TexParams texParams;
-
-        // mipmap
-        bool usemipmap     = false;
-        const char* mipmap = getOptionalString(samplerProperties, "mipmap", "false");
-        if (mipmap && strcasecmp(mipmap, "true") == 0)
-        {
-            texture->generateMipmap();
-            usemipmap = true;
-        }
 
         // valid options: REPEAT, CLAMP
         const char* wrapS = getOptionalString(samplerProperties, "wrapS", "CLAMP_TO_EDGE");
@@ -353,11 +352,11 @@ bool Material::parseSampler(rhi::ProgramState* programState, Properties* sampler
     if (_textureSlots.find(textureName) == _textureSlots.end())
     {
         _textureSlots[textureName] = _textureSlotIndex;
-        programState->setTexture(location, _textureSlotIndex++, texture->getBackendTexture());
+        programState->setTexture(location, _textureSlotIndex++, texture->getRHITexture());
     }
     else
     {
-        programState->setTexture(location, _textureSlots[textureName], texture->getBackendTexture());
+        programState->setTexture(location, _textureSlots[textureName], texture->getRHITexture());
     }
 
     return true;

--- a/axmol/renderer/MeshCommand.cpp
+++ b/axmol/renderer/MeshCommand.cpp
@@ -45,13 +45,13 @@ namespace ax
 {
 
 MeshCommand::MeshCommand()
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     : _rendererRecreatedListener(nullptr)
 #endif
 {
     _type = RenderCommand::Type::MESH_COMMAND;
     _is3D = true;
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // listen the event that renderer was recreated on Android/WP8
     _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED,
                                                              AX_CALLBACK_1(MeshCommand::listenRendererRecreated, this));
@@ -76,12 +76,12 @@ void MeshCommand::init(float globalZOrder, const Mat4& transform)
 
 MeshCommand::~MeshCommand()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
 }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 void MeshCommand::listenRendererRecreated(EventCustom* event) {}
 #endif
 

--- a/axmol/renderer/MeshCommand.h
+++ b/axmol/renderer/MeshCommand.h
@@ -74,12 +74,12 @@ public:
 
     void init(float globalZOrder, const Mat4& transform);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     void listenRendererRecreated(EventCustom* event);
 #endif
 
 protected:
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _rendererRecreatedListener;
 #endif
 };

--- a/axmol/renderer/Texture2D.cpp
+++ b/axmol/renderer/Texture2D.cpp
@@ -49,12 +49,71 @@ THE SOFTWARE.
 #include "axmol/rhi/RHIUtils.h"
 #include "axmol/renderer/Renderer.h"
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 #    include "axmol/renderer/TextureCache.h"
 #endif
 
 namespace ax
 {
+static bool createStringTextureData(std::string_view text,
+                                    const FontDefinition& textDefinition,
+                                    Data& outData,
+                                    int& imageWidth,
+                                    int& imageHeight,
+                                    bool& premultipliedAlpha)
+{
+    Device::TextAlign align;
+
+    if (TextVAlignment::TOP == textDefinition._vertAlignment)
+    {
+        align = (TextHAlignment::CENTER == textDefinition._alignment) ? Device::TextAlign::TOP
+                : (TextHAlignment::LEFT == textDefinition._alignment) ? Device::TextAlign::TOP_LEFT
+                                                                        : Device::TextAlign::TOP_RIGHT;
+    }
+    else if (TextVAlignment::CENTER == textDefinition._vertAlignment)
+    {
+        align = (TextHAlignment::CENTER == textDefinition._alignment) ? Device::TextAlign::CENTER
+                : (TextHAlignment::LEFT == textDefinition._alignment) ? Device::TextAlign::LEFT
+                                                                        : Device::TextAlign::RIGHT;
+    }
+    else if (TextVAlignment::BOTTOM == textDefinition._vertAlignment)
+    {
+        align = (TextHAlignment::CENTER == textDefinition._alignment) ? Device::TextAlign::BOTTOM
+                : (TextHAlignment::LEFT == textDefinition._alignment) ? Device::TextAlign::BOTTOM_LEFT
+                                                                        : Device::TextAlign::BOTTOM_RIGHT;
+    }
+    else
+    {
+        AXASSERT(false, "Not supported alignment format!");
+        return false;
+    }
+
+#if (AX_TARGET_PLATFORM != AX_PLATFORM_ANDROID) && (AX_TARGET_PLATFORM != AX_PLATFORM_IOS)
+    AXASSERT(textDefinition._stroke._strokeEnabled == false, "Currently stroke only supported on iOS and Android!");
+#endif
+
+    auto textDef            = textDefinition;
+    auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
+    textDef._fontSize *= contentScaleFactor;
+    textDef._dimensions.width *= contentScaleFactor;
+    textDef._dimensions.height *= contentScaleFactor;
+    textDef._stroke._strokeSize *= contentScaleFactor;
+    textDef._shadow._shadowEnabled = false;
+
+    outData = Device::getTextureDataForText(text, textDef, align, imageWidth, imageHeight, premultipliedAlpha);
+    if (outData.isNull())
+        return false;
+
+    const auto maxTextureSize = rhi::DriverBase::getInstance()->getMaxTextureSize();
+    if (imageWidth > maxTextureSize || imageHeight > maxTextureSize)
+    {
+        AXLOGW("Texture2D::initWithString fail, the texture size:{}x{} too large, max texture size:{}", imageWidth,
+                imageHeight, maxTextureSize);
+        return false;
+    }
+
+    return true;
+}
 
 void Texture2D::chooseSamplerDesc(bool antialiasEnabled, bool mipEnabled, rhi::SamplerDesc& desc)
 {
@@ -93,7 +152,7 @@ Texture2D::Texture2D()
 
 Texture2D::~Texture2D()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     VolatileTextureMgr::removeTexture(this);
 #endif
 
@@ -249,7 +308,7 @@ bool Texture2D::initWithMipmaps(std::span<MipmapInfo> mipmaps,
     desc.height = pixelsHigh;
     desc.pixelFormat = pixelFormat;
     desc.mipLevels   = mipmaps.size();
-    return initWithSpec(desc, (std::span<TextureSliceData>&)mipmaps, renderFormat, preMultipliedAlpha);
+    return initWithSpec(desc, reinterpret_cast<std::span<TextureSliceData>&>(mipmaps), renderFormat, preMultipliedAlpha);
 }
 
 bool Texture2D::initWithSpec(rhi::TextureDesc desc,
@@ -279,17 +338,13 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
 
     bool compressed = rhi::RHIUtils::isCompressed(desc.pixelFormat);
 
-    if (compressed && !Configuration::getInstance()->supportsPVRTC() && !Configuration::getInstance()->supportsETC1() &&
+    if (compressed && !Configuration::getInstance()->supportsPVRTC() &&
         !Configuration::getInstance()->supportsETC2() && !Configuration::getInstance()->supportsS3TC() &&
         !Configuration::getInstance()->supportsASTC() && !Configuration::getInstance()->supportsATITC())
     {
         AXLOGW("WARNING: PVRTC/ETC images are not supported");
         return false;
     }
-
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    VolatileTextureMgr::getOrAddVolatileTexture(this);
-#endif
 
     // !override renderFormat since some render format by RHI
     #if AX_RENDER_API == AX_RENDER_API_MTL
@@ -332,45 +387,7 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
     chooseSamplerDesc(true, desc.mipLevels != 1, desc.samplerDesc);
     _rhiTexture = static_cast<rhi::Texture*>(rhi::DriverBase::getInstance()->createTexture(desc));
 
-    for (auto& subres : subDatas)
-    {
-        if (!subres.data)
-            continue;
-        auto width  = (std::max)(1, _pixelsWide >> subres.mipLevel);
-        auto height = (std::max)(1, _pixelsHigh >> subres.mipLevel);
-        uint8_t* convertedData{nullptr};
-        size_t convertedDataLen{0};
-
-        const void* pixelData{nullptr};
-        size_t pixelDataSize{0};
-        if (_originalPF != renderFormat && !compressed)  // need conversion
-        {
-            auto convertedFormat =
-                rhi::RHIUtils::convertDataToFormat((const uint8_t*)subres.data, subres.dataSize, _originalPF,
-                                                           renderFormat, &convertedData, &convertedDataLen);
-            if (convertedFormat != renderFormat || !convertedData)
-            {
-                AXLOGE("PixelFormat convert fail");
-                continue;
-            }
-            pixelData      = convertedData;
-            pixelDataSize = convertedDataLen;
-        }
-        else
-        {
-            pixelData = subres.data;
-            pixelDataSize = subres.dataSize;
-        }
-
-        if (compressed)
-            _rhiTexture->updateCompressedData(pixelData, width, height, pixelDataSize, subres.mipLevel,
-                                              subres.layerIndex);
-        else
-            _rhiTexture->updateData(pixelData, width, height, subres.mipLevel, subres.layerIndex);
-
-        if (convertedData)
-            free(convertedData);
-    }
+    updateData(subDatas, renderFormat, compressed);
 
     if (desc.arraySize == 2)
     {
@@ -383,23 +400,6 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
     }
 
     return true;
-}
-
-bool Texture2D::isRenderTarget() const
-{
-    return _rhiTexture && _rhiTexture->getTextureUsage() == rhi::TextureUsage::RENDER_TARGET;
-}
-
-bool Texture2D::updateSubData(const void* data, int offsetX, int offsetY, int width, int height, int level, int layerIndex)
-{
-    if (_rhiTexture && width > 0 && height > 0)
-    {
-        // updateSubData must be called with the same pixel format as the original pixel format
-        assert(_rhiTexture->getPixelFormat() == _originalPF);
-        _rhiTexture->updateSubData(offsetX, offsetY, width, height, level, data, layerIndex);
-        return true;
-    }
-    return false;
 }
 
 // implementation Texture2D (Text)
@@ -434,70 +434,154 @@ bool Texture2D::initWithString(std::string_view text, const FontDefinition& text
     if (text.empty())
         return false;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // cache the texture data
     VolatileTextureMgr::addStringTexture(this, text, textDefinition);
 #endif
 
-    bool ret = false;
-    Device::TextAlign align;
-
-    if (TextVAlignment::TOP == textDefinition._vertAlignment)
-    {
-        align = (TextHAlignment::CENTER == textDefinition._alignment) ? Device::TextAlign::TOP
-                : (TextHAlignment::LEFT == textDefinition._alignment) ? Device::TextAlign::TOP_LEFT
-                                                                      : Device::TextAlign::TOP_RIGHT;
-    }
-    else if (TextVAlignment::CENTER == textDefinition._vertAlignment)
-    {
-        align = (TextHAlignment::CENTER == textDefinition._alignment) ? Device::TextAlign::CENTER
-                : (TextHAlignment::LEFT == textDefinition._alignment) ? Device::TextAlign::LEFT
-                                                                      : Device::TextAlign::RIGHT;
-    }
-    else if (TextVAlignment::BOTTOM == textDefinition._vertAlignment)
-    {
-        align = (TextHAlignment::CENTER == textDefinition._alignment) ? Device::TextAlign::BOTTOM
-                : (TextHAlignment::LEFT == textDefinition._alignment) ? Device::TextAlign::BOTTOM_LEFT
-                                                                      : Device::TextAlign::BOTTOM_RIGHT;
-    }
-    else
-    {
-        AXASSERT(false, "Not supported alignment format!");
-        return false;
-    }
-
-#if (AX_TARGET_PLATFORM != AX_PLATFORM_ANDROID) && (AX_TARGET_PLATFORM != AX_PLATFORM_IOS)
-    AXASSERT(textDefinition._stroke._strokeEnabled == false, "Currently stroke only supported on iOS and Android!");
-#endif
-
-    int imageWidth;
-    int imageHeight;
-    auto textDef            = textDefinition;
-    auto contentScaleFactor = AX_CONTENT_SCALE_FACTOR();
-    textDef._fontSize *= contentScaleFactor;
-    textDef._dimensions.width *= contentScaleFactor;
-    textDef._dimensions.height *= contentScaleFactor;
-    textDef._stroke._strokeSize *= contentScaleFactor;
-    textDef._shadow._shadowEnabled = false;
-
-    bool hasPremultipliedAlpha;
-    Data outData = Device::getTextureDataForText(text, textDef, align, imageWidth, imageHeight, hasPremultipliedAlpha);
-    if (outData.isNull())
+    Data outData;
+    int imageWidth, imageHeight;
+    bool premultipliedAlpha{false};
+    if (!createStringTextureData(text, textDefinition, outData, imageWidth, imageHeight, premultipliedAlpha))
         return false;
 
-    const auto maxTextureSize = rhi::DriverBase::getInstance()->getMaxTextureSize();
-    if (imageWidth > maxTextureSize || imageHeight > maxTextureSize)
-    {
-        AXLOGW("Texture2D::initWithString fail, the texture size:{}x{} too large, max texture size:{}", imageWidth,
-               imageHeight, maxTextureSize);
-        return false;
-    }
-
-    Vec2 imageSize = Vec2((float)imageWidth, (float)imageHeight);
     const PixelFormat pixelFormat = PixelFormat::RGBA8;
 
     return initWithData(outData.getBytes(), imageWidth * imageHeight * 4, pixelFormat, imageWidth, imageHeight,
-                       hasPremultipliedAlpha);
+                        premultipliedAlpha);
+}
+
+bool Texture2D::updateData(std::string_view text, const FontDefinition& textDefinition) {
+    if (text.empty())
+        return false;
+
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
+    // cache the texture data
+    VolatileTextureMgr::addStringTexture(this, text, textDefinition);
+#endif
+
+   Data outData;
+    int imageWidth, imageHeight;
+    bool premultipliedAlpha{false};
+    if (!createStringTextureData(text, textDefinition, outData, imageWidth, imageHeight, premultipliedAlpha))
+        return false;
+
+    TextureSliceData subDatas[] = {
+        {outData.getBytes(), (uint32_t)(imageWidth * imageHeight * 4), 0, 0}  // layerIndex = 0, mipLevel = 0
+    };
+
+    return updateData(subDatas);
+}
+
+bool Texture2D::updateData(Image* image)
+{
+    if (!_rhiTexture) [[unlikely]]
+        return false;
+
+    if (image->getNumberOfMipmaps() > 1)
+    {
+        auto mipmaps = image->getMipmaps();
+        return updateData(reinterpret_cast<std::span<TextureSliceData>&>(mipmaps));
+    }
+    else
+    {
+        TextureSliceData subDatas[] = {{image->getData(), (uint32_t)image->getDataSize(), 0, 0}};
+        return updateData(subDatas);
+    }
+}
+
+bool Texture2D::updateData(std::span<TextureSliceData> subDatas) {
+    if (!_rhiTexture)[[unlikely]]
+        return false;
+
+    const auto renderFormat = _rhiTexture->getPixelFormat();
+    updateData(subDatas, _rhiTexture->getPixelFormat(), rhi::RHIUtils::isCompressed(renderFormat));
+    return true;
+}
+
+void Texture2D::updateData(std::span<TextureSliceData> subDatas, PixelFormat renderFormat, bool compressed)
+{
+    for (auto& subres : subDatas)
+    {
+        auto width  = (std::max)(1, _pixelsWide >> subres.mipLevel);
+        auto height = (std::max)(1, _pixelsHigh >> subres.mipLevel);
+
+        if (!subres.data) [[unlikely]]
+        {
+            // uncompressed pixel data can be nullptr for initializing texture storage purpose
+            if (!compressed)
+                _rhiTexture->updateData(nullptr, width, height, subres.mipLevel, subres.layerIndex);
+            continue;
+        }
+
+        uint8_t* convertedData{nullptr};
+        size_t convertedDataLen{0};
+
+        const void* pixelData{nullptr};
+        size_t pixelDataSize{0};
+        if (_originalPF != renderFormat && !compressed)  // need conversion
+        {
+            auto convertedFormat =
+                rhi::RHIUtils::convertDataToFormat((const uint8_t*)subres.data, subres.dataSize, _originalPF,
+                                                   renderFormat, &convertedData, &convertedDataLen);
+            if (convertedFormat != renderFormat || !convertedData)
+            {
+                AXLOGE("PixelFormat convert fail");
+                continue;
+            }
+            pixelData     = convertedData;
+            pixelDataSize = convertedDataLen;
+        }
+        else
+        {
+            pixelData     = subres.data;
+            pixelDataSize = subres.dataSize;
+        }
+
+        if (compressed)
+            _rhiTexture->updateCompressedData(pixelData, width, height, pixelDataSize, subres.mipLevel,
+                                              subres.layerIndex);
+        else
+            _rhiTexture->updateData(pixelData, width, height, subres.mipLevel, subres.layerIndex);
+
+        if (convertedData)
+            free(convertedData);
+    }
+}
+
+bool Texture2D::updateData(const void* data, int width, int height, int level, int layerIndex)
+{
+    if (_rhiTexture && width > 0 && height > 0)
+    {
+        // updateData must be called with the same pixel format as the original pixel format
+        assert(_rhiTexture->getPixelFormat() == _originalPF);
+        _rhiTexture->updateData(data, width, height, level, layerIndex);
+        return true;
+    }
+    return false;
+}
+
+bool Texture2D::updateSubData(const void* data, int offsetX, int offsetY, int width, int height, int level, int layerIndex)
+{
+    if (_rhiTexture && width > 0 && height > 0)
+    {
+        // updateSubData must be called with the same pixel format as the original pixel format
+        assert(_rhiTexture->getPixelFormat() == _originalPF);
+        _rhiTexture->updateSubData(offsetX, offsetY, width, height, level, data, layerIndex);
+        return true;
+    }
+    return false;
+}
+
+void Texture2D::invalidate()
+{
+    if(_rhiTexture)
+        _rhiTexture->invalidate();
+}
+
+bool Texture2D::isRenderTarget() const
+{
+    return _rhiTexture && _rhiTexture->getTextureUsage() == rhi::TextureUsage::RENDER_TARGET;
 }
 
 bool Texture2D::hasMipmaps() const

--- a/axmol/renderer/Texture2D.cpp
+++ b/axmol/renderer/Texture2D.cpp
@@ -46,7 +46,7 @@ THE SOFTWARE.
 #include "axmol/rhi/DriverBase.h"
 #include "axmol/rhi/ProgramState.h"
 #include "axmol/renderer/Shaders.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 #include "axmol/renderer/Renderer.h"
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
@@ -69,9 +69,10 @@ rhi::SamplerDesc Texture2D::chooseSamplerDesc(bool antialiasEnabled, bool mipEna
 }
 
 Texture2D::Texture2D()
-    : _pixelFormat(rhi::PixelFormat::NONE)
+    : _originalPF(rhi::PixelFormat::AUTO)
     , _pixelsWide(0)
     , _pixelsHigh(0)
+    , _rhiTexture(nullptr)
     , _maxS(0.0)
     , _maxT(0.0)
     , _flags(TextureFlag::ANTIALIAS_ENABLED)
@@ -79,10 +80,6 @@ Texture2D::Texture2D()
     , _ninePatchInfo(nullptr)
     , _valid(true)
 {
-    rhi::TextureDesc textureDesc;
-    textureDesc.textureFormat = PixelFormat::NONE;
-    _texture =
-        static_cast<rhi::Texture*>(rhi::DriverBase::getInstance()->createTexture(textureDesc));
 }
 
 Texture2D::~Texture2D()
@@ -93,13 +90,13 @@ Texture2D::~Texture2D()
 
     AX_SAFE_DELETE(_ninePatchInfo);
 
-    AX_SAFE_RELEASE(_texture);
+    AX_SAFE_RELEASE(_rhiTexture);
     AX_SAFE_RELEASE(_programState);
 }
 
 rhi::PixelFormat Texture2D::getPixelFormat() const
 {
-    return _pixelFormat;
+    return _originalPF;
 }
 
 int Texture2D::getPixelsWide() const
@@ -114,7 +111,7 @@ int Texture2D::getPixelsHigh() const
 
 rhi::Texture* Texture2D::getBackendTexture() const
 {
-    return _texture;
+    return _rhiTexture;
 }
 
 Vec2 Texture2D::getContentSize() const
@@ -165,42 +162,21 @@ void Texture2D::setPremultipliedAlpha(bool premultipliedAlpha)
 }
 
 bool Texture2D::initWithData(const void* data,
-                             ssize_t dataLen,
+                             ssize_t dataSize,
                              rhi::PixelFormat pixelFormat,
                              rhi::PixelFormat renderFormat,
                              int pixelsWide,
                              int pixelsHigh,
                              bool preMultipliedAlpha)
 {
-    AXASSERT(dataLen > 0 && pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
+    AXASSERT(dataSize > 0 && pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
 
     // if data has no mipmaps, we will consider it has only one mipmap
-    MipmapInfo mipmap;
-    mipmap.address = (unsigned char*)data;
-    mipmap.len     = static_cast<int>(dataLen);
-    return initWithMipmaps(&mipmap, 1, pixelFormat, renderFormat, pixelsWide, pixelsHigh, preMultipliedAlpha);
+    MipmapInfo mipmaps[] = {MipmapInfo{.data = (void*)data, .dataSize = static_cast<uint32_t>(dataSize)}};
+    return initWithMipmaps(mipmaps, pixelFormat, renderFormat, pixelsWide, pixelsHigh, preMultipliedAlpha);
 }
 
-bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps,
-                                int mipmapsNum,
-                                rhi::PixelFormat pixelFormat,
-                                rhi::PixelFormat renderFormat,
-                                int pixelsWide,
-                                int pixelsHigh,
-                                bool preMultipliedAlpha)
-{
-    // the pixelFormat must be a certain value
-    updateWithMipmaps(mipmaps, mipmapsNum, pixelFormat, renderFormat, pixelsWide, pixelsHigh, preMultipliedAlpha);
-
-    return true;
-}
-
-bool Texture2D::updateWithImage(Image* image, int index)
-{
-    return updateWithImage(image, image->getPixelFormat(), index);
-}
-
-bool Texture2D::updateWithImage(Image* image, rhi::PixelFormat format, int index)
+bool Texture2D::initWithImage(Image* image, rhi::PixelFormat renderFormat)
 {
     if (image == nullptr)
     {
@@ -211,132 +187,81 @@ bool Texture2D::updateWithImage(Image* image, rhi::PixelFormat format, int index
     if (this->_filePath.empty())
         this->_filePath = image->getFilePath();
 
-    int imageWidth  = image->getWidth();
-    int imageHeight = image->getHeight();
-
-    Configuration* conf = Configuration::getInstance();
-
-    int maxTextureSize = conf->getMaxTextureSize();
-    if (imageWidth > maxTextureSize || imageHeight > maxTextureSize)
-    {
-        AXLOGW("axmol: WARNING: Image ({} x {}) is bigger than the supported {} x {}", imageWidth, imageHeight,
-              maxTextureSize, maxTextureSize);
-        return false;
-    }
-
-    unsigned char* tempData               = image->getData();
-    // Vec2 imageSize                        = Vec2((float)imageWidth, (float)imageHeight);
-    rhi::PixelFormat renderFormat     = (PixelFormat::NONE == format) ? image->getPixelFormat() : format;
-    rhi::PixelFormat imagePixelFormat = image->getPixelFormat();
-    size_t tempDataLen                    = image->getDataLen();
-
-#if AX_RENDER_API == AX_RENDER_API_MTL
-    //! override renderFormat, since some render format is not supported by metal
-    switch (renderFormat)
-    {
-#    if (AX_TARGET_PLATFORM != AX_PLATFORM_IOS || TARGET_OS_SIMULATOR)
-    // packed 16 bits pixels only available on iOS
-    case PixelFormat::RGB565:
-    case PixelFormat::RGB5A1:
-    case PixelFormat::RGBA4:
-#    endif
-    case PixelFormat::R8:
-    case PixelFormat::RG8:
-    case PixelFormat::RGB8:
-        // Note: conversion to RGBA8 will happends
-        renderFormat = PixelFormat::RGBA8;
-        break;
-    default:
-        break;
-    }
-#elif AX_RENDER_API == AX_RENDER_API_D3D
-    //! override renderFormat, since some render format is not supported by d3d
-    switch (renderFormat)
-    {
-    case PixelFormat::RGB8:
-        // Note: conversion to RGBA8 will happends
-        renderFormat = PixelFormat::RGBA8;
-        break;
-    default:
-        break;
-    }
-#endif
+    auto imagePixelFormat = image->getPixelFormat();
+    int imageWidth        = image->getWidth();
+    int imageHeight       = image->getHeight();
+    auto imageData        = image->getData();
+    auto imageDataSize    = image->getDataSize();
 
     if (image->getNumberOfMipmaps() > 1)
     {
-        if (renderFormat != imagePixelFormat)
-        {
-            AXLOGW("WARNING: This image has more than 1 mipmaps and we will not convert the data format");
-        }
-
         // pixel format of data is not converted, renderFormat can be different from pixelFormat
         // it will be done later
-        updateWithMipmaps(image->getMipmaps(), image->getNumberOfMipmaps(), imagePixelFormat, renderFormat, imageHeight, imageWidth, image->hasPremultipliedAlpha(), index);
+        initWithMipmaps(image->getMipmaps(),
+                        imagePixelFormat, renderFormat, imageHeight,
+                        imageWidth, image->hasPremultipliedAlpha());
     }
     else if (image->isCompressed())
     {  // !Only hardware support texture will be compression PixelFormat, otherwise, will convert to RGBA8 duraing image
        // load
-        renderFormat = imagePixelFormat;
-        updateWithData(tempData, tempDataLen, imagePixelFormat, image->getPixelFormat(), imageWidth, imageHeight, image->hasPremultipliedAlpha(), index);
+        initWithData(imageData, imageDataSize, imagePixelFormat, image->getPixelFormat(), imageWidth, imageHeight,
+                     image->hasPremultipliedAlpha());
     }
     else
     {
         // after conversion, renderFormat == pixelFormat of data
-        updateWithData(tempData, tempDataLen, imagePixelFormat, renderFormat, imageWidth, imageHeight,
-                       image->hasPremultipliedAlpha(), index);
+        initWithData(imageData, imageDataSize, imagePixelFormat, renderFormat, imageWidth, imageHeight,
+                     image->hasPremultipliedAlpha());
     }
 
     return true;
 }
 
-bool Texture2D::updateWithData(const void* data,
-                               ssize_t dataLen,
-                               rhi::PixelFormat pixelFormat,
-                               rhi::PixelFormat renderFormat,
-                               int pixelsWide,
-                               int pixelsHigh,
-                               bool preMultipliedAlpha,
-                               int index)
-{
-    AXASSERT(dataLen > 0 && pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
-
-    // if data has no mipmaps, we will consider it has only one mipmap
-    MipmapInfo mipmap;
-    mipmap.address = (unsigned char*)data;
-    mipmap.len     = static_cast<int>(dataLen);
-    return updateWithMipmaps(&mipmap, 1, pixelFormat, renderFormat, pixelsWide, pixelsHigh, preMultipliedAlpha, index);
-}
-
-bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
-                                  int mipmapsNum,
+bool Texture2D::initWithMipmaps(std::span<MipmapInfo> mipmaps,
                                   rhi::PixelFormat pixelFormat,
                                   rhi::PixelFormat renderFormat,
                                   int pixelsWide,
                                   int pixelsHigh,
-                                  bool preMultipliedAlpha,
-                                  int index)
+                                  bool preMultipliedAlpha)
 {
-    // the pixelFormat must be a certain value
-    AXASSERT(pixelFormat != PixelFormat::NONE, "the \"pixelFormat\" param must be a certain value!");
-    AXASSERT(pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
 
-    if (mipmapsNum <= 0)
-    {
-        AXLOGW("WARNING: mipmap number is less than 1");
-        return false;
-    }
+    rhi::TextureDesc desc;
 
-    auto& pfd = rhi::PixelFormatUtils::getFormatDesc(pixelFormat);
+    desc.width = pixelsWide;
+    desc.height = pixelsHigh;
+    desc.pixelFormat = pixelFormat;
+    desc.mipLevels   = mipmaps.size();
+    desc.samplerDesc = chooseSamplerDesc(true, desc.mipLevels > 1);
+
+    return initWithSpec(desc, (std::span<TextureSliceData>&)mipmaps, renderFormat, preMultipliedAlpha);
+}
+
+bool Texture2D::initWithSpec(rhi::TextureDesc desc,
+                             std::span<TextureSliceData> subDatas,
+                             PixelFormat renderFormat,
+                             bool preMultipliedAlpha)
+{
+    if (renderFormat == rhi::PixelFormat::AUTO)
+        renderFormat = desc.pixelFormat;
+
+    AXASSERT(desc.pixelFormat != rhi::PixelFormat::AUTO && renderFormat != rhi::PixelFormat::AUTO,
+             "PixelFormat should not be Auto");
+    AXASSERT(desc.width > 0 && desc.height > 0, "Invalid size");
+
+    if (_rhiTexture)
+        return true;
+
+    auto& pfd = rhi::RHIUtils::getFormatDesc(desc.pixelFormat);
     if (!pfd.bpp)
     {
-        AXLOGW("WARNING: unsupported pixelformat: {:x}", (uint32_t)pixelFormat);
+        AXLOGW("WARNING: unsupported pixelformat: {:x}", (uint32_t)desc.pixelFormat);
 #if AX_RENDER_API == AX_RENDER_API_MTL
         AXASSERT(false, "pixeformat not found in _pixelFormatInfoTables, register required!");
 #endif
         return false;
     }
 
-    bool compressed = rhi::PixelFormatUtils::isCompressed(pixelFormat);
+    bool compressed = rhi::RHIUtils::isCompressed(desc.pixelFormat);
 
     if (compressed && !Configuration::getInstance()->supportsPVRTC() && !Configuration::getInstance()->supportsETC1() &&
         !Configuration::getInstance()->supportsETC2() && !Configuration::getInstance()->supportsS3TC() &&
@@ -350,124 +275,112 @@ bool Texture2D::updateWithMipmaps(MipmapInfo* mipmaps,
     VolatileTextureMgr::getOrAddVolatileTexture(this);
 #endif
 
-    rhi::TextureDesc textureDesc;
-    textureDesc.width  = pixelsWide;
-    textureDesc.height = pixelsHigh;
-
-    textureDesc.samplerDesc = chooseSamplerDesc(_flags & TextureFlag::ANTIALIAS_ENABLED, mipmapsNum > 1);
-
-    int width                           = pixelsWide;
-    int height                          = pixelsHigh;
-    rhi::PixelFormat oriPixelFormat = pixelFormat;
-    for (int i = 0; i < mipmapsNum; ++i)
+    // !override renderFormat since some render format by RHI
+    #if AX_RENDER_API == AX_RENDER_API_MTL
+    switch (renderFormat)
     {
-        unsigned char* data    = mipmaps[i].address;
-        size_t dataLen         = mipmaps[i].len;
-        unsigned char* outData = data;
-        size_t outDataLen      = dataLen;
-
-        if (renderFormat != oriPixelFormat && !compressed)  // need conversion
-        {
-            auto convertedFormat = rhi::PixelFormatUtils::convertDataToFormat(data, dataLen, oriPixelFormat,
-                                                                                  renderFormat, &outData, &outDataLen);
-#if AX_RENDER_API == AX_RENDER_API_MTL
-            AXASSERT(convertedFormat == renderFormat, "PixelFormat convert failed!");
+#    if (AX_TARGET_PLATFORM != AX_PLATFORM_IOS || TARGET_OS_SIMULATOR)
+    // packed 16 bits pixels only available on iOS
+    case PixelFormat::RGB565:
+    case PixelFormat::RGB5A1:
+    case PixelFormat::RGBA4:
+#    endif
+    case PixelFormat::RGB8:
+        // Note: conversion to RGBA8 will happends
+        renderFormat = PixelFormat::RGBA8;
+        break;
+    default:
+        break;
+    }
+#elif AX_RENDER_API == AX_RENDER_API_D3D
+    switch (renderFormat)
+    {
+    case PixelFormat::RGB8:
+        // Note: conversion to RGBA8 will happends
+        renderFormat = PixelFormat::RGBA8;
+        break;
+    default:
+        break;
+    }
 #endif
-            if (convertedFormat == renderFormat)
-                pixelFormat = renderFormat;
-        }
 
-        textureDesc.textureFormat = pixelFormat;
-        AXASSERT(textureDesc.textureFormat != rhi::PixelFormat::NONE, "PixelFormat should not be NONE");
+    _originalPF      = desc.pixelFormat;
+    _contentSize = Vec2((float)desc.width, (float)desc.height);
+    _pixelsWide  = desc.width;
+    _pixelsHigh  = desc.height;
+    _maxS        = 1;
+    _maxT        = 1;
 
-        if (_texture->getTextureFormat() != textureDesc.textureFormat)
-            _texture->updateTextureDesc(textureDesc, index);
+    desc.pixelFormat = renderFormat;
+    _rhiTexture = static_cast<rhi::Texture*>(rhi::DriverBase::getInstance()->createTexture(desc));
 
-        if (compressed)
+    for (auto& subres : subDatas)
+    {
+        if (!subres.data)
+            continue;
+
+        auto width  = (std::max)(1, _pixelsWide >> subres.mipLevel);
+        auto height = (std::max)(1, _pixelsHigh >> subres.mipLevel);
+
+        uint8_t* convertedData{nullptr};
+        size_t convertedDataLen{0};
+
+        const void* pixelData{nullptr};
+        size_t pixelDataSize{0};
+        if (_originalPF != renderFormat && !compressed)  // need conversion
         {
-            _texture->updateCompressedData(data, width, height, dataLen, i, index);
+            auto convertedFormat =
+                rhi::RHIUtils::convertDataToFormat((const uint8_t*)subres.data, subres.dataSize, _originalPF,
+                                                           renderFormat, &convertedData, &convertedDataLen);
+            if (convertedFormat != renderFormat || !convertedData)
+            {
+                AXLOGE("PixelFormat convert fail");
+                continue;
+            }
+            pixelData      = convertedData;
+            pixelDataSize = convertedDataLen;
         }
         else
         {
-            _texture->updateData(outData, width, height, i, index);
+            pixelData = subres.data;
+            pixelDataSize = subres.dataSize;
         }
 
-        if (outData && outData != data && outDataLen > 0)
-        {
-            free(outData);
-            outData    = nullptr;
-            outDataLen = 0;
-        }
+        if (compressed)
+            _rhiTexture->updateCompressedData(pixelData, width, height, pixelDataSize, subres.mipLevel,
+                                              subres.layerIndex);
+        else
+            _rhiTexture->updateData(pixelData, width, height, subres.mipLevel, subres.layerIndex);
 
-        if (i > 0 && (width != height || utils::nextPOT(width) != width))
-        {
-            AXLOGW(
-                "Texture2D. WARNING. Mipmap level {} is not squared. Texture won't render correctly. width={} "
-                "!= height={}",
-                i, width, height);
-        }
-
-        width  = MAX(width >> 1, 1);
-        height = MAX(height >> 1, 1);
+        if (convertedData)
+            free(convertedData);
     }
 
-    if (index == 0)
-    {
-        _contentSize = Vec2((float)pixelsWide, (float)pixelsHigh);
-        _pixelsWide  = pixelsWide;
-        _pixelsHigh  = pixelsHigh;
-        _pixelFormat = pixelFormat;
-        _maxS        = 1;
-        _maxT        = 1;
-
-        setPremultipliedAlpha(preMultipliedAlpha);
-    }
-
-    // pitfall: we do merge RGB+A at at dual sampler shader, so must mark as _hasPremultipliedAlpha = true to makesure
-    // alpha blend works well.
-    if (index > 0)
+    if (desc.arraySize == 2)
     {
         setPremultipliedAlpha(Image::isCompressedImageHavePMA(Image::CompressedImagePMAFlag::DUAL_SAMPLER));
         _samplerFlags |= TextureSamplerFlag::DUAL_SAMPLER;
     }
+    else
+    {
+        setPremultipliedAlpha(preMultipliedAlpha);
+    }
+
+    setRenderTarget(desc.textureUsage == TextureUsage::RENDER_TARGET);
 
     return true;
 }
 
-bool Texture2D::updateWithSubData(void* data, int offsetX, int offsetY, int width, int height, int index)
+bool Texture2D::updateWithSubData(const void* data, int offsetX, int offsetY, int width, int height, int level, int layerIndex)
 {
-    if (_texture && width > 0 && height > 0)
+    if (_rhiTexture && width > 0 && height > 0)
     {
-        uint8_t* textureData = static_cast<uint8_t*>(data);
-        _texture->updateSubData(offsetX, offsetY, width, height, 0, textureData, index);
+        // updateWithSubData must be called with the same pixel format as the original pixel format
+        assert(_rhiTexture->getPixelFormat() == _originalPF);
+        _rhiTexture->updateSubData(offsetX, offsetY, width, height, level, data, layerIndex);
         return true;
     }
     return false;
-}
-
-// implementation Texture2D (Image)
-bool Texture2D::initWithImage(Image* image)
-{
-    if (image == nullptr)
-    {
-        AXLOGW("Texture2D. Can't create Texture. UIImage is nil");
-        return false;
-    }
-
-    return initWithImage(image, image->getPixelFormat());
-}
-
-bool Texture2D::initWithImage(Image* image, rhi::PixelFormat format)
-{
-    if (image == nullptr)
-    {
-        AXLOGW("Texture2D. Can't create Texture. UIImage is nil");
-        return false;
-    }
-
-    this->_filePath = image->getFilePath();
-
-    return updateWithImage(image, format);
 }
 
 // implementation Texture2D (Text)
@@ -571,19 +484,19 @@ bool Texture2D::initWithString(std::string_view text, const FontDefinition& text
     return ret;
 }
 
-bool Texture2D::updateTextureDesc(const rhi::TextureDesc& descriptor, bool preMultipliedAlpha)
+bool Texture2D::updateTextureDesc(const rhi::TextureDesc& desc, bool preMultipliedAlpha)
 {
-    AX_ASSERT(_texture);
+    AX_ASSERT(_rhiTexture);
 
-    _texture->updateTextureDesc(descriptor);
-    _pixelsWide = _contentSize.width = _texture->getWidth();
-    _pixelsHigh = _contentSize.height = _texture->getHeight();
+    _rhiTexture->updateTextureDesc(desc);
+    _pixelsWide = _contentSize.width = _rhiTexture->getWidth();
+    _pixelsHigh = _contentSize.height = _rhiTexture->getHeight();
     setPremultipliedAlpha(preMultipliedAlpha);
 
-    setRenderTarget(descriptor.textureUsage == TextureUsage::RENDER_TARGET);
+    setRenderTarget(desc.textureUsage == TextureUsage::RENDER_TARGET);
 
-    if (_pixelFormat == PixelFormat::NONE)
-        _pixelFormat = descriptor.textureFormat;
+    if (_originalPF == PixelFormat::AUTO)
+        _originalPF = desc.pixelFormat;
 
     return true;
 }
@@ -598,7 +511,7 @@ void Texture2D::setRenderTarget(bool renderTarget)
 
 bool Texture2D::hasMipmaps() const
 {
-    return _texture->hasMipmaps();
+    return _rhiTexture->hasMipmaps();
 }
 
 void Texture2D::setAliasTexParameters()
@@ -611,8 +524,8 @@ void Texture2D::setAliasTexParameters()
 
     _flags &= ~TextureFlag::ANTIALIAS_ENABLED;
 
-    const auto desc = chooseSamplerDesc(false, _texture->hasMipmaps());
-    _texture->updateSamplerDesc(desc);
+    const auto desc = chooseSamplerDesc(false, _rhiTexture->hasMipmaps());
+    _rhiTexture->updateSamplerDesc(desc);
 }
 
 void Texture2D::setAntiAliasTexParameters()
@@ -624,23 +537,23 @@ void Texture2D::setAntiAliasTexParameters()
     }
     _flags |= TextureFlag::ANTIALIAS_ENABLED;
 
-    const auto desc = chooseSamplerDesc(true, _texture->hasMipmaps());
-    _texture->updateSamplerDesc(desc);
+    const auto desc = chooseSamplerDesc(true, _rhiTexture->hasMipmaps());
+    _rhiTexture->updateSamplerDesc(desc);
 }
 
 const char* Texture2D::getStringForFormat() const
 {
-    return rhi::PixelFormatUtils::getFormatDesc(_pixelFormat).name;
+    return rhi::RHIUtils::getFormatDesc(_originalPF).name;
 }
 
 unsigned int Texture2D::getBitsPerPixelForFormat(rhi::PixelFormat format) const
 {
-    return rhi::PixelFormatUtils::getFormatDesc(format).bpp;
+    return rhi::RHIUtils::getFormatDesc(format).bpp;
 }
 
 unsigned int Texture2D::getBitsPerPixelForFormat() const
 {
-    return getBitsPerPixelForFormat(_pixelFormat);
+    return getBitsPerPixelForFormat(_originalPF);
 }
 
 void Texture2D::addSpriteFrameCapInset(SpriteFrame* spritframe, const Rect& capInsets)
@@ -700,7 +613,7 @@ void Texture2D::removeSpriteFrameCapInset(SpriteFrame* spriteFrame)
 
 void Texture2D::setTexParameters(const Texture2D::TexParams& desc)
 {
-    _texture->updateSamplerDesc(desc);
+    _rhiTexture->updateSamplerDesc(desc);
 }
 
 void Texture2D::generateMipmap()
@@ -708,7 +621,7 @@ void Texture2D::generateMipmap()
     AXASSERT(_pixelsWide == utils::nextPOT(_pixelsWide) && _pixelsHigh == utils::nextPOT(_pixelsHigh),
              "Mipmap texture only works in POT textures");
 
-    _texture->generateMipmaps();
+    _rhiTexture->generateMipmaps();
 }
 
 void Texture2D::initProgram()
@@ -746,7 +659,7 @@ void Texture2D::initProgram()
     blendDesc.sourceRGBBlendFactor = blendDesc.sourceAlphaBlendFactor = blendFunc.src;
     blendDesc.destinationRGBBlendFactor = blendDesc.destinationAlphaBlendFactor = blendFunc.dst;
 
-    _programState->setTexture(_textureLocation, 0, _texture);
+    _programState->setTexture(_textureLocation, 0, _rhiTexture);
 }
 
 void Texture2D::drawAtPoint(const Vec2& point, float globalZOrder)

--- a/axmol/renderer/Texture2D.cpp
+++ b/axmol/renderer/Texture2D.cpp
@@ -88,7 +88,6 @@ Texture2D::Texture2D()
     , _flags(TextureFlag::ANTIALIAS_ENABLED)
     , _samplerFlags(TextureSamplerFlag::DEFAULT)
     , _ninePatchInfo(nullptr)
-    , _valid(true)
 {
 }
 
@@ -373,7 +372,7 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
             free(convertedData);
     }
 
-    if (desc.arraySize == 2)
+    if (desc.arraySize == 2 && _originalPF == PixelFormat::ETC1)
     {
         setPremultipliedAlpha(Image::isCompressedImageHavePMA(Image::CompressedImagePMAFlag::DUAL_SAMPLER));
         _samplerFlags |= TextureSamplerFlag::DUAL_SAMPLER;
@@ -383,16 +382,19 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
         setPremultipliedAlpha(preMultipliedAlpha);
     }
 
-    setRenderTarget(desc.textureUsage == TextureUsage::RENDER_TARGET);
-
     return true;
 }
 
-bool Texture2D::updateWithSubData(const void* data, int offsetX, int offsetY, int width, int height, int level, int layerIndex)
+bool Texture2D::isRenderTarget() const
+{
+    return _rhiTexture && _rhiTexture->getTextureUsage() == rhi::TextureUsage::RENDER_TARGET;
+}
+
+bool Texture2D::updateSubData(const void* data, int offsetX, int offsetY, int width, int height, int level, int layerIndex)
 {
     if (_rhiTexture && width > 0 && height > 0)
     {
-        // updateWithSubData must be called with the same pixel format as the original pixel format
+        // updateSubData must be called with the same pixel format as the original pixel format
         assert(_rhiTexture->getPixelFormat() == _originalPF);
         _rhiTexture->updateSubData(offsetX, offsetY, width, height, level, data, layerIndex);
         return true;
@@ -494,36 +496,8 @@ bool Texture2D::initWithString(std::string_view text, const FontDefinition& text
     Vec2 imageSize = Vec2((float)imageWidth, (float)imageHeight);
     const PixelFormat pixelFormat = PixelFormat::RGBA8;
 
-    ret = initWithData(outData.getBytes(), imageWidth * imageHeight * 4, pixelFormat, imageWidth, imageHeight);
-
-    setPremultipliedAlpha(hasPremultipliedAlpha);
-
-    return ret;
-}
-
-bool Texture2D::updateTextureDesc(const rhi::TextureDesc& desc, bool preMultipliedAlpha)
-{
-    AX_ASSERT(_rhiTexture);
-
-    _rhiTexture->updateTextureDesc(desc);
-    _pixelsWide = _contentSize.width = _rhiTexture->getWidth();
-    _pixelsHigh = _contentSize.height = _rhiTexture->getHeight();
-    setPremultipliedAlpha(preMultipliedAlpha);
-
-    setRenderTarget(desc.textureUsage == TextureUsage::RENDER_TARGET);
-
-    if (_originalPF == PixelFormat::NONE)
-        _originalPF = desc.pixelFormat;
-
-    return true;
-}
-
-void Texture2D::setRenderTarget(bool renderTarget)
-{
-    if (renderTarget)
-        _flags |= TextureFlag::RENDERTARGET;
-    else
-        _flags &= TextureFlag::RENDERTARGET;
+    return initWithData(outData.getBytes(), imageWidth * imageHeight * 4, pixelFormat, imageWidth, imageHeight,
+                       hasPremultipliedAlpha);
 }
 
 bool Texture2D::hasMipmaps() const
@@ -533,7 +507,6 @@ bool Texture2D::hasMipmaps() const
 
 void Texture2D::setAliasTexParameters()
 {
-
     if ((_flags & TextureFlag::ANTIALIAS_ENABLED) == 0)
     {
         return;
@@ -548,7 +521,6 @@ void Texture2D::setAliasTexParameters()
 
 void Texture2D::setAntiAliasTexParameters()
 {
-
     if (_flags & TextureFlag::ANTIALIAS_ENABLED)
     {
         return;

--- a/axmol/renderer/Texture2D.cpp
+++ b/axmol/renderer/Texture2D.cpp
@@ -372,7 +372,7 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
             free(convertedData);
     }
 
-    if (desc.arraySize == 2 && _originalPF == PixelFormat::ETC1)
+    if (desc.arraySize == 2)
     {
         setPremultipliedAlpha(Image::isCompressedImageHavePMA(Image::CompressedImagePMAFlag::DUAL_SAMPLER));
         _samplerFlags |= TextureSamplerFlag::DUAL_SAMPLER;

--- a/axmol/renderer/Texture2D.cpp
+++ b/axmol/renderer/Texture2D.cpp
@@ -56,20 +56,30 @@ THE SOFTWARE.
 namespace ax
 {
 
-rhi::SamplerDesc Texture2D::chooseSamplerDesc(bool antialiasEnabled, bool mipEnabled)
+void Texture2D::chooseSamplerDesc(bool antialiasEnabled, bool mipEnabled, rhi::SamplerDesc& desc)
 {
-    return antialiasEnabled ? rhi::SamplerDesc{.minFilter = rhi::SamplerFilter::MIN_LINEAR,
-                                               .magFilter = rhi::SamplerFilter::MAG_LINEAR,
-                                               .mipFilter = mipEnabled ? rhi::SamplerFilter::MIP_LINEAR
-                                                                       : rhi::SamplerFilter::MIP_NONE}
-                            : rhi::SamplerDesc{.minFilter = rhi::SamplerFilter::MIN_NEAREST,
-                                               .magFilter = rhi::SamplerFilter::MAG_NEAREST,
-                                               .mipFilter = mipEnabled ? rhi::SamplerFilter::MIP_NEAREST
-                                                                       : rhi::SamplerFilter::MIP_NONE};
+    if (antialiasEnabled)
+    {
+        desc.minFilter = rhi::SamplerFilter::MIN_LINEAR;
+        desc.magFilter = rhi::SamplerFilter::MAG_LINEAR;
+    }
+    else
+    {
+        desc.minFilter = rhi::SamplerFilter::MIN_NEAREST;
+        desc.magFilter = rhi::SamplerFilter::MAG_NEAREST;
+    }
+
+    if (mipEnabled)
+    {
+        if(desc.mipFilter == rhi::SamplerFilter::MIP_DEFAULT)
+            desc.mipFilter = antialiasEnabled ? rhi::SamplerFilter::MIP_LINEAR : rhi::SamplerFilter::MIP_NEAREST;
+    }
+    else
+        desc.mipFilter = rhi::SamplerFilter::MIP_DEFAULT;
 }
 
 Texture2D::Texture2D()
-    : _originalPF(rhi::PixelFormat::AUTO)
+    : _originalPF(rhi::PixelFormat::NONE)
     , _pixelsWide(0)
     , _pixelsHigh(0)
     , _rhiTexture(nullptr)
@@ -109,7 +119,7 @@ int Texture2D::getPixelsHigh() const
     return _pixelsHigh;
 }
 
-rhi::Texture* Texture2D::getBackendTexture() const
+rhi::Texture* Texture2D::getRHITexture() const
 {
     return _rhiTexture;
 }
@@ -161,22 +171,7 @@ void Texture2D::setPremultipliedAlpha(bool premultipliedAlpha)
         _flags &= ~TextureFlag::PREMULTIPLIEDALPHA;
 }
 
-bool Texture2D::initWithData(const void* data,
-                             ssize_t dataSize,
-                             rhi::PixelFormat pixelFormat,
-                             rhi::PixelFormat renderFormat,
-                             int pixelsWide,
-                             int pixelsHigh,
-                             bool preMultipliedAlpha)
-{
-    AXASSERT(dataSize > 0 && pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
-
-    // if data has no mipmaps, we will consider it has only one mipmap
-    MipmapInfo mipmaps[] = {MipmapInfo{.data = (void*)data, .dataSize = static_cast<uint32_t>(dataSize)}};
-    return initWithMipmaps(mipmaps, pixelFormat, renderFormat, pixelsWide, pixelsHigh, preMultipliedAlpha);
-}
-
-bool Texture2D::initWithImage(Image* image, rhi::PixelFormat renderFormat)
+bool Texture2D::initWithImage(Image* image, rhi::PixelFormat renderFormat, bool autoGenMipmaps)
 {
     if (image == nullptr)
     {
@@ -204,17 +199,41 @@ bool Texture2D::initWithImage(Image* image, rhi::PixelFormat renderFormat)
     else if (image->isCompressed())
     {  // !Only hardware support texture will be compression PixelFormat, otherwise, will convert to RGBA8 duraing image
        // load
-        initWithData(imageData, imageDataSize, imagePixelFormat, image->getPixelFormat(), imageWidth, imageHeight,
-                     image->hasPremultipliedAlpha());
+        initWithData(imageData, imageDataSize, imagePixelFormat, imagePixelFormat, imageWidth, imageHeight,
+                     image->hasPremultipliedAlpha(), autoGenMipmaps);
     }
     else
     {
         // after conversion, renderFormat == pixelFormat of data
         initWithData(imageData, imageDataSize, imagePixelFormat, renderFormat, imageWidth, imageHeight,
-                     image->hasPremultipliedAlpha());
+                     image->hasPremultipliedAlpha(), autoGenMipmaps);
     }
 
     return true;
+}
+
+bool Texture2D::initWithData(const void* data,
+                             ssize_t dataSize,
+                             rhi::PixelFormat pixelFormat,
+                             rhi::PixelFormat renderFormat,
+                             int pixelsWide,
+                             int pixelsHigh,
+                             bool preMultipliedAlpha,
+                             bool autoGenMipmaps)
+{
+    AXASSERT(dataSize > 0 && pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
+
+    rhi::TextureDesc desc;
+
+    desc.width       = pixelsWide;
+    desc.height      = pixelsHigh;
+    desc.pixelFormat = pixelFormat;
+
+    if (autoGenMipmaps)
+        desc.mipLevels = 0;  // generate mipmaps by GPU
+
+    TextureSliceData subDatas[] = {data, (uint32_t)dataSize, 0, 0};  // layerIndex = 0, mipLevel = 0
+    return initWithSpec(desc, subDatas, renderFormat, preMultipliedAlpha);
 }
 
 bool Texture2D::initWithMipmaps(std::span<MipmapInfo> mipmaps,
@@ -231,8 +250,6 @@ bool Texture2D::initWithMipmaps(std::span<MipmapInfo> mipmaps,
     desc.height = pixelsHigh;
     desc.pixelFormat = pixelFormat;
     desc.mipLevels   = mipmaps.size();
-    desc.samplerDesc = chooseSamplerDesc(true, desc.mipLevels > 1);
-
     return initWithSpec(desc, (std::span<TextureSliceData>&)mipmaps, renderFormat, preMultipliedAlpha);
 }
 
@@ -241,10 +258,10 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
                              PixelFormat renderFormat,
                              bool preMultipliedAlpha)
 {
-    if (renderFormat == rhi::PixelFormat::AUTO)
+    if (renderFormat == rhi::PixelFormat::NONE)
         renderFormat = desc.pixelFormat;
 
-    AXASSERT(desc.pixelFormat != rhi::PixelFormat::AUTO && renderFormat != rhi::PixelFormat::AUTO,
+    AXASSERT(desc.pixelFormat != rhi::PixelFormat::NONE && renderFormat != rhi::PixelFormat::NONE,
              "PixelFormat should not be Auto");
     AXASSERT(desc.width > 0 && desc.height > 0, "Invalid size");
 
@@ -312,16 +329,16 @@ bool Texture2D::initWithSpec(rhi::TextureDesc desc,
     _maxT        = 1;
 
     desc.pixelFormat = renderFormat;
+
+    chooseSamplerDesc(true, desc.mipLevels != 1, desc.samplerDesc);
     _rhiTexture = static_cast<rhi::Texture*>(rhi::DriverBase::getInstance()->createTexture(desc));
 
     for (auto& subres : subDatas)
     {
         if (!subres.data)
             continue;
-
         auto width  = (std::max)(1, _pixelsWide >> subres.mipLevel);
         auto height = (std::max)(1, _pixelsHigh >> subres.mipLevel);
-
         uint8_t* convertedData{nullptr};
         size_t convertedDataLen{0};
 
@@ -495,7 +512,7 @@ bool Texture2D::updateTextureDesc(const rhi::TextureDesc& desc, bool preMultipli
 
     setRenderTarget(desc.textureUsage == TextureUsage::RENDER_TARGET);
 
-    if (_originalPF == PixelFormat::AUTO)
+    if (_originalPF == PixelFormat::NONE)
         _originalPF = desc.pixelFormat;
 
     return true;
@@ -524,7 +541,8 @@ void Texture2D::setAliasTexParameters()
 
     _flags &= ~TextureFlag::ANTIALIAS_ENABLED;
 
-    const auto desc = chooseSamplerDesc(false, _rhiTexture->hasMipmaps());
+    rhi::SamplerDesc desc;
+    chooseSamplerDesc(false, _rhiTexture->hasMipmaps(), desc);
     _rhiTexture->updateSamplerDesc(desc);
 }
 
@@ -537,7 +555,8 @@ void Texture2D::setAntiAliasTexParameters()
     }
     _flags |= TextureFlag::ANTIALIAS_ENABLED;
 
-    const auto desc = chooseSamplerDesc(true, _rhiTexture->hasMipmaps());
+    rhi::SamplerDesc desc;
+    chooseSamplerDesc(true, _rhiTexture->hasMipmaps(), desc);
     _rhiTexture->updateSamplerDesc(desc);
 }
 
@@ -614,14 +633,6 @@ void Texture2D::removeSpriteFrameCapInset(SpriteFrame* spriteFrame)
 void Texture2D::setTexParameters(const Texture2D::TexParams& desc)
 {
     _rhiTexture->updateSamplerDesc(desc);
-}
-
-void Texture2D::generateMipmap()
-{
-    AXASSERT(_pixelsWide == utils::nextPOT(_pixelsWide) && _pixelsHigh == utils::nextPOT(_pixelsHigh),
-             "Mipmap texture only works in POT textures");
-
-    _rhiTexture->generateMipmaps();
 }
 
 void Texture2D::initProgram()

--- a/axmol/renderer/Texture2D.h
+++ b/axmol/renderer/Texture2D.h
@@ -105,7 +105,7 @@ public:
 
 public:
 
-    static rhi::SamplerDesc chooseSamplerDesc(bool antialiasEnabled, bool mipEnabled);
+    static void chooseSamplerDesc(bool antialiasEnabled, bool mipEnabled, rhi::SamplerDesc& desc);
 
     /**
      */
@@ -115,73 +115,14 @@ public:
      */
     virtual ~Texture2D();
 
-    /** Initializes with a texture2d with data.
-
-     @param data Specifies a pointer to the image data in memory.
-     @param dataLen The image data length.
-     @param pixelFormat The image pixelFormat.
-     @param pixelsWide The image width.
-     @param pixelsHigh The image height.
-     @param contentSize The image content size.
-     @param preMultipliedAlpha The texture has premultiplied alpha
-     * @lua NA
-     */
-    bool initWithData(const void* data,
-                      ssize_t dataLen,
-                      rhi::PixelFormat pixelFormat,
-                      int pixelsWide,
-                      int pixelsHigh,
-                      bool preMultipliedAlpha = false)
-    {
-        return initWithData(data, dataLen, pixelFormat, pixelFormat, pixelsWide, pixelsHigh,
-                            preMultipliedAlpha);
-    }
-
-    /** Initializes with a texture2d with data.
-
-     @param data Specifies a pointer to the image data in memory.
-     @param dataLen The image data length.
-     @param pixelFormat The image pixelFormat.
-     @param renderFormat The format converted to.
-     @param pixelsWide The image width.
-     @param pixelsHigh The image height.
-     @param contentSize The image content size.
-     @param preMultipliedAlpha The texture has premultiplied alpha
-     * @lua NA
-     */
-    bool initWithData(const void* data,
-                      ssize_t dataLen,
-                      rhi::PixelFormat pixelFormat,
-                      rhi::PixelFormat renderFormat,
-                      int pixelsWide,
-                      int pixelsHigh,
-                      bool preMultipliedAlpha = false);
-
-    /** Initializes with mipmaps.
-
-     @param mipmaps Specifies a pointer to the image data in memory.
-     @param mipmapsNum The mipmaps number.
-     @param pixelFormat The image pixelFormat.
-     @param pixelsWide The image width.
-     @param pixelsHigh The image height.
-     @param preMultipliedAlpha The texture has premultiplied alpha
-     */
-    bool initWithMipmaps(std::span<MipmapInfo> mipmaps,
-                         rhi::PixelFormat pixelFormat,
-                         rhi::PixelFormat renderFormat,
-                         int pixelsWide,
-                         int pixelsHigh,
-                         bool preMultipliedAlpha = false);
-
-    /**
-  Initializes a texture from a UIImage object.
+    /** Initializes a texture from a Image object.
 
     We will use the format you passed to the function to convert the image format to the texture format.
-    If you pass PixelFormat::AUTO, we will auto detect the image render type and use that type for texture to render.
-    @param image An UIImage object.
+    If you pass PixelFormat::NONE, we will auto detect the image render type and use that type for texture to render.
+    @param image An Image object.
     @param format Texture pixel formats.
     */
-    bool initWithImage(Image* image, PixelFormat renderFormat = PixelFormat::AUTO);
+    bool initWithImage(Image* image, PixelFormat renderFormat = PixelFormat::NONE, bool autoGenMipmaps = false);
 
     /** Initializes a texture from a string with dimensions, alignment, font name and font size.
 
@@ -210,9 +151,70 @@ public:
      */
     bool initWithString(std::string_view text, const FontDefinition& textDefinition);
 
+
+    /** Initializes with a texture2d with data.
+
+     @param data Specifies a pointer to the image data in memory.
+     @param dataSize The image data length.
+     @param pixelFormat The image pixelFormat.
+     @param pixelsWide The image width.
+     @param pixelsHigh The image height.
+     @param contentSize The image content size.
+     @param preMultipliedAlpha The texture has premultiplied alpha
+     * @lua NA
+     */
+    bool initWithData(const void* data,
+                      ssize_t dataSize,
+                      rhi::PixelFormat pixelFormat,
+                      int pixelsWide,
+                      int pixelsHigh,
+                      bool preMultipliedAlpha = false,
+                      bool autoGenMipmaps     = false)
+    {
+        return initWithData(data, dataSize, pixelFormat, pixelFormat, pixelsWide, pixelsHigh, preMultipliedAlpha,
+                            autoGenMipmaps);
+    }
+
+    /** Initializes with a texture2d with data.
+
+     @param data Specifies a pointer to the image data in memory.
+     @param dataSize The image data length.
+     @param pixelFormat The image pixelFormat.
+     @param renderFormat The format converted to.
+     @param pixelsWide The image width.
+     @param pixelsHigh The image height.
+     @param contentSize The image content size.
+     @param preMultipliedAlpha The texture has premultiplied alpha
+     * @lua NA
+     */
+    bool initWithData(const void* data,
+                      ssize_t dataSize,
+                      rhi::PixelFormat pixelFormat,
+                      rhi::PixelFormat renderFormat,
+                      int pixelsWide,
+                      int pixelsHigh,
+                      bool preMultipliedAlpha = false,
+                      bool autoGenMipmaps     = false);
+
+    /** Initializes with mipmaps.
+
+     @param mipmaps Specifies a pointer to the image data in memory.
+     @param mipmapsNum The mipmaps number.
+     @param pixelFormat The image pixelFormat.
+     @param pixelsWide The image width.
+     @param pixelsHigh The image height.
+     @param preMultipliedAlpha The texture has premultiplied alpha
+     */
+    bool initWithMipmaps(std::span<MipmapInfo> mipmaps,
+                         rhi::PixelFormat pixelFormat,
+                         rhi::PixelFormat renderFormat,
+                         int pixelsWide,
+                         int pixelsHigh,
+                         bool preMultipliedAlpha = false);
+
     bool initWithSpec(rhi::TextureDesc desc,
                       std::span<TextureSliceData> subDatas,
-                      PixelFormat renderFormat,
+                      PixelFormat renderFormat = PixelFormat::NONE,
                       bool preMultipliedAlpha = false);
 
     /** Update with texture data.
@@ -242,12 +244,6 @@ public:
     inline bool isRenderTarget() const { return _flags & TextureFlag::RENDERTARGET; }
 
     void setTexParameters(const TexParams& params);
-
-    /** Generates mipmap images for the texture.
-     It only works if the texture size is POT (power of 2).
-     @since v0.99.0
-     */
-    void generateMipmap();
 
     /** Sets antialias texture parameters:
      - GL_TEXTURE_MIN_FILTER = GL_LINEAR
@@ -305,7 +301,7 @@ public:
     /** Gets the height of the texture in pixels. */
     int getPixelsHigh() const;
 
-    rhi::Texture* getBackendTexture() const;
+    rhi::Texture* getRHITexture() const;
 
     /** Gets max S. */
     float getMaxS() const;

--- a/axmol/renderer/Texture2D.h
+++ b/axmol/renderer/Texture2D.h
@@ -217,6 +217,25 @@ public:
                       PixelFormat renderFormat = PixelFormat::NONE,
                       bool preMultipliedAlpha = false);
 
+    /*
+     * @brief update data by text
+    */
+    bool updateData(std::string_view text, const FontDefinition& textDefinition);
+
+    /**
+     * @brief update data by image
+     *
+     * @param image
+     */
+    bool updateData(Image* image);
+
+    /**
+     * @brief update data by subDatas
+     *
+     * @param subDatas
+     */
+    bool updateData(std::span<TextureSliceData> subDatas);
+
     /**
      * Update the texture with a new image data.
      * @param data Specifies a pointer to the image data in memory.
@@ -225,10 +244,7 @@ public:
      * @param level Specifies the mipmap level to update. Default is 0.
      * @param layerIndex Specifies the layer index to update. Default is 0.
     */
-    bool updateData(const void* data, int width, int height, int level = 0, int layerIndex = 0)
-    {
-        return updateSubData(data, 0, 0, width, height, level, layerIndex);
-    }
+    bool updateData(const void* data, int width, int height, int level = 0, int layerIndex = 0);
 
     /** Update texture sub data.
 
@@ -239,6 +255,15 @@ public:
      @param height Specifies the height of the texture subimage.
      */
     bool updateSubData(const void* data, int offsetX, int offsetY, int width, int height, int level = 0, int layerIndex = 0);
+
+    /*
+    * Invalidate the texture for we can re-create RHI GPU texture when app context loss recovery
+    * For example:
+    *   texture2d->invalidate();
+    *   texture2d->updateData(...); // re-create the texture
+    */
+    void invalidate();
+
     /**
     Drawing extensions to make it easy to draw basic quads using a Texture2D object.
     These functions require GL_TEXTURE_2D and both GL_VERTEX_ARRAY and GL_TEXTURE_COORD_ARRAY client states to be
@@ -373,6 +398,8 @@ private:
     void initProgram();
 
 protected:
+
+    void updateData(std::span<TextureSliceData> subDatas, PixelFormat renderFormat, bool compressed);
 
     /** width in pixels */
     int _pixelsWide;

--- a/axmol/renderer/Texture2D.h
+++ b/axmol/renderer/Texture2D.h
@@ -217,7 +217,20 @@ public:
                       PixelFormat renderFormat = PixelFormat::NONE,
                       bool preMultipliedAlpha = false);
 
-    /** Update with texture data.
+    /**
+     * Update the texture with a new image data.
+     * @param data Specifies a pointer to the image data in memory.
+     * @param width Specifies the width of the texture.
+     * @param height Specifies the height of the texture.
+     * @param level Specifies the mipmap level to update. Default is 0.
+     * @param layerIndex Specifies the layer index to update. Default is 0.
+    */
+    bool updateData(const void* data, int width, int height, int level = 0, int layerIndex = 0)
+    {
+        return updateSubData(data, 0, 0, width, height, level, layerIndex);
+    }
+
+    /** Update texture sub data.
 
      @param data Specifies a pointer to the image data in memory.
      @param offsetX Specifies a texel offset in the x direction within the texture array.
@@ -225,7 +238,7 @@ public:
      @param width Specifies the width of the texture subimage.
      @param height Specifies the height of the texture subimage.
      */
-    bool updateWithSubData(const void* data, int offsetX, int offsetY, int width, int height, int level = 0, int layerIndex = 0);
+    bool updateSubData(const void* data, int offsetX, int offsetY, int width, int height, int level = 0, int layerIndex = 0);
     /**
     Drawing extensions to make it easy to draw basic quads using a Texture2D object.
     These functions require GL_TEXTURE_2D and both GL_VERTEX_ARRAY and GL_TEXTURE_COORD_ARRAY client states to be
@@ -236,12 +249,7 @@ public:
     /** Draws a texture inside a rect.*/
     void drawInRect(const Rect& rect, float globalZOrder);
 
-
-    //!!Used for render buffer, such depth stencil attachment
-    bool updateTextureDesc(const rhi::TextureDesc& descriptor, bool preMultipliedAlpha = false);
-
-    void setRenderTarget(bool renderTarget);
-    inline bool isRenderTarget() const { return _flags & TextureFlag::RENDERTARGET; }
+    bool isRenderTarget() const;
 
     void setTexParameters(const TexParams& params);
 
@@ -365,8 +373,6 @@ private:
     void initProgram();
 
 protected:
-    /** pixel format of the texture */
-    rhi::PixelFormat _originalPF;
 
     /** width in pixels */
     int _pixelsWide;
@@ -386,15 +392,17 @@ protected:
     /** content size */
     Vec2 _contentSize;
 
-    uint16_t _flags : 16;
-    uint16_t _samplerFlags : 16;
+    uint8_t _flags;
+    uint8_t _samplerFlags;
+
+    /** pixel format of the texture */
+    rhi::PixelFormat _originalPF;
 
     NinePatchInfo* _ninePatchInfo;
     friend class SpriteFrameCache;
     friend class TextureCache;
     friend class ui::Scale9Sprite;
 
-    bool _valid;
     std::string _filePath;
 
     rhi::ProgramState* _programState = nullptr;

--- a/axmol/renderer/Texture2D.h
+++ b/axmol/renderer/Texture2D.h
@@ -29,8 +29,8 @@ THE SOFTWARE.
 #pragma once
 
 #include <string>
-#include <map>
 #include <unordered_map>
+#include <span>
 
 #include "axmol/base/Object.h"
 #include "axmol/math/Math.h"
@@ -43,7 +43,18 @@ namespace ax
 class Image;
 class NinePatchInfo;
 class SpriteFrame;
-typedef struct _MipmapInfo MipmapInfo;
+
+template<typename _PointerType>
+struct TextureSliceDataBase
+{
+    _PointerType data   = nullptr;
+    uint32_t dataSize   = 0;
+    uint16_t layerIndex = 0;
+    uint16_t mipLevel   = 0;
+};
+
+using MipmapInfo = TextureSliceDataBase<void*>;
+using TextureSliceData = TextureSliceDataBase<const void*>;
 
 namespace ui
 {
@@ -155,79 +166,22 @@ public:
      @param pixelsHigh The image height.
      @param preMultipliedAlpha The texture has premultiplied alpha
      */
-    bool initWithMipmaps(MipmapInfo* mipmaps,
-                         int mipmapsNum,
+    bool initWithMipmaps(std::span<MipmapInfo> mipmaps,
                          rhi::PixelFormat pixelFormat,
                          rhi::PixelFormat renderFormat,
                          int pixelsWide,
                          int pixelsHigh,
                          bool preMultipliedAlpha = false);
 
-    /** Update with image.
-
-    @param data Specifies a pointer to the image data in memory.
-    @param offsetX Specifies a texel offset in the x direction within the texture array.
-    @param offsetY Specifies a texel offset in the y direction within the texture array.
-    @param width Specifies the width of the texture subimage.
-    @param height Specifies the height of the texture subimage.
-    */
-    bool updateWithImage(Image* image, int index = 0);
-    bool updateWithImage(Image* image, rhi::PixelFormat format, int index = 0);
-    bool updateWithData(const void* data,
-                        ssize_t dataLen,
-                        rhi::PixelFormat pixelFormat,
-                        rhi::PixelFormat renderFormat,
-                        int pixelsWide,
-                        int pixelsHigh,
-                        bool preMultipliedAlpha,
-                        int index = 0);
-    bool updateWithMipmaps(MipmapInfo* mipmaps,
-                           int mipmapsNum,
-                           rhi::PixelFormat pixelFormat,
-                           rhi::PixelFormat renderFormat,
-                           int pixelsWide,
-                           int pixelsHigh,
-                           bool preMultipliedAlpha = false,
-                           int index               = 0);
-
-    /** Update with texture data.
-
-     @param data Specifies a pointer to the image data in memory.
-     @param offsetX Specifies a texel offset in the x direction within the texture array.
-     @param offsetY Specifies a texel offset in the y direction within the texture array.
-     @param width Specifies the width of the texture subimage.
-     @param height Specifies the height of the texture subimage.
-     */
-    bool updateWithSubData(void* data, int offsetX, int offsetY, int width, int height, int index = 0);
     /**
-    Drawing extensions to make it easy to draw basic quads using a Texture2D object.
-    These functions require GL_TEXTURE_2D and both GL_VERTEX_ARRAY and GL_TEXTURE_COORD_ARRAY client states to be
-    enabled.
-    */
-    /** Draws a texture at a given point. */
-    void drawAtPoint(const Vec2& point, float globalZOrder);
-    /** Draws a texture inside a rect.*/
-    void drawInRect(const Rect& rect, float globalZOrder);
+  Initializes a texture from a UIImage object.
 
-    /**
-    Extensions to make it easy to create a Texture2D object from an image file.
-    */
-    /**
-    Initializes a texture from a UIImage object.
-
-    We will use the pixel format of the image.
-    NOTE: It will not convert the pvr image file.
+    We will use the format you passed to the function to convert the image format to the texture format.
+    If you pass PixelFormat::AUTO, we will auto detect the image render type and use that type for texture to render.
     @param image An UIImage object.
+    @param format Texture pixel formats.
     */
-    bool initWithImage(Image* image);
-
-    /**
-    Initializes a texture from an Image object and convert it to the given
-    format if necessary.
-
-    NOTE: It will not convert the pvr image file.
-    */
-    bool initWithImage(Image* image, PixelFormat format);
+    bool initWithImage(Image* image, PixelFormat renderFormat = PixelFormat::AUTO);
 
     /** Initializes a texture from a string with dimensions, alignment, font name and font size.
 
@@ -255,6 +209,31 @@ public:
      @param textDefinition A FontDefinition object contains font attributes.
      */
     bool initWithString(std::string_view text, const FontDefinition& textDefinition);
+
+    bool initWithSpec(rhi::TextureDesc desc,
+                      std::span<TextureSliceData> subDatas,
+                      PixelFormat renderFormat,
+                      bool preMultipliedAlpha = false);
+
+    /** Update with texture data.
+
+     @param data Specifies a pointer to the image data in memory.
+     @param offsetX Specifies a texel offset in the x direction within the texture array.
+     @param offsetY Specifies a texel offset in the y direction within the texture array.
+     @param width Specifies the width of the texture subimage.
+     @param height Specifies the height of the texture subimage.
+     */
+    bool updateWithSubData(const void* data, int offsetX, int offsetY, int width, int height, int level = 0, int layerIndex = 0);
+    /**
+    Drawing extensions to make it easy to draw basic quads using a Texture2D object.
+    These functions require GL_TEXTURE_2D and both GL_VERTEX_ARRAY and GL_TEXTURE_COORD_ARRAY client states to be
+    enabled.
+    */
+    /** Draws a texture at a given point. */
+    void drawAtPoint(const Vec2& point, float globalZOrder);
+    /** Draws a texture inside a rect.*/
+    void drawInRect(const Rect& rect, float globalZOrder);
+
 
     //!!Used for render buffer, such depth stencil attachment
     bool updateTextureDesc(const rhi::TextureDesc& descriptor, bool preMultipliedAlpha = false);
@@ -391,7 +370,7 @@ private:
 
 protected:
     /** pixel format of the texture */
-    rhi::PixelFormat _pixelFormat;
+    rhi::PixelFormat _originalPF;
 
     /** width in pixels */
     int _pixelsWide;
@@ -400,7 +379,7 @@ protected:
     int _pixelsHigh;
 
     /** texture name */
-    rhi::Texture* _texture;
+    rhi::Texture* _rhiTexture;
 
     /** texture max S */
     float _maxS;

--- a/axmol/renderer/TextureAtlas.cpp
+++ b/axmol/renderer/TextureAtlas.cpp
@@ -60,7 +60,7 @@ TextureAtlas::~TextureAtlas()
 
     AX_SAFE_RELEASE(_texture);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
 }

--- a/axmol/renderer/TextureAtlas.h
+++ b/axmol/renderer/TextureAtlas.h
@@ -238,7 +238,7 @@ protected:
     /** Quads that are going to be rendered */
     V3F_T2F_C4B_Quad* _quads = nullptr;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _rendererRecreatedListener = nullptr;
 #endif
 };

--- a/axmol/renderer/TextureCache.cpp
+++ b/axmol/renderer/TextureCache.cpp
@@ -341,23 +341,35 @@ void TextureCache::addImageAsyncCallBack(float /*dt*/)
                 // generate texture in render thread
                 texture = new Texture2D();
 
-                texture->initWithImage(image, asyncStruct->pixelFormat);
+                if (asyncStruct->imageAlpha.getFileType() != Image::Format::ETC1)
+                {
+                    texture->initWithImage(image, asyncStruct->pixelFormat);
+                }
+                else
+                {
+                    TextureSliceData subDatas[] = {
+                        TextureSliceData{image->getData(), static_cast<uint16_t>(image->getDataSize()), 0, 0},
+                        TextureSliceData{asyncStruct->imageAlpha.getData(),
+                                         static_cast<uint16_t>(asyncStruct->imageAlpha.getDataSize()), 1, 0}};
+                    texture->initWithSpec(rhi::TextureDesc{.width       = static_cast<uint16_t>(image->getWidth()),
+                                                           .height      = static_cast<uint16_t>(image->getHeight()),
+                                                           .arraySize   = 2,
+                                                           .pixelFormat = image->getPixelFormat()},
+                                          subDatas);
+                }
+
                 // parse 9-patch info
                 this->parseNinePatchImage(image, texture, asyncStruct->filename);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-                // cache the texture file name
-                VolatileTextureMgr::addImageTexture(texture, asyncStruct->filename);
-#endif
+
                 // cache the texture. retain it, since it is added in the map
                 _textures.emplace(asyncStruct->filename, texture);
                 texture->retain();
 
                 texture->autorelease();
-                // ETC1 ALPHA supports.
-                if (asyncStruct->imageAlpha.getFileType() == Image::Format::ETC1)
-                {
-                    //texture->updateWithImage(&asyncStruct->imageAlpha, asyncStruct->pixelFormat, 1);
-                }
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+                // cache the texture file name
+                VolatileTextureMgr::addImageTexture(texture, asyncStruct->filename);
+#endif
             }
             else
             {

--- a/axmol/renderer/TextureCache.cpp
+++ b/axmol/renderer/TextureCache.cpp
@@ -63,6 +63,14 @@ std::string TextureCache::getETC1AlphaFileSuffix()
     return s_etc1AlphaFileSuffix;
 }
 
+std::string TextureCache::checkETC1AlphaFile(std::string_view path) {
+    std::string ret;
+    ret.reserve(path.size() + TextureCache::s_etc1AlphaFileSuffix.size());
+    ret += path;
+    ret += TextureCache::s_etc1AlphaFileSuffix;
+    return FileUtils::getInstance()->isFileExist(ret) ? ret : std::string{};
+}
+
 TextureCache::TextureCache() : _loadingThread(nullptr), _needQuit(false), _asyncRefCount(0) {}
 
 TextureCache::~TextureCache()
@@ -366,7 +374,7 @@ void TextureCache::addImageAsyncCallBack(float /*dt*/)
                 texture->retain();
 
                 texture->autorelease();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
                 // cache the texture file name
                 VolatileTextureMgr::addImageTexture(texture, asyncStruct->filename);
 #endif
@@ -477,24 +485,17 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderForma
 
             texture = new Texture2D();
 
-            std::string alphFullPath;
-            auto checkAlphaFile = [&alphFullPath , & path]()
-            {
-                alphFullPath.reserve(path.size() + TextureCache::s_etc1AlphaFileSuffix.size());
-                alphFullPath += path;
-                alphFullPath += TextureCache::s_etc1AlphaFileSuffix;
-                return FileUtils::getInstance()->isFileExist(alphFullPath);
-            };
+            std::string alphaFullPath;
 
             bool ret;
-            if (image->getFileType() != Image::Format::ETC1 || !checkAlphaFile())
+            if (image->getFileType() != Image::Format::ETC1 || (alphaFullPath = checkETC1AlphaFile(fullpath)).empty())
             {
                 ret = texture->initWithImage(image, renderFormat, autoGenMipmaps);
             }
             else
             { // ETC1 ALPHA supports.
                 Image imageAlpha;
-                ret = imageAlpha.initWithImageFile(alphFullPath);
+                ret = imageAlpha.initWithImageFile(alphaFullPath);
                 if (ret)
                 {
                     rhi::TextureDesc desc{
@@ -514,12 +515,11 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderForma
                         desc.mipLevels = 0;  // generate mipmaps by GPU
                     ret = texture->initWithSpec(desc, subDatas, renderFormat);
                 }
-
             }
 
             if (ret)
             {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
                 // cache the texture file name
                 VolatileTextureMgr::addImageTexture(texture, fullpath);
 #endif
@@ -588,7 +588,7 @@ Texture2D* TextureCache::addImage(Image* image, std::string_view key, PixelForma
 
     } while (0);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     VolatileTextureMgr::addImage(texture, image);
 #endif
 
@@ -622,7 +622,7 @@ Texture2D* TextureCache::addImage(const Data& imageData, std::string_view key)
             if (texture->initWithImage(image))
             {
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
                 VolatileTextureMgr::addImage(texture, image);
 #endif
                 _textures.emplace(key, texture);
@@ -848,15 +848,15 @@ void TextureCache::renameTextureWithKey(std::string_view srcName, std::string_vi
     }
 }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 
 std::list<VolatileTexture*> VolatileTextureMgr::_textures;
 bool VolatileTextureMgr::_isReloading = false;
 
 VolatileTexture::VolatileTexture(Texture2D* t)
     : _texture(t)
-    , _uiImage(nullptr)
-    , _cashedImageType(kInvalid)
+    , _image(nullptr)
+    , _cachedImageType(kInvalid)
     , _textureData(nullptr)
     , _pixelFormat(rhi::PixelFormat::RGBA8)
     , _fileName("")
@@ -865,7 +865,7 @@ VolatileTexture::VolatileTexture(Texture2D* t)
 
 VolatileTexture::~VolatileTexture()
 {
-    AX_SAFE_RELEASE(_uiImage);
+    AX_SAFE_RELEASE(_image);
 }
 
 void VolatileTextureMgr::addImageTexture(Texture2D* tt, std::string_view imageFileName)
@@ -875,9 +875,9 @@ void VolatileTextureMgr::addImageTexture(Texture2D* tt, std::string_view imageFi
         return;
     }
 
-    VolatileTexture* vt = getOrAddVolatileTexture(tt);
+    VolatileTexture* vt = ensureVolatileTexture(tt);
 
-    vt->_cashedImageType = VolatileTexture::kImageFile;
+    vt->_cachedImageType = VolatileTexture::kImageFile;
     vt->_fileName        = imageFileName;
     vt->_pixelFormat     = tt->getPixelFormat();
 }
@@ -887,18 +887,18 @@ void VolatileTextureMgr::addImage(Texture2D* tt, Image* image)
     if (tt == nullptr || image == nullptr)
         return;
 
-    VolatileTexture* vt = getOrAddVolatileTexture(tt);
+    VolatileTexture* vt = ensureVolatileTexture(tt);
 
-    if(vt->_uiImage != image) {
-        AX_SAFE_RELEASE(vt->_uiImage);
+    if(vt->_image != image) {
+        AX_SAFE_RELEASE(vt->_image);
         image->retain();
-        vt->_uiImage         = image;
-        vt->_cashedImageType = VolatileTexture::kImage;
+        vt->_image         = image;
+        vt->_cachedImageType = VolatileTexture::kImage;
         vt->_pixelFormat     = tt->getPixelFormat();
     }
 }
 
-VolatileTexture* VolatileTextureMgr::getOrAddVolatileTexture(Texture2D* tt)
+VolatileTexture* VolatileTextureMgr::ensureVolatileTexture(Texture2D* tt)
 {
     VolatileTexture* vt = nullptr;
     for (const auto& texture : _textures)
@@ -931,9 +931,9 @@ void VolatileTextureMgr::addDataTexture(Texture2D* tt,
         return;
     }
 
-    VolatileTexture* vt = getOrAddVolatileTexture(tt);
+    VolatileTexture* vt = ensureVolatileTexture(tt);
 
-    vt->_cashedImageType = VolatileTexture::kImageData;
+    vt->_cachedImageType = VolatileTexture::kImageData;
     vt->_textureData     = data;
     vt->_dataLen         = dataLen;
     vt->_pixelFormat     = pixelFormat;
@@ -947,9 +947,9 @@ void VolatileTextureMgr::addStringTexture(Texture2D* tt, std::string_view text, 
         return;
     }
 
-    VolatileTexture* vt = getOrAddVolatileTexture(tt);
+    VolatileTexture* vt = ensureVolatileTexture(tt);
 
-    vt->_cashedImageType = VolatileTexture::kString;
+    vt->_cachedImageType = VolatileTexture::kString;
     vt->_text            = text;
     vt->_fontDefinition  = fontDefinition;
 }
@@ -973,59 +973,71 @@ void VolatileTextureMgr::reloadAllTextures()
     _isReloading = true;
     AXLOGD("reload all texture");
 
-    for (auto&& texture : _textures)
+    for (auto&& vt : _textures)
     {
-        VolatileTexture* vt = texture;
-
-        switch (vt->_cashedImageType)
-        {
-        case VolatileTexture::kImageFile:
-        {
-            reloadTexture(vt->_texture, vt->_fileName, vt->_pixelFormat);
-
-            // etc1 support check whether alpha texture exists & load it
-            Image image;
-            if (image.initWithImageFile(vt->_fileName + TextureCache::getETC1AlphaFileSuffix()))
-            {
-                vt->_texture->initWithImage(&image, vt->_pixelFormat);
-            }
-        }
-        break;
-        case VolatileTexture::kImageData:
-        {
-            vt->_texture->initWithData(vt->_textureData, vt->_dataLen, vt->_pixelFormat, vt->_textureSize.width,
-                                       vt->_textureSize.height);
-        }
-        break;
-        case VolatileTexture::kString:
-        {
-            vt->_texture->initWithString(vt->_text, vt->_fontDefinition);
-        }
-        break;
-        case VolatileTexture::kImage:
-        {
-            vt->_texture->initWithImage(vt->_uiImage, vt->_pixelFormat);
-        }
-        break;
-        default:
-            break;
-        }
+        reloadTexture(vt);
     }
 
     _isReloading = false;
 }
 
-void VolatileTextureMgr::reloadTexture(Texture2D* texture, std::string_view filename, rhi::PixelFormat pixelFormat)
+void VolatileTextureMgr::reloadTexture(VolatileTexture* vt)
 {
+    auto texture = vt->_texture;
+
     if (!texture)
         return;
 
-    Image image;
+    if(vt->_cachedImageType != VolatileTexture::kInvalid) {
+        texture->invalidate();
+        switch (vt->_cachedImageType) {
+            case VolatileTexture::kImageFile: {
+                Image image;
 
-    if (image.initWithImageFile(filename))
-        texture->initWithImage(&image, pixelFormat);
+                if (!image.initWithImageFile(vt->_fileName))
+                    return;
+
+                if (image.getFileType() != Image::Format::ETC1) {
+                    texture->updateData(&image);
+                } else {
+                    std::string alphaFilePath = TextureCache::checkETC1AlphaFile(vt->_fileName);
+                    if (!alphaFilePath.empty()) {
+                        Image imageAlpha;
+                        auto ret = imageAlpha.initWithImageFile(alphaFilePath);
+                        if (ret) {
+                            TextureSliceData subDatas[2] = {
+                                    TextureSliceData{image.getData(),
+                                                     static_cast<uint16_t>(image.getDataSize()), 0},
+                                    TextureSliceData{imageAlpha.getData(),
+                                                     static_cast<uint16_t>(imageAlpha.getDataSize()),
+                                                     1}
+                            };
+
+                            texture->updateData(subDatas);
+                        }
+                    } else {
+                        texture->updateData(&image);
+                    }
+                }
+                break;
+            }
+            case VolatileTexture::kImage:
+                texture->updateData(vt->_image);
+                break;
+            case VolatileTexture::kImageData:
+                texture->updateData(vt->_textureData, vt->_textureSize.width,
+                                    vt->_textureSize.height);
+                break;
+            case VolatileTexture::kString:
+                texture->updateData(vt->_text, vt->_fontDefinition);
+                break;
+        }
+    }
+    else {
+        AXLOGE("VolatileTexture:{}, no valid data to restore", fmt::ptr(vt));
+    }
 }
 
-#endif  // AX_ENABLE_CACHE_TEXTURE_DATA
+#endif  // AX_ENABLE_CONTEXT_LOSS_RECOVERY
 
 }

--- a/axmol/renderer/TextureCache.cpp
+++ b/axmol/renderer/TextureCache.cpp
@@ -87,7 +87,7 @@ public:
         : filename(fn)
         , callback(f)
         , callbackKey(key)
-        , pixelFormat(PixelFormat::NONE)
+        , pixelFormat(PixelFormat::AUTO)
         , loadSuccess(false)
     {}
 
@@ -356,7 +356,7 @@ void TextureCache::addImageAsyncCallBack(float /*dt*/)
                 // ETC1 ALPHA supports.
                 if (asyncStruct->imageAlpha.getFileType() == Image::Format::ETC1)
                 {
-                    texture->updateWithImage(&asyncStruct->imageAlpha, asyncStruct->pixelFormat, 1);
+                    //texture->updateWithImage(&asyncStruct->imageAlpha, asyncStruct->pixelFormat, 1);
                 }
             }
             else
@@ -433,10 +433,10 @@ Texture2D* TextureCache::getDummyTexture()
 
 Texture2D* TextureCache::addImage(std::string_view path)
 {
-    return addImage(path, PixelFormat::NONE);
+    return addImage(path, PixelFormat::AUTO);
 }
 
-Texture2D* TextureCache::addImage(std::string_view path, PixelFormat format)
+Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderFormat)
 {
     Texture2D* texture = nullptr;
     Image* image       = nullptr;
@@ -465,7 +465,45 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat format)
 
             texture = new Texture2D();
 
-            if (texture->initWithImage(image, format))
+            std::string alphFullPath;
+            auto checkAlphaFile = [&alphFullPath , & path]()
+            {
+                alphFullPath.reserve(path.size() + TextureCache::s_etc1AlphaFileSuffix.size());
+                alphFullPath += path;
+                alphFullPath += TextureCache::s_etc1AlphaFileSuffix;
+                return FileUtils::getInstance()->isFileExist(alphFullPath);
+            };
+
+            bool ret;
+            if (image->getFileType() != Image::Format::ETC1 || !checkAlphaFile())
+            {
+                ret = texture->initWithImage(image, renderFormat);
+            }
+            else
+            { // ETC1 ALPHA supports.
+                Image imageAlpha;
+                ret = imageAlpha.initWithImageFile(alphFullPath);
+                if (ret)
+                {
+                    rhi::TextureDesc desc{
+                        .width       = static_cast<uint16_t>(image->getWidth()),
+                        .height      = static_cast<uint16_t>(image->getHeight()),
+                        .arraySize = 2,
+                        .pixelFormat = image->getPixelFormat(),
+                    };
+                    TextureSliceData subDatas[2] = {
+                        TextureSliceData{image->getData(), static_cast<uint16_t>(image->getDataSize()), 0},
+                        TextureSliceData{imageAlpha.getData(),
+                                                   static_cast<uint16_t>(imageAlpha.getDataSize()),
+                                                   1}
+                    };
+
+                    ret = texture->initWithSpec(desc, subDatas, renderFormat);
+                }
+
+            }
+
+            if (ret)
             {
 #if AX_ENABLE_CACHE_TEXTURE_DATA
                 // cache the texture file name
@@ -473,19 +511,6 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat format)
 #endif
                 // texture already retained, no need to re-retain it
                 _textures.emplace(fullpath, texture);
-
-                //-- ANDROID ETC1 ALPHA SUPPORTS.
-                std::string alphaFullPath{path};
-                alphaFullPath += s_etc1AlphaFileSuffix;
-                if (image->getFileType() == Image::Format::ETC1 && !s_etc1AlphaFileSuffix.empty() &&
-                    FileUtils::getInstance()->isFileExist(alphaFullPath))
-                {
-                    Image imageAlpha;
-                    if (imageAlpha.initWithImageFile(alphaFullPath))
-                    {
-                        texture->updateWithImage(&imageAlpha, format, 1);
-                    }
-                }
 
                 // parse 9-patch info
                 this->parseNinePatchImage(image, texture, path);
@@ -516,7 +541,7 @@ void TextureCache::parseNinePatchImage(ax::Image* image, ax::Texture2D* texture,
 
 Texture2D* TextureCache::addImage(Image* image, std::string_view key)
 {
-    return addImage(image, key, PixelFormat::NONE);
+    return addImage(image, key, PixelFormat::AUTO);
 }
 
 Texture2D* TextureCache::addImage(Image* image, std::string_view key, PixelFormat format)
@@ -948,7 +973,7 @@ void VolatileTextureMgr::reloadAllTextures()
             Image image;
             if (image.initWithImageFile(vt->_fileName + TextureCache::getETC1AlphaFileSuffix()))
             {
-                vt->_texture->updateWithImage(&image, vt->_pixelFormat, 1);
+                vt->_texture->initWithImage(&image, vt->_pixelFormat);
             }
         }
         break;

--- a/axmol/renderer/TextureCache.cpp
+++ b/axmol/renderer/TextureCache.cpp
@@ -87,7 +87,7 @@ public:
         : filename(fn)
         , callback(f)
         , callbackKey(key)
-        , pixelFormat(PixelFormat::AUTO)
+        , pixelFormat(PixelFormat::NONE)
         , loadSuccess(false)
     {}
 
@@ -431,12 +431,12 @@ Texture2D* TextureCache::getDummyTexture()
     return texture;
 }
 
-Texture2D* TextureCache::addImage(std::string_view path)
+Texture2D* TextureCache::addImage(std::string_view path, bool autoGenMipmaps)
 {
-    return addImage(path, PixelFormat::AUTO);
+    return addImage(path, PixelFormat::NONE, autoGenMipmaps);
 }
 
-Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderFormat)
+Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderFormat, bool autoGenMipmaps)
 {
     Texture2D* texture = nullptr;
     Image* image       = nullptr;
@@ -477,7 +477,7 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderForma
             bool ret;
             if (image->getFileType() != Image::Format::ETC1 || !checkAlphaFile())
             {
-                ret = texture->initWithImage(image, renderFormat);
+                ret = texture->initWithImage(image, renderFormat, autoGenMipmaps);
             }
             else
             { // ETC1 ALPHA supports.
@@ -498,6 +498,8 @@ Texture2D* TextureCache::addImage(std::string_view path, PixelFormat renderForma
                                                    1}
                     };
 
+                    if (autoGenMipmaps)
+                        desc.mipLevels = 0;  // generate mipmaps by GPU
                     ret = texture->initWithSpec(desc, subDatas, renderFormat);
                 }
 
@@ -541,7 +543,7 @@ void TextureCache::parseNinePatchImage(ax::Image* image, ax::Texture2D* texture,
 
 Texture2D* TextureCache::addImage(Image* image, std::string_view key)
 {
-    return addImage(image, key, PixelFormat::AUTO);
+    return addImage(image, key, PixelFormat::NONE);
 }
 
 Texture2D* TextureCache::addImage(Image* image, std::string_view key, PixelFormat format)
@@ -795,7 +797,7 @@ std::string TextureCache::getCachedTextureInfo() const
         totalBytes += bytes;
         count++;
         auto msg = fmt::format_to_z(tmp, "\"{}\" rc={} id={} {} x {} @ {} bpp => {} KB\n", texture.first,
-                 tex->getReferenceCount(), fmt::ptr(tex->getBackendTexture()), tex->getPixelsWide(),
+                 tex->getReferenceCount(), fmt::ptr(tex->getRHITexture()), tex->getPixelsWide(),
                  tex->getPixelsHigh(), bpp, bytes / 1024);
 
         ret += msg;

--- a/axmol/renderer/TextureCache.h
+++ b/axmol/renderer/TextureCache.h
@@ -99,8 +99,8 @@ public:
     * Supported image extensions: .png, .bmp, .jpeg, .pvr.
      @param filepath The file path.
     */
-    Texture2D* addImage(std::string_view filepath);
-    Texture2D* addImage(std::string_view filepath, PixelFormat format);
+    Texture2D* addImage(std::string_view filepath, bool autoGenMipmaps = false);
+    Texture2D* addImage(std::string_view filepath, PixelFormat format, bool autoGenMipmaps = false);
 
     /** Returns a Texture2D object given a file image.
     * If the file image was not previously loaded, it will create a new Texture2D object and it will return it.

--- a/axmol/renderer/TextureCache.h
+++ b/axmol/renderer/TextureCache.h
@@ -41,7 +41,7 @@ THE SOFTWARE.
 #include "axmol/renderer/Texture2D.h"
 #include "axmol/platform/Image.h"
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 #    include <list>
 #endif
 
@@ -224,6 +224,8 @@ private:
     void parseNinePatchImage(Image* image, Texture2D* texture, std::string_view path);
 
 public:
+    static std::string checkETC1AlphaFile(std::string_view path);
+
 protected:
     struct AsyncStruct;
 
@@ -247,7 +249,7 @@ protected:
     static std::string s_etc1AlphaFileSuffix;
 };
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 
 class VolatileTexture
 {
@@ -258,7 +260,7 @@ class VolatileTexture
         kImageData,
         kString,
         kImage,
-    } ccCachedImageType;
+    } CachedImageType;
 
 private:
     VolatileTexture(Texture2D* t);
@@ -271,9 +273,9 @@ protected:
     friend class VolatileTextureMgr;
     Texture2D* _texture;
 
-    Image* _uiImage;
+    Image* _image;
 
-    ccCachedImageType _cashedImageType;
+    CachedImageType _cachedImageType;
 
     void* _textureData;
     int _dataLen;
@@ -306,11 +308,10 @@ public:
 
     // find VolatileTexture by Texture2D*
     // if not found, create a new one
-    AX_DEPRECATED(2.2) static VolatileTexture* findVolotileTexture(Texture2D* tt) { return getOrAddVolatileTexture(tt); }
-    static VolatileTexture* getOrAddVolatileTexture(Texture2D* tt);
+    static VolatileTexture* ensureVolatileTexture(Texture2D* tt);
 
 private:
-    static void reloadTexture(Texture2D* texture, std::string_view filename, rhi::PixelFormat pixelFormat);
+    static void reloadTexture(VolatileTexture* vt);
 };
 
 #endif

--- a/axmol/renderer/TextureCube.cpp
+++ b/axmol/renderer/TextureCube.cpp
@@ -29,7 +29,7 @@
 #include "axmol/platform/FileUtils.h"
 #include "axmol/rhi/Texture.h"
 #include "axmol/rhi/DriverBase.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 
 namespace ax
 {
@@ -228,7 +228,7 @@ bool TextureCube::init(std::string_view positive_x,
         if (ePixelFmt != rhi::PixelFormat::RGBA8)
         {
             size_t len = 0;
-            rhi::PixelFormatUtils::convertDataToFormat(pData, img->getDataLen(), ePixelFmt,
+            rhi::RHIUtils::convertDataToFormat(pData, img->getDataSize(), ePixelFmt,
                                                            rhi::PixelFormat::RGBA8, &cData, &len);
             if (cData != pData)  // convert error
             {

--- a/axmol/renderer/TextureCube.h
+++ b/axmol/renderer/TextureCube.h
@@ -68,7 +68,7 @@ public:
     */
     void setTexParameters(const Texture2D::TexParams&);
 
-    rhi::Texture* getBackendTexture() { return _texture; }
+    rhi::Texture* getRHITexture() { return _texture; }
 
     const std::vector<std::string>& getImagePaths() const { return _imgPath; }
 

--- a/axmol/renderer/TrianglesCommand.cpp
+++ b/axmol/renderer/TrianglesCommand.cpp
@@ -56,10 +56,10 @@ void TrianglesCommand::init(float globalOrder,
     _mv = mv;
 
     auto batchId = _pipelineDesc.programState->getBatchId();
-    if (_batchId != batchId || _texture != texture->getBackendTexture() || _blendType != blendType)
+    if (_batchId != batchId || _texture != texture->getRHITexture() || _blendType != blendType)
     {
         _batchId   = batchId;
-        _texture   = texture->getBackendTexture();
+        _texture   = texture->getRHITexture();
         _blendType = blendType;
 
         // TODO: minggo set it in Node?

--- a/axmol/renderer/shaders/dualSampler.frag
+++ b/axmol/renderer/shaders/dualSampler.frag
@@ -1,20 +1,25 @@
 #version 310 es
 precision highp float;
 precision highp int;
+precision highp sampler2DArray;
 
 
 layout(location = COLOR0) in vec4 v_color;
 layout(location = TEXCOORD0) in vec2 v_texCoord;
 
-layout(binding = 0) uniform sampler2D u_tex0;
-layout(binding = 1) uniform sampler2D u_tex1;
+layout(binding = 0) uniform sampler2DArray u_tex0;
 
 layout(location = SV_Target0) out vec4 FragColor;
 
 void main() {
-    vec4 texColor = vec4(texture(u_tex0, v_texCoord).rgb, texture(u_tex1, v_texCoord).r);
+    vec3 uv0 = vec3(v_texCoord, 0.0);
+    vec3 uv1 = vec3(v_texCoord, 1.0);
 
-    texColor.rgb *= texColor.a; // Premultiply with Alpha channel
+    vec3 rgb   = texture(u_tex0, uv0).rgb;
+    float a    = texture(u_tex0, uv1).r;
+
+    vec4 texColor = vec4(rgb, a);
+    texColor.rgb *= texColor.a;
 
     FragColor = v_color * texColor;
 }

--- a/axmol/renderer/shaders/dualSampler_gray.frag
+++ b/axmol/renderer/shaders/dualSampler_gray.frag
@@ -1,20 +1,21 @@
 #version 310 es
 precision highp float;
 precision highp int;
-
+precision highp sampler2DArray;
 
 layout(location = COLOR0) in vec4 v_color;
 layout(location = TEXCOORD0) in vec2 v_texCoord;
 
-layout(binding = 0) uniform sampler2D u_tex0;
-layout(binding = 1) uniform sampler2D u_tex1;
+layout(binding = 0) uniform sampler2DArray u_tex0;
 
 layout(location = SV_Target0) out vec4 FragColor;
 
 void main()
 {
-    vec4 texColor = texture(u_tex0, v_texCoord);
-    texColor.a = texture(u_tex1, v_texCoord).r;
+    vec3 uv0 = vec3(v_texCoord, 0.0);
+    vec3 uv1 = vec3(v_texCoord, 1.0);
+    vec4 texColor = texture(u_tex0, uv0);
+    texColor.a = texture(u_tex0, uv1).r;
     texColor.rgb *= texColor.a; // premultiply alpha channel
 
     texColor = v_color * texColor;

--- a/axmol/renderer/shaders/dualSampler_hsv.frag
+++ b/axmol/renderer/shaders/dualSampler_hsv.frag
@@ -1,14 +1,14 @@
 #version 310 es
 precision highp float;
 precision highp int;
+precision highp sampler2DArray;
 
 #include "colorUtils.glsl"
 
 layout(location = TEXCOORD0) in vec2 v_texCoord;
 layout(location = COLOR0) in vec4 v_color;
 
-layout(binding = 0) uniform sampler2D u_tex0;
-layout(binding = 1) uniform sampler2D u_tex1;
+layout(binding = 0) uniform sampler2DArray u_tex0;
 
 layout(std140) uniform fs_ub {
     vec3 u_hsv;
@@ -18,7 +18,9 @@ layout(location = SV_Target0) out vec4 FragColor;
 
 void main()
 {
-    vec4 texColor = vec4(texture(u_tex0, v_texCoord).rgb, texture(u_tex1, v_texCoord).r);
+    vec3 uv0 = vec3(v_texCoord, 0.0);
+    vec3 uv1 = vec3(v_texCoord, 1.0);
+    vec4 texColor = vec4(texture(u_tex0, uv0).rgb, texture(u_tex0, uv1).r);
     texColor.rgb *= texColor.a; // Premultiply with Alpha channel
 
     texColor.rgb = transformHSV(texColor.rgb, u_hsv);

--- a/axmol/renderer/shaders/terrain.frag
+++ b/axmol/renderer/shaders/terrain.frag
@@ -23,15 +23,15 @@ layout(location = SV_Target0) out vec4 FragColor;
 
 void main()
 {
-    vec4 lightColor = vec4(1.0,1.0,1.0,1.0);
-    // if(u_has_light_map<=0)
-    // {
-    //     lightColor = vec4(1.0,1.0,1.0,1.0);
-    // }
-    // else
-    // {
-    //     lightColor = texture(u_lightMap,v_texCoord);
-    // }
+    vec4 lightColor;
+    if(u_has_light_map<=0)
+    {
+        lightColor = vec4(1.0,1.0,1.0,1.0);
+    }
+    else
+    {
+        lightColor = texture(u_lightMap,v_texCoord);
+    }
     float lightFactor = dot(-u_lightDir,v_normal);
     if(u_has_alpha<=0)
     {

--- a/axmol/renderer/shaders/terrain.frag
+++ b/axmol/renderer/shaders/terrain.frag
@@ -23,15 +23,15 @@ layout(location = SV_Target0) out vec4 FragColor;
 
 void main()
 {
-    vec4 lightColor;
-    if(u_has_light_map<=0)
-    {
-        lightColor = vec4(1.0,1.0,1.0,1.0);
-    }
-    else
-    {
-        lightColor = texture(u_lightMap,v_texCoord);
-    }
+    vec4 lightColor = vec4(1.0,1.0,1.0,1.0);
+    // if(u_has_light_map<=0)
+    // {
+    //     lightColor = vec4(1.0,1.0,1.0,1.0);
+    // }
+    // else
+    // {
+    //     lightColor = texture(u_lightMap,v_texCoord);
+    // }
     float lightFactor = dot(-u_lightDir,v_normal);
     if(u_has_alpha<=0)
     {

--- a/axmol/renderer/shaders/terrain.vert
+++ b/axmol/renderer/shaders/terrain.vert
@@ -4,7 +4,7 @@ layout(location = POSITION) in vec4 a_position;
 layout(location = TEXCOORD0) in vec2 a_texCoord;
 layout(location = NORMAL) in vec3 a_normal;
 layout(location = TEXCOORD0) out vec2 v_texCoord;
-layout(location = 1) out vec3 v_normal;
+layout(location = NORMAL) out vec3 v_normal;
 
 layout(std140) uniform vs_ub {
     mat4 u_MVPMatrix;

--- a/axmol/rhi/CMakeLists.txt
+++ b/axmol/rhi/CMakeLists.txt
@@ -7,7 +7,7 @@ set(_AX_RHI_HEADER
   rhi/DepthStencilState.h
   rhi/DriverBase.h
   rhi/PixelBufferDesc.h
-  rhi/PixelFormatUtils.h
+  rhi/RHIUtils.h
   rhi/Program.h
   rhi/ProgramState.h
   rhi/RenderPassDesc.h
@@ -26,7 +26,7 @@ set(_AX_RHI_SRC
   rhi/DriverBase.cpp
   rhi/ShaderModule.cpp
   rhi/Texture.cpp
-  rhi/PixelFormatUtils.cpp
+  rhi/RHIUtils.cpp
   rhi/VertexLayout.cpp
   rhi/Program.cpp
   rhi/ProgramState.cpp

--- a/axmol/rhi/Program.h
+++ b/axmol/rhi/Program.h
@@ -180,7 +180,7 @@ protected:
      */
     Program(std::string_view vs, std::string_view fs);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     /**
      * In case of EGL context lost, the engine will reload shaders. Thus location of uniform may changed.
      * The engine will maintain the relationship between the original uniform location and the current active uniform

--- a/axmol/rhi/ProgramState.cpp
+++ b/axmol/rhi/ProgramState.cpp
@@ -68,7 +68,7 @@ void TextureBindingInfo::assign(const TextureBindingInfo& other)
         this->tex  = other.tex;
         AX_SAFE_RETAIN(this->tex);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         location = other.location;
 #endif
     }
@@ -81,7 +81,7 @@ void TextureBindingInfo::assign(TextureBindingInfo&& other)
         std::swap(slot, other.slot);
         std::swap(tex, other.tex);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         std::swap(location, other.location);
 #endif
     }
@@ -90,13 +90,13 @@ void TextureBindingInfo::assign(TextureBindingInfo&& other)
 void TextureBindingInfo::reset(int location_, int slot_, rhi::Texture* tex_)
 {
     AX_SAFE_RELEASE(this->tex);
-    
+
     this->slot = slot_;
     this->tex  = tex_;
 
     AX_SAFE_RETAIN(this->tex);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     this->location = location_;
 #endif
 }
@@ -127,7 +127,7 @@ bool ProgramState::init(Program* program)
 
     _uniformBuffers.resize((std::max)(_vertexUniformBufferSize + _fragmentUniformBufferSize, (size_t)1), 0);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener =
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { this->resetUniforms(); });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
@@ -151,7 +151,7 @@ void ProgramState::updateBatchId()
 
 void ProgramState::resetUniforms()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     if (_program == nullptr)
         return;
 
@@ -174,7 +174,7 @@ ProgramState::~ProgramState()
 {
     AX_SAFE_RELEASE(_program);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 

--- a/axmol/rhi/ProgramState.cpp
+++ b/axmol/rhi/ProgramState.cpp
@@ -37,69 +37,36 @@ namespace ax::rhi {
 // static field
 std::vector<ProgramState::AutoBindingResolver*> ProgramState::_customAutoBindingResolvers;
 
-TextureInfo::TextureInfo(std::vector<int>&& _slots, std::vector<rhi::Texture*>&& _textures)
-    : TextureInfo(std::move(_slots), std::vector<int>(_slots.size(), 0), std::move(_textures))
-{}
-
-TextureInfo::TextureInfo(std::vector<int>&& _slots,
-                         std::vector<int>&& _indexs,
-                         std::vector<rhi::Texture*>&& _textures)
-    : slots(std::move(_slots)), indexs(std::move(_indexs)), textures(std::move(_textures))
-{
-    retainTextures();
-}
-
-/* CLASS TextureInfo */
-TextureInfo::TextureInfo(const TextureInfo& other)
+TextureBindingInfo::TextureBindingInfo(const TextureBindingInfo& other)
 {
     this->assign(other);
 }
 
-TextureInfo::TextureInfo(TextureInfo&& other)
+TextureBindingInfo::TextureBindingInfo(TextureBindingInfo&& other)
 {
     this->assign(std::move(other));
 }
 
-TextureInfo::~TextureInfo()
-{
-    releaseTextures();
-}
-
-void TextureInfo::retainTextures()
-{
-    for (auto&& texture : textures)
-        AX_SAFE_RETAIN(texture);
-}
-
-void TextureInfo::releaseTextures()
-{
-    for (auto&& texture : textures)
-        AX_SAFE_RELEASE(texture);
-    textures.clear();
-}
-
-TextureInfo& TextureInfo::operator=(const TextureInfo& other) noexcept
+TextureBindingInfo& TextureBindingInfo::operator=(const TextureBindingInfo& other) noexcept
 {
     this->assign(other);
     return *this;
 }
 
-TextureInfo& TextureInfo::operator=(TextureInfo&& other) noexcept
+TextureBindingInfo& TextureBindingInfo::operator=(TextureBindingInfo&& other) noexcept
 {
     this->assign(std::move(other));
     return *this;
 }
 
-void TextureInfo::assign(const TextureInfo& other)
+void TextureBindingInfo::assign(const TextureBindingInfo& other)
 {
     if (this != &other)
     {
-        releaseTextures();
-
-        indexs   = other.indexs;
-        slots    = other.slots;
-        textures = other.textures;
-        retainTextures();
+        AX_SAFE_RELEASE(this->tex);
+        this->slot = other.slot;
+        this->tex  = other.tex;
+        AX_SAFE_RETAIN(this->tex);
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
         location = other.location;
@@ -107,40 +74,36 @@ void TextureInfo::assign(const TextureInfo& other)
     }
 }
 
-void TextureInfo::assign(TextureInfo&& other)
+void TextureBindingInfo::assign(TextureBindingInfo&& other)
 {
     if (this != &other)
     {
-        releaseTextures();
-
-        indexs   = std::move(other.indexs);
-        slots    = std::move(other.slots);
-        textures = std::move(other.textures);
+        std::swap(slot, other.slot);
+        std::swap(tex, other.tex);
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-        location       = other.location;
-        other.location = -1;
+        std::swap(location, other.location);
 #endif
     }
 }
 
-void TextureInfo::assign(int slot, int index, rhi::Texture* texture)
+void TextureBindingInfo::reset(int location_, int slot_, rhi::Texture* tex_)
 {
-    if (textures.size() != 1 or textures[0] != texture or slots[0] != slot or indexs[0] != index)
-    {
-        releaseTextures();
-        indexs.resize(1);
-        indexs[0] = index;
-        slots.resize(1);
-        slots[0] = slot;
-        textures.resize(1);
-        textures[0] = texture;
-        AX_SAFE_RETAIN(texture);
+    AX_SAFE_RELEASE(this->tex);
+    
+    this->slot = slot_;
+    this->tex  = tex_;
+
+    AX_SAFE_RETAIN(this->tex);
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-        location = -1;
+    this->location = location_;
 #endif
-    }
+}
+
+TextureBindingInfo::~TextureBindingInfo()
+{
+    AX_SAFE_RELEASE(this->tex);
 }
 
 /* CLASS ProgramState */
@@ -199,9 +162,9 @@ void ProgramState::resetUniforms()
         auto mappedLocation = _program->getMappedLocation(location);
 
         // check if current location had been set before
-        if (_vertexTextureInfos.find(location) != _vertexTextureInfos.end())
+        if (_textureBindingInfos.find(location) != _textureBindingInfos.end())
         {
-            _vertexTextureInfos[location].location = mappedLocation;
+            _textureBindingInfos[location].location = mappedLocation;
         }
     }
 #endif
@@ -222,8 +185,7 @@ ProgramState::~ProgramState()
 ProgramState* ProgramState::clone() const
 {
     ProgramState* cp          = new ProgramState(_program);
-    cp->_vertexTextureInfos   = _vertexTextureInfos;
-    cp->_fragmentTextureInfos = _fragmentTextureInfos;
+    cp->_textureBindingInfos  = _textureBindingInfos;
     cp->_uniformBuffers       = _uniformBuffers;
 
     cp->_ownVertexLayout = _ownVertexLayout;
@@ -319,76 +281,17 @@ void ProgramState::setSharedVertexLayout(VertexLayout* vertexLayout)
 
 void ProgramState::setTexture(rhi::Texture* texture)
 {
-    for (int slot = 0; slot < texture->getCount() && slot < AX_META_TEXTURES; ++slot)
+    auto location = getUniformLocation((rhi::Uniform)(rhi::Uniform::TEXTURE));
+    setTexture(location, 0, texture);
+}
+
+void ProgramState::setTexture(const rhi::UniformLocation& uniformLocation, int slot, rhi::Texture* texture)
+{
+    if (uniformLocation.fragStage)
     {
-        auto location = getUniformLocation((rhi::Uniform)(rhi::Uniform::TEXTURE + slot));
-        setTexture(location, slot, slot, texture);
+        auto& textureBinding = _textureBindingInfos[uniformLocation.fragStage.location];
+        textureBinding.reset(uniformLocation.fragStage.location, slot, texture);
     }
-}
-
-void ProgramState::setTexture(const rhi::UniformLocation& uniformLocation,
-                              int slot,
-                              rhi::Texture* texture)
-{
-    setTexture(uniformLocation, slot, 0, texture);
-}
-
-void ProgramState::setTexture(const rhi::UniformLocation& uniformLocation,
-                              int slot,
-                              int index,
-                              rhi::Texture* texture)
-{
-    if (uniformLocation.vertStage)
-        setTexture(uniformLocation.vertStage.location, slot, index, texture, _vertexTextureInfos);
-#if AX_RENDER_API == AX_RENDER_API_MTL || AX_RENDER_API == AX_RENDER_API_D3D
-    if (uniformLocation.fragStage)
-        setTexture(uniformLocation.fragStage.location, slot, index, texture, _fragmentTextureInfos);
-#endif
-}
-
-void ProgramState::setTextureArray(const rhi::UniformLocation& uniformLocation,
-                                   std::vector<int> slots,
-                                   std::vector<rhi::Texture*> textures)
-{
-    if (uniformLocation.vertStage)
-        setTextureArray(uniformLocation.vertStage.location, std::move(slots), std::move(textures), _vertexTextureInfos);
-#if AX_RENDER_API == AX_RENDER_API_MTL || AX_RENDER_API == AX_RENDER_API_D3D
-    if (uniformLocation.fragStage)
-        setTextureArray(uniformLocation.fragStage.location, std::move(slots), std::move(textures),
-                        _fragmentTextureInfos);
-#endif
-}
-
-void ProgramState::setTexture(int location,
-                              int slot,
-                              int index,
-                              rhi::Texture* texture,
-                              std::unordered_map<int, TextureInfo>& textureInfo)
-{
-    if (location < 0)
-        return;
-
-    auto& info = textureInfo[location];
-    info.assign(slot, index, texture);
-
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    info.location = location;
-#endif
-}
-
-void ProgramState::setTextureArray(int location,
-                                   std::vector<int> slots,
-                                   std::vector<rhi::Texture*> textures,
-                                   std::unordered_map<int, TextureInfo>& textureInfo)
-{
-    assert(slots.size() == textures.size());
-
-    auto& info = textureInfo[location];
-    info       = {std::move(slots), std::move(textures)};
-
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    info.location = location;
-#endif
 }
 
 void ProgramState::setParameterAutoBinding(std::string_view uniform, std::string_view autoBinding)

--- a/axmol/rhi/ProgramState.h
+++ b/axmol/rhi/ProgramState.h
@@ -68,7 +68,7 @@ struct AX_DLL TextureBindingInfo
 
     int slot{0};
     rhi::Texture* tex{nullptr};
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     int location = -1;
 #endif
 };
@@ -342,7 +342,7 @@ protected:
     uint64_t _batchId    = -1;
     bool _isBatchable = false;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener = nullptr;
 #endif
 };

--- a/axmol/rhi/ProgramState.h
+++ b/axmol/rhi/ProgramState.h
@@ -51,29 +51,23 @@ class VertexLayout;
 /**
  * Store texture information.
  */
-struct AX_DLL TextureInfo
+struct AX_DLL TextureBindingInfo
 {
-    TextureInfo(std::vector<int>&& _slots, std::vector<rhi::Texture*>&& _textures);
-    TextureInfo(std::vector<int>&& _slots, std::vector<int>&& _indexs, std::vector<rhi::Texture*>&& _textures);
-    TextureInfo() = default;
-    TextureInfo(const TextureInfo&);
-    TextureInfo(TextureInfo&& rhs);
+    TextureBindingInfo() = default;
+    TextureBindingInfo(const TextureBindingInfo&);
+    TextureBindingInfo(TextureBindingInfo&& rhs);
+    ~TextureBindingInfo();
 
-    ~TextureInfo();
+    TextureBindingInfo& operator=(const TextureBindingInfo& other) noexcept;
+    TextureBindingInfo& operator=(TextureBindingInfo&& other) noexcept;
 
-    TextureInfo& operator=(const TextureInfo& other) noexcept;
-    TextureInfo& operator=(TextureInfo&& other) noexcept;
+    void assign(const TextureBindingInfo& other);
+    void assign(TextureBindingInfo&& other);
 
-    void assign(const TextureInfo& other);
-    void assign(TextureInfo&& other);
-    void assign(int slot, int index, rhi::Texture* texture);
+    void reset(int location, int slot, rhi::Texture* tex);
 
-    void retainTextures();
-    void releaseTextures();
-
-    std::vector<int> slots;
-    std::vector<int> indexs;
-    std::vector<rhi::Texture*> textures;
+    int slot{0};
+    rhi::Texture* tex{nullptr};
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     int location = -1;
 #endif
@@ -180,39 +174,12 @@ public:
      */
     void setTexture(const rhi::UniformLocation& uniformLocation, int slot, rhi::Texture* texture);
 
-    /**
-     * Set texture.
-     * @param uniformLocation Specifies texture location.
-     * @param slot Specifies texture slot selector.
-     * @param index Specifies texture index selector
-     * @param texture Specifies a pointer to backend texture.
-     */
-    void setTexture(const rhi::UniformLocation& uniformLocation,
-                    int slot,
-                    int index,
-                    rhi::Texture* texture);
-
-    /**
-     * Set textures in array.
-     * @param uniformLocation Specifies texture location.
-     * @param slots Specifies texture slot selector.
-     * @param textures Specifies a vector of backend texture object.
-     */
-    void setTextureArray(const rhi::UniformLocation& uniformLocation,
-                         std::vector<int> slots,
-                         std::vector<rhi::Texture*> textures);
 
     /**
      * Get vertex texture informations
      * @return Vertex texture informations. Key is the texture location, Value store the texture informations
      */
-    inline const std::unordered_map<int, TextureInfo>& getVertexTextureInfos() const { return _vertexTextureInfos; }
-
-    /**
-     * Get fragment texture informations
-     * @return Fragment texture informations. Key is the texture location, Value store the texture informations
-     */
-    inline const std::unordered_map<int, TextureInfo>& getFragmentTextureInfos() const { return _fragmentTextureInfos; }
+    inline const std::unordered_map<int, TextureBindingInfo>& getTextureBindingInfos() const { return _textureBindingInfos; }
 
     /**
      * Get vertex uniform buffer. The buffer store all the vertex uniform's data.
@@ -343,31 +310,6 @@ protected:
 #endif
 
     /**
-     * Set texture.
-     * @param location Specifies the location of texture.
-     * @param slot Specifies slot selector of texture.
-     * @param texture Specifies the texture to set in given location.
-     * @param textureInfo Specifies the texture information to update.
-     */
-    void setTexture(int location,
-                    int slot,
-                    int index,
-                    rhi::Texture* texture,
-                    std::unordered_map<int, TextureInfo>& textureInfo);
-
-    /**
-     * Set textures in array.
-     * @param location Specifies the location of texture.
-     * @param slots Specifies slot selector of texture.
-     * @param textures Specifies the texture to set in given location.
-     * @param textureInfo Specifies the texture information to update.
-     */
-    void setTextureArray(int location,
-                         std::vector<int> slots,
-                         std::vector<rhi::Texture*> textures,
-                         std::unordered_map<int, TextureInfo>& textureInfo);
-
-    /**
      * Reset uniform informations when EGL context lost
      */
     void resetUniforms();
@@ -389,8 +331,7 @@ protected:
     std::size_t _vertexUniformBufferSize   = 0;
     std::size_t _fragmentUniformBufferSize = 0;
 
-    std::unordered_map<int, TextureInfo> _vertexTextureInfos;
-    std::unordered_map<int, TextureInfo> _fragmentTextureInfos;
+    std::unordered_map<int, TextureBindingInfo> _textureBindingInfos;
 
     std::unordered_map<std::string, std::string> _autoBindings;
 

--- a/axmol/rhi/RHITypes.h
+++ b/axmol/rhi/RHITypes.h
@@ -164,7 +164,7 @@ enum class PixelFormat : uint8_t
     /* the count of pixel format supported by axmol */
     COUNT,
 
-    AUTO = 0xff
+    NONE = 0xFF,  //!< No pixel format, used for invalid texture
 };
 
 enum class TextureUsage : uint8_t
@@ -327,9 +327,9 @@ enum class SamplerFilter : uint32_t
     MAG_LINEAR,
 
     // mip filter
-    MIP_NONE = 0,
-    MIP_NEAREST,
+    MIP_NEAREST = 0,
     MIP_LINEAR,
+    MIP_DEFAULT = 0b11,
 
     // alias
     NEAREST = 0,
@@ -363,7 +363,7 @@ struct SamplerDesc
 {
     SamplerFilter minFilter : 2         = SamplerFilter::MIN_LINEAR;
     SamplerFilter magFilter : 1         = SamplerFilter::MAG_LINEAR;
-    SamplerFilter mipFilter : 2         = SamplerFilter::MIP_NONE;
+    SamplerFilter mipFilter : 2         = SamplerFilter::MIP_DEFAULT;
     SamplerAddressMode sAddressMode : 2 = SamplerAddressMode::CLAMP;
     SamplerAddressMode tAddressMode : 2 = SamplerAddressMode::CLAMP;
     SamplerAddressMode wAddressMode : 2 = SamplerAddressMode::CLAMP;
@@ -381,6 +381,7 @@ struct TextureDesc
     uint16_t width            = 1;
     uint16_t height           = 1;
     uint16_t arraySize        = 1;
+    // =1: no mipmaps, =0: generate mipmaps by GPU, >1: mipmaps enabled manually
     uint16_t mipLevels        = 1;
     TextureType textureType   = TextureType::TEXTURE_2D;
     PixelFormat pixelFormat   = PixelFormat::RGBA8;

--- a/axmol/rhi/RHITypes.h
+++ b/axmol/rhi/RHITypes.h
@@ -89,7 +89,7 @@ refer to:
   https://developer.apple.com/documentation/metal/mtlpixelformat?language=objc
  */
 
-enum class PixelFormat : uint32_t
+enum class PixelFormat : uint8_t
 {
     /* below is compression format */
 
@@ -164,10 +164,10 @@ enum class PixelFormat : uint32_t
     /* the count of pixel format supported by axmol */
     COUNT,
 
-    NONE = 0xffff
+    AUTO = 0xff
 };
 
-enum class TextureUsage : uint32_t
+enum class TextureUsage : uint8_t
 {
     READ,
     WRITE,
@@ -299,7 +299,7 @@ enum class Winding : uint32_t
     COUNTER_CLOCK_WISE
 };
 
-enum class TextureType : uint32_t
+enum class TextureType : uint8_t
 {
     TEXTURE_2D,
     TEXTURE_CUBE
@@ -378,12 +378,13 @@ using SamplerHandle = void*;
  */
 struct TextureDesc
 {
+    uint16_t width            = 1;
+    uint16_t height           = 1;
+    uint16_t arraySize        = 1;
+    uint16_t mipLevels        = 1;
     TextureType textureType   = TextureType::TEXTURE_2D;
-    PixelFormat textureFormat = PixelFormat::RGBA8;
+    PixelFormat pixelFormat   = PixelFormat::RGBA8;
     TextureUsage textureUsage = TextureUsage::READ;
-    uint32_t width            = 1;
-    uint32_t height           = 1;
-    uint32_t depth            = 1;
     SamplerDesc samplerDesc{};
 };
 

--- a/axmol/rhi/RHIUtils.cpp
+++ b/axmol/rhi/RHIUtils.cpp
@@ -23,12 +23,12 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 
 namespace ax::rhi
 {
 
-namespace PixelFormatUtils
+namespace RHIUtils
 {
 
 static const PixelFormatDesc s_pixelFormatDescriptors[] = {
@@ -452,7 +452,7 @@ static void convertBGRA8ToRGBA8(const unsigned char* data, size_t dataLen, unsig
 // converter function end
 //////////////////////////////////////////////////////////////////////////
 
-static ax::rhi::PixelFormat convertR8ToFormat(const unsigned char* data,
+static PixelFormat convertR8ToFormat(const unsigned char* data,
                                               size_t dataLen,
                                               PixelFormat format,
                                               unsigned char** outData,
@@ -512,7 +512,7 @@ static ax::rhi::PixelFormat convertR8ToFormat(const unsigned char* data,
     return format;
 }
 
-static ax::rhi::PixelFormat convertRG8ToFormat(const unsigned char* data,
+static PixelFormat convertRG8ToFormat(const unsigned char* data,
                                                size_t dataLen,
                                                PixelFormat format,
                                                unsigned char** outData,
@@ -568,7 +568,7 @@ static ax::rhi::PixelFormat convertRG8ToFormat(const unsigned char* data,
     return format;
 }
 
-static ax::rhi::PixelFormat convertRGB8ToFormat(const unsigned char* data,
+static PixelFormat convertRGB8ToFormat(const unsigned char* data,
                                                 size_t dataLen,
                                                 PixelFormat format,
                                                 unsigned char** outData,
@@ -623,7 +623,7 @@ static ax::rhi::PixelFormat convertRGB8ToFormat(const unsigned char* data,
     return format;
 }
 
-static ax::rhi::PixelFormat convertRGBA8ToFormat(const unsigned char* data,
+static PixelFormat convertRGBA8ToFormat(const unsigned char* data,
                                                  size_t dataLen,
                                                  PixelFormat format,
                                                  unsigned char** outData,
@@ -680,7 +680,7 @@ static ax::rhi::PixelFormat convertRGBA8ToFormat(const unsigned char* data,
     return format;
 }
 
-static ax::rhi::PixelFormat convertRGB5A1ToFormat(const unsigned char* data,
+static PixelFormat convertRGB5A1ToFormat(const unsigned char* data,
                                                   size_t dataLen,
                                                   PixelFormat format,
                                                   unsigned char** outData,
@@ -714,7 +714,7 @@ static ax::rhi::PixelFormat convertRGB5A1ToFormat(const unsigned char* data,
     return format;
 }
 
-static ax::rhi::PixelFormat convertRGB565ToFormat(const unsigned char* data,
+static PixelFormat convertRGB565ToFormat(const unsigned char* data,
                                                   size_t dataLen,
                                                   PixelFormat format,
                                                   unsigned char** outData,
@@ -748,7 +748,7 @@ static ax::rhi::PixelFormat convertRGB565ToFormat(const unsigned char* data,
     return format;
 }
 
-static ax::rhi::PixelFormat convertRGBA4ToFormat(const unsigned char* data,
+static PixelFormat convertRGBA4ToFormat(const unsigned char* data,
                                                  size_t dataLen,
                                                  PixelFormat format,
                                                  unsigned char** outData,
@@ -818,7 +818,7 @@ static PixelFormat convertBGRA8ToFormat(const unsigned char* data,
  rgba(1) -> 12345678
 
  */
-ax::rhi::PixelFormat convertDataToFormat(const unsigned char* data,
+PixelFormat convertDataToFormat(const unsigned char* data,
                                          size_t dataLen,
                                          PixelFormat originFormat,
                                          PixelFormat format,
@@ -859,6 +859,6 @@ ax::rhi::PixelFormat convertDataToFormat(const unsigned char* data,
         return originFormat;
     }
 }
-}  // namespace PixelFormatUtils
+}  // namespace RHIUtils
 
 }  // namespace ax::rhi

--- a/axmol/rhi/RHIUtils.h
+++ b/axmol/rhi/RHIUtils.h
@@ -58,7 +58,7 @@ inline bool isCompressed(PixelFormat format)
 /**convert functions*/
 
 /**
-Convert the format to the format param you specified, if the format is PixelFormat::AUTO, it will detect it
+Convert the format to the format param you specified, if the format is PixelFormat::NONE, it will detect it
 automatically and convert to the closest format for you. It will return the converted format to you. if the outData !=
 data, you must delete it manually.
 */
@@ -69,9 +69,9 @@ PixelFormat convertDataToFormat(const unsigned char* data,
                                 unsigned char** outData,
                                 size_t* outDataLen);
 
-inline uint8_t computeMipLevels(const TextureDesc& desc)
+inline uint8_t computeMipLevels(int width, int height)
 {
-    return static_cast<uint8_t>(floor(log2(std::max(desc.width, desc.height))) + 1);
+    return static_cast<uint8_t>(floor(log2((std::max)(width, height))) + 1);
 }
 } // namespace RHIUtils
 }  // namespace ax::rhi

--- a/axmol/rhi/RHIUtils.h
+++ b/axmol/rhi/RHIUtils.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #include "axmol/platform/PlatformMacros.h"
-#include "axmol/renderer/Texture2D.h"
+#include "axmol/rhi/RHITypes.h"
 
 namespace ax::rhi
 {
-namespace PixelFormatUtils
+namespace RHIUtils
 {
 struct PixelFormatDesc
 {
@@ -58,7 +58,7 @@ inline bool isCompressed(PixelFormat format)
 /**convert functions*/
 
 /**
-Convert the format to the format param you specified, if the format is PixelFormat::NONE, it will detect it
+Convert the format to the format param you specified, if the format is PixelFormat::AUTO, it will detect it
 automatically and convert to the closest format for you. It will return the converted format to you. if the outData !=
 data, you must delete it manually.
 */
@@ -68,5 +68,10 @@ PixelFormat convertDataToFormat(const unsigned char* data,
                                 PixelFormat format,
                                 unsigned char** outData,
                                 size_t* outDataLen);
-};  // namespace PixelFormatUtils
+
+inline uint8_t computeMipLevels(const TextureDesc& desc)
+{
+    return static_cast<uint8_t>(floor(log2(std::max(desc.width, desc.height))) + 1);
+}
+} // namespace RHIUtils
 }  // namespace ax::rhi

--- a/axmol/rhi/SamplerCache.cpp
+++ b/axmol/rhi/SamplerCache.cpp
@@ -51,6 +51,11 @@ void SamplerCache::removeAllSamplers()
     _samplers.clear();
 }
 
+void SamplerCache::invalidateAll()
+{
+    _samplers.clear();
+}
+
 SamplerHandle SamplerCache::getSampler(const SamplerDesc& desc)
 {
     auto key = *reinterpret_cast<const uint32_t*>(&desc);

--- a/axmol/rhi/SamplerCache.h
+++ b/axmol/rhi/SamplerCache.h
@@ -40,6 +40,8 @@ public:
 
     void removeAllSamplers();
 
+    void invalidateAll();
+
     SamplerHandle getSampler(const SamplerDesc& desc);
 
 private:

--- a/axmol/rhi/Texture.cpp
+++ b/axmol/rhi/Texture.cpp
@@ -42,6 +42,10 @@ void Texture::updateTextureDesc(const TextureDesc& desc)
     _overrideMipLevels = desc.mipLevels;
 }
 
+void Texture::invalidate()
+{
+}
+
 void Texture::zeroTexData()
 {
     if (!RHIUtils::isCompressed(_desc.pixelFormat))

--- a/axmol/rhi/Texture.cpp
+++ b/axmol/rhi/Texture.cpp
@@ -42,4 +42,20 @@ void Texture::updateTextureDesc(const TextureDesc& desc)
     _overrideMipLevels = desc.mipLevels;
 }
 
+void Texture::zeroTexData()
+{
+    if (!RHIUtils::isCompressed(_desc.pixelFormat))
+    {
+        const auto w = getWidth();
+        const auto h = getHeight();
+        auto size    = w * h * _bitsPerPixel / 8;
+        assert(size > 0);
+
+        axstd::byte_buffer blackPixels;
+        blackPixels.resize(size, 0);
+
+        updateData(blackPixels.data(), w, h, 0, 0);
+    }
+}
+
 }  // namespace ax::rhi

--- a/axmol/rhi/Texture.cpp
+++ b/axmol/rhi/Texture.cpp
@@ -24,21 +24,17 @@
  ****************************************************************************/
 
 #include "axmol/rhi/Texture.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 #include <cassert>
 namespace ax::rhi
 {
 
 Texture::~Texture() {}
 
-void Texture::updateTextureDesc(const TextureDesc& descriptor, int /*index*/)
+void Texture::updateTextureDesc(const TextureDesc& desc)
 {
-    _bitsPerPixel  = PixelFormatUtils::getBitsPerPixel(descriptor.textureFormat);
-    _textureType   = descriptor.textureType;
-    _textureFormat = descriptor.textureFormat;
-    _textureUsage  = descriptor.textureUsage;
-    _width         = (std::max)(descriptor.width, (uint32_t)1);
-    _height        = (std::max)(descriptor.height, (uint32_t)1);
+    _bitsPerPixel = RHIUtils::getBitsPerPixel(desc.pixelFormat);
+    _desc         = desc;
 
     if (_bitsPerPixel == 0)
     {

--- a/axmol/rhi/Texture.cpp
+++ b/axmol/rhi/Texture.cpp
@@ -37,9 +37,9 @@ void Texture::updateTextureDesc(const TextureDesc& desc)
     _desc         = desc;
 
     if (_bitsPerPixel == 0)
-    {
         _bitsPerPixel = (uint8_t)(8 * 4);
-    }
+
+    _overrideMipLevels = desc.mipLevels;
 }
 
 }  // namespace ax::rhi

--- a/axmol/rhi/Texture.h
+++ b/axmol/rhi/Texture.h
@@ -155,6 +155,12 @@ public:
 
     bool shouldGenMipmaps(int level = 0) const { return _desc.mipLevels == 0 && level == 0 && !_overrideMipLevels; }
 
+    /**
+     * clear texture data to zero.
+     * @remark: only works for uncompressed texture.
+    */
+    void zeroTexData();
+
 protected:
     /**
      * @param descriptor Specifies the texture descriptor.

--- a/axmol/rhi/Texture.h
+++ b/axmol/rhi/Texture.h
@@ -153,6 +153,8 @@ public:
      */
     virtual void updateFaceData(TextureCubeFace side, const void* data) = 0;
 
+    virtual void invalidate();
+
     bool shouldGenMipmaps(int level = 0) const { return _desc.mipLevels == 0 && level == 0 && !_overrideMipLevels; }
 
     /**

--- a/axmol/rhi/Texture.h
+++ b/axmol/rhi/Texture.h
@@ -47,7 +47,7 @@ public:
      * Update sampler
      * @param sampler Specifies the sampler descriptor.
      */
-    virtual void updateSamplerDesc(const SamplerDesc& sampler) = 0;
+    virtual void updateSamplerDesc(const SamplerDesc& desc) = 0;
 
     /// Generate mipmaps.
     virtual void generateMipmaps() = 0;
@@ -56,36 +56,36 @@ public:
      * Update texture description.
      * @param descriptor Specifies texture and sampler descriptor.
      */
-    virtual void updateTextureDesc(const TextureDesc& descriptor, int index = 0);
+    virtual void updateTextureDesc(const TextureDesc& desc);
 
     /**
      * Get texture format.
-     * @return Texture format.
+     * @return Texture pixel format.
      */
-    inline PixelFormat getTextureFormat() const { return _textureFormat; }
+    inline PixelFormat getPixelFormat() const { return _desc.pixelFormat; }
 
     /**
      * Get texture usage. Symbolic constant can be READ, WRITE or RENDER_TARGET.
      * @return Texture usage.
      */
-    inline TextureUsage getTextureUsage() const { return _textureUsage; }
+    inline TextureUsage getTextureUsage() const { return _desc.textureUsage; }
 
     /**
      * Get texture type. Symbolic constant value can be either TEXTURE_2D or TEXTURE_CUBE.
      * @return Texture type.
      */
-    inline TextureType getTextureType() const { return _textureType; }
+    inline TextureType getTextureType() const { return _desc.textureType; }
 
     /**
      * Check if mipmap had generated before.
      * @return true if the mipmap has always generated before, otherwise false.
      */
-    inline bool hasMipmaps() const { return _hasMipmaps; }
+    inline bool hasMipmaps() const { return _desc.mipLevels > 1; }
 
     virtual int getCount() const { return 1; };
 
-    int getWidth() const { return _width; }
-    int getHeight() const { return _height; }
+    int getWidth() const { return _desc.width; }
+    int getHeight() const { return _desc.height; }
 
     /**
      * Update a two-dimensional texture image
@@ -94,8 +94,13 @@ public:
      * @param height Specifies the height of the texture image.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateData(uint8_t* data, std::size_t width, std::size_t height, std::size_t level, int index = 0) = 0;
+    virtual void updateData(const void* data,
+                            std::size_t width,
+                            std::size_t height,
+                            std::size_t level,
+                            int layerIndex) = 0;
 
     /**
      * Update a two-dimensional texture image in a compressed format
@@ -105,13 +110,14 @@ public:
      * @param dataLen Specifies the totoal size of compressed image in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateCompressedData(uint8_t* data,
+    virtual void updateCompressedData(const void* data,
                                       std::size_t width,
                                       std::size_t height,
                                       std::size_t dataLen,
                                       std::size_t level,
-                                      int index = 0) = 0;
+                                      int layerIndex) = 0;
 
     /**
      * Update a two-dimensional texture subimage
@@ -122,14 +128,15 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the image data in memory.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
     virtual void updateSubData(std::size_t xoffset,
                                std::size_t yoffset,
                                std::size_t width,
                                std::size_t height,
                                std::size_t level,
-                               uint8_t* data,
-                               int index = 0) = 0;
+                               const void* data,
+                               int layerIndex) = 0;
 
     /**
      * Update a two-dimensional texture subimage in a compressed format
@@ -141,6 +148,7 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the compressed image data in memory.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
     virtual void updateCompressedSubData(std::size_t xoffset,
                                          std::size_t yoffset,
@@ -148,15 +156,15 @@ public:
                                          std::size_t height,
                                          std::size_t dataLen,
                                          std::size_t level,
-                                         uint8_t* data,
-                                         int index = 0) = 0;
+                                         const void* data,
+                                         int layerIndex) = 0;
 
     /**
      * Update texutre cube data in give slice side.
      * @param side Specifies which slice texture of cube to be update.
      * @param data Specifies a pointer to the image data in memory.
      */
-    virtual void updateFaceData(TextureCubeFace side, void* data, int index = 0) = 0;
+    virtual void updateFaceData(TextureCubeFace side, const void* data) = 0;
 
 protected:
     /**
@@ -167,13 +175,12 @@ protected:
 
     /// The bytes of all components.
     uint8_t _bitsPerPixel = 0;
-    bool _hasMipmaps      = false;
-    uint32_t _width       = 0;
-    uint32_t _height      = 0;
 
-    TextureType _textureType   = TextureType::TEXTURE_2D;
-    PixelFormat _textureFormat = PixelFormat::RGBA8;
-    TextureUsage _textureUsage = TextureUsage::READ;
+    //TextureType _textureType   = TextureType::TEXTURE_2D;
+    //PixelFormat _textureFormat = PixelFormat::RGBA8;
+    //TextureUsage _textureUsage = TextureUsage::READ;
+
+    TextureDesc _desc;
 };
 
 // end of _rhi group

--- a/axmol/rhi/Texture.h
+++ b/axmol/rhi/Texture.h
@@ -31,7 +31,8 @@
 
 #include <functional>
 
-namespace ax::rhi {
+namespace ax::rhi
+{
 /**
  * @addtogroup _rhi
  * @{
@@ -48,9 +49,6 @@ public:
      * @param sampler Specifies the sampler descriptor.
      */
     virtual void updateSamplerDesc(const SamplerDesc& desc) = 0;
-
-    /// Generate mipmaps.
-    virtual void generateMipmaps() = 0;
 
     /**
      * Update texture description.
@@ -80,12 +78,10 @@ public:
      * Check if mipmap had generated before.
      * @return true if the mipmap has always generated before, otherwise false.
      */
-    inline bool hasMipmaps() const { return _desc.mipLevels > 1; }
+    inline bool hasMipmaps() const { return _overrideMipLevels > 1; }
 
-    virtual int getCount() const { return 1; };
-
-    int getWidth() const { return _desc.width; }
-    int getHeight() const { return _desc.height; }
+    int getWidth() const { return static_cast<int>(_desc.width); }
+    int getHeight() const { return static_cast<int>(_desc.height); }
 
     /**
      * Update a two-dimensional texture image
@@ -96,27 +92,23 @@ public:
      * reduction image.
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateData(const void* data,
-                            std::size_t width,
-                            std::size_t height,
-                            std::size_t level,
-                            int layerIndex) = 0;
+    virtual void updateData(const void* data, int width, int height, int level, int layerIndex) = 0;
 
     /**
      * Update a two-dimensional texture image in a compressed format
      * @param data Specifies a pointer to the compressed image data in memory.
      * @param width Specifies the width of the texture image.
      * @param height Specifies the height of the texture image.
-     * @param dataLen Specifies the totoal size of compressed image in bytes.
+     * @param dataSize Specifies the totoal size of compressed image in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
     virtual void updateCompressedData(const void* data,
-                                      std::size_t width,
-                                      std::size_t height,
-                                      std::size_t dataLen,
-                                      std::size_t level,
+                                      int width,
+                                      int height,
+                                      std::size_t dataSize,
+                                      int level,
                                       int layerIndex) = 0;
 
     /**
@@ -130,13 +122,8 @@ public:
      * @param data Specifies a pointer to the image data in memory.
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateSubData(std::size_t xoffset,
-                               std::size_t yoffset,
-                               std::size_t width,
-                               std::size_t height,
-                               std::size_t level,
-                               const void* data,
-                               int layerIndex) = 0;
+    virtual void
+    updateSubData(int xoffset, int yoffset, int width, int height, int level, const void* data, int layerIndex) = 0;
 
     /**
      * Update a two-dimensional texture subimage in a compressed format
@@ -144,18 +131,18 @@ public:
      * @param yoffset Specifies a texel offset in the y direction within the texture array.
      * @param width Specifies the width of the texture subimage.
      * @param height Specifies the height of the texture subimage.
-     * @param dataLen Specifies the totoal size of compressed subimage in bytes.
+     * @param dataSize Specifies the totoal size of compressed subimage in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the compressed image data in memory.
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateCompressedSubData(std::size_t xoffset,
-                                         std::size_t yoffset,
-                                         std::size_t width,
-                                         std::size_t height,
-                                         std::size_t dataLen,
-                                         std::size_t level,
+    virtual void updateCompressedSubData(int xoffset,
+                                         int yoffset,
+                                         int width,
+                                         int height,
+                                         std::size_t dataSize,
+                                         int level,
                                          const void* data,
                                          int layerIndex) = 0;
 
@@ -166,6 +153,8 @@ public:
      */
     virtual void updateFaceData(TextureCubeFace side, const void* data) = 0;
 
+    bool shouldGenMipmaps(int level = 0) const { return _desc.mipLevels == 0 && level == 0 && !_overrideMipLevels; }
+
 protected:
     /**
      * @param descriptor Specifies the texture descriptor.
@@ -174,15 +163,11 @@ protected:
     virtual ~Texture();
 
     /// The bytes of all components.
-    uint8_t _bitsPerPixel = 0;
-
-    //TextureType _textureType   = TextureType::TEXTURE_2D;
-    //PixelFormat _textureFormat = PixelFormat::RGBA8;
-    //TextureUsage _textureUsage = TextureUsage::READ;
-
+    uint8_t _bitsPerPixel       = 0;
+    uint16_t _overrideMipLevels = 0;
     TextureDesc _desc;
 };
 
 // end of _rhi group
 /// @}
-}
+}  // namespace ax::rhi

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -576,24 +576,14 @@ void CommandBufferImpl::prepareDrawing()
 
     // bind texture
     _textureBounds = 0;
-    const auto& textureInfo = _programState->getFragmentTextureInfos();
-    for (const auto& texBinding : textureInfo)
+    for (const auto& [_,bindingInfo] : _programState->getTextureBindingInfos())
     {
-        auto texture = texBinding.second;
-        auto& slots  = texBinding.second.slots;
-
-        int i = 0;
-        for (const auto& texture : texture.textures)
-        {
-            auto textureImpl = static_cast<TextureImpl*>(texture);
-            // static_cast<TextureImpl*>(texture)->apply(slots[i], indexs[i]);
-            auto& textureHandle = textureImpl->internalHandle(i);
-            context->PSSetShaderResources(slots[i], 1, &textureHandle.srv);
-            auto samplerState = textureImpl->getSamplerState();
-            context->PSSetSamplers(slots[i], 1, &samplerState);
-            ++i;
-            ++_textureBounds;
-        }
+        auto textureImpl = static_cast<TextureImpl*>(bindingInfo.tex);
+        auto& textureHandle = textureImpl->internalHandle();
+        context->PSSetShaderResources(bindingInfo.slot, 1, &textureHandle.srv);
+        auto samplerState = textureImpl->getSamplerState();
+        context->PSSetSamplers(bindingInfo.slot, 1, &samplerState);
+        ++_textureBounds;
     }
 
     // depth stencil

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -346,26 +346,24 @@ SamplerHandle DriverImpl::createSampler(const SamplerDesc& desc)
     }
     else
     {
-        const int minL = static_cast<int>(desc.minFilter) & 1;
-        const int magL = static_cast<int>(desc.magFilter) & 1;
-        const int mipL = static_cast<int>(desc.mipFilter) & 1;
+        const auto minL = ((int)desc.minFilter & (int)SamplerFilter::MIN_LINEAR);
+        const auto magL = ((int)desc.magFilter & (int)SamplerFilter::MAG_LINEAR);
+        const auto mipL = ((int)desc.mipFilter & (int)SamplerFilter::MIP_LINEAR);
 
-        if (!minL && !magL && !mipL)
-            sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-        else if (!minL && !magL && mipL)
-            sd.Filter = D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR;
-        else if (!minL && magL && !mipL)
-            sd.Filter = D3D11_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
-        else if (!minL && magL && mipL)
-            sd.Filter = D3D11_FILTER_MIN_POINT_MAG_MIP_LINEAR;
-        else if (minL && !magL && !mipL)
-            sd.Filter = D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT;
-        else if (minL && !magL && mipL)
-            sd.Filter = D3D11_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR;
-        else if (minL && magL && !mipL)
-            sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
-        else
-            sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        // minL<<2 | magL<<1 | mipL
+        static const D3D11_FILTER filterTable[8] = {
+            D3D11_FILTER_MIN_MAG_MIP_POINT,                // 000
+            D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR,         // 001
+            D3D11_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,   // 010
+            D3D11_FILTER_MIN_POINT_MAG_MIP_LINEAR,         // 011
+            D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT,         // 100
+            D3D11_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,  // 101
+            D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT,         // 110
+            D3D11_FILTER_MIN_MAG_MIP_LINEAR                // 111
+        };
+
+        const int idx = (minL << 2) | (magL << 1) | (mipL ? 1 : 0);
+        sd.Filter     = filterTable[idx];
 
         sd.MaxAnisotropy = 1;
     }

--- a/axmol/rhi/d3d/RenderPipelineD3D.cpp
+++ b/axmol/rhi/d3d/RenderPipelineD3D.cpp
@@ -252,15 +252,7 @@ void RenderPipelineImpl::update(const RenderTarget*, const PipelineDesc& desc)
 
     constexpr UINT sampleMask = 0xFFFFFFFF;
 
-    if (desc.blendDesc.blendEnabled)
-    {
-        // axmol don't call glBlendColor, so the default blendFactor shoud be transparent
-        const FLOAT blendColor[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-        _context->OMSetBlendState(blendState.Get(), blendColor, sampleMask);
-    }
-    else
-    {
-        _context->OMSetBlendState(nullptr, nullptr, sampleMask);
-    }
+    const FLOAT blendColor[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    _context->OMSetBlendState(blendState.Get(), blendColor, sampleMask);
 }
 }  // namespace ax::rhi::d3d

--- a/axmol/rhi/d3d/RenderTargetD3D.cpp
+++ b/axmol/rhi/d3d/RenderTargetD3D.cpp
@@ -87,7 +87,7 @@ void RenderTargetImpl::update(ID3D11DeviceContext* context) const
         {
             if (_depthStencil)
             {
-                auto fmtInfo = UtilsD3D::toDxgiFormatInfo(_depthStencil.texture->getTextureFormat());
+                auto fmtInfo = UtilsD3D::toDxgiFormatInfo(_depthStencil.texture->getPixelFormat());
                 D3D11_DEPTH_STENCIL_VIEW_DESC desc{};
                 desc.Format = fmtInfo->fmtDsv;
                 desc.ViewDimension      = D3D11_DSV_DIMENSION_TEXTURE2D;

--- a/axmol/rhi/d3d/TextureD3D.cpp
+++ b/axmol/rhi/d3d/TextureD3D.cpp
@@ -102,7 +102,7 @@ static void fromD3DTexDesc(TextureDesc& td, const D3D11_TEXTURE2D_DESC& desc)
         td.pixelFormat = PixelFormat::D24S8;
         break;
     default:
-        td.pixelFormat = PixelFormat::AUTO;
+        td.pixelFormat = PixelFormat::NONE;
         break;
     }
 
@@ -158,82 +158,30 @@ void TextureImpl::updateTextureDesc(const TextureDesc& desc)
     updateSamplerDesc(desc.samplerDesc);
 }
 
-// ------------------------------------------------------------
-// generateMipmaps
-// ------------------------------------------------------------
-void TextureImpl::generateMipmaps()
-{
-    if (TextureUsage::RENDER_TARGET == _desc.textureUsage)
-        return;
-    if (!_nativeTexture)
-    {
-        // geneate mipmaps by GPU required at least upload data once
-        return;
-    }
-
-    auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
-
-    bool gpuMipmaps = false;
-
-    if (_desc.mipLevels == 0)
-    {  // recreate mipmaps
-        context->GenerateMips(_nativeTexture.srv);
-        gpuMipmaps = true;
-    }
-    else if (_desc.mipLevels == 1)
-    {
-        // FIXME: consider add a member mipLevels to TextureDesc to avoid recreate texture
-        auto storedTexture = _nativeTexture.detach();
-
-        // mark mipLevels=0 to recreate a texture which can be generate mips by GPU
-        _desc.mipLevels = 0;
-        ensureNativeTexture();
-        if (_nativeTexture)
-        {
-            context->CopySubresourceRegion(_nativeTexture.tex2d, 0, 0, 0, 0, storedTexture.tex2d, 0, nullptr);
-            context->GenerateMips(_nativeTexture.srv);
-            storedTexture.destroy();
-            gpuMipmaps = true;
-        }
-        else
-        {
-            AXLOGW("generate mipmaps fail");
-            _nativeTexture = storedTexture;
-        }
-    }  // other, not support geneate mipmaps by GPU
-
-    if (gpuMipmaps)
-    {
-        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
-        _nativeTexture.srv->GetDesc(&srvDesc);
-        _desc.mipLevels = srvDesc.Texture2D.MipLevels;
-    }
-}
-
 void TextureImpl::updateData(const void* data,
-                             std::size_t width,
-                             std::size_t height,
-                             std::size_t level,
+                             int width,
+                             int height,
+                             int level,
                              int layerIndex /*=0*/)
 {
     updateSubData(0, 0, width, height, level, data, layerIndex);
 }
 
 void TextureImpl::updateCompressedData(const void* data,
-                                       std::size_t width,
-                                       std::size_t height,
-                                       std::size_t dataLen,
-                                       std::size_t level,
+                                       int width,
+                                       int height,
+                                       std::size_t dataSize,
+                                       int level,
                                        int layerIndex /*=0*/)
 {
-    updateCompressedSubData(0, 0, width, height, dataLen, level, data, layerIndex);
+    updateCompressedSubData(0, 0, width, height, dataSize, level, data, layerIndex);
 }
 
-void TextureImpl::updateSubData(std::size_t xoffset,
-                                std::size_t yoffset,
-                                std::size_t width,
-                                std::size_t height,
-                                std::size_t level,
+void TextureImpl::updateSubData(int xoffset,
+                                int yoffset,
+                                int width,
+                                int height,
+                                int level,
                                 const void* data,
                                 int layerIndex /*=0*/)
 {
@@ -254,14 +202,17 @@ void TextureImpl::updateSubData(std::size_t xoffset,
     auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
     UINT subresource = D3D11CalcSubresource(level, layerIndex, _desc.mipLevels);
     context->UpdateSubresource(_nativeTexture, subresource, &box, data, rowPitch, slicePitch);
+
+    if (shouldGenMipmaps(level))
+        generateMipmaps(context);
 }
 
-void TextureImpl::updateCompressedSubData(std::size_t xoffset,
-                                          std::size_t yoffset,
-                                          std::size_t width,
-                                          std::size_t height,
-                                          std::size_t dataLen,
-                                          std::size_t level,
+void TextureImpl::updateCompressedSubData(int xoffset,
+                                          int yoffset,
+                                          int width,
+                                          int height,
+                                          std::size_t /*dataSize*/,
+                                          int level,
                                           const void* data,
                                           int layerIndex /*=0*/)
 {
@@ -279,6 +230,9 @@ void TextureImpl::updateCompressedSubData(std::size_t xoffset,
     auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
     UINT subresource = D3D11CalcSubresource(level, layerIndex, _desc.mipLevels);
     context->UpdateSubresource(_nativeTexture, subresource, &box, data, 0, 0);
+
+    if (shouldGenMipmaps(level))
+        generateMipmaps(context);
 }
 
 void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
@@ -305,6 +259,9 @@ void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
     // 3. update
     //-------------------------------------------------------------------
     context->UpdateSubresource(_nativeTexture, subresource, nullptr, data, rowPitch, slicePitch);
+
+    if (shouldGenMipmaps())
+        generateMipmaps(context);
 }
 
 void TextureImpl::ensureNativeTexture()
@@ -380,6 +337,28 @@ void TextureImpl::ensureNativeTexture()
     }
 
     _nativeTexture = TextureHandle{texture.Detach(), srv.Detach()};
+}
+
+
+// ------------------------------------------------------------
+// generateMipmaps
+// ------------------------------------------------------------
+void TextureImpl::generateMipmaps(ID3D11DeviceContext* context)
+{
+    if (TextureUsage::RENDER_TARGET == _desc.textureUsage)
+        return;
+    if (!_nativeTexture)
+    {
+        // geneate mipmaps by GPU required at least upload data once
+        return;
+    }
+
+    // generate mipmaps
+    context->GenerateMips(_nativeTexture.srv);
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+    _nativeTexture.srv->GetDesc(&srvDesc);
+
+    _overrideMipLevels = (std::max)(1u, srvDesc.Texture2D.MipLevels);
 }
 
 }  // namespace ax::rhi::d3d

--- a/axmol/rhi/d3d/TextureD3D.cpp
+++ b/axmol/rhi/d3d/TextureD3D.cpp
@@ -118,9 +118,6 @@ static void fromD3DTexDesc(TextureDesc& td, const D3D11_TEXTURE2D_DESC& desc)
 TextureImpl::TextureImpl(ID3D11Device* device, const TextureDesc& desc) : _device(device)
 {
     updateTextureDesc(desc);
-
-    if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
-        zeroTexData();
 }
 
 TextureImpl::TextureImpl(ID3D11Device* device, ID3D11Texture2D* texture) : _device(device)
@@ -190,6 +187,9 @@ void TextureImpl::updateSubData(int xoffset,
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
     ensureNativeTexture();
+
+    if(!data) [[unlikely]]
+        return;
 
     D3D11_BOX box{};
     box.left   = static_cast<UINT>(xoffset);

--- a/axmol/rhi/d3d/TextureD3D.cpp
+++ b/axmol/rhi/d3d/TextureD3D.cpp
@@ -24,7 +24,7 @@
 #include "axmol/rhi/d3d/TextureD3D.h"
 #include "axmol/rhi/d3d/DriverD3D.h"
 #include "axmol/rhi/d3d/UtilsD3D.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 #include "axmol/rhi/SamplerCache.h"
 
 namespace ax::rhi::d3d
@@ -55,12 +55,13 @@ static void translateTexDesc(const TextureDesc& desc, D3D11_TEXTURE2D_DESC& outD
     outDesc.Height             = desc.height;
     outDesc.SampleDesc.Count   = 1;
     outDesc.SampleDesc.Quality = 0;
+    outDesc.MipLevels          = desc.mipLevels;
     translateUsage(desc.textureUsage, outDesc);
 
     switch (desc.textureType)
     {
     case TextureType::TEXTURE_2D:
-        outDesc.ArraySize = 1;
+        outDesc.ArraySize = desc.arraySize;
         break;
     case TextureType::TEXTURE_CUBE:
         outDesc.ArraySize = 6;
@@ -69,7 +70,7 @@ static void translateTexDesc(const TextureDesc& desc, D3D11_TEXTURE2D_DESC& outD
     }
 
     // depth-stencil
-    switch (desc.textureFormat)
+    switch (desc.pixelFormat)
     {
     case PixelFormat::D24S8:
         outDesc.BindFlags |= D3D11_BIND_DEPTH_STENCIL;
@@ -85,24 +86,23 @@ static void fromD3DTexDesc(TextureDesc& td, const D3D11_TEXTURE2D_DESC& desc)
 {
     td.textureType = TextureType::TEXTURE_2D;
 
-    td.width  = desc.Width;
-    td.height = desc.Height;
-
-    td.depth = 1;  // desc.ArraySize
+    td.width     = static_cast<uint16_t>(desc.Width);
+    td.height    = static_cast<uint16_t>(desc.Height);
+    td.arraySize = desc.ArraySize;
 
     switch (desc.Format)
     {
     case DXGI_FORMAT_R8G8B8A8_UNORM:
-        td.textureFormat = PixelFormat::RGBA8;
+        td.pixelFormat = PixelFormat::RGBA8;
         break;
     case DXGI_FORMAT_R8_UNORM:
-        td.textureFormat = PixelFormat::R8;
+        td.pixelFormat = PixelFormat::R8;
         break;
     case DXGI_FORMAT_D24_UNORM_S8_UINT:
-        td.textureFormat = PixelFormat::D24S8;
+        td.pixelFormat = PixelFormat::D24S8;
         break;
     default:
-        td.textureFormat = PixelFormat::NONE;
+        td.pixelFormat = PixelFormat::AUTO;
         break;
     }
 
@@ -112,105 +112,29 @@ static void fromD3DTexDesc(TextureDesc& td, const D3D11_TEXTURE2D_DESC& desc)
         td.textureUsage = TextureUsage::READ;
 }
 
-TextureHandle TextureResource::createTexture(UINT mipLevels)
-{
-    D3D11_TEXTURE2D_DESC texDesc{};
-    translateTexDesc(_desc, texDesc);
-
-    texDesc.MipLevels = mipLevels;
-
-    if (mipLevels == 0)
-    {
-        texDesc.MiscFlags |= D3D11_RESOURCE_MISC_GENERATE_MIPS;
-        texDesc.BindFlags |= D3D11_BIND_RENDER_TARGET;
-    }
-
-    auto fmtInfo = UtilsD3D::toDxgiFormatInfo(_desc.textureFormat);
-    assert(fmtInfo);
-    if (fmtInfo->format == DXGI_FORMAT_UNKNOWN)
-    {
-        AXLOGE("axmol: D3D not support pixel format: {}", (int)_desc.textureFormat);
-        return TextureHandle{};
-    }
-
-    texDesc.Format = fmtInfo->format;
-
-    ComPtr<ID3D11Texture2D> texture;
-    HRESULT hr = _device->CreateTexture2D(&texDesc, nullptr, texture.GetAddressOf());
-    if (FAILED(hr) || !texture)
-    {
-        return TextureHandle{};
-    }
-
-    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
-    srvDesc.Format = fmtInfo->fmtSrv;
-    switch (_desc.textureType)
-    {
-    case TextureType::TEXTURE_CUBE:
-        srvDesc.ViewDimension               = D3D11_SRV_DIMENSION_TEXTURECUBE;
-        srvDesc.TextureCube.MipLevels       = -1;
-        srvDesc.TextureCube.MostDetailedMip = 0;
-        break;
-    default:
-        srvDesc.ViewDimension             = D3D11_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels       = -1;
-        srvDesc.Texture2D.MostDetailedMip = 0;
-    }
-
-    ComPtr<ID3D11ShaderResourceView> srv;
-    hr = _device->CreateShaderResourceView(texture.Get(), &srvDesc, srv.GetAddressOf());
-
-    if (FAILED(hr) || !srv)
-    {
-        return TextureHandle{};
-    }
-
-    return TextureHandle{texture.Detach(), srv.Detach()};
-}
-
-TextureHandle TextureResource::ensure(int index)
-{
-    if (index < 0 || index >= _textures.size())
-        return TextureHandle{};
-
-    if (_textures[index])
-        return _textures[index];
-
-    _textures[index] = createTexture(1);
-    _maxIdx          = (std::max)(_maxIdx, index + 1);
-
-    return _textures[index];
-}
-
 // ------------------------------------------------------------
 // ctor / dtor
 // ------------------------------------------------------------
-TextureImpl::TextureImpl(ID3D11Device* device, const TextureDesc& descriptor) : _textureRes(device)
+TextureImpl::TextureImpl(ID3D11Device* device, const TextureDesc& desc) : _device(device)
 {
-    updateTextureDesc(descriptor);
-    // TODO:
-    // _rendererRecreatedListener = EventDispatcher::addListener(
-    //     EventType::RENDERER_RECREATED, [this](auto&&) { updateTextureDesc(this->_textureDesc); });
+    updateTextureDesc(desc);
 }
 
-TextureImpl::TextureImpl(ID3D11Device* device, ID3D11Texture2D* texture) : _textureRes(device)
+TextureImpl::TextureImpl(ID3D11Device* device, ID3D11Texture2D* texture) : _device(device)
 {
     texture->AddRef();
-    _textureRes._textures[0].tex2d = texture;
-    _textureRes._maxIdx            = 0;
+    _nativeTexture.tex2d = texture;
 
     D3D11_TEXTURE2D_DESC desc;
     texture->GetDesc(&desc);
-    fromD3DTexDesc(_textureRes._desc, desc);
+    fromD3DTexDesc(_desc, desc);
 
-    Texture::updateTextureDesc(_textureRes._desc);
+    Texture::updateTextureDesc(_desc);
 }
 
 TextureImpl::~TextureImpl()
 {
-    // TODO:
-    // EventDispatcher::removeListener(_rendererRecreatedListener);
-    _textureRes.destroy();
+    _nativeTexture.destroy();
 }
 
 // ------------------------------------------------------------
@@ -218,23 +142,20 @@ TextureImpl::~TextureImpl()
 // ------------------------------------------------------------
 void TextureImpl::updateSamplerDesc(const SamplerDesc& desc)
 {
-    _textureRes._samplerState = static_cast<ID3D11SamplerState*>(SamplerCache::getInstance()->getSampler(desc));
+    _desc.samplerDesc = desc;
+    _samplerState     = static_cast<ID3D11SamplerState*>(SamplerCache::getInstance()->getSampler(desc));
 }
 
 // ------------------------------------------------------------
 // updateTextureDesc
 // ------------------------------------------------------------
-void TextureImpl::updateTextureDesc(const TextureDesc& descriptor, int index /*=0*/)
+void TextureImpl::updateTextureDesc(const TextureDesc& desc)
 {
+    _desc = desc;
 
-    _textureRes._desc = descriptor;
+    Texture::updateTextureDesc(desc);
 
-    Texture::updateTextureDesc(descriptor);
-
-    updateSamplerDesc(descriptor.samplerDesc);
-
-    if (descriptor.textureFormat != PixelFormat::NONE)
-        _textureRes.ensure(index);
+    updateSamplerDesc(desc.samplerDesc);
 }
 
 // ------------------------------------------------------------
@@ -242,69 +163,70 @@ void TextureImpl::updateTextureDesc(const TextureDesc& descriptor, int index /*=
 // ------------------------------------------------------------
 void TextureImpl::generateMipmaps()
 {
-    if (TextureUsage::RENDER_TARGET == _textureUsage)
+    if (TextureUsage::RENDER_TARGET == _desc.textureUsage)
         return;
-
-    if (!_hasMipmaps)
+    if (!_nativeTexture)
     {
-        _hasMipmaps  = true;
-        auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
+        // geneate mipmaps by GPU required at least upload data once
+        return;
+    }
 
+    auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
+
+    bool gpuMipmaps = false;
+
+    if (_desc.mipLevels == 0)
+    {  // recreate mipmaps
+        context->GenerateMips(_nativeTexture.srv);
+        gpuMipmaps = true;
+    }
+    else if (_desc.mipLevels == 1)
+    {
         // FIXME: consider add a member mipLevels to TextureDesc to avoid recreate texture
-        //
-        _textureRes.foreachTextures([context, this](TextureHandle& h, int) {
-            if (h && h.srv)
-            {
-                // recreate texture with mip
-                auto tmp = _textureRes.createTexture(0);
-                if (tmp)
-                {
-                    context->CopySubresourceRegion(tmp.tex2d, 0, 0, 0, 0, h.tex2d, 0, nullptr);
-                    context->GenerateMips(tmp.srv);
-                    h.Release();
-                    h = tmp;
-                }
-            }
-        });
+        auto storedTexture = _nativeTexture.detach();
 
-        auto mainTexture = _textureRes._textures[0];
-        if (mainTexture.srv)
+        // mark mipLevels=0 to recreate a texture which can be generate mips by GPU
+        _desc.mipLevels = 0;
+        ensureNativeTexture();
+        if (_nativeTexture)
         {
-            D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
-            mainTexture.srv->GetDesc(&srvDesc);
-            _textureRes._mipLevels = srvDesc.Texture2D.MipLevels;
+            context->CopySubresourceRegion(_nativeTexture.tex2d, 0, 0, 0, 0, storedTexture.tex2d, 0, nullptr);
+            context->GenerateMips(_nativeTexture.srv);
+            storedTexture.destroy();
+            gpuMipmaps = true;
         }
+        else
+        {
+            AXLOGW("generate mipmaps fail");
+            _nativeTexture = storedTexture;
+        }
+    }  // other, not support geneate mipmaps by GPU
+
+    if (gpuMipmaps)
+    {
+        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+        _nativeTexture.srv->GetDesc(&srvDesc);
+        _desc.mipLevels = srvDesc.Texture2D.MipLevels;
     }
 }
 
-void TextureImpl::updateData(uint8_t* data, std::size_t width, std::size_t height, std::size_t level, int index /*=0*/)
+void TextureImpl::updateData(const void* data,
+                             std::size_t width,
+                             std::size_t height,
+                             std::size_t level,
+                             int layerIndex /*=0*/)
 {
-    assert(_textureType == TextureType::TEXTURE_2D);
-    _textureRes.ensure(index);
-    AX_ASSERT(index <= _textureRes._maxIdx);
-
-    auto rowPitch = PixelFormatUtils::computeRowPitch(_textureFormat, static_cast<uint32_t>(width));
-
-    UINT slicePitch = rowPitch * static_cast<UINT>(height);
-
-    auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
-    context->UpdateSubresource(_textureRes._textures[index].tex2d, static_cast<UINT>(level), nullptr, data, rowPitch,
-                               slicePitch);
+    updateSubData(0, 0, width, height, level, data, layerIndex);
 }
 
-void TextureImpl::updateCompressedData(uint8_t* data,
+void TextureImpl::updateCompressedData(const void* data,
                                        std::size_t width,
                                        std::size_t height,
                                        std::size_t dataLen,
                                        std::size_t level,
-                                       int index /*=0*/)
+                                       int layerIndex /*=0*/)
 {
-    assert(_textureType == TextureType::TEXTURE_2D);
-    _textureRes.ensure(index);
-    AX_ASSERT(index <= _textureRes._maxIdx);
-
-    auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
-    context->UpdateSubresource(_textureRes._textures[index].tex2d, static_cast<UINT>(level), nullptr, data, 0, 0);
+    updateCompressedSubData(0, 0, width, height, dataLen, level, data, layerIndex);
 }
 
 void TextureImpl::updateSubData(std::size_t xoffset,
@@ -312,12 +234,11 @@ void TextureImpl::updateSubData(std::size_t xoffset,
                                 std::size_t width,
                                 std::size_t height,
                                 std::size_t level,
-                                uint8_t* data,
-                                int index /*=0*/)
+                                const void* data,
+                                int layerIndex /*=0*/)
 {
-    assert(_textureType == TextureType::TEXTURE_2D);
-    _textureRes.ensure(index);
-    AX_ASSERT(index <= _textureRes._maxIdx);
+    assert(_desc.textureType == TextureType::TEXTURE_2D);
+    ensureNativeTexture();
 
     D3D11_BOX box{};
     box.left   = static_cast<UINT>(xoffset);
@@ -327,12 +248,12 @@ void TextureImpl::updateSubData(std::size_t xoffset,
     box.bottom = static_cast<UINT>(yoffset + height);
     box.back   = 1;
 
-    auto rowPitch   = PixelFormatUtils::computeRowPitch(_textureFormat, static_cast<uint32_t>(width));
+    auto rowPitch   = RHIUtils::computeRowPitch(_desc.pixelFormat, static_cast<uint32_t>(width));
     UINT slicePitch = rowPitch * static_cast<UINT>(height);
 
     auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
-    context->UpdateSubresource(_textureRes._textures[index].tex2d, static_cast<UINT>(level), &box, data, rowPitch,
-                               slicePitch);
+    UINT subresource = D3D11CalcSubresource(level, layerIndex, _desc.mipLevels);
+    context->UpdateSubresource(_nativeTexture, subresource, &box, data, rowPitch, slicePitch);
 }
 
 void TextureImpl::updateCompressedSubData(std::size_t xoffset,
@@ -341,12 +262,11 @@ void TextureImpl::updateCompressedSubData(std::size_t xoffset,
                                           std::size_t height,
                                           std::size_t dataLen,
                                           std::size_t level,
-                                          uint8_t* data,
-                                          int index /*=0*/)
+                                          const void* data,
+                                          int layerIndex /*=0*/)
 {
-    assert(_textureType == TextureType::TEXTURE_2D);
-    _textureRes.ensure(index);
-    AX_ASSERT(index <= _textureRes._maxIdx);
+    assert(_desc.textureType == TextureType::TEXTURE_2D);
+    ensureNativeTexture();
 
     D3D11_BOX box{};
     box.left   = static_cast<UINT>(xoffset);
@@ -357,38 +277,109 @@ void TextureImpl::updateCompressedSubData(std::size_t xoffset,
     box.back   = 1;
 
     auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
-    context->UpdateSubresource(_textureRes._textures[index].tex2d, static_cast<UINT>(level), &box, data, 0, 0);
+    UINT subresource = D3D11CalcSubresource(level, layerIndex, _desc.mipLevels);
+    context->UpdateSubresource(_nativeTexture, subresource, &box, data, 0, 0);
 }
 
-void TextureImpl::updateFaceData(TextureCubeFace side, void* data, int index)
+void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
 {
-    assert(_textureType == TextureType::TEXTURE_CUBE);
-    _textureRes.ensure(index);
-    assert(index <= _textureRes._maxIdx);
+    assert(_desc.textureType == TextureType::TEXTURE_CUBE);
+    ensureNativeTexture();
 
     auto context = static_cast<DriverImpl*>(DriverBase::getInstance())->getContext();
-
-    auto& texHandle = _textureRes.getTexture(index);
 
     //-------------------------------------------------------------------
     // 1. compute SubResource： = 6 * (mip-levels)
     //-------------------------------------------------------------------
-    const uint32_t mipLevels   = 1;  // texHandle.tex2d->getMipLevels();
     const uint32_t mipLevel    = 0;
-    const uint32_t arraySlice  = static_cast<uint32_t>(side) + index * 6;
-    const uint32_t subresource = ::D3D11CalcSubresource(mipLevel, arraySlice, mipLevels);
+    const uint32_t arraySlice  = static_cast<uint32_t>(side);
+    const uint32_t subresource = ::D3D11CalcSubresource(mipLevel, arraySlice, _desc.mipLevels);
 
     //-------------------------------------------------------------------
     // 2. compute RowPitch / SlicePitch
     //-------------------------------------------------------------------
-    const uint32_t rowPitch =
-        PixelFormatUtils::computeRowPitch(_textureFormat, static_cast<uint32_t>(_textureRes._desc.width));
-    const uint32_t slicePitch = _textureRes._desc.height * rowPitch;
+    const uint32_t rowPitch = RHIUtils::computeRowPitch(_desc.pixelFormat, static_cast<uint32_t>(_desc.width));
+    const uint32_t slicePitch = _desc.height * rowPitch;
 
     //-------------------------------------------------------------------
     // 3. update
     //-------------------------------------------------------------------
-    context->UpdateSubresource(_textureRes._textures[index].tex2d, subresource, nullptr, data, rowPitch, slicePitch);
+    context->UpdateSubresource(_nativeTexture, subresource, nullptr, data, rowPitch, slicePitch);
+}
+
+void TextureImpl::ensureNativeTexture()
+{
+    if (_nativeTexture)
+        return;
+    D3D11_TEXTURE2D_DESC texDesc{};
+    translateTexDesc(_desc, texDesc);
+
+    texDesc.MipLevels = _desc.mipLevels;
+
+    if (_desc.mipLevels == 0)
+    {  // means we must invoke generateMipmaps by GPU
+        texDesc.MiscFlags |= D3D11_RESOURCE_MISC_GENERATE_MIPS;
+        texDesc.BindFlags |= D3D11_BIND_RENDER_TARGET;
+    }
+
+    auto fmtInfo = UtilsD3D::toDxgiFormatInfo(_desc.pixelFormat);
+    assert(fmtInfo);
+    if (fmtInfo->format == DXGI_FORMAT_UNKNOWN)
+    {
+        AXLOGE("axmol: D3D not support pixel format: {}", (int)_desc.pixelFormat);
+        return;
+    }
+
+    texDesc.Format = fmtInfo->format;
+
+    ComPtr<ID3D11Texture2D> texture;
+    HRESULT hr = _device->CreateTexture2D(&texDesc, nullptr, texture.GetAddressOf());
+    if (FAILED(hr) || !texture)
+    {
+        return;
+    }
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+    srvDesc.Format = fmtInfo->fmtSrv;
+
+    // srvDesc.xxx.MipLevels:
+    //   Set to -1 to indicate all the mipmap levels from MostDetailedMip on down to least detailed.
+    // srvDesc.xxx.MostDetailedMip
+    //   Index of the most detailed mipmap level to use; this number is between 0 and MipLevels (from the original
+    //   Texture2D for which ID3D11Device::CreateShaderResourceView creates a view) -1.
+    switch (_desc.textureType)
+    {
+    case TextureType::TEXTURE_CUBE:
+        srvDesc.ViewDimension               = D3D11_SRV_DIMENSION_TEXTURECUBE;
+        srvDesc.TextureCube.MipLevels       = -1;
+        srvDesc.TextureCube.MostDetailedMip = 0;
+        break;
+    default:
+        if (texDesc.ArraySize == 1)
+        {
+            srvDesc.ViewDimension             = D3D11_SRV_DIMENSION_TEXTURE2D;
+            srvDesc.Texture2D.MipLevels       = -1;
+            srvDesc.Texture2D.MostDetailedMip = 0;
+        }
+        else
+        {
+            srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+            srvDesc.Texture2DArray.MipLevels = -1;
+            srvDesc.Texture2DArray.MostDetailedMip = 0;
+            srvDesc.Texture2DArray.ArraySize       = texDesc.ArraySize;
+        }
+    }
+
+    ComPtr<ID3D11ShaderResourceView> srv;
+    hr = _device->CreateShaderResourceView(texture.Get(), &srvDesc, srv.GetAddressOf());
+
+    if (FAILED(hr) || !srv)
+    {
+        AXLOGE("create srv from texture fail:{}", hr);
+        return;
+    }
+
+    _nativeTexture = TextureHandle{texture.Detach(), srv.Detach()};
 }
 
 }  // namespace ax::rhi::d3d

--- a/axmol/rhi/d3d/TextureD3D.cpp
+++ b/axmol/rhi/d3d/TextureD3D.cpp
@@ -118,6 +118,9 @@ static void fromD3DTexDesc(TextureDesc& td, const D3D11_TEXTURE2D_DESC& desc)
 TextureImpl::TextureImpl(ID3D11Device* device, const TextureDesc& desc) : _device(device)
 {
     updateTextureDesc(desc);
+
+    if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
+        zeroTexData();
 }
 
 TextureImpl::TextureImpl(ID3D11Device* device, ID3D11Texture2D* texture) : _device(device)

--- a/axmol/rhi/d3d/TextureD3D.h
+++ b/axmol/rhi/d3d/TextureD3D.h
@@ -87,9 +87,9 @@ public:
      * reduction image.
      */
     void updateData(const void* data,
-                    std::size_t width,
-                    std::size_t height,
-                    std::size_t level,
+                    int width,
+                    int height,
+                    int level,
                     int layerIndex = 0) override;
 
     /**
@@ -97,15 +97,15 @@ public:
      * @param data Specifies a pointer to the compressed image data in memory.
      * @param width Specifies the width of the texture image.
      * @param height Specifies the height of the texture image.
-     * @param dataLen Specifies the totoal size of compressed image in bytes.
+     * @param dataSize Specifies the totoal size of compressed image in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      */
     void updateCompressedData(const void* data,
-                              std::size_t width,
-                              std::size_t height,
-                              std::size_t dataLen,
-                              std::size_t level,
+                              int width,
+                              int height,
+                              std::size_t dataSize,
+                              int level,
                               int layerIndex = 0) override;
 
     /**
@@ -118,11 +118,11 @@ public:
      * reduction image.
      * @param data Specifies a pointer to the image data in memory.
      */
-    void updateSubData(std::size_t xoffset,
-                       std::size_t yoffset,
-                       std::size_t width,
-                       std::size_t height,
-                       std::size_t level,
+    void updateSubData(int xoffset,
+                       int yoffset,
+                       int width,
+                       int height,
+                       int level,
                        const void* data,
                        int layerIndex = 0) override;
 
@@ -132,17 +132,17 @@ public:
      * @param yoffset Specifies a texel offset in the y direction within the texture array.
      * @param width Specifies the width of the texture subimage.
      * @param height Specifies the height of the texture subimage.
-     * @param dataLen Specifies the totoal size of compressed subimage in bytes.
+     * @param dataSize Specifies the totoal size of compressed subimage in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the compressed image data in memory.
      */
-    void updateCompressedSubData(std::size_t xoffset,
-                                 std::size_t yoffset,
-                                 std::size_t width,
-                                 std::size_t height,
-                                 std::size_t dataLen,
-                                 std::size_t level,
+    void updateCompressedSubData(int xoffset,
+                                 int yoffset,
+                                 int width,
+                                 int height,
+                                 std::size_t dataSize,
+                                 int level,
                                  const void* data,
                                  int layerIndex = 0) override;
 
@@ -158,11 +158,6 @@ public:
      * @param sampler Specifies the sampler descriptor.
      */
     void updateSamplerDesc(const SamplerDesc& sampler) override;
-
-    /**
-     * Generate mipmaps.
-     */
-    void generateMipmaps() override;
 
     /**
      * Update texture description.
@@ -182,6 +177,8 @@ public:
 
 private:
     void ensureNativeTexture();
+
+    void generateMipmaps(ID3D11DeviceContext* context);
 
     ID3D11Device* _device;
     TextureHandle _nativeTexture{};

--- a/axmol/rhi/d3d/TextureD3D.h
+++ b/axmol/rhi/d3d/TextureD3D.h
@@ -30,7 +30,7 @@
 #include <d3d11.h>
 #include <dxgi.h>
 #include <wrl/client.h>
-#include <array> // std::array
+#include <array>  // std::array
 
 namespace ax::rhi::d3d
 {
@@ -40,62 +40,24 @@ struct TextureHandle
 {
     explicit operator bool() const { return tex2d != nullptr; }
 
-    void Release()
+    void destroy()
     {
         SafeRelease(srv);
         SafeRelease(tex2d);
     }
 
+    TextureHandle detach()
+    {
+        auto ret = *this;
+        tex2d    = nullptr;
+        srv      = nullptr;
+        return ret;
+    }
+
+    operator ID3D11Resource* () { return tex2d; }
+
     ID3D11Texture2D* tex2d{};
-    ID3D11ShaderResourceView* srv{}; // Note: default color attachment not create srv yet.
-};
-
-/**
- * Store texture resource.
- */
-struct TextureResource
-{
-    TextureResource(ID3D11Device* d3d11device)
-    {
-        _device = d3d11device;
-        _textures.fill(TextureHandle{});
-    }
-    ~TextureResource() { destroy(); }
-
-    template <typename _Fty>
-    void foreachTextures(const _Fty& cb)
-    {
-        int idx = 0;
-        while (_textures[idx])
-        {
-            auto& h = _textures[idx];
-            cb(h, idx++);
-        }
-    }
-
-    TextureHandle createTexture(UINT mipLevels);
-
-    TextureHandle ensure(int index);
-
-    void destroy()
-    {
-        foreachTextures([this](TextureHandle& tex, int) {
-            if (tex)
-                tex.Release();
-        });
-        _textures.fill(TextureHandle{});
-    }
-
-    const TextureHandle& getTexture(int index) const { return _textures[index]; }
-
-    ID3D11Device* _device;
-
-    TextureDesc _desc;
-
-    std::array<TextureHandle, AX_META_TEXTURES + 1> _textures;
-    ID3D11SamplerState* _samplerState = nullptr;
-    int _maxIdx                       = 0;
-    UINT _mipLevels                   = -1; // means only 1 layer
+    ID3D11ShaderResourceView* srv{};  // Note: default color attachment not create srv yet.
 };
 
 /**
@@ -110,9 +72,9 @@ class TextureImpl : public rhi::Texture
 {
 public:
     /**
-     * @param descriptor Specifies the texture description.
+     * @param desc Specifies the texture description.
      */
-    TextureImpl(ID3D11Device* device, const TextureDesc& descriptor);
+    TextureImpl(ID3D11Device* device, const TextureDesc& desc);
     TextureImpl(ID3D11Device* device, ID3D11Texture2D* texture);
     ~TextureImpl();
 
@@ -124,7 +86,11 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      */
-    void updateData(uint8_t* data, std::size_t width, std::size_t height, std::size_t level, int index = 0) override;
+    void updateData(const void* data,
+                    std::size_t width,
+                    std::size_t height,
+                    std::size_t level,
+                    int layerIndex = 0) override;
 
     /**
      * Update a two-dimensional texture image in a compressed format
@@ -135,12 +101,12 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      */
-    void updateCompressedData(uint8_t* data,
+    void updateCompressedData(const void* data,
                               std::size_t width,
                               std::size_t height,
                               std::size_t dataLen,
                               std::size_t level,
-                              int index = 0) override;
+                              int layerIndex = 0) override;
 
     /**
      * Update a two-dimensional texture subimage
@@ -157,8 +123,8 @@ public:
                        std::size_t width,
                        std::size_t height,
                        std::size_t level,
-                       uint8_t* data,
-                       int index = 0) override;
+                       const void* data,
+                       int layerIndex = 0) override;
 
     /**
      * Update a two-dimensional texture subimage in a compressed format
@@ -177,15 +143,15 @@ public:
                                  std::size_t height,
                                  std::size_t dataLen,
                                  std::size_t level,
-                                 uint8_t* data,
-                                 int index = 0) override;
+                                 const void* data,
+                                 int layerIndex = 0) override;
 
     /**
      * Update texutre cube data in give slice side.
      * @param side Specifies which slice texture of cube to be update.
      * @param data Specifies a pointer to the image data in memory.
      */
-    void updateFaceData(TextureCubeFace side, void* data, int index) override;
+    void updateFaceData(TextureCubeFace side, const void* data) override;
 
     /**
      * Update sampler
@@ -202,23 +168,24 @@ public:
      * Update texture description.
      * @param descriptor Specifies texture and sampler descriptor.
      */
-    void updateTextureDesc(const TextureDesc& descriptor, int index = 0) override;
+    void updateTextureDesc(const TextureDesc& desc) override;
 
     /**
      * Get texture object.
      * @return Texture object.
      */
-    const TextureHandle& internalHandle(int index = 0) const { return _textureRes._textures[index]; }
+    const TextureHandle& internalHandle() const { return _nativeTexture; }
 
-    ID3D11SamplerState* getSamplerState() const { return _textureRes._samplerState;  }
+    ID3D11SamplerState* getSamplerState() const { return _samplerState; }
 
-    const TextureDesc& getDesc() const { return _textureRes._desc; }
-
-    int getCount() const override { return _textureRes._maxIdx + 1; }
+    const TextureDesc& getDesc() const { return _desc; }
 
 private:
-    TextureResource _textureRes;
-    EventListener* _rendererRecreatedListener = nullptr;
+    void ensureNativeTexture();
+
+    ID3D11Device* _device;
+    TextureHandle _nativeTexture{};
+    ID3D11SamplerState* _samplerState         = nullptr;
 };
 
 // end of d3d group

--- a/axmol/rhi/d3d/TextureD3D.h
+++ b/axmol/rhi/d3d/TextureD3D.h
@@ -177,7 +177,6 @@ public:
 
 private:
     void ensureNativeTexture();
-
     void generateMipmaps(ID3D11DeviceContext* context);
 
     ID3D11Device* _device;

--- a/axmol/rhi/d3d/UtilsD3D.cpp
+++ b/axmol/rhi/d3d/UtilsD3D.cpp
@@ -41,7 +41,7 @@
 
 #include "axmol/base/Logging.h"
 
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 
 using namespace Microsoft::WRL;
 

--- a/axmol/rhi/metal/CommandBufferMTL.h
+++ b/axmol/rhi/metal/CommandBufferMTL.h
@@ -237,7 +237,6 @@ protected:
 private:
     void prepareDrawing() const;
     void setTextures() const;
-    void doSetTextures(bool isVertex) const;
     void setUniformBuffer() const;
     void afterDraw();
     void flush();

--- a/axmol/rhi/metal/DriverMTL.mm
+++ b/axmol/rhi/metal/DriverMTL.mm
@@ -530,7 +530,7 @@ SamplerHandle DriverImpl::createSampler(const SamplerDesc& desc)
     // --- Mip Filter ---
     switch (desc.mipFilter)
     {
-        case SamplerFilter::MIP_NONE:
+        case SamplerFilter::MIP_DEFAULT:
             samplerDesc.mipFilter = MTLSamplerMipFilterNotMipmapped;
             break;
         case SamplerFilter::MIP_NEAREST:

--- a/axmol/rhi/metal/ProgramMTL.h
+++ b/axmol/rhi/metal/ProgramMTL.h
@@ -48,7 +48,7 @@ public:
      * @param fragmentShader Specifes the fragment shader source.
      */
     ProgramImpl(std::string_view vertexShader, std::string_view fragmentShader);
-    virtual ~ProgramImpl();
+    ~ProgramImpl() override;
 
     /**
      * Get uniform location by name.

--- a/axmol/rhi/metal/RenderPipelineMTL.h
+++ b/axmol/rhi/metal/RenderPipelineMTL.h
@@ -71,8 +71,8 @@ private:
     id<MTLDevice> _mtlDevice                           = nil;
 
     MTLRenderPipelineDescriptor* _mtlRenderPipelineDesc = nil;
-    PixelFormat _colorAttachmentsFormat[MAX_COLOR_ATTCHMENT]  = {PixelFormat::AUTO};
-    PixelFormat _depthStencilPF                        = PixelFormat::AUTO;
+    PixelFormat _colorAttachmentsFormat[MAX_COLOR_ATTCHMENT]  = {PixelFormat::NONE};
+    PixelFormat _depthStencilPF                        = PixelFormat::NONE;
 
     tsl::robin_map<uint32_t, id<MTLRenderPipelineState>> _mtlStateCache;
 };

--- a/axmol/rhi/metal/RenderPipelineMTL.h
+++ b/axmol/rhi/metal/RenderPipelineMTL.h
@@ -71,8 +71,8 @@ private:
     id<MTLDevice> _mtlDevice                           = nil;
 
     MTLRenderPipelineDescriptor* _mtlRenderPipelineDesc = nil;
-    PixelFormat _colorAttachmentsFormat[MAX_COLOR_ATTCHMENT]  = {PixelFormat::NONE};
-    PixelFormat _depthStencilPF                        = PixelFormat::NONE;
+    PixelFormat _colorAttachmentsFormat[MAX_COLOR_ATTCHMENT]  = {PixelFormat::AUTO};
+    PixelFormat _depthStencilPF                        = PixelFormat::AUTO;
 
     tsl::robin_map<uint32_t, id<MTLRenderPipelineState>> _mtlStateCache;
 };

--- a/axmol/rhi/metal/RenderPipelineMTL.mm
+++ b/axmol/rhi/metal/RenderPipelineMTL.mm
@@ -308,7 +308,7 @@ void RenderPipelineImpl::setBlendStateAndFormat(const BlendDesc& blendDesc)
 {
     for (int i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
     {
-        if (PixelFormat::AUTO == _colorAttachmentsFormat[i])
+        if (PixelFormat::NONE == _colorAttachmentsFormat[i])
         {
             _mtlRenderPipelineDesc.colorAttachments[i].pixelFormat = MTLPixelFormat::MTLPixelFormatInvalid;
             continue;

--- a/axmol/rhi/metal/RenderPipelineMTL.mm
+++ b/axmol/rhi/metal/RenderPipelineMTL.mm
@@ -308,7 +308,7 @@ void RenderPipelineImpl::setBlendStateAndFormat(const BlendDesc& blendDesc)
 {
     for (int i = 0; i < MAX_COLOR_ATTCHMENT; ++i)
     {
-        if (PixelFormat::NONE == _colorAttachmentsFormat[i])
+        if (PixelFormat::AUTO == _colorAttachmentsFormat[i])
         {
             _mtlRenderPipelineDesc.colorAttachments[i].pixelFormat = MTLPixelFormat::MTLPixelFormatInvalid;
             continue;

--- a/axmol/rhi/metal/RenderTargetMTL.mm
+++ b/axmol/rhi/metal/RenderTargetMTL.mm
@@ -111,7 +111,7 @@ PixelFormat RenderTargetImpl::getColorAttachmentPixelFormat(int index) const
     if (isDefaultRenderTarget() && index == 0)
         return PixelFormat::BGRA8;
     auto& rb = this->_color[index];
-    return rb ? rb.texture->getPixelFormat() : PixelFormat::AUTO;
+    return rb ? rb.texture->getPixelFormat() : PixelFormat::NONE;
 }
 
 PixelFormat RenderTargetImpl::getDepthStencilAttachmentPixelFormat() const
@@ -120,7 +120,7 @@ PixelFormat RenderTargetImpl::getDepthStencilAttachmentPixelFormat() const
         return PixelFormat::D24S8;
     if (_depthStencil)
         return _depthStencil.texture->getPixelFormat();
-    return PixelFormat::AUTO;
+    return PixelFormat::NONE;
 }
 
 }

--- a/axmol/rhi/metal/RenderTargetMTL.mm
+++ b/axmol/rhi/metal/RenderTargetMTL.mm
@@ -111,7 +111,7 @@ PixelFormat RenderTargetImpl::getColorAttachmentPixelFormat(int index) const
     if (isDefaultRenderTarget() && index == 0)
         return PixelFormat::BGRA8;
     auto& rb = this->_color[index];
-    return rb ? rb.texture->getTextureFormat() : PixelFormat::NONE;
+    return rb ? rb.texture->getPixelFormat() : PixelFormat::AUTO;
 }
 
 PixelFormat RenderTargetImpl::getDepthStencilAttachmentPixelFormat() const
@@ -119,8 +119,8 @@ PixelFormat RenderTargetImpl::getDepthStencilAttachmentPixelFormat() const
     if (isDefaultRenderTarget())
         return PixelFormat::D24S8;
     if (_depthStencil)
-        return _depthStencil.texture->getTextureFormat();
-    return PixelFormat::NONE;
+        return _depthStencil.texture->getPixelFormat();
+    return PixelFormat::AUTO;
 }
 
 }

--- a/axmol/rhi/metal/TextureMTL.h
+++ b/axmol/rhi/metal/TextureMTL.h
@@ -58,9 +58,9 @@ public:
      * reduction image.
      */
     void updateData(const void* data,
-                    std::size_t width,
-                    std::size_t height,
-                    std::size_t level,
+                    int width,
+                    int height,
+                    int level,
                     int layerIndex = 0) override;
 
     /**
@@ -68,15 +68,15 @@ public:
      * @param data Specifies a pointer to the compressed image data in memory.
      * @param width Specifies the width of the texture image.
      * @param height Specifies the height of the texture image.
-     * @param dataLen Specifies the totoal size of compressed image in bytes.
+     * @param dataSize Specifies the totoal size of compressed image in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      */
     void updateCompressedData(const void* data,
-                              std::size_t width,
-                              std::size_t height,
-                              std::size_t dataLen,
-                              std::size_t level,
+                              int width,
+                              int height,
+                              std::size_t dataSize,
+                              int level,
                               int layerIndex = 0) override;
 
     /**
@@ -89,11 +89,11 @@ public:
      * reduction image.
      * @param data Specifies a pointer to the image data in memory.
      */
-    void updateSubData(std::size_t xoffset,
-                       std::size_t yoffset,
-                       std::size_t width,
-                       std::size_t height,
-                       std::size_t level,
+    void updateSubData(int xoffset,
+                       int yoffset,
+                       int width,
+                       int height,
+                       int level,
                        const void* data,
                        int layerIndex = 0) override;
 
@@ -103,17 +103,17 @@ public:
      * @param yoffset Specifies a texel offset in the y direction within the texture array.
      * @param width Specifies the width of the texture subimage.
      * @param height Specifies the height of the texture subimage.
-     * @param dataLen Specifies the totoal size of compressed subimage in bytes.
+     * @param dataSize Specifies the totoal size of compressed subimage in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the compressed image data in memory.
      */
-    void updateCompressedSubData(std::size_t xoffset,
-                                 std::size_t yoffset,
-                                 std::size_t width,
-                                 std::size_t height,
-                                 std::size_t dataLen,
-                                 std::size_t level,
+    void updateCompressedSubData(int xoffset,
+                                 int yoffset,
+                                 int width,
+                                 int height,
+                                 std::size_t dataSize,
+                                 int level,
                                  const void* data,
                                  int layerIndex = 0) override;
 
@@ -126,7 +126,7 @@ public:
     /**
      * Generate mipmaps.
      */
-    void generateMipmaps() override;
+    void generateMipmaps();
 
     /**
      * Update texture description.
@@ -158,7 +158,7 @@ public:
 
 private:
     void ensureNativeTexture();
-    
+
     id<MTLDevice> _mtlDevice;
     id<MTLTexture> _mtlTexture = nil;
     id<MTLSamplerState> _mtlSamplerState = nil;

--- a/axmol/rhi/metal/TextureMTL.h
+++ b/axmol/rhi/metal/TextureMTL.h
@@ -36,37 +36,6 @@ namespace ax::rhi::mtl {
  * @{
  */
 
-struct TextureInfoMTL
-{
-    TextureInfoMTL(id<MTLDevice> mtlDevice)
-    {
-        _mtlDevice = mtlDevice;
-        _mtlTextures.fill(nil);
-    }
-    ~TextureInfoMTL() { destroy(); }
-
-    id<MTLTexture> ensure(int index);
-    void destroy();
-
-    id<MTLTexture> createTexture(id<MTLDevice> mtlDevice, const TextureDesc& descriptor);
-    void recreateSampler(const SamplerDesc& descriptor);
-
-    MTLSamplerAddressMode _sAddressMode;
-    MTLSamplerAddressMode _tAddressMode;
-    MTLSamplerMinMagFilter _minFilter;
-    MTLSamplerMinMagFilter _magFilter;
-    MTLSamplerMipFilter _mipFilter;
-
-    id<MTLDevice> _mtlDevice;
-    std::array<id<MTLTexture>, AX_META_TEXTURES + 1> _mtlTextures;
-    int _maxIdx = -1;
-
-    TextureDesc _desc;
-
-    id<MTLSamplerState> _mtlSamplerState = nil;
-    unsigned int _bytesPerRow            = 0;
-};
-
 /**
  * TextureImpl
  */
@@ -88,11 +57,11 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      */
-    virtual void updateData(uint8_t* data,
-                            std::size_t width,
-                            std::size_t height,
-                            std::size_t level,
-                            int index = 0) override;
+    void updateData(const void* data,
+                    std::size_t width,
+                    std::size_t height,
+                    std::size_t level,
+                    int layerIndex = 0) override;
 
     /**
      * Update a two-dimensional texture image in a compressed format
@@ -103,12 +72,12 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      */
-    virtual void updateCompressedData(uint8_t* data,
-                                      std::size_t width,
-                                      std::size_t height,
-                                      std::size_t dataLen,
-                                      std::size_t level,
-                                      int index = 0) override;
+    void updateCompressedData(const void* data,
+                              std::size_t width,
+                              std::size_t height,
+                              std::size_t dataLen,
+                              std::size_t level,
+                              int layerIndex = 0) override;
 
     /**
      * Update a two-dimensional texture subimage
@@ -120,13 +89,13 @@ public:
      * reduction image.
      * @param data Specifies a pointer to the image data in memory.
      */
-    virtual void updateSubData(std::size_t xoffset,
-                               std::size_t yoffset,
-                               std::size_t width,
-                               std::size_t height,
-                               std::size_t level,
-                               uint8_t* data,
-                               int index = 0) override;
+    void updateSubData(std::size_t xoffset,
+                       std::size_t yoffset,
+                       std::size_t width,
+                       std::size_t height,
+                       std::size_t level,
+                       const void* data,
+                       int layerIndex = 0) override;
 
     /**
      * Update a two-dimensional texture subimage in a compressed format
@@ -139,14 +108,14 @@ public:
      * reduction image.
      * @param data Specifies a pointer to the compressed image data in memory.
      */
-    virtual void updateCompressedSubData(std::size_t xoffset,
-                                         std::size_t yoffset,
-                                         std::size_t width,
-                                         std::size_t height,
-                                         std::size_t dataLen,
-                                         std::size_t level,
-                                         uint8_t* data,
-                                         int index = 0) override;
+    void updateCompressedSubData(std::size_t xoffset,
+                                 std::size_t yoffset,
+                                 std::size_t width,
+                                 std::size_t height,
+                                 std::size_t dataLen,
+                                 std::size_t level,
+                                 const void* data,
+                                 int layerIndex = 0) override;
 
     /**
      * Update sampler
@@ -163,36 +132,36 @@ public:
      * Update texture description.
      * @param desc Specifies texture and sampler descriptor.
      */
-    void updateTextureDesc(const TextureDesc& desc, int index = 0) override;
+    void updateTextureDesc(const TextureDesc& desc) override;
 
     /**
      * Update texutre cube data in give slice side.
      * @param side Specifies which slice texture of cube to be update.
      * @param data Specifies a pointer to the image data in memory.
      */
-    void updateFaceData(TextureCubeFace side, void* data, int index = 0) override;
-
-    int getCount() const override { return _textureInfo._maxIdx + 1; }
+    void updateFaceData(TextureCubeFace side, const void* data) override;
 
     /**
      * Get MTLTexture object. reinterpret_cast<id<MTLTexture>>(handler);
      * @return A MTLTexture object.
      */
-    id<MTLTexture> internalHandle(int index = 0) const
+    id<MTLTexture> internalHandle() const
     {
-        return _textureInfo._mtlTextures[index];
+        return _mtlTexture;
     }
 
     /**
      * Get MTLSamplerState object
      * @return A MTLSamplerState object.
      */
-    inline id<MTLSamplerState> internalSampler() const { return _textureInfo._mtlSamplerState; }
+    inline id<MTLSamplerState> internalSampler() const { return _mtlSamplerState; }
 
 private:
-    TextureInfoMTL _textureInfo;
-
-    MTLRegion _region;
+    void ensureNativeTexture();
+    
+    id<MTLDevice> _mtlDevice;
+    id<MTLTexture> _mtlTexture = nil;
+    id<MTLSamplerState> _mtlSamplerState = nil;
 };
 
 // end of _metal group

--- a/axmol/rhi/metal/TextureMTL.mm
+++ b/axmol/rhi/metal/TextureMTL.mm
@@ -53,6 +53,9 @@ static bool isColorRenderable(PixelFormat textureFormat)
 TextureImpl::TextureImpl(id<MTLDevice> mtlDevice, const TextureDesc& desc) : _mtlDevice(mtlDevice)
 {
     updateTextureDesc(desc);
+
+    if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
+        zeroTexData();
 }
 
 TextureImpl::~TextureImpl() {}
@@ -144,7 +147,7 @@ void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
                     withBytes:data
                   bytesPerRow:bytesPerRow
                 bytesPerImage:slicePitch];
-    
+
     if (shouldGenMipmaps())
         generateMipmaps();
 }
@@ -155,7 +158,7 @@ void TextureImpl::ensureNativeTexture()
     MTLPixelFormat pixelFormat = UtilsMTL::toMTLPixelFormat(_desc.pixelFormat);
     if (pixelFormat == MTLPixelFormatInvalid)
         return;
-    
+
     bool needMipmaps = _desc.mipLevels != 1;
 
     MTLTextureDescriptor* textureDesc = nil;

--- a/axmol/rhi/metal/TextureMTL.mm
+++ b/axmol/rhi/metal/TextureMTL.mm
@@ -69,50 +69,50 @@ void TextureImpl::updateTextureDesc(const TextureDesc& desc)
     updateSamplerDesc(desc.samplerDesc);
 }
 
-void TextureImpl::updateData(const void* data, std::size_t width, std::size_t height, std::size_t level, int index)
+void TextureImpl::updateData(const void* data, int width, int height, int level, int index)
 {
     updateSubData(0, 0, width, height, level, data, index);
 }
 
-void TextureImpl::updateSubData(std::size_t xoffset,
-                               std::size_t yoffset,
-                               std::size_t width,
-                               std::size_t height,
-                               std::size_t level,
+void TextureImpl::updateSubData(int xoffset,
+                               int yoffset,
+                               int width,
+                               int height,
+                               int level,
                                const void* data,
                                int layerIndex)
 {
     ensureNativeTexture();
 
     MTLRegion region = {
-        {xoffset, yoffset, 0},  // MTLOrigin
-        {width, height, 1}      // MTLSize
+        {(NSUInteger)xoffset, (NSUInteger)yoffset, 0},  // MTLOrigin
+        {(NSUInteger)width, (NSUInteger)height, 1}      // MTLSize
     };
 
     auto bytesPerRow = RHIUtils::computeRowPitch(_desc.pixelFormat, static_cast<uint32_t>(width));
     auto slicePitch = bytesPerRow * _desc.height;
     [_mtlTexture replaceRegion:region mipmapLevel:level slice:layerIndex withBytes:data bytesPerRow:bytesPerRow bytesPerImage:slicePitch];
 
-//    if (!_hasMipmaps && level > 0)
-//        _hasMipmaps = true;
+    if (shouldGenMipmaps(level))
+        generateMipmaps();
 }
 
 void TextureImpl::updateCompressedData(const void* data,
-                                      std::size_t width,
-                                      std::size_t height,
-                                      std::size_t dataLen,
-                                      std::size_t level,
+                                      int width,
+                                      int height,
+                                      std::size_t dataSize,
+                                      int level,
                                       int layerIndex)
 {
-    updateCompressedSubData(0, 0, width, height, dataLen, level, data, layerIndex);
+    updateCompressedSubData(0, 0, width, height, dataSize, level, data, layerIndex);
 }
 
-void TextureImpl::updateCompressedSubData(std::size_t xoffset,
-                                         std::size_t yoffset,
-                                         std::size_t width,
-                                         std::size_t height,
-                                         std::size_t dataLen,
-                                         std::size_t level,
+void TextureImpl::updateCompressedSubData(int xoffset,
+                                         int yoffset,
+                                         int width,
+                                         int height,
+                                         std::size_t /*dataSize*/,
+                                         int level,
                                          const void* data,
                                          int layerIndex)
 {
@@ -124,11 +124,9 @@ void TextureImpl::generateMipmaps()
     if (TextureUsage::RENDER_TARGET == _desc.textureUsage || !isColorRenderable(_desc.pixelFormat))
         return;
 
-    if (_desc.mipLevels == 0)
-    {
-        UtilsMTL::generateMipmaps(internalHandle());
-        _desc.mipLevels = RHIUtils::computeMipLevels(_desc);
-    }
+
+    UtilsMTL::generateMipmaps(_mtlTexture);
+    _overrideMipLevels = RHIUtils::computeMipLevels(_desc.width, _desc.height);
 }
 
 void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
@@ -146,6 +144,9 @@ void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
                     withBytes:data
                   bytesPerRow:bytesPerRow
                 bytesPerImage:slicePitch];
+    
+    if (shouldGenMipmaps())
+        generateMipmaps();
 }
 
 void TextureImpl::ensureNativeTexture()
@@ -154,6 +155,8 @@ void TextureImpl::ensureNativeTexture()
     MTLPixelFormat pixelFormat = UtilsMTL::toMTLPixelFormat(_desc.pixelFormat);
     if (pixelFormat == MTLPixelFormatInvalid)
         return;
+    
+    bool needMipmaps = _desc.mipLevels != 1;
 
     MTLTextureDescriptor* textureDesc = nil;
     switch (_desc.textureType)
@@ -162,7 +165,7 @@ void TextureImpl::ensureNativeTexture()
         textureDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
                                                                                width:_desc.width
                                                                               height:_desc.height
-                                                                           mipmapped:YES];
+                                                                           mipmapped:needMipmaps];
         if (_desc.arraySize > 1) {
             textureDesc.textureType = MTLTextureType2DArray;
             textureDesc.arrayLength = _desc.arraySize;
@@ -171,7 +174,7 @@ void TextureImpl::ensureNativeTexture()
     case TextureType::TEXTURE_CUBE:
         textureDesc = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:pixelFormat
                                                                                   size:_desc.width
-                                                                             mipmapped:YES];
+                                                                             mipmapped:needMipmaps];
         break;
     default:
         return;

--- a/axmol/rhi/metal/TextureMTL.mm
+++ b/axmol/rhi/metal/TextureMTL.mm
@@ -53,9 +53,6 @@ static bool isColorRenderable(PixelFormat textureFormat)
 TextureImpl::TextureImpl(id<MTLDevice> mtlDevice, const TextureDesc& desc) : _mtlDevice(mtlDevice)
 {
     updateTextureDesc(desc);
-
-    if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
-        zeroTexData();
 }
 
 TextureImpl::~TextureImpl() {}
@@ -86,6 +83,9 @@ void TextureImpl::updateSubData(int xoffset,
                                int layerIndex)
 {
     ensureNativeTexture();
+
+    if(!data) [[unlikely]]
+        return;
 
     MTLRegion region = {
         {(NSUInteger)xoffset, (NSUInteger)yoffset, 0},  // MTLOrigin

--- a/axmol/rhi/metal/TextureMTL.mm
+++ b/axmol/rhi/metal/TextureMTL.mm
@@ -26,7 +26,7 @@
 #include "axmol/rhi/metal/TextureMTL.h"
 #include "axmol/rhi/metal/UtilsMTL.h"
 #include "axmol/base/Macros.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 #include "axmol/rhi/SamplerCache.h"
 
 namespace ax::rhi::mtl {
@@ -49,107 +49,27 @@ static bool isColorRenderable(PixelFormat textureFormat)
 }
 }
 
-/// CLASS TextureInfoMTL
-id<MTLTexture> TextureInfoMTL::ensure(int index)
-{
-    if (index < AX_META_TEXTURES)
-    {
-        id<MTLTexture>& mtlTexture = _mtlTextures[index];
-        if (mtlTexture)
-            return mtlTexture;
-        mtlTexture = createTexture(_mtlDevice, _desc);
-        if (_maxIdx < index)
-            _maxIdx = index;
-        return mtlTexture;
-    }
-    return nil;
-}
-
-void TextureInfoMTL::destroy()
-{
-    if (_maxIdx == -1)
-        return;
-
-    id<MTLTexture> texture;
-    int i = 0;
-    while ((texture = _mtlTextures[i++]))
-        [texture release];
-
-    _mtlSamplerState = nil;
-
-    _maxIdx = -1;
-}
-
-id<MTLTexture> TextureInfoMTL::createTexture(id<MTLDevice> mtlDevice, const TextureDesc& descriptor)
-{
-    MTLPixelFormat pixelFormat = UtilsMTL::toMTLPixelFormat(descriptor.textureFormat);
-    if (pixelFormat == MTLPixelFormatInvalid)
-        return nil;
-
-    MTLTextureDescriptor* textureDesc = nil;
-    switch (descriptor.textureType)
-    {
-    case TextureType::TEXTURE_2D:
-        textureDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
-                                                                               width:descriptor.width
-                                                                              height:descriptor.height
-                                                                           mipmapped:YES];
-        break;
-    case TextureType::TEXTURE_CUBE:
-        textureDesc = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:pixelFormat
-                                                                                  size:descriptor.width
-                                                                             mipmapped:YES];
-        break;
-    default:
-        return nil;
-    }
-
-    if (TextureUsage::RENDER_TARGET == descriptor.textureUsage)
-    {
-        // DepthStencil, and Multisample textures must be allocated with the MTLResourceStorageModePrivate resource
-        // option
-        if (PixelFormat::D24S8 == descriptor.textureFormat && descriptor.textureType == TextureType::TEXTURE_2D)
-            textureDesc.resourceOptions = MTLResourceStorageModePrivate;
-        textureDesc.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-    }
-
-    return [mtlDevice newTextureWithDescriptor:textureDesc];
-}
-
-void TextureInfoMTL::recreateSampler(const SamplerDesc& desc)
-{
-    _mtlSamplerState = (id<MTLSamplerState>)SamplerCache::getInstance()->getSampler(desc);
-}
-
 /// CLASS TextureImpl
-TextureImpl::TextureImpl(id<MTLDevice> mtlDevice, const TextureDesc& descriptor) : _textureInfo(mtlDevice)
+TextureImpl::TextureImpl(id<MTLDevice> mtlDevice, const TextureDesc& desc) : _mtlDevice(mtlDevice)
 {
-    updateTextureDesc(descriptor);
+    updateTextureDesc(desc);
 }
 
 TextureImpl::~TextureImpl() {}
 
-void TextureImpl::updateSamplerDesc(const SamplerDesc& sampler)
+void TextureImpl::updateSamplerDesc(const SamplerDesc& desc)
 {
-    _textureInfo.recreateSampler(sampler);
+    _mtlSamplerState = (id<MTLSamplerState>)SamplerCache::getInstance()->getSampler(desc);
 }
 
-void TextureImpl::updateTextureDesc(const TextureDesc& desc, int index)
+void TextureImpl::updateTextureDesc(const TextureDesc& desc)
 {
-    Texture::updateTextureDesc(desc, index);
+    Texture::updateTextureDesc(desc);
 
-    _textureInfo._desc = desc;
-    _textureInfo.ensure(index);
     updateSamplerDesc(desc.samplerDesc);
-
-    _textureInfo._bytesPerRow = PixelFormatUtils::computeRowPitch(desc.textureFormat, desc.width);
-
-    if (desc.textureType == TextureType::TEXTURE_CUBE) {
-        _region                   = MTLRegionMake2D(0, 0, desc.width, desc.height);
-    }
 }
 
-void TextureImpl::updateData(uint8_t* data, std::size_t width, std::size_t height, std::size_t level, int index)
+void TextureImpl::updateData(const void* data, std::size_t width, std::size_t height, std::size_t level, int index)
 {
     updateSubData(0, 0, width, height, level, data, index);
 }
@@ -159,34 +79,32 @@ void TextureImpl::updateSubData(std::size_t xoffset,
                                std::size_t width,
                                std::size_t height,
                                std::size_t level,
-                               uint8_t* data,
-                               int index)
+                               const void* data,
+                               int layerIndex)
 {
-    auto mtlTexture = _textureInfo.ensure(index);
-    if (!mtlTexture)
-        return;
+    ensureNativeTexture();
 
     MTLRegion region = {
         {xoffset, yoffset, 0},  // MTLOrigin
         {width, height, 1}      // MTLSize
     };
 
-    auto bytesPerRow = PixelFormatUtils::computeRowPitch(_textureFormat, static_cast<uint32_t>(width));
+    auto bytesPerRow = RHIUtils::computeRowPitch(_desc.pixelFormat, static_cast<uint32_t>(width));
+    auto slicePitch = bytesPerRow * _desc.height;
+    [_mtlTexture replaceRegion:region mipmapLevel:level slice:layerIndex withBytes:data bytesPerRow:bytesPerRow bytesPerImage:slicePitch];
 
-    [mtlTexture replaceRegion:region mipmapLevel:level withBytes:data bytesPerRow:bytesPerRow];
-
-    if (!_hasMipmaps && level > 0)
-        _hasMipmaps = true;
+//    if (!_hasMipmaps && level > 0)
+//        _hasMipmaps = true;
 }
 
-void TextureImpl::updateCompressedData(uint8_t* data,
+void TextureImpl::updateCompressedData(const void* data,
                                       std::size_t width,
                                       std::size_t height,
                                       std::size_t dataLen,
                                       std::size_t level,
-                                      int index)
+                                      int layerIndex)
 {
-    updateCompressedSubData(0, 0, width, height, dataLen, level, data, index);
+    updateCompressedSubData(0, 0, width, height, dataLen, level, data, layerIndex);
 }
 
 void TextureImpl::updateCompressedSubData(std::size_t xoffset,
@@ -195,38 +113,80 @@ void TextureImpl::updateCompressedSubData(std::size_t xoffset,
                                          std::size_t height,
                                          std::size_t dataLen,
                                          std::size_t level,
-                                         uint8_t* data,
-                                         int index)
+                                         const void* data,
+                                         int layerIndex)
 {
-    updateSubData(xoffset, yoffset, width, height, level, data, index);
+    updateSubData(xoffset, yoffset, width, height, level, data, layerIndex);
 }
 
 void TextureImpl::generateMipmaps()
 {
-    if (TextureUsage::RENDER_TARGET == _textureUsage || !isColorRenderable(_textureFormat))
+    if (TextureUsage::RENDER_TARGET == _desc.textureUsage || !isColorRenderable(_desc.pixelFormat))
         return;
 
-    if (!_hasMipmaps)
+    if (_desc.mipLevels == 0)
     {
-        _hasMipmaps = true;
         UtilsMTL::generateMipmaps(internalHandle());
+        _desc.mipLevels = RHIUtils::computeMipLevels(_desc);
     }
 }
 
-void TextureImpl::updateFaceData(TextureCubeFace side, void* data, int index)
+void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
 {
+    ensureNativeTexture();
     NSUInteger slice = static_cast<int>(side);
-    auto mtlTexture  = _textureInfo.ensure(index);
-    if (!mtlTexture)
-        return;
 
-    auto slicePitch = _textureInfo._bytesPerRow * _textureInfo._desc.height;
-    [mtlTexture replaceRegion:_region
+    auto bytesPerRow = RHIUtils::computeRowPitch(_desc.pixelFormat, static_cast<uint32_t>(_desc.width));
+    auto slicePitch = bytesPerRow * _desc.height;
+
+    auto region = MTLRegionMake2D(0, 0, _desc.width, _desc.height);
+    [_mtlTexture replaceRegion:region
                   mipmapLevel:0
                         slice:slice
                     withBytes:data
-                  bytesPerRow:_textureInfo._bytesPerRow
+                  bytesPerRow:bytesPerRow
                 bytesPerImage:slicePitch];
+}
+
+void TextureImpl::ensureNativeTexture()
+{
+    if(_mtlTexture) return;
+    MTLPixelFormat pixelFormat = UtilsMTL::toMTLPixelFormat(_desc.pixelFormat);
+    if (pixelFormat == MTLPixelFormatInvalid)
+        return;
+
+    MTLTextureDescriptor* textureDesc = nil;
+    switch (_desc.textureType)
+    {
+    case TextureType::TEXTURE_2D:
+        textureDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
+                                                                               width:_desc.width
+                                                                              height:_desc.height
+                                                                           mipmapped:YES];
+        if (_desc.arraySize > 1) {
+            textureDesc.textureType = MTLTextureType2DArray;
+            textureDesc.arrayLength = _desc.arraySize;
+        }
+        break;
+    case TextureType::TEXTURE_CUBE:
+        textureDesc = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:pixelFormat
+                                                                                  size:_desc.width
+                                                                             mipmapped:YES];
+        break;
+    default:
+        return;
+    }
+
+    if (TextureUsage::RENDER_TARGET == _desc.textureUsage)
+    {
+        // DepthStencil, and Multisample textures must be allocated with the MTLResourceStorageModePrivate resource
+        // option
+        if (PixelFormat::D24S8 == _desc.pixelFormat && _desc.textureType == TextureType::TEXTURE_2D)
+            textureDesc.resourceOptions = MTLResourceStorageModePrivate;
+        textureDesc.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+    }
+
+    _mtlTexture = [_mtlDevice newTextureWithDescriptor:textureDesc];
 }
 
 }

--- a/axmol/rhi/metal/UtilsMTL.mm
+++ b/axmol/rhi/metal/UtilsMTL.mm
@@ -26,7 +26,7 @@
 #include "axmol/rhi/metal/UtilsMTL.h"
 #include "axmol/rhi/metal/DriverMTL.h"
 #include "axmol/rhi/metal/TextureMTL.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 #include "axmol/base/Configuration.h"
 
 namespace ax::rhi::mtl {

--- a/axmol/rhi/opengl/BufferGL.cpp
+++ b/axmol/rhi/opengl/BufferGL.cpp
@@ -52,7 +52,7 @@ BufferImpl::BufferImpl(std::size_t size, BufferType type, BufferUsage usage) : B
 {
     glGenBuffers(1, &_buffer);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _backToForegroundListener =
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { this->reloadBuffer(); });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
@@ -63,7 +63,7 @@ BufferImpl::~BufferImpl()
 {
     if (_buffer)
         __state->deleteBuffer(_type, _buffer);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     AX_SAFE_DELETE_ARRAY(_data);
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
@@ -71,12 +71,12 @@ BufferImpl::~BufferImpl()
 
 void BufferImpl::usingDefaultStoredData(bool needDefaultStoredData)
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     _needDefaultStoredData = needDefaultStoredData;
 #endif
 }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 void BufferImpl::reloadBuffer()
 {
     glGenBuffers(1, &_buffer);
@@ -112,7 +112,7 @@ void BufferImpl::updateData(const void* data, std::size_t size)
         CHECK_GL_ERROR_DEBUG();
         _bufferAllocated = size;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         if (data)
             fillBuffer(data, 0, size);
 #endif
@@ -131,7 +131,7 @@ void BufferImpl::updateSubData(const void* data, std::size_t offset, std::size_t
 
         glBufferSubData(__state->bindBuffer(_type, _buffer), offset, size, data);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         fillBuffer(data, offset, size);
 #endif
         CHECK_GL_ERROR_DEBUG();

--- a/axmol/rhi/opengl/BufferGL.h
+++ b/axmol/rhi/opengl/BufferGL.h
@@ -85,7 +85,7 @@ public:
     inline GLuint getHandler() const { return _buffer; }
 
 private:
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     void reloadBuffer();
     void fillBuffer(const void* data, std::size_t offset, std::size_t size);
 

--- a/axmol/rhi/opengl/CommandBufferGL.h
+++ b/axmol/rhi/opengl/CommandBufferGL.h
@@ -239,7 +239,7 @@ protected:
     Viewport _viewPort;
     GLboolean _alphaTestEnabled = false;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _backToForegroundListener = nullptr;
 #endif
 };

--- a/axmol/rhi/opengl/DriverGL.cpp
+++ b/axmol/rhi/opengl/DriverGL.cpp
@@ -176,9 +176,9 @@ Buffer* DriverImpl::createBuffer(std::size_t size, BufferType type, BufferUsage 
     return new BufferImpl(size, type, usage);
 }
 
-Texture* DriverImpl::createTexture(const TextureDesc& descriptor)
+Texture* DriverImpl::createTexture(const TextureDesc& desc)
 {
-    return new TextureImpl(descriptor);
+    return new TextureImpl(desc);
 }
 
 RenderTarget* DriverImpl::createDefaultRenderTarget()

--- a/axmol/rhi/opengl/DriverGL.cpp
+++ b/axmol/rhi/opengl/DriverGL.cpp
@@ -231,7 +231,7 @@ SamplerHandle DriverImpl::createSampler(const SamplerDesc& desc)
         case SamplerFilter::MIP_LINEAR:
             minFilterGL = GL_NEAREST_MIPMAP_LINEAR;
             break;
-        default: // MIP_NONE
+        default: // MIP_DEFAULT
             minFilterGL = GL_NEAREST;
         }
     }

--- a/axmol/rhi/opengl/ProgramGL.cpp
+++ b/axmol/rhi/opengl/ProgramGL.cpp
@@ -81,7 +81,7 @@ ProgramImpl::ProgramImpl(std::string_view vertexShader, std::string_view fragmen
 
     reflectVertexInputs();
     reflectUniformInfos();
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     for (const auto& uniform : _activeUniformInfos)
     {
         auto location                            = uniform.second.location;
@@ -107,12 +107,12 @@ ProgramImpl::~ProgramImpl()
     if (_program)
         glDeleteProgram(_program);
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
 }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 void ProgramImpl::reloadProgram()
 {
     _activeUniformInfos.clear();
@@ -396,7 +396,7 @@ UniformLocation ProgramImpl::getUniformLocation(std::string_view uniform) const
         const auto& uniformInfo = iter->second;
         if (uniformInfo.bufferOffset != -1)
         {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
             uniformLocation.vertStage.location = _mapToOriginalLocation.at(uniformInfo.location);
 #else
             uniformLocation.vertStage.location = uniformInfo.location;
@@ -406,7 +406,7 @@ UniformLocation ProgramImpl::getUniformLocation(std::string_view uniform) const
         else
         { // means it's sampler
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
             uniformLocation.fragStage.location = _mapToOriginalLocation.at(uniformInfo.location);
 #else
             uniformLocation.fragStage.location = uniformInfo.location;
@@ -427,7 +427,7 @@ int ProgramImpl::getMaxFragmentLocation() const
     return _maxLocation;
 }
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
 int ProgramImpl::getMappedLocation(int location) const
 {
     if (_mapToCurrentActiveLocation.find(location) != _mapToCurrentActiveLocation.end())

--- a/axmol/rhi/opengl/ProgramGL.cpp
+++ b/axmol/rhi/opengl/ProgramGL.cpp
@@ -338,8 +338,8 @@ void ProgramImpl::reflectUniformInfos()
             uniform.bufferOffset = uniformOffset;
         }
         else
-        {  // must be samper: sampler2D or samplerCube
-            assert(uniform.type == GL_SAMPLER_2D || uniform.type == GL_SAMPLER_CUBE);
+        {  // must be samper: sampler2D, sampler2DArray, samplerCube
+            assert(uniform.type == GL_SAMPLER_2D || uniform.type == GL_SAMPLER_CUBE || uniform.type == GL_SAMPLER_2D_ARRAY);
             uniform.location     = glGetUniformLocation(_program, uniformName.data());
             uniform.bufferOffset = -1;
         }
@@ -378,7 +378,6 @@ const VertexInputDesc* ProgramImpl::getVertexInputDesc(VertexInputKind name) con
 
 const VertexInputDesc* ProgramImpl::getVertexInputDesc(std::string_view name) const
 {
-    // return glGetAttribLocation(_program, name.data());
     auto it = _activeVertexInputs.find(name);
     return it != _activeVertexInputs.end() ? &it->second : nullptr;
 }
@@ -395,12 +394,25 @@ UniformLocation ProgramImpl::getUniformLocation(std::string_view uniform) const
     if (iter != _activeUniformInfos.end())
     {
         const auto& uniformInfo = iter->second;
+        if (uniformInfo.bufferOffset != -1)
+        {
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-        uniformLocation.vertStage.location = _mapToOriginalLocation.at(uniformInfo.location);
+            uniformLocation.vertStage.location = _mapToOriginalLocation.at(uniformInfo.location);
 #else
-        uniformLocation.vertStage.location = uniformInfo.location;
+            uniformLocation.vertStage.location = uniformInfo.location;
 #endif
-        uniformLocation.vertStage.offset = uniformInfo.bufferOffset;
+            uniformLocation.vertStage.offset = uniformInfo.bufferOffset;
+        }
+        else
+        { // means it's sampler
+
+#if AX_ENABLE_CACHE_TEXTURE_DATA
+            uniformLocation.fragStage.location = _mapToOriginalLocation.at(uniformInfo.location);
+#else
+            uniformLocation.fragStage.location = uniformInfo.location;
+#endif
+            uniformLocation.fragStage.offset   = -1;  // samplers don't have offset
+        }
     }
 
     return uniformLocation;

--- a/axmol/rhi/opengl/ProgramGL.h
+++ b/axmol/rhi/opengl/ProgramGL.h
@@ -172,7 +172,7 @@ private:
 
     void clearUniformBuffers();
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     void reloadProgram();
     int getMappedLocation(int location) const override;
     int getOriginalLocation(int location) const override;
@@ -193,7 +193,7 @@ private:
     hlookup::string_map<VertexInputDesc> _activeVertexInputs;
     hlookup::string_map<UniformInfo> _activeUniformInfos;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     std::unordered_map<std::string, int>
         _originalUniformLocations;  ///< record the uniform location when shader was first created.
     std::unordered_map<int, int> _mapToCurrentActiveLocation;  ///<

--- a/axmol/rhi/opengl/ProgramGL.h
+++ b/axmol/rhi/opengl/ProgramGL.h
@@ -173,7 +173,7 @@ private:
     void clearUniformBuffers();
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    virtual void reloadProgram();
+    void reloadProgram();
     int getMappedLocation(int location) const override;
     int getOriginalLocation(int location) const override;
     const std::unordered_map<std::string, int> getAllUniformsLocation() const override

--- a/axmol/rhi/opengl/RenderTargetGL.cpp
+++ b/axmol/rhi/opengl/RenderTargetGL.cpp
@@ -35,7 +35,7 @@ RenderTargetImpl::RenderTargetImpl(bool defaultRenderTarget, DriverImpl* driver)
     if (!defaultRenderTarget)
     {
         glGenFramebuffers(1, &_FBO);
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
             glGenFramebuffers(1, &_FBO);
             _dirtyFlags = TargetBufferFlags::ALL;
@@ -53,7 +53,7 @@ RenderTargetImpl::~RenderTargetImpl()
 {
     if (!_defaultRenderTarget)
     {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
 

--- a/axmol/rhi/opengl/RenderTargetGL.h
+++ b/axmol/rhi/opengl/RenderTargetGL.h
@@ -23,7 +23,7 @@ public:
 
 public:
     GLuint _FBO = 0;
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     EventListenerCustom* _rendererRecreatedListener{nullptr};
 #endif
 };

--- a/axmol/rhi/opengl/TextureGL.cpp
+++ b/axmol/rhi/opengl/TextureGL.cpp
@@ -41,18 +41,6 @@ namespace ax::rhi::gl
 TextureImpl::TextureImpl(const TextureDesc& desc)
 {
     updateTextureDesc(desc);
-
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    // Listen this event to restored texture id after coming to foreground on GLES.
-    _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
-        if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
-            zeroTexData();
-    });
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
-#endif
-
-    if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
-        zeroTexData();
 }
 
 void TextureImpl::updateTextureDesc(const TextureDesc& desc)
@@ -71,15 +59,10 @@ void TextureImpl::updateTextureDesc(const TextureDesc& desc)
         _nativeDesc.target = GL_TEXTURE_CUBE_MAP;
         break;
     }
-
-    updateSamplerDesc(desc.samplerDesc);
 }
 
 TextureImpl::~TextureImpl()
 {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
-#endif
     if (_nativeTexture)
     {
         __state->deleteTexture(_nativeTexture);
@@ -87,6 +70,13 @@ TextureImpl::~TextureImpl()
     }
 
     _nativeSampler = 0;
+}
+
+void TextureImpl::invalidate()
+{
+    _nativeTexture     = 0;
+    _nativeSampler     = 0;
+    _overrideMipLevels = _desc.mipLevels;
 }
 
 void TextureImpl::updateSamplerDesc(const SamplerDesc& desc)
@@ -106,15 +96,11 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
 
     if (initial)
     {  // allocate texture storage for we can use glTexSubImageXXX later
-        if (_desc.arraySize == 1)
-        {
-            if (_nativeDesc.type != 0)
-                glTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0, _nativeDesc.format, _nativeDesc.type, nullptr);
-            else
-                glCompressedTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
-                                       imageSize, nullptr);
-        }
-        else if (_desc.arraySize > 0)
+
+        updateSamplerDesc(_desc.samplerDesc);
+
+        // we must allocate texture storage for GL_TEXTURE_2D_ARRAY
+        if (_desc.arraySize > 1)
         {
             if (_nativeDesc.type != 0)
                 glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
@@ -122,6 +108,15 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
             else
                 glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
                                        _desc.arraySize, 0, imageSize * _desc.arraySize, nullptr);
+        }
+        else if (_desc.arraySize == 1)
+        {
+            // if (_nativeDesc.type != 0)
+            //     glTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
+            //                  _nativeDesc.format, _nativeDesc.type, nullptr);
+            // else
+            //     glCompressedTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
+            //                            imageSize, nullptr);
         }
         else
         {
@@ -133,7 +128,22 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
 
 void TextureImpl::updateData(const void* data, int width, int height, int level, int layerIndex)
 {
-    updateSubData(0, 0, width, height, level, data, layerIndex);
+    if (!_nativeTexture && _desc.arraySize == 1)
+    {
+        ensureNativeTexture();
+
+        // !configure unpack alignment only when mipmapsNum == 1 and the data is uncompressed
+        configureUnpackAlignment(width);
+
+        glTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, width, height, 0, _nativeDesc.format,
+                     _nativeDesc.type, data);
+
+        CHECK_GL_ERROR_DEBUG();
+    }
+    else
+    {
+        updateSubData(0, 0, width, height, level, data, layerIndex);
+    }
 
     if (shouldGenMipmaps(level))
         generateMipmaps();
@@ -146,8 +156,21 @@ void TextureImpl::updateCompressedData(const void* data,
                                        int level,
                                        int layerIndex)
 {
-    updateCompressedSubData(0, 0, width, height, dataSize, level, data, layerIndex);
+    if (!_nativeTexture && _desc.arraySize == 1)
+    {
+        ensureNativeTexture(dataSize);
 
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+        glCompressedTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, (GLsizei)width, (GLsizei)height, 0,
+                               dataSize, data);
+
+        CHECK_GL_ERROR_DEBUG();
+    }
+    else
+    {
+        updateCompressedSubData(0, 0, width, height, dataSize, level, data, layerIndex);
+    }
     if (shouldGenMipmaps(level))
         generateMipmaps();
 }
@@ -162,13 +185,14 @@ void TextureImpl::updateSubData(int xoffset,
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
     ensureNativeTexture();
+    if (!data) [[unlikely]]
+        return;
 
     // !configure unpack alignment only when mipmapsNum == 1 and the data is uncompressed
     configureUnpackAlignment(width);
 
     if (_desc.arraySize == 1)
-        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format,
-                        _nativeDesc.type,
+        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format, _nativeDesc.type,
                         data);
     else
         glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,

--- a/axmol/rhi/opengl/TextureGL.cpp
+++ b/axmol/rhi/opengl/TextureGL.cpp
@@ -32,84 +32,21 @@
 #include "axmol/rhi/opengl/MacrosGL.h"
 #include "axmol/rhi/opengl/UtilsGL.h"
 #include "axmol/rhi/SamplerCache.h"
+#include "axmol/rhi/RHIUtils.h"
 
-namespace ax::rhi::gl {
+namespace ax::rhi::gl
+{
 
 #define ISPOW2(n) (((n) & (n - 1)) == 0)
 
-namespace
-{
-bool isMipmapEnabled(GLint filter)
-{
-    switch (filter)
-    {
-    case GL_LINEAR_MIPMAP_LINEAR:
-    case GL_LINEAR_MIPMAP_NEAREST:
-    case GL_NEAREST_MIPMAP_NEAREST:
-    case GL_NEAREST_MIPMAP_LINEAR:
-        return true;
-    default:
-        break;
-    }
-    return false;
-}
-}  // namespace
-
-/// CLASS TextureInfoGL
-void TextureInfoGL::applySampler(const SamplerDesc& desc, bool isPow2, bool hasMipmaps)
-{
-    this->sampler = static_cast<GLuint>(reinterpret_cast<uintptr_t>(SamplerCache::getInstance()->getSampler(desc)));
-}
-
-void TextureInfoGL::apply(int slot, int index) const
-{
-    __state->activeTexture(GL_TEXTURE0 + slot);
-    __state->bindTexture(this->target, index < AX_META_TEXTURES ? textures[index] : textures[0]);
-    __state->bindSampler(slot, this->sampler);
-}
-
-GLuint TextureInfoGL::ensure(int index)
-{
-    if (index >= AX_META_TEXTURES)
-        return 0;
-    // glActiveTexture(GL_TEXTURE0 + index);
-    auto& texID = this->textures[index];
-    if (!texID)
-        glGenTextures(1, &texID);
-    __state->bindTexture(this->target, texID);
-
-    if (this->maxIdx < index)
-        this->maxIdx = index;
-
-    return texID;
-}
-
-void TextureInfoGL::onRendererRecreated()
-{
-    int idx = 0;
-    for (auto&& texID : textures)
-    {
-        if (texID)
-        {
-            // NOTE: glDeleteTextures() doesn't need to be called here, because the textures were
-            // destroyed when the GL context was lost.
-            texID = 0;
-            ensure(idx);
-        }
-        ++idx;
-    }
-}
-
 /// CLASS TextureImpl
-TextureImpl::TextureImpl(const TextureDesc& descriptor)
+TextureImpl::TextureImpl(const TextureDesc& desc)
 {
-    _textureType = descriptor.textureType;
-    updateTextureDesc(descriptor);
+    updateTextureDesc(desc);
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     // Listen this event to restored texture id after coming to foreground on GLES.
     _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
-        _textureInfo.onRendererRecreated();
         if (_usedForRT)
             this->ensureTexStorageForRT();
     });
@@ -117,36 +54,49 @@ TextureImpl::TextureImpl(const TextureDesc& descriptor)
 #endif
 }
 
-void TextureImpl::updateTextureDesc(const TextureDesc& descriptor, int index)
+void TextureImpl::updateTextureDesc(const TextureDesc& desc)
 {
-    _textureInfo.target = _textureType == rhi::TextureType::TEXTURE_2D ? GL_TEXTURE_2D : GL_TEXTURE_CUBE_MAP;
+    assert(desc.textureType == rhi::TextureType::TEXTURE_2D || _desc.width == _desc.height);
 
-    assert(descriptor.textureType == rhi::TextureType::TEXTURE_2D || _width == _height);
+    Texture::updateTextureDesc(desc);
 
-    Texture::updateTextureDesc(descriptor, index);
+    UtilsGL::toGLTypes(desc.pixelFormat, _nativeDesc.internalFormat, _nativeDesc.format, _nativeDesc.type);
+    switch (desc.textureType)
+    {
+    case TextureType::TEXTURE_2D:
+        _nativeDesc.target = _desc.arraySize == 1 ? GL_TEXTURE_2D : GL_TEXTURE_2D_ARRAY;
+        break;
+    case TextureType::TEXTURE_CUBE:
+        _nativeDesc.target = GL_TEXTURE_CUBE_MAP;
+        break;
+    }
 
-    UtilsGL::toGLTypes(descriptor.textureFormat, _textureInfo.internalFormat, _textureInfo.format, _textureInfo.type);
+    updateSamplerDesc(desc.samplerDesc);
 
-    updateSamplerDesc(descriptor.samplerDesc);
-
-    const bool useForRT = descriptor.textureUsage == TextureUsage::RENDER_TARGET;
+    if (_desc.arraySize == 1)
+    {
+        const bool useForRT = desc.textureUsage == TextureUsage::RENDER_TARGET;
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    _usedForRT = useForRT;
+        _usedForRT = useForRT;
 #endif
-    if(useForRT) {
-        ensureTexStorageForRT();
+        if (useForRT)
+        {
+            ensureTexStorageForRT();
+        }
     }
 }
 
 void TextureImpl::ensureTexStorageForRT()
 {
-    auto size     = _width * _height * _bitsPerPixel / 8;
+    const auto w = getWidth();
+    const auto h = getHeight();
+    auto size    = w * h * _bitsPerPixel / 8;
     assert(size > 0);
 
-    uint8_t* data = (uint8_t*)malloc(size);
-    memset(data, 0, size);
-    updateData(data, _width, _height, 0);
-    free(data);
+    axstd::byte_buffer blackPixels;
+    blackPixels.resize(size, 0);
+
+    updateData(blackPixels.data(), w, h, 0, 0);
 }
 
 TextureImpl::~TextureImpl()
@@ -154,23 +104,57 @@ TextureImpl::~TextureImpl()
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
-    _textureInfo.destroy();
+    if (_nativeTexture)
+    {
+        __state->deleteTexture(_nativeTexture);
+        _nativeTexture = 0;
+    }
+
+    _nativeSampler = 0;
 }
 
-void TextureImpl::updateSamplerDesc(const SamplerDesc& sampler)
+void TextureImpl::updateSamplerDesc(const SamplerDesc& desc)
 {
-    bool isPow2 = ISPOW2(_width) && ISPOW2(_height);
-    _textureInfo.applySampler(sampler, isPow2, _hasMipmaps);
+    // TODO: check mip POT
+    // bool isPow2 = ISPOW2(_width) && ISPOW2(_height);
+    // _textureInfo.applySampler(sampler, isPow2, _hasMipmaps);
+
+    this->_nativeSampler =
+        static_cast<GLuint>(reinterpret_cast<uintptr_t>(SamplerCache::getInstance()->getSampler(desc)));
 }
 
-void TextureImpl::updateData(uint8_t* data, std::size_t width, std::size_t height, std::size_t level, int index)
+void TextureImpl::ensureNativeTexture(size_t imageSize)
 {
-    assert(_textureInfo.target == GL_TEXTURE_2D);
-    if (!_textureInfo.ensure(index))
-        return;
+    bool initial = !_nativeTexture;
+
+    if (initial)
+        glGenTextures(1, &_nativeTexture);
+
+    __state->bindTexture(_nativeDesc.target, _nativeTexture);
+
+    if (initial && _desc.arraySize > 1)
+    { // allocate texture2d array storage
+        if (_nativeDesc.type != 0)
+        {
+            glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, _desc.arraySize,
+                         0, _nativeDesc.format, _nativeDesc.type, nullptr);
+        }
+        else
+        {
+            glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
+                                   _desc.arraySize, 0, imageSize * _desc.arraySize, nullptr);
+        }
+        CHECK_GL_ERROR_DEBUG();
+    }
+}
+
+void TextureImpl::updateData(const void* data, std::size_t width, std::size_t height, std::size_t level, int layerIndex)
+{
+    assert(_desc.textureType == TextureType::TEXTURE_2D);
+    ensureNativeTexture();
 
     // Set the row align only when mipmapsNum == 1 and the data is uncompressed
-    auto mipmapEnabled = _hasMipmaps; // TODO: mipLevels
+    auto mipmapEnabled = _desc.samplerDesc.mipFilter != SamplerFilter::MIP_NONE;
     if (!mipmapEnabled)
     {
         unsigned int bytesPerRow = width * _bitsPerPixel / 8;
@@ -197,44 +181,49 @@ void TextureImpl::updateData(uint8_t* data, std::size_t width, std::size_t heigh
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     }
 
-    glTexImage2D(GL_TEXTURE_2D, level, _textureInfo.internalFormat, width, height,
-                 0,  // border
-                 _textureInfo.format, _textureInfo.type, data);
+    if (_desc.arraySize == 1)
+        glTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, width, height, 0, _nativeDesc.format,
+                     _nativeDesc.type, data);
+    else
+        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, width, height, 1, _nativeDesc.internalFormat,
+                     _nativeDesc.type, data);
 
     CHECK_GL_ERROR_DEBUG();
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    if (_generateMipmaps)
+    if (_generateMipmaps && level == 0)
     {
-        _hasMipmaps = false;
+        // _hasMipmaps = false;
         generateMipmaps();
     }
 #endif
 
-    if (!_hasMipmaps && level > 0)
-        _hasMipmaps = true;
+    if (!_desc.mipLevels && level > 0)
+        _desc.mipLevels = level + 1;
 }
 
-void TextureImpl::updateCompressedData(uint8_t* data,
+void TextureImpl::updateCompressedData(const void* data,
                                        std::size_t width,
                                        std::size_t height,
-                                       std::size_t dataLen,
+                                       std::size_t dataSize,
                                        std::size_t level,
-                                       int index)
+                                       int layerIndex)
 {
-    assert(_textureInfo.target == GL_TEXTURE_2D);
-    if (!_textureInfo.ensure(index))
-        return;
+    assert(_desc.textureType == TextureType::TEXTURE_2D);
+    ensureNativeTexture(dataSize);
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-    glCompressedTexImage2D(GL_TEXTURE_2D, level, _textureInfo.internalFormat, (GLsizei)width, (GLsizei)height,
-                           0,  // border
-                           dataLen, data);
+    if (_desc.arraySize == 1)
+        glCompressedTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, (GLsizei)width, (GLsizei)height, 0,
+                               dataSize, data);
+    else
+        glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, (GLsizei)width, (GLsizei)height, 1,
+                                  _nativeDesc.internalFormat, dataSize, data);
     CHECK_GL_ERROR_DEBUG();
 
-    if (!_hasMipmaps && level > 0)
-        _hasMipmaps = true;
+    if (!_desc.mipLevels && level > 0)
+        _desc.mipLevels = level + 1;
 }
 
 void TextureImpl::updateSubData(std::size_t xoffset,
@@ -242,77 +231,92 @@ void TextureImpl::updateSubData(std::size_t xoffset,
                                 std::size_t width,
                                 std::size_t height,
                                 std::size_t level,
-                                uint8_t* data,
-                                int index)
+                                const void* data,
+                                int layerIndex)
 {
-    assert(_textureInfo.target == GL_TEXTURE_2D);
-    if (!_textureInfo.ensure(index))
-        return;
+    assert(_desc.textureType == TextureType::TEXTURE_2D);
+    ensureNativeTexture();
 
     // !IMPORTANT: Set the unpack alignment to 1 byte to avoid issues with width or height no align with 4.
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-    glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _textureInfo.format, _textureInfo.type,
-                    data);
+    if (_desc.arraySize == 1)
+        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format, _nativeDesc.type, data);
+    else
+        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,
+                        _nativeDesc.internalFormat,
+                        _nativeDesc.type, data);
+
     CHECK_GL_ERROR_DEBUG();
 
-    if (!_hasMipmaps && level > 0)
-        _hasMipmaps = true;
+    // TODO:
+    // if (!_hasMipmaps && level > 0)
+    //     _hasMipmaps = true;
 }
 
 void TextureImpl::updateCompressedSubData(std::size_t xoffset,
                                           std::size_t yoffset,
                                           std::size_t width,
                                           std::size_t height,
-                                          std::size_t dataLen,
+                                          std::size_t dataSize,
                                           std::size_t level,
-                                          uint8_t* data,
-                                          int index)
+                                          const void* data,
+                                          int layerIndex)
 {
-    assert(_textureInfo.target == GL_TEXTURE_2D);
-    if (!_textureInfo.ensure(index))
-        return;
+    assert(_desc.textureType == TextureType::TEXTURE_2D);
+    ensureNativeTexture(dataSize);
 
-    glCompressedTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _textureInfo.internalFormat,
-                              dataLen, data);
+    if (_desc.arraySize == 1)
+        glCompressedTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.internalFormat,
+                              dataSize, data);
+    else
+        glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,
+                                  _nativeDesc.internalFormat, dataSize, data);
     CHECK_GL_ERROR_DEBUG();
 
-    if (!_hasMipmaps && level > 0)
-        _hasMipmaps = true;
+    // TODO:
+    // if (!_hasMipmaps && level > 0)
+    //    _hasMipmaps = true;
 }
 
-void TextureImpl::updateFaceData(TextureCubeFace side, void* data, int index)
+void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
 {
-    assert(_textureInfo.target == GL_TEXTURE_CUBE_MAP);
-    if (!_textureInfo.ensure(index))
-        return;
+    assert(_desc.textureType == TextureType::TEXTURE_CUBE);
+    ensureNativeTexture();
 
     CHECK_GL_ERROR_DEBUG();
     int i = static_cast<int>(side);
-    glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i,
-                 0,  // level
-                 _textureInfo.internalFormat, _width, _height,
-                 0,  // border
-                 _textureInfo.format, _textureInfo.type, data);
+
+    glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
+                _nativeDesc.format, _nativeDesc.type, data);
 
     CHECK_GL_ERROR_DEBUG();
     __state->bindTexture(GL_TEXTURE_CUBE_MAP, 0);
 }
 
+void TextureImpl::apply(int slot) const
+{
+    __state->activeTexture(GL_TEXTURE0 + slot);
+    __state->bindTexture(_nativeDesc.target, _nativeTexture);
+    __state->bindSampler(slot, _nativeSampler);
+}
+
 void TextureImpl::generateMipmaps()
 {
-    if (TextureUsage::RENDER_TARGET == _textureUsage)
+    if (TextureUsage::RENDER_TARGET == _desc.textureUsage)
         return;
 
-    if (!_hasMipmaps)
+    if (_desc.mipLevels == 0)  // 0 means chould auto generate by GPU
     {
+        __state->bindTexture(_nativeDesc.target, (GLuint)this->internalHandle());
+        glGenerateMipmap(_nativeDesc.target);
+
 #if AX_ENABLE_CACHE_TEXTURE_DATA
         _generateMipmaps = true;
 #endif
-        _hasMipmaps = true;
-        __state->bindTexture(_textureInfo.target, (GLuint)this->internalHandle());
-        glGenerateMipmap(_textureInfo.target);
+
+        _desc.mipLevels = RHIUtils::computeMipLevels(_desc);
     }
 }
 
-}
+}  // namespace ax::rhi::gl

--- a/axmol/rhi/opengl/TextureGL.cpp
+++ b/axmol/rhi/opengl/TextureGL.cpp
@@ -37,8 +37,6 @@
 namespace ax::rhi::gl
 {
 
-#define ISPOW2(n) (((n) & (n - 1)) == 0)
-
 /// CLASS TextureImpl
 TextureImpl::TextureImpl(const TextureDesc& desc)
 {
@@ -115,10 +113,6 @@ TextureImpl::~TextureImpl()
 
 void TextureImpl::updateSamplerDesc(const SamplerDesc& desc)
 {
-    // TODO: check mip POT
-    // bool isPow2 = ISPOW2(_width) && ISPOW2(_height);
-    // _textureInfo.applySampler(sampler, isPow2, _hasMipmaps);
-
     this->_nativeSampler =
         static_cast<GLuint>(reinterpret_cast<uintptr_t>(SamplerCache::getInstance()->getSampler(desc)));
 }
@@ -133,7 +127,7 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
     __state->bindTexture(_nativeDesc.target, _nativeTexture);
 
     if (initial && _desc.arraySize > 1)
-    { // allocate texture2d array storage
+    {  // allocate texture2d array storage
         if (_nativeDesc.type != 0)
         {
             glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, _desc.arraySize,
@@ -148,65 +142,32 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
     }
 }
 
-void TextureImpl::updateData(const void* data, std::size_t width, std::size_t height, std::size_t level, int layerIndex)
+void TextureImpl::updateData(const void* data, int width, int height, int level, int layerIndex)
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
     ensureNativeTexture();
 
-    // Set the row align only when mipmapsNum == 1 and the data is uncompressed
-    auto mipmapEnabled = _desc.samplerDesc.mipFilter != SamplerFilter::MIP_NONE;
-    if (!mipmapEnabled)
-    {
-        unsigned int bytesPerRow = width * _bitsPerPixel / 8;
-
-        if (bytesPerRow % 8 == 0)
-        {
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 8);
-        }
-        else if (bytesPerRow % 4 == 0)
-        {
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-        }
-        else if (bytesPerRow % 2 == 0)
-        {
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
-        }
-        else
-        {
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        }
-    }
-    else
-    {
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    }
+    // !configure unpack alignment only when mipmapsNum == 1 and the data is uncompressed
+    configureUnpackAlignment(width);
 
     if (_desc.arraySize == 1)
         glTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, width, height, 0, _nativeDesc.format,
                      _nativeDesc.type, data);
     else
         glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, width, height, 1, _nativeDesc.internalFormat,
-                     _nativeDesc.type, data);
+                        _nativeDesc.type, data);
 
     CHECK_GL_ERROR_DEBUG();
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    if (_generateMipmaps && level == 0)
-    {
-        // _hasMipmaps = false;
+    if (shouldGenMipmaps(level))
         generateMipmaps();
-    }
-#endif
-
-    if (!_desc.mipLevels && level > 0)
-        _desc.mipLevels = level + 1;
 }
 
 void TextureImpl::updateCompressedData(const void* data,
-                                       std::size_t width,
-                                       std::size_t height,
+                                       int width,
+                                       int height,
                                        std::size_t dataSize,
-                                       std::size_t level,
+                                       int level,
                                        int layerIndex)
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
@@ -215,68 +176,62 @@ void TextureImpl::updateCompressedData(const void* data,
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
     if (_desc.arraySize == 1)
-        glCompressedTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, (GLsizei)width, (GLsizei)height, 0,
-                               dataSize, data);
+        glCompressedTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, width, height, 0,
+                               static_cast<GLsizei>(dataSize), data);
     else
-        glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, (GLsizei)width, (GLsizei)height, 1,
+        glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, width, height, 1,
                                   _nativeDesc.internalFormat, dataSize, data);
     CHECK_GL_ERROR_DEBUG();
 
-    if (!_desc.mipLevels && level > 0)
-        _desc.mipLevels = level + 1;
+    if (shouldGenMipmaps(level))
+        generateMipmaps();
 }
 
-void TextureImpl::updateSubData(std::size_t xoffset,
-                                std::size_t yoffset,
-                                std::size_t width,
-                                std::size_t height,
-                                std::size_t level,
+void TextureImpl::updateSubData(int xoffset,
+                                int yoffset,
+                                int width,
+                                int height,
+                                int level,
                                 const void* data,
                                 int layerIndex)
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
     ensureNativeTexture();
 
-    // !IMPORTANT: Set the unpack alignment to 1 byte to avoid issues with width or height no align with 4.
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    // !configure unpack alignment only when mipmapsNum == 1 and the data is uncompressed
+    configureUnpackAlignment(width);
 
     if (_desc.arraySize == 1)
-        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format, _nativeDesc.type, data);
+        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format, _nativeDesc.type,
+                        data);
     else
         glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,
-                        _nativeDesc.internalFormat,
-                        _nativeDesc.type, data);
+                        _nativeDesc.internalFormat, _nativeDesc.type, data);
 
     CHECK_GL_ERROR_DEBUG();
-
-    // TODO:
-    // if (!_hasMipmaps && level > 0)
-    //     _hasMipmaps = true;
 }
 
-void TextureImpl::updateCompressedSubData(std::size_t xoffset,
-                                          std::size_t yoffset,
-                                          std::size_t width,
-                                          std::size_t height,
+void TextureImpl::updateCompressedSubData(int xoffset,
+                                          int yoffset,
+                                          int width,
+                                          int height,
                                           std::size_t dataSize,
-                                          std::size_t level,
+                                          int level,
                                           const void* data,
                                           int layerIndex)
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
     ensureNativeTexture(dataSize);
 
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
     if (_desc.arraySize == 1)
         glCompressedTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.internalFormat,
-                              dataSize, data);
+                                  static_cast<GLsizei>(dataSize), data);
     else
         glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,
-                                  _nativeDesc.internalFormat, dataSize, data);
+                                  _nativeDesc.internalFormat, static_cast<GLsizei>(dataSize), data);
     CHECK_GL_ERROR_DEBUG();
-
-    // TODO:
-    // if (!_hasMipmaps && level > 0)
-    //    _hasMipmaps = true;
 }
 
 void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
@@ -288,10 +243,13 @@ void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
     int i = static_cast<int>(side);
 
     glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
-                _nativeDesc.format, _nativeDesc.type, data);
+                 _nativeDesc.format, _nativeDesc.type, data);
 
     CHECK_GL_ERROR_DEBUG();
     __state->bindTexture(GL_TEXTURE_CUBE_MAP, 0);
+
+    if (shouldGenMipmaps())
+        generateMipmaps();
 }
 
 void TextureImpl::apply(int slot) const
@@ -306,17 +264,30 @@ void TextureImpl::generateMipmaps()
     if (TextureUsage::RENDER_TARGET == _desc.textureUsage)
         return;
 
-    if (_desc.mipLevels == 0)  // 0 means chould auto generate by GPU
+    __state->bindTexture(_nativeDesc.target, _nativeTexture);
+    glGenerateMipmap(_nativeDesc.target);
+
+    _overrideMipLevels = RHIUtils::computeMipLevels(_desc.width, _desc.height);
+}
+
+void TextureImpl::configureUnpackAlignment(unsigned int width)
+{
+    auto mipmapEnabled = _desc.samplerDesc.mipFilter != SamplerFilter::MIP_DEFAULT;
+    if (!mipmapEnabled)
     {
-        __state->bindTexture(_nativeDesc.target, (GLuint)this->internalHandle());
-        glGenerateMipmap(_nativeDesc.target);
+        unsigned int bytesPerRow = width * _bitsPerPixel / 8;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-        _generateMipmaps = true;
-#endif
-
-        _desc.mipLevels = RHIUtils::computeMipLevels(_desc);
+        if (bytesPerRow % 8 == 0)
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 8);
+        else if (bytesPerRow % 4 == 0)
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+        else if (bytesPerRow % 2 == 0)
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+        else
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     }
+    else
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 }
 
 }  // namespace ax::rhi::gl

--- a/axmol/rhi/opengl/TextureGL.cpp
+++ b/axmol/rhi/opengl/TextureGL.cpp
@@ -45,11 +45,14 @@ TextureImpl::TextureImpl(const TextureDesc& desc)
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     // Listen this event to restored texture id after coming to foreground on GLES.
     _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) {
-        if (_usedForRT)
-            this->ensureTexStorageForRT();
+        if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
+            zeroTexData();
     });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
+
+    if (_desc.textureUsage == TextureUsage::RENDER_TARGET)
+        zeroTexData();
 }
 
 void TextureImpl::updateTextureDesc(const TextureDesc& desc)
@@ -70,31 +73,6 @@ void TextureImpl::updateTextureDesc(const TextureDesc& desc)
     }
 
     updateSamplerDesc(desc.samplerDesc);
-
-    if (_desc.arraySize == 1)
-    {
-        const bool useForRT = desc.textureUsage == TextureUsage::RENDER_TARGET;
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-        _usedForRT = useForRT;
-#endif
-        if (useForRT)
-        {
-            ensureTexStorageForRT();
-        }
-    }
-}
-
-void TextureImpl::ensureTexStorageForRT()
-{
-    const auto w = getWidth();
-    const auto h = getHeight();
-    auto size    = w * h * _bitsPerPixel / 8;
-    assert(size > 0);
-
-    axstd::byte_buffer blackPixels;
-    blackPixels.resize(size, 0);
-
-    updateData(blackPixels.data(), w, h, 0, 0);
 }
 
 TextureImpl::~TextureImpl()
@@ -126,17 +104,28 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
 
     __state->bindTexture(_nativeDesc.target, _nativeTexture);
 
-    if (initial && _desc.arraySize > 1)
-    {  // allocate texture2d array storage
-        if (_nativeDesc.type != 0)
+    if (initial)
+    {  // allocate texture storage for we can use glTexSubImageXXX later
+        if (_desc.arraySize == 1)
         {
-            glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, _desc.arraySize,
-                         0, _nativeDesc.format, _nativeDesc.type, nullptr);
+            if (_nativeDesc.type != 0)
+                glTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0, _nativeDesc.format, _nativeDesc.type, nullptr);
+            else
+                glCompressedTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
+                                       imageSize, nullptr);
+        }
+        else if (_desc.arraySize > 0)
+        {
+            if (_nativeDesc.type != 0)
+                glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
+                             _desc.arraySize, 0, _nativeDesc.format, _nativeDesc.type, nullptr);
+            else
+                glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
+                                       _desc.arraySize, 0, imageSize * _desc.arraySize, nullptr);
         }
         else
         {
-            glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
-                                   _desc.arraySize, 0, imageSize * _desc.arraySize, nullptr);
+            AXLOGE("TextureDesc arraySize can't be 0");
         }
         CHECK_GL_ERROR_DEBUG();
     }
@@ -144,20 +133,7 @@ void TextureImpl::ensureNativeTexture(size_t imageSize)
 
 void TextureImpl::updateData(const void* data, int width, int height, int level, int layerIndex)
 {
-    assert(_desc.textureType == TextureType::TEXTURE_2D);
-    ensureNativeTexture();
-
-    // !configure unpack alignment only when mipmapsNum == 1 and the data is uncompressed
-    configureUnpackAlignment(width);
-
-    if (_desc.arraySize == 1)
-        glTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, width, height, 0, _nativeDesc.format,
-                     _nativeDesc.type, data);
-    else
-        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, width, height, 1, _nativeDesc.internalFormat,
-                        _nativeDesc.type, data);
-
-    CHECK_GL_ERROR_DEBUG();
+    updateSubData(0, 0, width, height, level, data, layerIndex);
 
     if (shouldGenMipmaps(level))
         generateMipmaps();
@@ -170,18 +146,7 @@ void TextureImpl::updateCompressedData(const void* data,
                                        int level,
                                        int layerIndex)
 {
-    assert(_desc.textureType == TextureType::TEXTURE_2D);
-    ensureNativeTexture(dataSize);
-
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-    if (_desc.arraySize == 1)
-        glCompressedTexImage2D(GL_TEXTURE_2D, level, _nativeDesc.internalFormat, width, height, 0,
-                               static_cast<GLsizei>(dataSize), data);
-    else
-        glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, 0, 0, layerIndex, width, height, 1,
-                                  _nativeDesc.internalFormat, dataSize, data);
-    CHECK_GL_ERROR_DEBUG();
+    updateCompressedSubData(0, 0, width, height, dataSize, level, data, layerIndex);
 
     if (shouldGenMipmaps(level))
         generateMipmaps();
@@ -202,7 +167,8 @@ void TextureImpl::updateSubData(int xoffset,
     configureUnpackAlignment(width);
 
     if (_desc.arraySize == 1)
-        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format, _nativeDesc.type,
+        glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format,
+                        _nativeDesc.type,
                         data);
     else
         glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,

--- a/axmol/rhi/opengl/TextureGL.h
+++ b/axmol/rhi/opengl/TextureGL.h
@@ -167,18 +167,13 @@ public:
     void ensureNativeTexture(size_t imageSize = 0);
 
 private:
-    void ensureTexStorageForRT();
-
     void configureUnpackAlignment(unsigned int width);
 
     NativeTextureDesc _nativeDesc{};
     GLuint _nativeTexture{0};
     GLuint _nativeSampler{0};  // weak ref
-
-    EventListener* _rendererRecreatedListener = nullptr;
-
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    bool _usedForRT = false;
+    EventListener* _rendererRecreatedListener = nullptr;
 #endif
 };
 

--- a/axmol/rhi/opengl/TextureGL.h
+++ b/axmol/rhi/opengl/TextureGL.h
@@ -49,7 +49,7 @@ struct NativeTextureDesc
  */
 
 /**
- * A 2D texture
+ * The texture implementation supports 2D, cubemap, and 2D array textures.
  */
 class TextureImpl : public rhi::Texture
 {
@@ -151,6 +151,8 @@ public:
      */
     void updateTextureDesc(const TextureDesc& descriptor) override;
 
+    void invalidate() override;
+
     /**
      * Get internal texture object handle.
      * @return Texture object.
@@ -172,9 +174,6 @@ private:
     NativeTextureDesc _nativeDesc{};
     GLuint _nativeTexture{0};
     GLuint _nativeSampler{0};  // weak ref
-#if AX_ENABLE_CACHE_TEXTURE_DATA
-    EventListener* _rendererRecreatedListener = nullptr;
-#endif
 };
 
 // end of _opengl group

--- a/axmol/rhi/opengl/TextureGL.h
+++ b/axmol/rhi/opengl/TextureGL.h
@@ -35,58 +35,12 @@
 namespace ax::rhi::gl
 {
 
-/**
- * Store texture information.
- */
-struct TextureInfoGL
+struct NativeTextureDesc
 {
-    void applySampler(const SamplerDesc& desc, bool isPow2, bool hasMipmaps);
-
-    TextureInfoGL() { textures.fill(0); }
-    ~TextureInfoGL() {}
-
-    template <typename _Fty>
-    void foreachTextures(const _Fty& cb)
-    {
-        int idx = 0;
-        while (textures[idx])
-        {
-            auto& h = textures[idx];
-            cb(h, idx++);
-        }
-    }
-
-    GLuint ensure(int index);
-    void onRendererRecreated();
-
-    void destroy()
-    {
-        foreachTextures([this](GLuint& texID, int) {
-            __state->deleteTexture(texID);
-            texID = 0;
-        });
-        textures.fill(0);
-    }
-
-    /// <summary>
-    /// Apply shader texture
-    /// </summary>
-    /// <param name="slot">the slot in shader</param>
-    /// <param name="index">the index in meta textrues</param>
-    /// <param name="target">the target GL_TEXTURE_2D,GL_TEXTURE_CUBE_MAP</param>
-    void apply(int slot, int index) const;
-
-    GLuint sampler{0};
-
-    // Used in glTexImage2D().
+    GLenum target        = GL_TEXTURE_2D;
     GLint internalFormat = GL_RGBA;
     GLenum format        = GL_RGBA;
     GLenum type          = GL_UNSIGNED_BYTE;
-
-    GLenum target = GL_TEXTURE_2D;
-
-    std::array<GLuint, AX_META_TEXTURES + 1> textures;
-    int maxIdx = 0;
 };
 
 /**
@@ -101,10 +55,10 @@ class TextureImpl : public rhi::Texture
 {
 public:
     /**
-     * @param descriptor Specifies the texture description.
+     * @param desc Specifies the texture description.
      */
-    TextureImpl(const TextureDesc& descriptor);
-    ~TextureImpl();
+    TextureImpl(const TextureDesc& desc);
+    ~TextureImpl() override;
 
     /**
      * Update a two-dimensional texture image
@@ -112,29 +66,31 @@ public:
      * @param width Specifies the width of the texture image.
      * @param height Specifies the height of the texture image.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
+     * @param layerIndex Specifies the layer index for 2D array textures.
      * reduction image.
      */
-    virtual void updateData(uint8_t* data,
-                            std::size_t width,
-                            std::size_t height,
-                            std::size_t level,
-                            int index = 0) override;
+    void updateData(const void* data,
+                    std::size_t width,
+                    std::size_t height,
+                    std::size_t level,
+                    int layerIndex) override;
 
     /**
      * Update a two-dimensional texture image in a compressed format
      * @param data Specifies a pointer to the compressed image data in memory.
      * @param width Specifies the width of the texture image.
      * @param height Specifies the height of the texture image.
-     * @param dataLen Specifies the totoal size of compressed image in bytes.
+     * @param dataSize Specifies the totoal size of compressed image in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateCompressedData(uint8_t* data,
-                                      std::size_t width,
-                                      std::size_t height,
-                                      std::size_t dataLen,
-                                      std::size_t level,
-                                      int index = 0) override;
+    void updateCompressedData(const void* data,
+                              std::size_t width,
+                              std::size_t height,
+                              std::size_t dataSize,
+                              std::size_t level,
+                              int layerIndex) override;
 
     /**
      * Update a two-dimensional texture subimage
@@ -145,14 +101,15 @@ public:
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the image data in memory.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateSubData(std::size_t xoffset,
-                               std::size_t yoffset,
-                               std::size_t width,
-                               std::size_t height,
-                               std::size_t level,
-                               uint8_t* data,
-                               int index = 0) override;
+    void updateSubData(std::size_t xoffset,
+                       std::size_t yoffset,
+                       std::size_t width,
+                       std::size_t height,
+                       std::size_t level,
+                       const void* data,
+                       int layerIndex) override;
 
     /**
      * Update a two-dimensional texture subimage in a compressed format
@@ -160,21 +117,22 @@ public:
      * @param yoffset Specifies a texel offset in the y direction within the texture array.
      * @param width Specifies the width of the texture subimage.
      * @param height Specifies the height of the texture subimage.
-     * @param dataLen Specifies the totoal size of compressed subimage in bytes.
+     * @param dataSize Specifies the totoal size of compressed subimage in bytes.
      * @param level Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap
      * reduction image.
      * @param data Specifies a pointer to the compressed image data in memory.
+     * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    virtual void updateCompressedSubData(std::size_t xoffset,
-                                         std::size_t yoffset,
-                                         std::size_t width,
-                                         std::size_t height,
-                                         std::size_t dataLen,
-                                         std::size_t level,
-                                         uint8_t* data,
-                                         int index = 0) override;
+    void updateCompressedSubData(std::size_t xoffset,
+                                 std::size_t yoffset,
+                                 std::size_t width,
+                                 std::size_t height,
+                                 std::size_t dataSize,
+                                 std::size_t level,
+                                 const void* data,
+                                 int layerIndex) override;
 
-    void updateFaceData(TextureCubeFace side, void* data, int index = 0) override;
+    void updateFaceData(TextureCubeFace side, const void* data) override;
 
     /**
      * Update sampler
@@ -191,27 +149,30 @@ public:
      * Update texture description.
      * @param descriptor Specifies texture and sampler descriptor.
      */
-    void updateTextureDesc(const TextureDesc& descriptor, int index = 0) override;
+    void updateTextureDesc(const TextureDesc& descriptor) override;
 
     /**
      * Get internal texture object handle.
      * @return Texture object.
      */
-    GLuint internalHandle(int index = 0) const { return _textureInfo.textures[index]; }
+    GLuint internalHandle() const { return _nativeSampler; }
 
     /**
      * Set texture to pipeline
      * @param index Specifies the texture image unit selector.
      * @param target GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
      */
-    void apply(int slot, int index) const { _textureInfo.apply(slot, index); }
+    void apply(int slot) const;
 
-    int getCount() const override { return _textureInfo.maxIdx + 1; }
+    void ensureNativeTexture(size_t imageSize = 0);
 
 private:
     void ensureTexStorageForRT();
 
-    TextureInfoGL _textureInfo;
+    NativeTextureDesc _nativeDesc{};
+    GLuint _nativeTexture{0};
+    GLuint _nativeSampler{0};  // weak ref
+
     EventListener* _rendererRecreatedListener = nullptr;
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA

--- a/axmol/rhi/opengl/TextureGL.h
+++ b/axmol/rhi/opengl/TextureGL.h
@@ -70,9 +70,9 @@ public:
      * reduction image.
      */
     void updateData(const void* data,
-                    std::size_t width,
-                    std::size_t height,
-                    std::size_t level,
+                    int width,
+                    int height,
+                    int level,
                     int layerIndex) override;
 
     /**
@@ -86,10 +86,10 @@ public:
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
     void updateCompressedData(const void* data,
-                              std::size_t width,
-                              std::size_t height,
+                              int width,
+                              int height,
                               std::size_t dataSize,
-                              std::size_t level,
+                              int level,
                               int layerIndex) override;
 
     /**
@@ -103,11 +103,11 @@ public:
      * @param data Specifies a pointer to the image data in memory.
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    void updateSubData(std::size_t xoffset,
-                       std::size_t yoffset,
-                       std::size_t width,
-                       std::size_t height,
-                       std::size_t level,
+    void updateSubData(int xoffset,
+                       int yoffset,
+                       int width,
+                       int height,
+                       int level,
                        const void* data,
                        int layerIndex) override;
 
@@ -123,12 +123,12 @@ public:
      * @param data Specifies a pointer to the compressed image data in memory.
      * @param layerIndex Specifies the layer index for 2D array textures.
      */
-    void updateCompressedSubData(std::size_t xoffset,
-                                 std::size_t yoffset,
-                                 std::size_t width,
-                                 std::size_t height,
+    void updateCompressedSubData(int xoffset,
+                                 int yoffset,
+                                 int width,
+                                 int height,
                                  std::size_t dataSize,
-                                 std::size_t level,
+                                 int level,
                                  const void* data,
                                  int layerIndex) override;
 
@@ -143,7 +143,7 @@ public:
     /**
      * Generate mipmaps.
      */
-    void generateMipmaps() override;
+    void generateMipmaps();
 
     /**
      * Update texture description.
@@ -155,7 +155,7 @@ public:
      * Get internal texture object handle.
      * @return Texture object.
      */
-    GLuint internalHandle() const { return _nativeSampler; }
+    GLuint internalHandle() const { return _nativeTexture; }
 
     /**
      * Set texture to pipeline
@@ -169,6 +169,8 @@ public:
 private:
     void ensureTexStorageForRT();
 
+    void configureUnpackAlignment(unsigned int width);
+
     NativeTextureDesc _nativeDesc{};
     GLuint _nativeTexture{0};
     GLuint _nativeSampler{0};  // weak ref
@@ -176,8 +178,7 @@ private:
     EventListener* _rendererRecreatedListener = nullptr;
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA
-    bool _generateMipmaps = false;
-    bool _usedForRT       = false;
+    bool _usedForRT = false;
 #endif
 };
 

--- a/axmol/rhi/opengl/UtilsGL.cpp
+++ b/axmol/rhi/opengl/UtilsGL.cpp
@@ -26,7 +26,7 @@
 #include "axmol/rhi/opengl/UtilsGL.h"
 #include "axmol/rhi/opengl/ProgramGL.h"
 #include "axmol/rhi/opengl/TextureGL.h"
-#include "axmol/rhi/PixelFormatUtils.h"
+#include "axmol/rhi/RHIUtils.h"
 #include "axmol/platform/GL.h"
 
 namespace ax::rhi::gl {

--- a/axmol/ui/UIMediaPlayer.cpp
+++ b/axmol/ui/UIMediaPlayer.cpp
@@ -926,6 +926,8 @@ MediaPlayer::MediaPlayer()
             {
                 pvd->_vpixelDesc = frame._vpd;
 
+                rhi::TextureDesc desc;
+
                 AX_SAFE_RELEASE(pvd->_vtexture);
                 pvd->_vtexture = new Texture2D();  // deault is Sampler Filter is: LINEAR
 
@@ -967,40 +969,41 @@ MediaPlayer::MediaPlayer()
             {
             case MEVideoPixelFormat::YUY2:
             {
-                pvd->_vtexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::RG8, PixelFormat::RG8,
-                                               bufferDim.x, bufferDim.y, false, 0);
-                pvd->_vchromaTexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::RGBA8,
-                                                     PixelFormat::RGBA8, bufferDim.x >> 1, bufferDim.y, false, 0);
+                // RG8
+                //pvd->_vtexture->updateWithSubData(frame._dataPointer, 0, 0, frame._dataLen,
+                //                               bufferDim.x, bufferDim.y, false);
+                //pvd->_vchromaTexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::RGBA8,
+                //                                     PixelFormat::RGBA8, bufferDim.x >> 1, bufferDim.y, false, 0);
                 break;
             }
             case MEVideoPixelFormat::NV12:
             {
-                pvd->_vtexture->updateWithData(frame._dataPointer, bufferDim.x * bufferDim.y, PixelFormat::R8,
-                                               PixelFormat::R8, bufferDim.x, bufferDim.y, false, 0);
-                pvd->_vchromaTexture->updateWithData(frame._cbcrDataPointer, (bufferDim.x * bufferDim.y) >> 1,
-                                                     PixelFormat::RG8, PixelFormat::RG8, bufferDim.x >> 1,
-                                                     bufferDim.y >> 1, false, 0);
+                //pvd->_vtexture->updateWithData(frame._dataPointer, bufferDim.x * bufferDim.y, PixelFormat::R8,
+                //                               PixelFormat::R8, bufferDim.x, bufferDim.y, false, 0);
+                //pvd->_vchromaTexture->updateWithData(frame._cbcrDataPointer, (bufferDim.x * bufferDim.y) >> 1,
+                //                                     PixelFormat::RG8, PixelFormat::RG8, bufferDim.x >> 1,
+                //                                     bufferDim.y >> 1, false, 0);
                 break;
             }
             case MEVideoPixelFormat::I420:
             {
-                pvd->_vtexture->updateWithData(frame._dataPointer, bufferDim.x * bufferDim.y, PixelFormat::R8,
-                                               PixelFormat::R8, bufferDim.x, bufferDim.y, false, 0);
-                const auto chromaTexDataSize = (bufferDim.x * bufferDim.y) >> 2;
-                pvd->_vchromaTexture->updateWithData(frame._cbcrDataPointer, chromaTexDataSize, PixelFormat::R8,
-                                                     PixelFormat::R8, bufferDim.x >> 1, bufferDim.y >> 1, false, 0);
-                pvd->_vchroma2Texture->updateWithData(frame._cbcrDataPointer + chromaTexDataSize, chromaTexDataSize,
-                                                      PixelFormat::R8, PixelFormat::R8, bufferDim.x >> 1,
-                                                      bufferDim.y >> 1, false, 0);
+                //pvd->_vtexture->updateWithData(frame._dataPointer, bufferDim.x * bufferDim.y, PixelFormat::R8,
+                //                               PixelFormat::R8, bufferDim.x, bufferDim.y, false, 0);
+                //const auto chromaTexDataSize = (bufferDim.x * bufferDim.y) >> 2;
+                //pvd->_vchromaTexture->updateWithData(frame._cbcrDataPointer, chromaTexDataSize, PixelFormat::R8,
+                //                                     PixelFormat::R8, bufferDim.x >> 1, bufferDim.y >> 1, false, 0);
+                //pvd->_vchroma2Texture->updateWithData(frame._cbcrDataPointer + chromaTexDataSize, chromaTexDataSize,
+                //                                      PixelFormat::R8, PixelFormat::R8, bufferDim.x >> 1,
+                //                                      bufferDim.y >> 1, false, 0);
                 break;
             }
             case MEVideoPixelFormat::RGB32:
-                pvd->_vtexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::RGBA8,
-                                               PixelFormat::RGBA8, bufferDim.x, bufferDim.y, false, 0);
+                //pvd->_vtexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::RGBA8,
+                //                               PixelFormat::RGBA8, bufferDim.x, bufferDim.y, false, 0);
                 break;
             case MEVideoPixelFormat::BGR32:
-                pvd->_vtexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::BGRA8,
-                                               PixelFormat::BGRA8, bufferDim.x, bufferDim.y, false, 0);
+                //pvd->_vtexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::BGRA8,
+                //                               PixelFormat::BGRA8, bufferDim.x, bufferDim.y, false, 0);
                 break;
             default:;
             }

--- a/axmol/ui/UIMediaPlayer.cpp
+++ b/axmol/ui/UIMediaPlayer.cpp
@@ -64,7 +64,7 @@ using namespace ax::ui;
 
 namespace
 {
-struct PrivateVideoDesc
+struct PrivateVideoContext
 {
     MediaEngine* _engine        = nullptr;
     Texture2D* _vtexture        = nullptr;
@@ -82,6 +82,178 @@ struct PrivateVideoDesc
     {
         if (_engine)
             _engine->close();
+    }
+
+    std::function<void(const MEVideoFrame& frame)> _renderFrameFunc;
+
+    void updatePixelDesc(const MEVideoPixelDesc& desc)
+    {
+        _vpixelDesc = desc;
+
+        auto pixelFormat = desc._PF;
+
+        AX_SAFE_RELEASE(_vtexture);
+        AX_SAFE_RELEASE_NULL(_vchromaTexture);
+        AX_SAFE_RELEASE_NULL(_vchroma2Texture);
+
+        auto programManager = ProgramManager::getInstance();
+
+        switch (pixelFormat)
+        {
+        case MEVideoPixelFormat::YUY2:
+            // RG8
+            _vtexture = new Texture2D();
+            _vtexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x),
+                    .height      = static_cast<uint16_t>(desc._dim.y),
+                    .pixelFormat = PixelFormat::RG8,
+                },
+                {});
+
+            // RGBA8
+            _vchromaTexture = new Texture2D();
+            _vchromaTexture->initWithSpec(
+                {
+                    .width  = static_cast<uint16_t>(desc._dim.x >> 1),
+                    .height = static_cast<uint16_t>(desc._dim.y),
+                    .pixelFormat = PixelFormat::RGBA8,
+                },
+                {});
+            _vchromaTexture->setAliasTexParameters();
+            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_YUY2);
+
+            _renderFrameFunc = [this](const MEVideoFrame& frame) {
+                if (_vtexture && _vchromaTexture)
+                {
+                    auto& bufferDim = frame._vpd._dim;
+                    _vtexture->updateData(frame._dataPointer, bufferDim.x, bufferDim.y);
+                    _vchromaTexture->updateData(frame._dataPointer, bufferDim.x >> 1, bufferDim.y);
+                }
+            };
+            break;
+        case MEVideoPixelFormat::NV12:
+            // R8
+            _vtexture = new Texture2D();
+            _vtexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x),
+                    .height      = static_cast<uint16_t>(desc._dim.y),
+                    .pixelFormat = PixelFormat::R8,
+                },
+                {});
+
+            // RG8
+            _vchromaTexture = new Texture2D();
+            _vchromaTexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x >> 1),
+                    .height      = static_cast<uint16_t>(desc._dim.y >> 1),
+                    .pixelFormat = PixelFormat::RG8,
+                },
+                {});
+            _vchromaTexture->setAliasTexParameters();
+            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_NV12);
+
+            // allocate tex storage
+            _renderFrameFunc = [this](const MEVideoFrame& frame) {
+                if (_vtexture && _vchromaTexture)
+                {
+                    auto& bufferDim = frame._vpd._dim;
+                    _vtexture->updateData(frame._dataPointer, bufferDim.x, bufferDim.y);
+                    _vchromaTexture->updateData(frame._cbcrDataPointer, bufferDim.x >> 1, bufferDim.y >> 1);
+                }
+            };
+            break;
+        case MEVideoPixelFormat::I420:
+            // R8
+            _vtexture = new Texture2D();
+            _vtexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x),
+                    .height      = static_cast<uint16_t>(desc._dim.y),
+                    .pixelFormat = PixelFormat::R8,
+                },
+                {});
+            // R8
+            _vchromaTexture = new Texture2D();
+            _vchromaTexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x >> 1),
+                    .height      = static_cast<uint16_t>(desc._dim.y >> 1),
+                    .pixelFormat = PixelFormat::R8,
+                },
+                {});
+            _vchromaTexture->setAliasTexParameters();
+            // R8
+            _vchroma2Texture = new Texture2D();
+            _vchroma2Texture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x >> 1),
+                    .height      = static_cast<uint16_t>(desc._dim.y >> 1),
+                    .pixelFormat = PixelFormat::R8,
+                },
+                {});
+            _vchroma2Texture->setAliasTexParameters();
+            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_I420);
+
+            _renderFrameFunc = [this](const MEVideoFrame& frame) {
+                if (_vtexture && _vchromaTexture && _vchroma2Texture)
+                {
+                    auto& bufferDim = frame._vpd._dim;
+                    const auto chromaTexDataSize = (bufferDim.x * bufferDim.y) >> 2;
+                    _vtexture->updateData(frame._dataPointer, bufferDim.x, bufferDim.y);
+                    _vchromaTexture->updateData(frame._cbcrDataPointer, bufferDim.x >> 1, bufferDim.y >> 1);
+                    _vchroma2Texture->updateData(frame._cbcrDataPointer + chromaTexDataSize, bufferDim.x >> 1,
+                                                 bufferDim.y >> 1);
+                }
+            };
+            break;
+        case MEVideoPixelFormat::RGB32:
+            // RGBA8
+            _vtexture = new Texture2D();
+            _vtexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x),
+                    .height      = static_cast<uint16_t>(desc._dim.y),
+                    .pixelFormat = PixelFormat::RGBA8,
+                },
+                {});
+            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_RGB32);
+
+            _renderFrameFunc = [this](const MEVideoFrame& frame) {
+                if (_vtexture)
+                {
+                    auto& bufferDim = frame._vpd._dim;
+                    _vtexture->updateData(frame._dataPointer, bufferDim.x, bufferDim.y);
+                }
+            };
+            break;
+        case MEVideoPixelFormat::BGR32:
+            // BGRA8
+            _vtexture = new Texture2D();
+            _vtexture->initWithSpec(
+                {
+                    .width       = static_cast<uint16_t>(desc._dim.x),
+                    .height      = static_cast<uint16_t>(desc._dim.y),
+                    .pixelFormat = PixelFormat::BGRA8,
+                },
+                {});
+            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_BGR32);
+            _renderFrameFunc = [this](const MEVideoFrame& frame) {
+                if (_vtexture) {
+                    auto& bufferDim = frame._vpd._dim;
+                    _vtexture->updateData(frame._dataPointer, bufferDim.x, bufferDim.y);
+                }
+            };
+            break;
+        }
+    }
+
+    void renderFrame(const MEVideoFrame& frame)
+    {
+        if (_renderFrameFunc)
+            _renderFrameFunc(const_cast<MEVideoFrame&>(frame));
     }
 
     void rescaleTo(MediaPlayer* videoView)
@@ -868,7 +1040,7 @@ void BasicMediaController::updateControlsForContentSize(const Vec2& contentSize)
 
 MediaPlayer::MediaPlayer()
 {
-    auto pvd      = new PrivateVideoDesc{};
+    auto pvd      = new PrivateVideoContext{};
     _videoContext = pvd;
 #    if AX_VIDEOPLAYER_DEBUG_DRAW
     _debugDrawNode = DrawNode::create();
@@ -924,45 +1096,11 @@ MediaPlayer::MediaPlayer()
             auto bPixelDescChnaged = !frame._vpd.equals(pvd->_vpixelDesc);
             if (bPixelDescChnaged)
             {
-                pvd->_vpixelDesc = frame._vpd;
-
-                rhi::TextureDesc desc;
-
-                AX_SAFE_RELEASE(pvd->_vtexture);
-                pvd->_vtexture = new Texture2D();  // deault is Sampler Filter is: LINEAR
-
-                AX_SAFE_RELEASE_NULL(pvd->_vchromaTexture);
-                AX_SAFE_RELEASE_NULL(pvd->_vchroma2Texture);
-                if (pixelFormat >= MEVideoPixelFormat::YUY2)
-                {  // use separated texture we can set differrent sample filter
-                    pvd->_vchromaTexture = new Texture2D();  // Sampler Filter: NEAREST
-                    pvd->_vchromaTexture->setAliasTexParameters();
-
-                    if (pixelFormat == MEVideoPixelFormat::I420)
-                    {
-                        pvd->_vchroma2Texture = new Texture2D();  // Sampler Filter: NEAREST
-                        pvd->_vchroma2Texture->setAliasTexParameters();
-                    }
-                }
-
-                auto programManager = ProgramManager::getInstance();
-
-                switch (pixelFormat)
-                {
-                case MEVideoPixelFormat::YUY2:
-                    pvd->_vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_YUY2);
-                    break;
-                case MEVideoPixelFormat::NV12:
-                    pvd->_vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_NV12);
-                    break;
-                case MEVideoPixelFormat::I420:
-                    pvd->_vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_I420);
-                    break;
-                default:
-                    pvd->_vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_RGB32);
-                }
+                pvd->updatePixelDesc(frame._vpd);
             }
 
+            pvd->renderFrame(frame);
+            #if 0
             auto& bufferDim = frame._vpd._dim;
 
             switch (pixelFormat)
@@ -970,7 +1108,7 @@ MediaPlayer::MediaPlayer()
             case MEVideoPixelFormat::YUY2:
             {
                 // RG8
-                //pvd->_vtexture->updateWithSubData(frame._dataPointer, 0, 0, frame._dataLen,
+                //pvd->_vtexture->updateSubData(frame._dataPointer, 0, 0, frame._dataLen,
                 //                               bufferDim.x, bufferDim.y, false);
                 //pvd->_vchromaTexture->updateWithData(frame._dataPointer, frame._dataLen, PixelFormat::RGBA8,
                 //                                     PixelFormat::RGBA8, bufferDim.x >> 1, bufferDim.y, false, 0);
@@ -1007,6 +1145,7 @@ MediaPlayer::MediaPlayer()
                 break;
             default:;
             }
+            #endif
             if (bPixelDescChnaged)
             {
                 pvd->_vrender->setTexture(pvd->_vtexture);
@@ -1018,7 +1157,7 @@ MediaPlayer::MediaPlayer()
                 if (pixelFormat >= MEVideoPixelFormat::YUY2)
                 {
                     auto ps = pvd->_vrender->getProgramState();
-                    PrivateVideoDesc::updateColorTransform(ps, frame._vpd._fullRange);
+                    PrivateVideoContext::updateColorTransform(ps, frame._vpd._fullRange);
 
                     ps->setTexture(ps->getUniformLocation("u_tex1"), 1, pvd->_vchromaTexture->getRHITexture());
 
@@ -1038,7 +1177,7 @@ MediaPlayer::MediaPlayer()
 
 MediaPlayer::~MediaPlayer()
 {
-    auto pvd = reinterpret_cast<PrivateVideoDesc*>(_videoContext);
+    auto pvd = reinterpret_cast<PrivateVideoContext*>(_videoContext);
 
     removeAllProtectedChildren();
 
@@ -1080,7 +1219,7 @@ void MediaPlayer::setFileName(std::string_view fileName)
     auto fullPath = FileUtils::getInstance()->fullPathForFilename(fileName);
     if (ax::utils::filePathToUrl(std::forward<std::string>(fullPath)) != _videoURL)
     {
-        reinterpret_cast<PrivateVideoDesc*>(_videoContext)->closePlayer();
+        reinterpret_cast<PrivateVideoContext*>(_videoContext)->closePlayer();
         _videoURL = std::move(fullPath);
     }
     _videoSource = MediaPlayer::Source::FILENAME;
@@ -1090,7 +1229,7 @@ void MediaPlayer::setURL(std::string_view videoUrl)
 {
     if (_videoURL != videoUrl)
     {
-        reinterpret_cast<PrivateVideoDesc*>(_videoContext)->closePlayer();
+        reinterpret_cast<PrivateVideoContext*>(_videoContext)->closePlayer();
         _videoURL = videoUrl;
     }
     _videoSource = MediaPlayer::Source::URL;
@@ -1100,7 +1239,7 @@ void MediaPlayer::setLooping(bool looping)
 {
     _isLooping = looping;
 
-    auto pvd = reinterpret_cast<PrivateVideoDesc*>(_videoContext);
+    auto pvd = reinterpret_cast<PrivateVideoContext*>(_videoContext);
     if (pvd->_engine)
         pvd->_engine->setLoop(looping);
 }
@@ -1125,7 +1264,7 @@ void MediaPlayer::setStyle(StyleType style)
 
 Node* MediaPlayer::getVirtualRenderer()
 {
-    auto pvd = reinterpret_cast<PrivateVideoDesc*>(_videoContext);
+    auto pvd = reinterpret_cast<PrivateVideoContext*>(_videoContext);
     return pvd->_vrender;
 }
 
@@ -1133,7 +1272,7 @@ void MediaPlayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags
 {
     ax::ui::Widget::draw(renderer, transform, flags);
 
-    auto pvd     = reinterpret_cast<PrivateVideoDesc*>(_videoContext);
+    auto pvd     = reinterpret_cast<PrivateVideoContext*>(_videoContext);
     auto vrender = pvd->_vrender;
     auto engine  = pvd->_engine;
     if (!vrender || !engine)
@@ -1157,7 +1296,7 @@ void MediaPlayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags
 void MediaPlayer::setContentSize(const Size& contentSize)
 {
     Widget::setContentSize(contentSize);
-    auto videoContext               = reinterpret_cast<PrivateVideoDesc*>(_videoContext);
+    auto videoContext               = reinterpret_cast<PrivateVideoContext*>(_videoContext);
     videoContext->_originalViewSize = contentSize;
     if (_mediaController)
     {
@@ -1170,7 +1309,7 @@ MediaPlayer::MediaState MediaPlayer::getState() const
     if (_videoURL.empty())
         return MediaState::CLOSED;
 
-    auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+    auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
     if (engine)
     {
         switch (engine->getState())
@@ -1217,7 +1356,7 @@ void MediaPlayer::setFullScreenEnabled(bool enabled)
     {
         _fullScreenEnabled = enabled;
 
-        auto pvd               = reinterpret_cast<PrivateVideoDesc*>(_videoContext);
+        auto pvd               = reinterpret_cast<PrivateVideoContext*>(_videoContext);
         const auto contentSize = enabled ? _director->getRenderView()->getDesignResolutionSize() : pvd->_originalViewSize;
         Widget::setContentSize(contentSize);
 
@@ -1235,7 +1374,7 @@ void MediaPlayer::setKeepAspectRatioEnabled(bool enable)
     if (_keepAspectRatioEnabled != enable)
     {
         _keepAspectRatioEnabled                                               = enable;
-        reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_scaleDirty = true;
+        reinterpret_cast<PrivateVideoContext*>(_videoContext)->_scaleDirty = true;
     }
 }
 
@@ -1243,7 +1382,7 @@ void MediaPlayer::setPlayRate(float fRate)
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
             engine->setRate(fRate);
     }
@@ -1253,7 +1392,7 @@ void MediaPlayer::play()
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             switch (engine->getState())
@@ -1286,7 +1425,7 @@ void MediaPlayer::pausePlayback()
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             engine->pause();
@@ -1299,7 +1438,7 @@ void MediaPlayer::resumePlayback()
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             switch (engine->getState())
@@ -1318,7 +1457,7 @@ void MediaPlayer::stop()
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             engine->stop();
@@ -1331,7 +1470,7 @@ void MediaPlayer::seekTo(float sec)
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             engine->setCurrentTime(sec);
@@ -1344,7 +1483,7 @@ float MediaPlayer::getCurrentTime()
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             return static_cast<float>(engine->getCurrentTime());
@@ -1358,7 +1497,7 @@ float MediaPlayer::getDuration()
 {
     if (!_videoURL.empty())
     {
-        auto engine = reinterpret_cast<PrivateVideoDesc*>(_videoContext)->_engine;
+        auto engine = reinterpret_cast<PrivateVideoContext*>(_videoContext)->_engine;
         if (engine)
         {
             return static_cast<float>(engine->getDuration());

--- a/axmol/ui/UIMediaPlayer.cpp
+++ b/axmol/ui/UIMediaPlayer.cpp
@@ -1020,10 +1020,10 @@ MediaPlayer::MediaPlayer()
                     auto ps = pvd->_vrender->getProgramState();
                     PrivateVideoDesc::updateColorTransform(ps, frame._vpd._fullRange);
 
-                    ps->setTexture(ps->getUniformLocation("u_tex1"), 1, pvd->_vchromaTexture->getBackendTexture());
+                    ps->setTexture(ps->getUniformLocation("u_tex1"), 1, pvd->_vchromaTexture->getRHITexture());
 
                     if (pixelFormat == MEVideoPixelFormat::I420)
-                        ps->setTexture(ps->getUniformLocation("u_tex2"), 2, pvd->_vchroma2Texture->getBackendTexture());
+                        ps->setTexture(ps->getUniformLocation("u_tex2"), 2, pvd->_vchroma2Texture->getRHITexture());
                 }
 
                 pvd->_scaleDirty = true;

--- a/extensions/DragonBones/src/DragonBones/CCFactory.cpp
+++ b/extensions/DragonBones/src/DragonBones/CCFactory.cpp
@@ -31,7 +31,7 @@ TextureAtlasData* CCFactory::_buildTextureAtlasData(TextureAtlasData* textureAtl
             if (texture == nullptr)
             {
                 ax::rhi::PixelFormat pixelFormat =
-                    ax::rhi::PixelFormat::AUTO;
+                    ax::rhi::PixelFormat::NONE;
                 switch (textureAtlasData->format)
                 {
                 case TextureFormat::RGBA8888:

--- a/extensions/DragonBones/src/DragonBones/CCFactory.cpp
+++ b/extensions/DragonBones/src/DragonBones/CCFactory.cpp
@@ -31,7 +31,7 @@ TextureAtlasData* CCFactory::_buildTextureAtlasData(TextureAtlasData* textureAtl
             if (texture == nullptr)
             {
                 ax::rhi::PixelFormat pixelFormat =
-                    ax::rhi::PixelFormat::NONE;
+                    ax::rhi::PixelFormat::AUTO;
                 switch (textureAtlasData->format)
                 {
                 case TextureFormat::RGBA8888:

--- a/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
@@ -197,30 +197,7 @@ Effekseer::TextureRef TextureLoader::Load(const EFK_CHAR* path, ::Effekseer::Tex
 
 		if (image != nullptr && texture != nullptr && image->initWithImageData((const uint8_t*)data_texture, size_texture))
 		{
-			if (texture->initWithImage(image))
-			{
-
-				if(texture->getPixelsWide() > 1 || texture->getPixelsHigh() > 1)
-				{
-#if AX_RENDER_API == AX_RENDER_API_MTL
-					texture->generateMipmap();
-#else
-					if (texture->getPixelsWide() == ax::utils::nextPOT(texture->getPixelsWide()) &&
-						texture->getPixelsHigh() == ax::utils::nextPOT(texture->getPixelsHigh()))
-					{
-						texture->generateMipmap();
-					}
-					else
-					{
-						char path8[300];
-						::Effekseer::ConvertUtf16ToUtf8(path8, 300, path);
-						AXLOGW("{} : The texture is not shown on a mobile. The size is not power of two.", path8);
-					}
-#endif
-				}
-
-			}
-			else
+			if (!texture->initWithImage(image, ax::PixelFormat::NONE, true))
 			{
 				AX_SAFE_DELETE(texture);
 				AX_SAFE_DELETE(image);

--- a/extensions/Effekseer/EffekseerForCocos2d-x/GL/Effekseer+GL.cpp
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/GL/Effekseer+GL.cpp
@@ -142,7 +142,7 @@ Effekseer::ModelLoaderRef CreateModelLoader(Effekseer::FileInterfaceRef effectFi
 
 void UpdateTextureData(::Effekseer::TextureRef textureData, cocos2d::Texture2D* texture)
 {
-	auto textureImpl = static_cast<ax::rhi::gl::TextureImpl*>(texture->getBackendTexture());
+	auto textureImpl = static_cast<ax::rhi::gl::TextureImpl*>(texture->getRHITexture());
 
 	auto device = EffekseerGraphicsDevice::create().DownCast<::EffekseerRendererGL::Backend::GraphicsDevice>();
 

--- a/extensions/Effekseer/EffekseerForCocos2d-x/Metal/Effekseer+Metal.mm
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/Metal/Effekseer+Metal.mm
@@ -172,7 +172,7 @@ Effekseer::ModelLoaderRef CreateModelLoader(Effekseer::FileInterfaceRef effectFi
 
 void UpdateTextureData(::Effekseer::TextureRef textureData, cocos2d::Texture2D* texture)
 {
-    auto textureImpl = static_cast<ax::rhi::mtl::TextureImpl*>(texture->getBackendTexture());
+    auto textureImpl = static_cast<ax::rhi::mtl::TextureImpl*>(texture->getRHITexture());
 	auto device = EffekseerGraphicsDevice::create().DownCast<::EffekseerRendererLLGI::Backend::GraphicsDevice>();
 
     auto backend = device->CreateTexture(textureImpl->internalHandle(), []() -> void {});

--- a/extensions/GUI/src/GUI/ControlExtension/ControlColourPicker.cpp
+++ b/extensions/GUI/src/GUI/ControlExtension/ControlColourPicker.cpp
@@ -65,7 +65,6 @@ bool ControlColourPicker::init()
     */
         //        spriteSheet->getTexture()->setAliasTexParameters();
         //         spriteSheet->getTexture()->setSamplerDescriptor(&params);
-        //         spriteSheet->getTexture()->generateMipmap();
 
         // Init default color
         _hsv.h = 0;

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -120,7 +120,7 @@ static void ImGui_ImplAxmol_UpdateTexture(ImTextureData* tex)
             auto texture = (Texture2D*)(intptr_t)tex->TexID;
             IM_ASSERT(texture != nullptr);
 
-            texture->updateWithSubData(bd->TempBuffer.getBytes(), r.x, r.y, r.w, r.h);
+            texture->updateSubData(bd->TempBuffer.getBytes(), r.x, r.y, r.w, r.h);
         }
 
         tex->SetStatus(ImTextureStatus_OK);

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -101,7 +101,7 @@ static void ImGui_ImplAxmol_UpdateTexture(ImTextureData* tex)
                               tex->Height, true);
 
         rhi::SamplerDesc desc{};
-        texture->getBackendTexture()->updateSamplerDesc(desc);
+        texture->getRHITexture()->updateSamplerDesc(desc);
 
         // Store identifiers
         tex->SetTexID((ImTextureID)(intptr_t)texture);
@@ -336,7 +336,7 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_RenderDrawData(ImDrawData* draw_data)
                         // setup attributes for ImDrawVert
                         desc.programState->setSharedVertexLayout(pinfo->layout);
                         desc.programState->setUniform(pinfo->projection, &bd->Projection, sizeof(Mat4));
-                        desc.programState->setTexture(pinfo->texture, 0, tex->getBackendTexture());
+                        desc.programState->setTexture(pinfo->texture, 0, tex->getRHITexture());
                         // In order to composite our output buffer we need to preserve alpha
                         desc.blendDesc.sourceAlphaBlendFactor = BlendFactor::ONE;
                         // set vertex/index buffer

--- a/extensions/Live2D/Framework/src/Rendering/axmol/CubismOffscreenSurface_Cocos2dx.cpp
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/CubismOffscreenSurface_Cocos2dx.cpp
@@ -45,7 +45,7 @@ void CubismOffscreenFrame_Cocos2dx::BeginDraw(CubismCommandBuffer_Cocos2dx* comm
     }
 
     // マスク用RenderTextureをactiveにセット
-    commandBuffer->SetColorBuffer(_renderTexture->getSprite()->getTexture()->getBackendTexture());
+    commandBuffer->SetColorBuffer(_renderTexture->getSprite()->getTexture()->getRHITexture());
 }
 
 void CubismOffscreenFrame_Cocos2dx::EndDraw(CubismCommandBuffer_Cocos2dx* commandBuffer)
@@ -95,7 +95,7 @@ csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBuf
             _renderTexture->getSprite()->getTexture()->setTexParameters(ax::Texture2D::TexParams{});
 
             texture2d                 = _renderTexture->getSprite()->getTexture();
-            _colorBuffer              = texture2d->getBackendTexture();
+            _colorBuffer              = texture2d->getRHITexture();
             _isInheritedRenderTexture = false;
         }
         else
@@ -104,7 +104,7 @@ csmBool CubismOffscreenFrame_Cocos2dx::CreateOffscreenFrame(csmUint32 displayBuf
             _renderTexture = renderTexture;
 
             texture2d    = _renderTexture->getSprite()->getTexture();
-            _colorBuffer = texture2d->getBackendTexture();
+            _colorBuffer = texture2d->getRHITexture();
 
 
             _isInheritedRenderTexture = true;

--- a/extensions/Live2D/Framework/src/Rendering/axmol/CubismRenderer_Cocos2dx.cpp
+++ b/extensions/Live2D/Framework/src/Rendering/axmol/CubismRenderer_Cocos2dx.cpp
@@ -1110,7 +1110,7 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         layout = programState->getMutableVertexLayout();
 
         //テクスチャ設定
-        programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
+        programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getRHITexture());
 
         // 頂点配列の設定
         layout->setAttrib("a_position", shaderSet->AttributePositionLocation, ax::rhi::VertexFormat::FLOAT2, 0, false);
@@ -1193,7 +1193,7 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
             // frameBufferに書かれたテクスチャ
             ax::Texture2D* tex = renderer->_offscreenFrameBuffer.GetColorBuffer();
 
-            programState->setTexture(shaderSet->SamplerTexture1Location, 1, tex->getBackendTexture());
+            programState->setTexture(shaderSet->SamplerTexture1Location, 1, tex->getRHITexture());
 
             // View座標をClippingContextの座標に変換するための行列を設定
             programState->setUniform(shaderSet->UniformClipMatrixLocation,
@@ -1208,7 +1208,7 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         }
 
         //テクスチャ設定
-        programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
+        programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getRHITexture());
 
         //座標変換
         programState->setUniform(shaderSet->UniformMatrixLocation, matrix4x4.GetArray(), sizeof(float) * 16);

--- a/extensions/Particle3D/src/Particle3D/PU/PUBillboardChain.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PUBillboardChain.cpp
@@ -691,7 +691,7 @@ void PUBillboardChain::render(Renderer* renderer, const Mat4& transform, Particl
 
             if (_texture)
             {
-                _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
+                _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
             }
 
             auto uColor = Vec4(1, 1, 1, 1);

--- a/extensions/Particle3D/src/Particle3D/PU/PURender.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PURender.cpp
@@ -280,7 +280,7 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4& transform, P
 
         if (_texture)
         {
-            _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
+            _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
         }
 
         auto uColor = Vec4(1, 1, 1, 1);
@@ -789,7 +789,7 @@ void PUParticle3DBoxRender::render(Renderer* renderer, const Mat4& transform, Pa
 
         if (_texture)
         {
-            _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
+            _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
         }
 
         auto& projectionMatrix = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
@@ -961,7 +961,7 @@ void PUSphereRender::render(Renderer* renderer, const Mat4& transform, ParticleS
 
         if (_texture)
         {
-            _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
+            _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
         }
 
         auto& projectionMatrix = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);

--- a/extensions/Particle3D/src/Particle3D/Particle3DRender.cpp
+++ b/extensions/Particle3D/src/Particle3D/Particle3DRender.cpp
@@ -179,7 +179,7 @@ void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, Par
 
     if (_texture)
     {
-        _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
+        _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
     }
     _stateBlock.setBlendFunc(particleSystem->getBlendFunc());
     auto uColor = Vec4(1, 1, 1, 1);

--- a/extensions/fairygui/src/fairygui/UIPackage.cpp
+++ b/extensions/fairygui/src/fairygui/UIPackage.cpp
@@ -621,39 +621,45 @@ void UIPackage::loadAtlas(PackageItem* item)
     Image::setPNGPremultipliedAlphaEnabled(true);
 #endif
 
+    auto checkAlphaFile = [item]() {
+        string alphaFilePath;
+        string ext = FileUtils::getPathExtension(item->file);
+        size_t pos = item->file.find_last_of('.');
+        if (pos != -1)
+            alphaFilePath = item->file.substr(0, pos) + "!a" + ext;
+        else
+            alphaFilePath = item->file + "!a" + ext;
+
+        return ToolSet::isFileExist(alphaFilePath) ? alphaFilePath : "";
+    };
+
     Texture2D* tex = new Texture2D();
-    tex->initWithImage(image);
-    item->texture = tex;
-    delete image;
 
-    string alphaFilePath;
-    string ext = FileUtils::getPathExtension(item->file);
-    size_t pos = item->file.find_last_of('.');
-    if (pos != -1)
-        alphaFilePath = item->file.substr(0, pos) + "!a" + ext;
-    else
-        alphaFilePath = item->file + "!a" + ext;
-
-    bool hasAlphaTexture = ToolSet::isFileExist(alphaFilePath);
-    if (hasAlphaTexture)
+    auto alphaFilePath = checkAlphaFile();
+    if (alphaFilePath.empty() || image->getFileType() != Image::Format::ETC1)
     {
-        image = new Image();
-        if (!image->initWithImageFile(alphaFilePath))
-        {
-            delete image;
-            return;
-        }
-
-#if defined(AX_VERSION)
-        if(image->getFileType() == Image::Format::ETC1)
-            tex->initWithImage(image);
-#else
-        tex = new Texture2D();
         tex->initWithImage(image);
-        item->texture->setAlphaTexture(tex);
-        tex->release();
-#endif
-        delete image;
+        item->texture = tex;
+        image->release();
+    }
+    else
+    {
+        auto alphaImage = new Image();
+        alphaImage->initWithImageFile(alphaFilePath);
+
+        TextureSliceData subDatas[] = {
+            TextureSliceData{image->getData(), static_cast<uint16_t>(image->getDataSize()), 0, 0},
+            TextureSliceData{alphaImage->getData(), static_cast<uint16_t>(alphaImage->getDataSize()), 1, 0}};
+        tex->initWithSpec(
+            rhi::TextureDesc{
+                .width       = static_cast<uint16_t>(image->getWidth()),
+                .height      = static_cast<uint16_t>(image->getHeight()),
+                .arraySize   = 2,
+                .pixelFormat = image->getPixelFormat(),
+            },
+            subDatas);
+        image->release();
+        alphaImage->release();
     }
 }
 

--- a/extensions/fairygui/src/fairygui/UIPackage.cpp
+++ b/extensions/fairygui/src/fairygui/UIPackage.cpp
@@ -646,7 +646,7 @@ void UIPackage::loadAtlas(PackageItem* item)
 
 #if defined(AX_VERSION)
         if(image->getFileType() == Image::Format::ETC1)
-            tex->updateWithImage(image, 1);
+            tex->initWithImage(image);
 #else
         tex = new Texture2D();
         tex->initWithImage(image);

--- a/extensions/scripting/lua-bindings/auto/axlua_3d_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_3d_auto.cpp
@@ -31,7 +31,7 @@ int lua_ax_3d_Animation3D_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -78,7 +78,7 @@ int lua_ax_3d_Animation3D_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Animation3DData arg0;
 
@@ -129,7 +129,7 @@ int lua_ax_3d_Animation3D_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -220,7 +220,7 @@ int lua_ax_3d_Animation3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -294,7 +294,7 @@ int lua_ax_3d_Animate3D_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -341,7 +341,7 @@ int lua_ax_3d_Animate3D_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -391,7 +391,7 @@ int lua_ax_3d_Animate3D_getWeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -438,7 +438,7 @@ int lua_ax_3d_Animate3D_setWeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -488,7 +488,7 @@ int lua_ax_3d_Animate3D_setOriginInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -538,7 +538,7 @@ int lua_ax_3d_Animate3D_getOriginInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -585,7 +585,7 @@ int lua_ax_3d_Animate3D_setQuality(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Animate3DQuality arg0;
 
@@ -635,7 +635,7 @@ int lua_ax_3d_Animate3D_getQuality(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -682,7 +682,7 @@ int lua_ax_3d_Animate3D_setKeyFrameUserInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         ax::ValueMap arg1;
@@ -735,7 +735,7 @@ int lua_ax_3d_Animate3D_removeFromMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -845,7 +845,7 @@ int lua_ax_3d_Animate3D_initWithFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Animation3D* arg0;
         int arg1;
@@ -892,7 +892,7 @@ int lua_ax_3d_Animate3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -911,7 +911,7 @@ int lua_ax_3d_Animate3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -1074,7 +1074,7 @@ int lua_ax_3d_Animate3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1160,7 +1160,7 @@ int lua_ax_3d_TextureCube_setTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D::TexParams arg0;
 
@@ -1184,7 +1184,7 @@ int lua_ax_3d_TextureCube_setTexParameters(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_3d_TextureCube_getBackendTexture(lua_State* tolua_S)
+int lua_ax_3d_TextureCube_getRHITexture(lua_State* tolua_S)
 {
     int argc = 0;
     ax::TextureCube* cobj = nullptr;
@@ -1204,29 +1204,29 @@ int lua_ax_3d_TextureCube_getBackendTexture(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_3d_TextureCube_getBackendTexture'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_3d_TextureCube_getRHITexture'", nullptr);
         return 0;
     }
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_3d_TextureCube_getBackendTexture'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_3d_TextureCube_getRHITexture'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->getBackendTexture();
+        auto&& ret = cobj->getRHITexture();
         object_to_luaval<ax::rhi::Texture>(tolua_S, "axrhi.Texture",(ax::rhi::Texture*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.TextureCube:getBackendTexture",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.TextureCube:getRHITexture",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_3d_TextureCube_getBackendTexture'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_3d_TextureCube_getRHITexture'.",&tolua_err);
 #endif
 
     return 0;
@@ -1257,7 +1257,7 @@ int lua_ax_3d_TextureCube_getImagePaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1304,7 +1304,7 @@ int lua_ax_3d_TextureCube_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1384,7 +1384,7 @@ int lua_ax_3d_TextureCube_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1422,7 +1422,7 @@ int lua_register_ax_3d_TextureCube(lua_State* tolua_S)
     tolua_beginmodule(tolua_S,"TextureCube");
         tolua_function(tolua_S,"new",lua_ax_3d_TextureCube_constructor);
         tolua_function(tolua_S,"setTexParameters",lua_ax_3d_TextureCube_setTexParameters);
-        tolua_function(tolua_S,"getBackendTexture",lua_ax_3d_TextureCube_getBackendTexture);
+        tolua_function(tolua_S,"getRHITexture",lua_ax_3d_TextureCube_getRHITexture);
         tolua_function(tolua_S,"getImagePaths",lua_ax_3d_TextureCube_getImagePaths);
         tolua_function(tolua_S,"reloadTexture",lua_ax_3d_TextureCube_reloadTexture);
         tolua_function(tolua_S,"create", lua_ax_3d_TextureCube_create);
@@ -1482,7 +1482,7 @@ int lua_ax_3d_AttachNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1553,7 +1553,7 @@ int lua_ax_3d_BillBoard_setMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BillBoard::Mode arg0;
 
@@ -1603,7 +1603,7 @@ int lua_ax_3d_BillBoard_getMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1638,7 +1638,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -1651,7 +1651,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -1667,7 +1667,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -1677,7 +1677,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -1690,7 +1690,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -1706,7 +1706,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -1797,7 +1797,7 @@ int lua_ax_3d_BillBoard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1871,7 +1871,7 @@ int lua_ax_3d_Mesh_getMeshVertexAttribCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1918,7 +1918,7 @@ int lua_ax_3d_Mesh_getMeshVertexAttribute(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -1968,7 +1968,7 @@ int lua_ax_3d_Mesh_getVertexSizeInBytes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2015,7 +2015,7 @@ int lua_ax_3d_Mesh_setVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -2065,7 +2065,7 @@ int lua_ax_3d_Mesh_isVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2112,7 +2112,7 @@ int lua_ax_3d_Mesh_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2159,7 +2159,7 @@ int lua_ax_3d_Mesh_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2206,7 +2206,7 @@ int lua_ax_3d_Mesh_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -2256,7 +2256,7 @@ int lua_ax_3d_Mesh_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2303,7 +2303,7 @@ int lua_ax_3d_Mesh_setIndexFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::IndexFormat arg0;
 
@@ -2353,7 +2353,7 @@ int lua_ax_3d_Mesh_setProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::ProgramState* arg0;
 
@@ -2403,7 +2403,7 @@ int lua_ax_3d_Mesh_setMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Material* arg0;
 
@@ -2453,7 +2453,7 @@ int lua_ax_3d_Mesh_getMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2500,7 +2500,7 @@ int lua_ax_3d_Mesh_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8) 
+    if (argc == 8)
     {
         ax::Renderer* arg0;
         double arg1;
@@ -2571,7 +2571,7 @@ int lua_ax_3d_Mesh_setSkin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MeshSkin* arg0;
 
@@ -2621,7 +2621,7 @@ int lua_ax_3d_Mesh_setMeshIndexData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MeshIndexData* arg0;
 
@@ -2671,7 +2671,7 @@ int lua_ax_3d_Mesh_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -2721,7 +2721,7 @@ int lua_ax_3d_Mesh_calculateAABB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2768,7 +2768,7 @@ int lua_ax_3d_Mesh_setInstanceCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2779,7 +2779,7 @@ int lua_ax_3d_Mesh_setInstanceCount(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -2829,7 +2829,7 @@ int lua_ax_3d_Mesh_enableInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -2843,7 +2843,7 @@ int lua_ax_3d_Mesh_enableInstancing(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         bool arg0;
         int arg1;
@@ -2896,7 +2896,7 @@ int lua_ax_3d_Mesh_setDynamicInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -2946,7 +2946,7 @@ int lua_ax_3d_Mesh_addInstanceChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -2996,7 +2996,7 @@ int lua_ax_3d_Mesh_shrinkToFitInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3043,7 +3043,7 @@ int lua_ax_3d_Mesh_rebuildInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3077,7 +3077,7 @@ int lua_ax_3d_Mesh_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3171,7 +3171,7 @@ int lua_ax_3d_Skeleton3D_getBoneCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3218,7 +3218,7 @@ int lua_ax_3d_Skeleton3D_getBoneByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -3268,7 +3268,7 @@ int lua_ax_3d_Skeleton3D_getBoneByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -3318,7 +3318,7 @@ int lua_ax_3d_Skeleton3D_getRootCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3365,7 +3365,7 @@ int lua_ax_3d_Skeleton3D_getRootBone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -3415,7 +3415,7 @@ int lua_ax_3d_Skeleton3D_getBoneIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Bone3D* arg0;
 
@@ -3465,7 +3465,7 @@ int lua_ax_3d_Skeleton3D_updateBoneMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3512,7 +3512,7 @@ int lua_ax_3d_Skeleton3D_removeAllBones(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3559,7 +3559,7 @@ int lua_ax_3d_Skeleton3D_addBone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Bone3D* arg0;
 
@@ -3596,7 +3596,7 @@ int lua_ax_3d_Skeleton3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3675,7 +3675,7 @@ int lua_ax_3d_Skybox_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextureCube* arg0;
 
@@ -3725,7 +3725,7 @@ int lua_ax_3d_Skybox_reload(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3772,7 +3772,7 @@ int lua_ax_3d_Skybox_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
+    if (argc == 6)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -3825,7 +3825,7 @@ int lua_ax_3d_Skybox_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 6)
         {
@@ -3853,7 +3853,7 @@ int lua_ax_3d_Skybox_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -3884,7 +3884,7 @@ int lua_ax_3d_Skybox_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3958,7 +3958,7 @@ int lua_ax_3d_MeshMaterial_getMaterialType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3993,7 +3993,7 @@ int lua_ax_3d_MeshMaterial_createBuiltInMaterial(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -4003,7 +4003,7 @@ int lua_ax_3d_MeshMaterial_createBuiltInMaterial(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -4273,7 +4273,7 @@ int lua_ax_3d_MeshRenderer_getMeshByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -4323,7 +4323,7 @@ int lua_ax_3d_MeshRenderer_getMeshByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -4373,7 +4373,7 @@ int lua_ax_3d_MeshRenderer_getMesh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4420,7 +4420,7 @@ int lua_ax_3d_MeshRenderer_getMeshCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4467,7 +4467,7 @@ int lua_ax_3d_MeshRenderer_getSkeleton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4514,7 +4514,7 @@ int lua_ax_3d_MeshRenderer_getAttachNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -4564,7 +4564,7 @@ int lua_ax_3d_MeshRenderer_removeAttachNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -4614,7 +4614,7 @@ int lua_ax_3d_MeshRenderer_removeAllAttachNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4661,7 +4661,7 @@ int lua_ax_3d_MeshRenderer_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -4711,7 +4711,7 @@ int lua_ax_3d_MeshRenderer_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4758,7 +4758,7 @@ int lua_ax_3d_MeshRenderer_setForceDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -4808,7 +4808,7 @@ int lua_ax_3d_MeshRenderer_isForceDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4855,7 +4855,7 @@ int lua_ax_3d_MeshRenderer_setCullFace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::CullMode arg0;
 
@@ -4905,7 +4905,7 @@ int lua_ax_3d_MeshRenderer_setCullFaceEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -4955,7 +4955,7 @@ int lua_ax_3d_MeshRenderer_setLightMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -5005,7 +5005,7 @@ int lua_ax_3d_MeshRenderer_getLightMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5052,7 +5052,7 @@ int lua_ax_3d_MeshRenderer_setWireframe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -5102,7 +5102,7 @@ int lua_ax_3d_MeshRenderer_isWireframe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5208,7 +5208,7 @@ int lua_ax_3d_MeshRenderer_getMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5219,7 +5219,7 @@ int lua_ax_3d_MeshRenderer_getMaterial(lua_State* tolua_S)
         object_to_luaval<ax::Material>(tolua_S, "ax.Material",(ax::Material*)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -5269,7 +5269,7 @@ int lua_ax_3d_MeshRenderer_getMeshes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5316,7 +5316,7 @@ int lua_ax_3d_MeshRenderer_genMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5327,7 +5327,7 @@ int lua_ax_3d_MeshRenderer_genMaterial(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -5464,7 +5464,7 @@ int lua_ax_3d_MeshRenderer_disableInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5511,7 +5511,7 @@ int lua_ax_3d_MeshRenderer_setDynamicInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -5561,7 +5561,7 @@ int lua_ax_3d_MeshRenderer_addInstanceChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -5575,7 +5575,7 @@ int lua_ax_3d_MeshRenderer_addInstanceChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -5628,7 +5628,7 @@ int lua_ax_3d_MeshRenderer_shrinkToFitInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5675,7 +5675,7 @@ int lua_ax_3d_MeshRenderer_rebuildInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5710,7 +5710,7 @@ int lua_ax_3d_MeshRenderer_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -5723,7 +5723,7 @@ int lua_ax_3d_MeshRenderer_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -5733,7 +5733,7 @@ int lua_ax_3d_MeshRenderer_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -5832,7 +5832,7 @@ int lua_ax_3d_MeshRendererCache_removeMeshRenderData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -5882,7 +5882,7 @@ int lua_ax_3d_MeshRendererCache_removeAllMeshRenderData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5984,7 +5984,7 @@ int lua_ax_3d_MeshRendererCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6056,7 +6056,7 @@ int lua_ax_3d_Terrain_setLightMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -6106,7 +6106,7 @@ int lua_ax_3d_Terrain_setLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -6156,7 +6156,7 @@ int lua_ax_3d_Terrain_initProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6203,7 +6203,7 @@ int lua_ax_3d_Terrain_initHeightMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -6253,7 +6253,7 @@ int lua_ax_3d_Terrain_initTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6300,7 +6300,7 @@ int lua_ax_3d_Terrain_getNormal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         int arg1;
@@ -6353,7 +6353,7 @@ int lua_ax_3d_Terrain_getImageHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         int arg1;
@@ -6406,7 +6406,7 @@ int lua_ax_3d_Terrain_setDrawWire(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -6456,7 +6456,7 @@ int lua_ax_3d_Terrain_setLODDistance(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         double arg1;
@@ -6512,7 +6512,7 @@ int lua_ax_3d_Terrain_setIsEnableFrustumCull(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -6562,7 +6562,7 @@ int lua_ax_3d_Terrain_setAlphaMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -6612,7 +6612,7 @@ int lua_ax_3d_Terrain_setDetailMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned int arg0;
         ax::Terrain::DetailMap arg1;
@@ -6666,7 +6666,7 @@ int lua_ax_3d_Terrain_setMaxDetailMapAmount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -6716,7 +6716,7 @@ int lua_ax_3d_Terrain_convertToTerrainSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -6766,7 +6766,7 @@ int lua_ax_3d_Terrain_resetHeightMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -6816,7 +6816,7 @@ int lua_ax_3d_Terrain_getMinHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6863,7 +6863,7 @@ int lua_ax_3d_Terrain_getMaxHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6910,7 +6910,7 @@ int lua_ax_3d_Terrain_setSkirtHeightRatio(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6960,7 +6960,7 @@ int lua_ax_3d_Terrain_reload(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7007,7 +7007,7 @@ int lua_ax_3d_Terrain_getTerrainSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7054,7 +7054,7 @@ int lua_ax_3d_Terrain_getHeightData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7101,7 +7101,7 @@ int lua_ax_3d_Terrain_initWithTerrainData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Terrain::TerrainData arg0;
         ax::Terrain::CrackFixedType arg1;
@@ -7142,7 +7142,7 @@ int lua_ax_3d_Terrain_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7234,7 +7234,7 @@ int lua_ax_3d_Bundle3D_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7281,7 +7281,7 @@ int lua_ax_3d_Bundle3D_load(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -7331,7 +7331,7 @@ int lua_ax_3d_Bundle3D_loadSkinData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         ax::SkinData* arg1;
@@ -7385,7 +7385,7 @@ int lua_ax_3d_Bundle3D_loadAnimationData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         ax::Animation3DData* arg1;
@@ -7439,7 +7439,7 @@ int lua_ax_3d_Bundle3D_loadNodes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::NodeDatas arg0;
 
@@ -7490,7 +7490,7 @@ int lua_ax_3d_Bundle3D_loadMaterials(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MaterialDatas arg0;
 
@@ -7672,7 +7672,7 @@ int lua_ax_3d_Bundle3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7726,7 +7726,7 @@ int lua_register_ax_3d_Bundle3D(lua_State* tolua_S)
 TOLUA_API int register_all_ax_3d(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-	
+
 	tolua_module(tolua_S,"ax",0);
 	tolua_beginmodule(tolua_S,"ax");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_3d_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_3d_auto.cpp
@@ -31,7 +31,7 @@ int lua_ax_3d_Animation3D_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -78,7 +78,7 @@ int lua_ax_3d_Animation3D_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Animation3DData arg0;
 
@@ -129,7 +129,7 @@ int lua_ax_3d_Animation3D_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -220,7 +220,7 @@ int lua_ax_3d_Animation3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -294,7 +294,7 @@ int lua_ax_3d_Animate3D_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -341,7 +341,7 @@ int lua_ax_3d_Animate3D_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -391,7 +391,7 @@ int lua_ax_3d_Animate3D_getWeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -438,7 +438,7 @@ int lua_ax_3d_Animate3D_setWeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -488,7 +488,7 @@ int lua_ax_3d_Animate3D_setOriginInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -538,7 +538,7 @@ int lua_ax_3d_Animate3D_getOriginInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -585,7 +585,7 @@ int lua_ax_3d_Animate3D_setQuality(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Animate3DQuality arg0;
 
@@ -635,7 +635,7 @@ int lua_ax_3d_Animate3D_getQuality(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -682,7 +682,7 @@ int lua_ax_3d_Animate3D_setKeyFrameUserInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         ax::ValueMap arg1;
@@ -735,7 +735,7 @@ int lua_ax_3d_Animate3D_removeFromMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -845,7 +845,7 @@ int lua_ax_3d_Animate3D_initWithFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Animation3D* arg0;
         int arg1;
@@ -892,7 +892,7 @@ int lua_ax_3d_Animate3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -911,7 +911,7 @@ int lua_ax_3d_Animate3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -1074,7 +1074,7 @@ int lua_ax_3d_Animate3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1160,7 +1160,7 @@ int lua_ax_3d_TextureCube_setTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D::TexParams arg0;
 
@@ -1210,7 +1210,7 @@ int lua_ax_3d_TextureCube_getRHITexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1257,7 +1257,7 @@ int lua_ax_3d_TextureCube_getImagePaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1304,7 +1304,7 @@ int lua_ax_3d_TextureCube_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1384,7 +1384,7 @@ int lua_ax_3d_TextureCube_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1482,7 +1482,7 @@ int lua_ax_3d_AttachNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1553,7 +1553,7 @@ int lua_ax_3d_BillBoard_setMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BillBoard::Mode arg0;
 
@@ -1603,7 +1603,7 @@ int lua_ax_3d_BillBoard_getMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1638,7 +1638,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -1651,7 +1651,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -1667,7 +1667,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -1677,7 +1677,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -1690,7 +1690,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -1706,7 +1706,7 @@ int lua_ax_3d_BillBoard_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -1797,7 +1797,7 @@ int lua_ax_3d_BillBoard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1871,7 +1871,7 @@ int lua_ax_3d_Mesh_getMeshVertexAttribCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1918,7 +1918,7 @@ int lua_ax_3d_Mesh_getMeshVertexAttribute(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -1968,7 +1968,7 @@ int lua_ax_3d_Mesh_getVertexSizeInBytes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2015,7 +2015,7 @@ int lua_ax_3d_Mesh_setVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -2065,7 +2065,7 @@ int lua_ax_3d_Mesh_isVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2112,7 +2112,7 @@ int lua_ax_3d_Mesh_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2159,7 +2159,7 @@ int lua_ax_3d_Mesh_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2206,7 +2206,7 @@ int lua_ax_3d_Mesh_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -2256,7 +2256,7 @@ int lua_ax_3d_Mesh_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2303,7 +2303,7 @@ int lua_ax_3d_Mesh_setIndexFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::IndexFormat arg0;
 
@@ -2353,7 +2353,7 @@ int lua_ax_3d_Mesh_setProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::ProgramState* arg0;
 
@@ -2403,7 +2403,7 @@ int lua_ax_3d_Mesh_setMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Material* arg0;
 
@@ -2453,7 +2453,7 @@ int lua_ax_3d_Mesh_getMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2500,7 +2500,7 @@ int lua_ax_3d_Mesh_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8)
+    if (argc == 8) 
     {
         ax::Renderer* arg0;
         double arg1;
@@ -2571,7 +2571,7 @@ int lua_ax_3d_Mesh_setSkin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MeshSkin* arg0;
 
@@ -2621,7 +2621,7 @@ int lua_ax_3d_Mesh_setMeshIndexData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MeshIndexData* arg0;
 
@@ -2671,7 +2671,7 @@ int lua_ax_3d_Mesh_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -2721,7 +2721,7 @@ int lua_ax_3d_Mesh_calculateAABB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2768,7 +2768,7 @@ int lua_ax_3d_Mesh_setInstanceCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2779,7 +2779,7 @@ int lua_ax_3d_Mesh_setInstanceCount(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -2829,7 +2829,7 @@ int lua_ax_3d_Mesh_enableInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -2843,7 +2843,7 @@ int lua_ax_3d_Mesh_enableInstancing(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         bool arg0;
         int arg1;
@@ -2896,7 +2896,7 @@ int lua_ax_3d_Mesh_setDynamicInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -2946,7 +2946,7 @@ int lua_ax_3d_Mesh_addInstanceChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -2996,7 +2996,7 @@ int lua_ax_3d_Mesh_shrinkToFitInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3043,7 +3043,7 @@ int lua_ax_3d_Mesh_rebuildInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3077,7 +3077,7 @@ int lua_ax_3d_Mesh_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3171,7 +3171,7 @@ int lua_ax_3d_Skeleton3D_getBoneCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3218,7 +3218,7 @@ int lua_ax_3d_Skeleton3D_getBoneByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -3268,7 +3268,7 @@ int lua_ax_3d_Skeleton3D_getBoneByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -3318,7 +3318,7 @@ int lua_ax_3d_Skeleton3D_getRootCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3365,7 +3365,7 @@ int lua_ax_3d_Skeleton3D_getRootBone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -3415,7 +3415,7 @@ int lua_ax_3d_Skeleton3D_getBoneIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Bone3D* arg0;
 
@@ -3465,7 +3465,7 @@ int lua_ax_3d_Skeleton3D_updateBoneMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3512,7 +3512,7 @@ int lua_ax_3d_Skeleton3D_removeAllBones(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3559,7 +3559,7 @@ int lua_ax_3d_Skeleton3D_addBone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Bone3D* arg0;
 
@@ -3596,7 +3596,7 @@ int lua_ax_3d_Skeleton3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3675,7 +3675,7 @@ int lua_ax_3d_Skybox_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureCube* arg0;
 
@@ -3725,7 +3725,7 @@ int lua_ax_3d_Skybox_reload(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3772,7 +3772,7 @@ int lua_ax_3d_Skybox_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -3825,7 +3825,7 @@ int lua_ax_3d_Skybox_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 6)
         {
@@ -3853,7 +3853,7 @@ int lua_ax_3d_Skybox_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -3884,7 +3884,7 @@ int lua_ax_3d_Skybox_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3958,7 +3958,7 @@ int lua_ax_3d_MeshMaterial_getMaterialType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3993,7 +3993,7 @@ int lua_ax_3d_MeshMaterial_createBuiltInMaterial(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -4003,7 +4003,7 @@ int lua_ax_3d_MeshMaterial_createBuiltInMaterial(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -4273,7 +4273,7 @@ int lua_ax_3d_MeshRenderer_getMeshByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -4323,7 +4323,7 @@ int lua_ax_3d_MeshRenderer_getMeshByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -4373,7 +4373,7 @@ int lua_ax_3d_MeshRenderer_getMesh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4420,7 +4420,7 @@ int lua_ax_3d_MeshRenderer_getMeshCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4467,7 +4467,7 @@ int lua_ax_3d_MeshRenderer_getSkeleton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4514,7 +4514,7 @@ int lua_ax_3d_MeshRenderer_getAttachNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -4564,7 +4564,7 @@ int lua_ax_3d_MeshRenderer_removeAttachNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -4614,7 +4614,7 @@ int lua_ax_3d_MeshRenderer_removeAllAttachNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4661,7 +4661,7 @@ int lua_ax_3d_MeshRenderer_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -4711,7 +4711,7 @@ int lua_ax_3d_MeshRenderer_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4758,7 +4758,7 @@ int lua_ax_3d_MeshRenderer_setForceDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -4808,7 +4808,7 @@ int lua_ax_3d_MeshRenderer_isForceDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4855,7 +4855,7 @@ int lua_ax_3d_MeshRenderer_setCullFace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::CullMode arg0;
 
@@ -4905,7 +4905,7 @@ int lua_ax_3d_MeshRenderer_setCullFaceEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -4955,7 +4955,7 @@ int lua_ax_3d_MeshRenderer_setLightMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -5005,7 +5005,7 @@ int lua_ax_3d_MeshRenderer_getLightMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5052,7 +5052,7 @@ int lua_ax_3d_MeshRenderer_setWireframe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -5102,7 +5102,7 @@ int lua_ax_3d_MeshRenderer_isWireframe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5208,7 +5208,7 @@ int lua_ax_3d_MeshRenderer_getMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5219,7 +5219,7 @@ int lua_ax_3d_MeshRenderer_getMaterial(lua_State* tolua_S)
         object_to_luaval<ax::Material>(tolua_S, "ax.Material",(ax::Material*)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -5269,7 +5269,7 @@ int lua_ax_3d_MeshRenderer_getMeshes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5316,7 +5316,7 @@ int lua_ax_3d_MeshRenderer_genMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5327,7 +5327,7 @@ int lua_ax_3d_MeshRenderer_genMaterial(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -5464,7 +5464,7 @@ int lua_ax_3d_MeshRenderer_disableInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5511,7 +5511,7 @@ int lua_ax_3d_MeshRenderer_setDynamicInstancing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -5561,7 +5561,7 @@ int lua_ax_3d_MeshRenderer_addInstanceChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -5575,7 +5575,7 @@ int lua_ax_3d_MeshRenderer_addInstanceChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -5628,7 +5628,7 @@ int lua_ax_3d_MeshRenderer_shrinkToFitInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5675,7 +5675,7 @@ int lua_ax_3d_MeshRenderer_rebuildInstances(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5710,7 +5710,7 @@ int lua_ax_3d_MeshRenderer_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -5723,7 +5723,7 @@ int lua_ax_3d_MeshRenderer_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -5733,7 +5733,7 @@ int lua_ax_3d_MeshRenderer_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -5832,7 +5832,7 @@ int lua_ax_3d_MeshRendererCache_removeMeshRenderData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -5882,7 +5882,7 @@ int lua_ax_3d_MeshRendererCache_removeAllMeshRenderData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5984,7 +5984,7 @@ int lua_ax_3d_MeshRendererCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6056,7 +6056,7 @@ int lua_ax_3d_Terrain_setLightMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -6106,7 +6106,7 @@ int lua_ax_3d_Terrain_setLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -6156,7 +6156,7 @@ int lua_ax_3d_Terrain_initProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6203,7 +6203,7 @@ int lua_ax_3d_Terrain_initHeightMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -6253,7 +6253,7 @@ int lua_ax_3d_Terrain_initTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6300,7 +6300,7 @@ int lua_ax_3d_Terrain_getNormal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         int arg1;
@@ -6353,7 +6353,7 @@ int lua_ax_3d_Terrain_getImageHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         int arg1;
@@ -6406,7 +6406,7 @@ int lua_ax_3d_Terrain_setDrawWire(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -6456,7 +6456,7 @@ int lua_ax_3d_Terrain_setLODDistance(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -6512,7 +6512,7 @@ int lua_ax_3d_Terrain_setIsEnableFrustumCull(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -6562,7 +6562,7 @@ int lua_ax_3d_Terrain_setAlphaMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -6612,7 +6612,7 @@ int lua_ax_3d_Terrain_setDetailMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::Terrain::DetailMap arg1;
@@ -6666,7 +6666,7 @@ int lua_ax_3d_Terrain_setMaxDetailMapAmount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -6716,7 +6716,7 @@ int lua_ax_3d_Terrain_convertToTerrainSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -6766,7 +6766,7 @@ int lua_ax_3d_Terrain_resetHeightMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -6816,7 +6816,7 @@ int lua_ax_3d_Terrain_getMinHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6863,7 +6863,7 @@ int lua_ax_3d_Terrain_getMaxHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6910,7 +6910,7 @@ int lua_ax_3d_Terrain_setSkirtHeightRatio(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6960,7 +6960,7 @@ int lua_ax_3d_Terrain_reload(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7007,7 +7007,7 @@ int lua_ax_3d_Terrain_getTerrainSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7054,7 +7054,7 @@ int lua_ax_3d_Terrain_getHeightData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7101,7 +7101,7 @@ int lua_ax_3d_Terrain_initWithTerrainData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Terrain::TerrainData arg0;
         ax::Terrain::CrackFixedType arg1;
@@ -7142,7 +7142,7 @@ int lua_ax_3d_Terrain_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7234,7 +7234,7 @@ int lua_ax_3d_Bundle3D_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7281,7 +7281,7 @@ int lua_ax_3d_Bundle3D_load(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -7331,7 +7331,7 @@ int lua_ax_3d_Bundle3D_loadSkinData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         ax::SkinData* arg1;
@@ -7385,7 +7385,7 @@ int lua_ax_3d_Bundle3D_loadAnimationData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         ax::Animation3DData* arg1;
@@ -7439,7 +7439,7 @@ int lua_ax_3d_Bundle3D_loadNodes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::NodeDatas arg0;
 
@@ -7490,7 +7490,7 @@ int lua_ax_3d_Bundle3D_loadMaterials(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MaterialDatas arg0;
 
@@ -7672,7 +7672,7 @@ int lua_ax_3d_Bundle3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7726,7 +7726,7 @@ int lua_register_ax_3d_Bundle3D(lua_State* tolua_S)
 TOLUA_API int register_all_ax_3d(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-
+	
 	tolua_module(tolua_S,"ax",0);
 	tolua_beginmodule(tolua_S,"ax");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -35,7 +35,7 @@ int lua_ax_base_Object_retain(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82,7 +82,7 @@ int lua_ax_base_Object_release(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -129,7 +129,7 @@ int lua_ax_base_Object_getReferenceCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -198,7 +198,7 @@ int lua_ax_base_Touch_getLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -245,7 +245,7 @@ int lua_ax_base_Touch_getPreviousLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -292,7 +292,7 @@ int lua_ax_base_Touch_getStartLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -339,7 +339,7 @@ int lua_ax_base_Touch_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -386,7 +386,7 @@ int lua_ax_base_Touch_getLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -433,7 +433,7 @@ int lua_ax_base_Touch_getPreviousLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -480,7 +480,7 @@ int lua_ax_base_Touch_getStartLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -606,7 +606,7 @@ int lua_ax_base_Touch_getID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -653,7 +653,7 @@ int lua_ax_base_Touch_getCurrentForce(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -700,7 +700,7 @@ int lua_ax_base_Touch_getMaxForce(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -734,7 +734,7 @@ int lua_ax_base_Touch_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -815,7 +815,7 @@ int lua_ax_base_Event_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -862,7 +862,7 @@ int lua_ax_base_Event_stopPropagation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -909,7 +909,7 @@ int lua_ax_base_Event_isStopped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -956,7 +956,7 @@ int lua_ax_base_Event_getCurrentTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -990,7 +990,7 @@ int lua_ax_base_Event_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Event::Type arg0;
 
@@ -1067,7 +1067,7 @@ int lua_ax_base_EventTouch_getEventCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1114,7 +1114,7 @@ int lua_ax_base_EventTouch_setEventCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventTouch::EventCode arg0;
 
@@ -1151,7 +1151,7 @@ int lua_ax_base_EventTouch_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1210,7 +1210,7 @@ int lua_ax_base_EventKeyboard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventKeyboard::KeyCode arg0;
         bool arg1;
@@ -1286,7 +1286,7 @@ int lua_ax_base_Action_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1333,7 +1333,7 @@ int lua_ax_base_Action_reverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1380,7 +1380,7 @@ int lua_ax_base_Action_isDone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1427,7 +1427,7 @@ int lua_ax_base_Action_startWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -1477,7 +1477,7 @@ int lua_ax_base_Action_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1524,7 +1524,7 @@ int lua_ax_base_Action_step(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -1574,7 +1574,7 @@ int lua_ax_base_Action_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -1624,7 +1624,7 @@ int lua_ax_base_Action_getTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1671,7 +1671,7 @@ int lua_ax_base_Action_setTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -1721,7 +1721,7 @@ int lua_ax_base_Action_getOriginalTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1768,7 +1768,7 @@ int lua_ax_base_Action_setOriginalTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -1818,7 +1818,7 @@ int lua_ax_base_Action_getTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1865,7 +1865,7 @@ int lua_ax_base_Action_setTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -1915,7 +1915,7 @@ int lua_ax_base_Action_getFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1962,7 +1962,7 @@ int lua_ax_base_Action_setFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -2046,7 +2046,7 @@ int lua_ax_base_FiniteTimeAction_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2093,7 +2093,7 @@ int lua_ax_base_FiniteTimeAction_setDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -2164,7 +2164,7 @@ int lua_ax_base_Speed_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2211,7 +2211,7 @@ int lua_ax_base_Speed_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -2261,7 +2261,7 @@ int lua_ax_base_Speed_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -2311,7 +2311,7 @@ int lua_ax_base_Speed_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2358,7 +2358,7 @@ int lua_ax_base_Speed_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -2436,7 +2436,7 @@ int lua_ax_base_Speed_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2512,7 +2512,7 @@ int lua_ax_base_Follow_isBoundarySet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2559,7 +2559,7 @@ int lua_ax_base_Follow_setBoundarySet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -2609,7 +2609,7 @@ int lua_ax_base_Follow_initWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -2623,7 +2623,7 @@ int lua_ax_base_Follow_initWithTarget(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         ax::Rect arg1;
@@ -2676,7 +2676,7 @@ int lua_ax_base_Follow_initWithTargetAndOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Node* arg0;
         double arg1;
@@ -2696,7 +2696,7 @@ int lua_ax_base_Follow_initWithTargetAndOffset(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Node* arg0;
         double arg1;
@@ -2852,7 +2852,7 @@ int lua_ax_base_Follow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2928,7 +2928,7 @@ int lua_ax_base_EventListener_checkAvailable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2975,7 +2975,7 @@ int lua_ax_base_EventListener_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3022,7 +3022,7 @@ int lua_ax_base_EventListener_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -3072,7 +3072,7 @@ int lua_ax_base_EventListener_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3129,7 +3129,7 @@ int lua_ax_base_EventListenerCustom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3199,7 +3199,7 @@ int lua_ax_base_ShaderCache_purge(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3246,7 +3246,7 @@ int lua_ax_base_ShaderCache_acquireVertexShaderModule(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -3296,7 +3296,7 @@ int lua_ax_base_ShaderCache_acquireFragmentShaderModule(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -3346,7 +3346,7 @@ int lua_ax_base_ShaderCache_removeUnusedShader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3486,7 +3486,7 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Image* arg0;
 
@@ -3500,7 +3500,7 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Image* arg0;
         ax::rhi::PixelFormat arg1;
@@ -3517,7 +3517,7 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Image* arg0;
         ax::rhi::PixelFormat arg1;
@@ -3774,7 +3774,7 @@ int lua_ax_base_Texture2D_initWithString(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
+int lua_ax_base_Texture2D_updateData(lua_State* tolua_S)
 {
     int argc = 0;
     ax::Texture2D* cobj = nullptr;
@@ -3794,13 +3794,58 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateData'", nullptr);
         return 0;
     }
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 3) 
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateData'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->updateData(arg0, arg1, arg2);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 4) 
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateData'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->updateData(arg0, arg1, arg2, arg3);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 5) 
     {
         const void* arg0;
         int arg1;
@@ -3811,23 +3856,86 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
         #pragma warning NO CONVERSION TO NATIVE FOR void*
 		ok = false;
 
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateData");
 
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateData");
 
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateData");
 
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateData");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateData'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4);
+        auto&& ret = cobj->updateData(arg0, arg1, arg2, arg3, arg4);
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 6)
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateData",argc, 3);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Texture2D_updateSubData(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateSubData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 5) 
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+        int arg4;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateSubData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateSubData'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->updateSubData(arg0, arg1, arg2, arg3, arg4);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 6) 
     {
         const void* arg0;
         int arg1;
@@ -3839,25 +3947,25 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
         #pragma warning NO CONVERSION TO NATIVE FOR void*
 		ok = false;
 
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateSubData");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateSubData'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4, arg5);
+        auto&& ret = cobj->updateSubData(arg0, arg1, arg2, arg3, arg4, arg5);
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 7)
+    if (argc == 7) 
     {
         const void* arg0;
         int arg1;
@@ -3870,32 +3978,32 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
         #pragma warning NO CONVERSION TO NATIVE FOR void*
 		ok = false;
 
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateSubData");
 
-        ok &= luaval_to_int32(tolua_S, 8,(int *)&arg6, "ax.Texture2D:updateWithSubData");
+        ok &= luaval_to_int32(tolua_S, 8,(int *)&arg6, "ax.Texture2D:updateSubData");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateSubData'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+        auto&& ret = cobj->updateSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateWithSubData",argc, 5);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateSubData",argc, 5);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateWithSubData'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateSubData'.",&tolua_err);
 #endif
 
     return 0;
@@ -3926,7 +4034,7 @@ int lua_ax_base_Texture2D_drawAtPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -3979,7 +4087,7 @@ int lua_ax_base_Texture2D_drawInRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Rect arg0;
         double arg1;
@@ -4002,125 +4110,6 @@ int lua_ax_base_Texture2D_drawInRect(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_drawInRect'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_updateTextureDesc(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateTextureDesc'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        ax::rhi::TextureDesc arg0;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR TextureDesc
-		ok = false;
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateTextureDesc'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateTextureDesc(arg0);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    if (argc == 2)
-    {
-        ax::rhi::TextureDesc arg0;
-        bool arg1;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR TextureDesc
-		ok = false;
-
-        ok &= luaval_to_boolean(tolua_S, 3,&arg1, "ax.Texture2D:updateTextureDesc");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateTextureDesc'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateTextureDesc(arg0, arg1);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateTextureDesc",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateTextureDesc'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_setRenderTarget(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_setRenderTarget'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        bool arg0;
-
-        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.Texture2D:setRenderTarget");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_setRenderTarget'", nullptr);
-            return 0;
-        }
-        cobj->setRenderTarget(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:setRenderTarget",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_setRenderTarget'.",&tolua_err);
 #endif
 
     return 0;
@@ -4151,7 +4140,7 @@ int lua_ax_base_Texture2D_isRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4198,7 +4187,7 @@ int lua_ax_base_Texture2D_setAntiAliasTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4245,7 +4234,7 @@ int lua_ax_base_Texture2D_setAliasTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4292,7 +4281,7 @@ int lua_ax_base_Texture2D_getStringForFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4390,7 +4379,7 @@ int lua_ax_base_Texture2D_getContentSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4437,7 +4426,7 @@ int lua_ax_base_Texture2D_hasPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4484,7 +4473,7 @@ int lua_ax_base_Texture2D_setPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -4534,7 +4523,7 @@ int lua_ax_base_Texture2D_hasMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4581,7 +4570,7 @@ int lua_ax_base_Texture2D_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4628,7 +4617,7 @@ int lua_ax_base_Texture2D_getSamplerFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4675,7 +4664,7 @@ int lua_ax_base_Texture2D_getPixelsWide(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4722,7 +4711,7 @@ int lua_ax_base_Texture2D_getPixelsHigh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4769,7 +4758,7 @@ int lua_ax_base_Texture2D_getRHITexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4816,7 +4805,7 @@ int lua_ax_base_Texture2D_getMaxS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4863,7 +4852,7 @@ int lua_ax_base_Texture2D_setMaxS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -4913,7 +4902,7 @@ int lua_ax_base_Texture2D_getMaxT(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4960,7 +4949,7 @@ int lua_ax_base_Texture2D_setMaxT(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -5010,7 +4999,7 @@ int lua_ax_base_Texture2D_getContentSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5057,7 +5046,7 @@ int lua_ax_base_Texture2D_getPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5091,7 +5080,7 @@ int lua_ax_base_Texture2D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5130,11 +5119,10 @@ int lua_register_ax_base_Texture2D(lua_State* tolua_S)
         tolua_function(tolua_S,"new",lua_ax_base_Texture2D_constructor);
         tolua_function(tolua_S,"initWithImage",lua_ax_base_Texture2D_initWithImage);
         tolua_function(tolua_S,"initWithString",lua_ax_base_Texture2D_initWithString);
-        tolua_function(tolua_S,"updateWithSubData",lua_ax_base_Texture2D_updateWithSubData);
+        tolua_function(tolua_S,"updateData",lua_ax_base_Texture2D_updateData);
+        tolua_function(tolua_S,"updateSubData",lua_ax_base_Texture2D_updateSubData);
         tolua_function(tolua_S,"drawAtPoint",lua_ax_base_Texture2D_drawAtPoint);
         tolua_function(tolua_S,"drawInRect",lua_ax_base_Texture2D_drawInRect);
-        tolua_function(tolua_S,"updateTextureDesc",lua_ax_base_Texture2D_updateTextureDesc);
-        tolua_function(tolua_S,"setRenderTarget",lua_ax_base_Texture2D_setRenderTarget);
         tolua_function(tolua_S,"isRenderTarget",lua_ax_base_Texture2D_isRenderTarget);
         tolua_function(tolua_S,"setAntiAliasTexParameters",lua_ax_base_Texture2D_setAntiAliasTexParameters);
         tolua_function(tolua_S,"setAliasTexParameters",lua_ax_base_Texture2D_setAliasTexParameters);
@@ -5188,7 +5176,7 @@ int lua_ax_base_Component_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5235,7 +5223,7 @@ int lua_ax_base_Component_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5282,7 +5270,7 @@ int lua_ax_base_Component_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -5332,7 +5320,7 @@ int lua_ax_base_Component_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5379,7 +5367,7 @@ int lua_ax_base_Component_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -5429,7 +5417,7 @@ int lua_ax_base_Component_getOwner(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5476,7 +5464,7 @@ int lua_ax_base_Component_setOwner(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -5526,7 +5514,7 @@ int lua_ax_base_Component_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -5576,7 +5564,7 @@ int lua_ax_base_Component_onAdd(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5623,7 +5611,7 @@ int lua_ax_base_Component_onRemove(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5734,7 +5722,7 @@ int lua_ax_base_Node_getDescription(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5781,7 +5769,7 @@ int lua_ax_base_Node_setLocalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -5831,7 +5819,7 @@ int lua_ax_base_Node_updateOrderOfArrival(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5878,7 +5866,7 @@ int lua_ax_base_Node_getLocalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5925,7 +5913,7 @@ int lua_ax_base_Node_setGlobalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -5975,7 +5963,7 @@ int lua_ax_base_Node_getGlobalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6022,7 +6010,7 @@ int lua_ax_base_Node_setScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6072,7 +6060,7 @@ int lua_ax_base_Node_getScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6119,7 +6107,7 @@ int lua_ax_base_Node_setScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6169,7 +6157,7 @@ int lua_ax_base_Node_getScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6216,7 +6204,7 @@ int lua_ax_base_Node_setScaleZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6266,7 +6254,7 @@ int lua_ax_base_Node_getScaleZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6372,7 +6360,7 @@ int lua_ax_base_Node_getScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6478,7 +6466,7 @@ int lua_ax_base_Node_setPositionNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -6528,7 +6516,7 @@ int lua_ax_base_Node_setNormalizedPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -6578,7 +6566,7 @@ int lua_ax_base_Node_getPositionNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6625,7 +6613,7 @@ int lua_ax_base_Node_getNormalizedPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6672,7 +6660,7 @@ int lua_ax_base_Node_setPositionX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6722,7 +6710,7 @@ int lua_ax_base_Node_getPositionX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6769,7 +6757,7 @@ int lua_ax_base_Node_setPositionY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6819,7 +6807,7 @@ int lua_ax_base_Node_getPositionY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6866,7 +6854,7 @@ int lua_ax_base_Node_setPosition3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -6916,7 +6904,7 @@ int lua_ax_base_Node_getPosition3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6963,7 +6951,7 @@ int lua_ax_base_Node_setPositionZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7013,7 +7001,7 @@ int lua_ax_base_Node_getPositionZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7060,7 +7048,7 @@ int lua_ax_base_Node_setSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7110,7 +7098,7 @@ int lua_ax_base_Node_getSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7157,7 +7145,7 @@ int lua_ax_base_Node_setSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7207,7 +7195,7 @@ int lua_ax_base_Node_getSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7254,7 +7242,7 @@ int lua_ax_base_Node_getAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7301,7 +7289,7 @@ int lua_ax_base_Node_getAnchorPointInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7348,7 +7336,7 @@ int lua_ax_base_Node_getContentSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7395,7 +7383,7 @@ int lua_ax_base_Node_hitTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -7445,7 +7433,7 @@ int lua_ax_base_Node_setVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -7495,7 +7483,7 @@ int lua_ax_base_Node_isVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7542,7 +7530,7 @@ int lua_ax_base_Node_setRotation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7592,7 +7580,7 @@ int lua_ax_base_Node_getRotation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7639,7 +7627,7 @@ int lua_ax_base_Node_setRotation3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -7689,7 +7677,7 @@ int lua_ax_base_Node_getRotation3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7736,7 +7724,7 @@ int lua_ax_base_Node_setRotationSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7786,7 +7774,7 @@ int lua_ax_base_Node_getRotationSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7833,7 +7821,7 @@ int lua_ax_base_Node_setRotationSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7883,7 +7871,7 @@ int lua_ax_base_Node_getRotationSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7930,7 +7918,7 @@ int lua_ax_base_Node_setIgnoreAnchorPointForPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -7980,7 +7968,7 @@ int lua_ax_base_Node_isIgnoreAnchorPointForPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8126,7 +8114,7 @@ int lua_ax_base_Node_getChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -8176,7 +8164,7 @@ int lua_ax_base_Node_getChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -8273,7 +8261,7 @@ int lua_ax_base_Node_getChildrenCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8320,7 +8308,7 @@ int lua_ax_base_Node_setParent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -8468,7 +8456,7 @@ int lua_ax_base_Node_removeChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -8482,7 +8470,7 @@ int lua_ax_base_Node_removeChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -8535,7 +8523,7 @@ int lua_ax_base_Node_removeChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -8549,7 +8537,7 @@ int lua_ax_base_Node_removeChildByTag(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         bool arg1;
@@ -8602,7 +8590,7 @@ int lua_ax_base_Node_removeChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -8616,7 +8604,7 @@ int lua_ax_base_Node_removeChildByName(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -8720,7 +8708,7 @@ int lua_ax_base_Node_reorderChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         int arg1;
@@ -8773,7 +8761,7 @@ int lua_ax_base_Node_sortAllChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8820,7 +8808,7 @@ int lua_ax_base_Node_getTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8867,7 +8855,7 @@ int lua_ax_base_Node_setTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -8917,7 +8905,7 @@ int lua_ax_base_Node_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8964,7 +8952,7 @@ int lua_ax_base_Node_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -9014,7 +9002,7 @@ int lua_ax_base_Node_setUserObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Object* arg0;
 
@@ -9064,7 +9052,7 @@ int lua_ax_base_Node_isRunning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9111,7 +9099,7 @@ int lua_ax_base_Node_cleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9276,7 +9264,7 @@ int lua_ax_base_Node_getScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9323,7 +9311,7 @@ int lua_ax_base_Node_getBoundingBox(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9370,7 +9358,7 @@ int lua_ax_base_Node_setEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventDispatcher* arg0;
 
@@ -9420,7 +9408,7 @@ int lua_ax_base_Node_getEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9467,7 +9455,7 @@ int lua_ax_base_Node_setActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionManager* arg0;
 
@@ -9564,7 +9552,7 @@ int lua_ax_base_Node_runAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Action* arg0;
 
@@ -9614,7 +9602,7 @@ int lua_ax_base_Node_stopAllActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9661,7 +9649,7 @@ int lua_ax_base_Node_stopAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Action* arg0;
 
@@ -9711,7 +9699,7 @@ int lua_ax_base_Node_stopActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -9761,7 +9749,7 @@ int lua_ax_base_Node_stopAllActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -9811,7 +9799,7 @@ int lua_ax_base_Node_stopActionsByFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -9861,7 +9849,7 @@ int lua_ax_base_Node_getActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -9911,7 +9899,7 @@ int lua_ax_base_Node_getNumberOfRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9958,7 +9946,7 @@ int lua_ax_base_Node_getNumberOfRunningActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -10008,7 +9996,7 @@ int lua_ax_base_Node_setScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scheduler* arg0;
 
@@ -10105,7 +10093,7 @@ int lua_ax_base_Node_isScheduled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -10155,7 +10143,7 @@ int lua_ax_base_Node_resume(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10202,7 +10190,7 @@ int lua_ax_base_Node_pause(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10249,7 +10237,7 @@ int lua_ax_base_Node_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -10299,7 +10287,7 @@ int lua_ax_base_Node_updateTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10448,7 +10436,7 @@ int lua_ax_base_Node_setNodeToParentTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -10498,7 +10486,7 @@ int lua_ax_base_Node_getParentToNodeTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10545,7 +10533,7 @@ int lua_ax_base_Node_getParentToNodeAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10592,7 +10580,7 @@ int lua_ax_base_Node_getNodeToWorldTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10639,7 +10627,7 @@ int lua_ax_base_Node_getNodeToWorldAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10686,7 +10674,7 @@ int lua_ax_base_Node_getWorldToNodeTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10733,7 +10721,7 @@ int lua_ax_base_Node_getWorldToNodeAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10780,7 +10768,7 @@ int lua_ax_base_Node_convertToNodeSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -10830,7 +10818,7 @@ int lua_ax_base_Node_convertToWorldSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -10880,7 +10868,7 @@ int lua_ax_base_Node_convertToNodeSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -10930,7 +10918,7 @@ int lua_ax_base_Node_convertToWorldSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -10980,7 +10968,7 @@ int lua_ax_base_Node_convertTouchToNodeSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Touch* arg0;
 
@@ -11030,7 +11018,7 @@ int lua_ax_base_Node_convertTouchToNodeSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Touch* arg0;
 
@@ -11080,7 +11068,7 @@ int lua_ax_base_Node_getWorldPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11127,7 +11115,7 @@ int lua_ax_base_Node_setWorldPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -11177,7 +11165,7 @@ int lua_ax_base_Node_getComponent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -11227,7 +11215,7 @@ int lua_ax_base_Node_addComponent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Component* arg0;
 
@@ -11332,7 +11320,7 @@ int lua_ax_base_Node_removeAllComponents(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11379,7 +11367,7 @@ int lua_ax_base_Node_getOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11426,7 +11414,7 @@ int lua_ax_base_Node_getDisplayedOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11473,7 +11461,7 @@ int lua_ax_base_Node_setOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -11523,7 +11511,7 @@ int lua_ax_base_Node_updateDisplayedOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -11573,7 +11561,7 @@ int lua_ax_base_Node_isCascadeOpacityEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11620,7 +11608,7 @@ int lua_ax_base_Node_setCascadeOpacityEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -11670,7 +11658,7 @@ int lua_ax_base_Node_getColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11717,7 +11705,7 @@ int lua_ax_base_Node_getDisplayedColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11764,7 +11752,7 @@ int lua_ax_base_Node_setColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -11814,7 +11802,7 @@ int lua_ax_base_Node_updateDisplayedColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -11864,7 +11852,7 @@ int lua_ax_base_Node_isCascadeColorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11911,7 +11899,7 @@ int lua_ax_base_Node_setCascadeColorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -11961,7 +11949,7 @@ int lua_ax_base_Node_setOpacityModifyRGB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -12011,7 +11999,7 @@ int lua_ax_base_Node_isOpacityModifyRGB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12058,7 +12046,7 @@ int lua_ax_base_Node_setOnEnterCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12112,7 +12100,7 @@ int lua_ax_base_Node_setOnExitCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12166,7 +12154,7 @@ int lua_ax_base_Node_setOnEnterTransitionDidFinishCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12220,7 +12208,7 @@ int lua_ax_base_Node_getOnEnterTransitionDidFinishCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12267,7 +12255,7 @@ int lua_ax_base_Node_setOnExitTransitionDidStartCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12321,7 +12309,7 @@ int lua_ax_base_Node_getOnExitTransitionDidStartCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12368,7 +12356,7 @@ int lua_ax_base_Node_getCameraMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12415,7 +12403,7 @@ int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned short arg0;
 
@@ -12429,7 +12417,7 @@ int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned short arg0;
         bool arg1;
@@ -12482,7 +12470,7 @@ int lua_ax_base_Node_applyMaskOnEnter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -12603,7 +12591,7 @@ int lua_ax_base_Node_setProgramStateWithRegistry(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::Texture2D* arg1;
@@ -12656,7 +12644,7 @@ int lua_ax_base_Node_setProgramStateByProgramId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned long long arg0;
 
@@ -12706,7 +12694,7 @@ int lua_ax_base_Node_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12753,7 +12741,7 @@ int lua_ax_base_Node_updateProgramStateTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -12803,7 +12791,7 @@ int lua_ax_base_Node_resetChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -12856,7 +12844,7 @@ int lua_ax_base_Node_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12903,7 +12891,7 @@ int lua_ax_base_Node_initLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12950,7 +12938,7 @@ int lua_ax_base_Node_setPhysicsBody(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::PhysicsBody* arg0;
 
@@ -13000,7 +12988,7 @@ int lua_ax_base_Node_getPhysicsBody(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13102,7 +13090,7 @@ int lua_ax_base_Node_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13320,7 +13308,7 @@ int lua_ax_base_Image_initWithImageFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -13370,7 +13358,7 @@ int lua_ax_base_Image_flipRawData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13417,7 +13405,7 @@ int lua_ax_base_Image_getFileType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13464,7 +13452,7 @@ int lua_ax_base_Image_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13511,7 +13499,7 @@ int lua_ax_base_Image_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13558,7 +13546,7 @@ int lua_ax_base_Image_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13605,7 +13593,7 @@ int lua_ax_base_Image_getNumberOfMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13652,7 +13640,7 @@ int lua_ax_base_Image_hasPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13699,7 +13687,7 @@ int lua_ax_base_Image_getFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13746,7 +13734,7 @@ int lua_ax_base_Image_getBitPerPixel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13793,7 +13781,7 @@ int lua_ax_base_Image_hasAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13840,7 +13828,7 @@ int lua_ax_base_Image_isCompressed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13887,7 +13875,7 @@ int lua_ax_base_Image_saveToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -13901,7 +13889,7 @@ int lua_ax_base_Image_saveToFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -13954,7 +13942,7 @@ int lua_ax_base_Image_premultiplyAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14001,7 +13989,7 @@ int lua_ax_base_Image_reversePremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14145,7 +14133,7 @@ int lua_ax_base_Image_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14233,7 +14221,7 @@ int lua_ax_base_PolygonInfo_setQuad(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::V3F_T2F_C4B_Quad* arg0;
 
@@ -14284,7 +14272,7 @@ int lua_ax_base_PolygonInfo_setQuads(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::V3F_T2F_C4B_Quad* arg0;
         int arg1;
@@ -14338,7 +14326,7 @@ int lua_ax_base_PolygonInfo_setTriangles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TrianglesCommand::Triangles arg0;
 
@@ -14389,7 +14377,7 @@ int lua_ax_base_PolygonInfo_getVertCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14436,7 +14424,7 @@ int lua_ax_base_PolygonInfo_getTrianglesCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14483,7 +14471,7 @@ int lua_ax_base_PolygonInfo_getArea(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14530,7 +14518,7 @@ int lua_ax_base_PolygonInfo_getRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14577,7 +14565,7 @@ int lua_ax_base_PolygonInfo_setRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -14627,7 +14615,7 @@ int lua_ax_base_PolygonInfo_getFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14674,7 +14662,7 @@ int lua_ax_base_PolygonInfo_setFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -14711,7 +14699,7 @@ int lua_ax_base_PolygonInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14776,7 +14764,7 @@ int lua_ax_base_AutoPolygon_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -14847,7 +14835,7 @@ int lua_ax_base_SpriteFrame_getRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14894,7 +14882,7 @@ int lua_ax_base_SpriteFrame_setRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -14944,7 +14932,7 @@ int lua_ax_base_SpriteFrame_isRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14991,7 +14979,7 @@ int lua_ax_base_SpriteFrame_setRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -15041,7 +15029,7 @@ int lua_ax_base_SpriteFrame_getRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15088,7 +15076,7 @@ int lua_ax_base_SpriteFrame_setRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -15138,7 +15126,7 @@ int lua_ax_base_SpriteFrame_getCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15185,7 +15173,7 @@ int lua_ax_base_SpriteFrame_setCenterRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -15235,7 +15223,7 @@ int lua_ax_base_SpriteFrame_hasCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15282,7 +15270,7 @@ int lua_ax_base_SpriteFrame_getOffsetInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15329,7 +15317,7 @@ int lua_ax_base_SpriteFrame_setOffsetInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15379,7 +15367,7 @@ int lua_ax_base_SpriteFrame_getOriginalSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15426,7 +15414,7 @@ int lua_ax_base_SpriteFrame_setOriginalSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15476,7 +15464,7 @@ int lua_ax_base_SpriteFrame_getOriginalSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15523,7 +15511,7 @@ int lua_ax_base_SpriteFrame_setOriginalSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15573,7 +15561,7 @@ int lua_ax_base_SpriteFrame_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15620,7 +15608,7 @@ int lua_ax_base_SpriteFrame_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -15670,7 +15658,7 @@ int lua_ax_base_SpriteFrame_getOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15717,7 +15705,7 @@ int lua_ax_base_SpriteFrame_setOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15767,7 +15755,7 @@ int lua_ax_base_SpriteFrame_getAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15814,7 +15802,7 @@ int lua_ax_base_SpriteFrame_setAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15864,7 +15852,7 @@ int lua_ax_base_SpriteFrame_hasAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15911,7 +15899,7 @@ int lua_ax_base_SpriteFrame_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16108,7 +16096,7 @@ int lua_ax_base_SpriteFrame_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16143,7 +16131,7 @@ int lua_ax_base_SpriteFrame_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -16168,7 +16156,7 @@ int lua_ax_base_SpriteFrame_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -16206,7 +16194,7 @@ int lua_ax_base_SpriteFrame_createWithTexture(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -16231,7 +16219,7 @@ int lua_ax_base_SpriteFrame_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -16268,7 +16256,7 @@ int lua_ax_base_SpriteFrame_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16366,7 +16354,7 @@ int lua_ax_base_AnimationFrame_getSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16413,7 +16401,7 @@ int lua_ax_base_AnimationFrame_setSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -16463,7 +16451,7 @@ int lua_ax_base_AnimationFrame_getDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16510,7 +16498,7 @@ int lua_ax_base_AnimationFrame_setDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -16607,7 +16595,7 @@ int lua_ax_base_AnimationFrame_setUserInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -16657,7 +16645,7 @@ int lua_ax_base_AnimationFrame_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16704,7 +16692,7 @@ int lua_ax_base_AnimationFrame_initWithSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::SpriteFrame* arg0;
         double arg1;
@@ -16787,7 +16775,7 @@ int lua_ax_base_AnimationFrame_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16866,7 +16854,7 @@ int lua_ax_base_Animation_addSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -16916,7 +16904,7 @@ int lua_ax_base_Animation_addSpriteFrameWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -16966,7 +16954,7 @@ int lua_ax_base_Animation_addSpriteFrameWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         ax::Rect arg1;
@@ -17019,7 +17007,7 @@ int lua_ax_base_Animation_getTotalDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17066,7 +17054,7 @@ int lua_ax_base_Animation_setDelayPerUnit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -17116,7 +17104,7 @@ int lua_ax_base_Animation_getDelayPerUnit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17163,7 +17151,7 @@ int lua_ax_base_Animation_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17210,7 +17198,7 @@ int lua_ax_base_Animation_getFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17257,7 +17245,7 @@ int lua_ax_base_Animation_setFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::AnimationFrame *> arg0;
 
@@ -17307,7 +17295,7 @@ int lua_ax_base_Animation_getRestoreOriginalFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17354,7 +17342,7 @@ int lua_ax_base_Animation_setRestoreOriginalFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -17404,7 +17392,7 @@ int lua_ax_base_Animation_getLoops(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17451,7 +17439,7 @@ int lua_ax_base_Animation_setLoops(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -17501,7 +17489,7 @@ int lua_ax_base_Animation_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17548,7 +17536,7 @@ int lua_ax_base_Animation_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17595,7 +17583,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::SpriteFrame *> arg0;
 
@@ -17609,7 +17597,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vector<ax::SpriteFrame *> arg0;
         double arg1;
@@ -17626,7 +17614,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vector<ax::SpriteFrame *> arg0;
         double arg1;
@@ -17682,7 +17670,7 @@ int lua_ax_base_Animation_initWithAnimationFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vector<ax::AnimationFrame *> arg0;
         double arg1;
@@ -17726,7 +17714,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -17742,7 +17730,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -17761,7 +17749,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -17860,7 +17848,7 @@ int lua_ax_base_Animation_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17949,7 +17937,7 @@ int lua_ax_base_ActionInterval_getElapsed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17996,7 +17984,7 @@ int lua_ax_base_ActionInterval_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -18046,7 +18034,7 @@ int lua_ax_base_ActionInterval_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18093,7 +18081,7 @@ int lua_ax_base_ActionInterval_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -18166,7 +18154,7 @@ int lua_ax_base_Sequence_initWithTwoActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::FiniteTimeAction* arg0;
         ax::FiniteTimeAction* arg1;
@@ -18219,7 +18207,7 @@ int lua_ax_base_Sequence_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::FiniteTimeAction *> arg0;
 
@@ -18256,7 +18244,7 @@ int lua_ax_base_Sequence_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18328,7 +18316,7 @@ int lua_ax_base_Repeat_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FiniteTimeAction* arg0;
 
@@ -18378,7 +18366,7 @@ int lua_ax_base_Repeat_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18425,7 +18413,7 @@ int lua_ax_base_Repeat_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::FiniteTimeAction* arg0;
         unsigned int arg1;
@@ -18503,7 +18491,7 @@ int lua_ax_base_Repeat_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18577,7 +18565,7 @@ int lua_ax_base_RepeatForever_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -18627,7 +18615,7 @@ int lua_ax_base_RepeatForever_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18674,7 +18662,7 @@ int lua_ax_base_RepeatForever_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -18747,7 +18735,7 @@ int lua_ax_base_RepeatForever_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18821,7 +18809,7 @@ int lua_ax_base_Spawn_initWithTwoActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::FiniteTimeAction* arg0;
         ax::FiniteTimeAction* arg1;
@@ -18874,7 +18862,7 @@ int lua_ax_base_Spawn_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::FiniteTimeAction *> arg0;
 
@@ -18911,7 +18899,7 @@ int lua_ax_base_Spawn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19038,7 +19026,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19054,7 +19042,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -19073,7 +19061,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19110,7 +19098,7 @@ int lua_ax_base_RotateTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19253,7 +19241,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -19272,7 +19260,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19288,7 +19276,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19325,7 +19313,7 @@ int lua_ax_base_RotateBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19448,7 +19436,7 @@ int lua_ax_base_MoveBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19464,7 +19452,7 @@ int lua_ax_base_MoveBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19501,7 +19489,7 @@ int lua_ax_base_MoveBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19624,7 +19612,7 @@ int lua_ax_base_MoveTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19640,7 +19628,7 @@ int lua_ax_base_MoveTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19677,7 +19665,7 @@ int lua_ax_base_MoveTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19749,7 +19737,7 @@ int lua_ax_base_SkewTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -19832,7 +19820,7 @@ int lua_ax_base_SkewTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19904,7 +19892,7 @@ int lua_ax_base_SkewBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -19987,7 +19975,7 @@ int lua_ax_base_SkewBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20059,7 +20047,7 @@ int lua_ax_base_JumpBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -20147,7 +20135,7 @@ int lua_ax_base_JumpBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20219,7 +20207,7 @@ int lua_ax_base_JumpTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -20307,7 +20295,7 @@ int lua_ax_base_JumpTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20379,7 +20367,7 @@ int lua_ax_base_BezierBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::BezierConfig arg1;
@@ -20420,7 +20408,7 @@ int lua_ax_base_BezierBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20491,7 +20479,7 @@ int lua_ax_base_BezierTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::BezierConfig arg1;
@@ -20532,7 +20520,7 @@ int lua_ax_base_BezierTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20682,7 +20670,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -20701,7 +20689,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -20717,7 +20705,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -20760,7 +20748,7 @@ int lua_ax_base_ScaleTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20820,7 +20808,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -20839,7 +20827,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -20855,7 +20843,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -20898,7 +20886,7 @@ int lua_ax_base_ScaleBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20969,7 +20957,7 @@ int lua_ax_base_Blink_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         int arg1;
@@ -21047,7 +21035,7 @@ int lua_ax_base_Blink_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21119,7 +21107,7 @@ int lua_ax_base_FadeTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         uint16_t arg1;
@@ -21197,7 +21185,7 @@ int lua_ax_base_FadeTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21269,7 +21257,7 @@ int lua_ax_base_FadeIn_setReverseAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FadeTo* arg0;
 
@@ -21342,7 +21330,7 @@ int lua_ax_base_FadeIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21414,7 +21402,7 @@ int lua_ax_base_FadeOut_setReverseAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FadeTo* arg0;
 
@@ -21487,7 +21475,7 @@ int lua_ax_base_FadeOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21559,7 +21547,7 @@ int lua_ax_base_TintTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::Color32 arg1;
@@ -21600,7 +21588,7 @@ int lua_ax_base_TintTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -21616,7 +21604,7 @@ int lua_ax_base_TintTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -21659,7 +21647,7 @@ int lua_ax_base_TintTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21731,7 +21719,7 @@ int lua_ax_base_TintBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         int32_t arg1;
@@ -21819,7 +21807,7 @@ int lua_ax_base_TintBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21914,7 +21902,7 @@ int lua_ax_base_DelayTime_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21985,7 +21973,7 @@ int lua_ax_base_Animate_setAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Animation* arg0;
 
@@ -22082,7 +22070,7 @@ int lua_ax_base_Animate_getCurrentFrameIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22129,7 +22117,7 @@ int lua_ax_base_Animate_initWithAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Animation* arg0;
 
@@ -22202,7 +22190,7 @@ int lua_ax_base_Animate_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22277,7 +22265,7 @@ int lua_ax_base_TargetedAction_setForcedTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -22374,7 +22362,7 @@ int lua_ax_base_TargetedAction_initWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         ax::FiniteTimeAction* arg1;
@@ -22452,7 +22440,7 @@ int lua_ax_base_TargetedAction_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22526,7 +22514,7 @@ int lua_ax_base_ActionFloat_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -22622,7 +22610,7 @@ int lua_ax_base_ActionFloat_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22694,7 +22682,7 @@ int lua_ax_base_Scene_getDefaultCamera(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22741,7 +22729,7 @@ int lua_ax_base_Scene_render(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Renderer* arg0;
         ax::Mat4 arg1;
@@ -22758,7 +22746,7 @@ int lua_ax_base_Scene_render(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Renderer* arg0;
         ax::Mat4 arg1;
@@ -22814,7 +22802,7 @@ int lua_ax_base_Scene_initWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -22864,7 +22852,7 @@ int lua_ax_base_Scene_setCameraOrderDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22911,7 +22899,7 @@ int lua_ax_base_Scene_onProjectionChanged(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventCustom* arg0;
 
@@ -22961,7 +22949,7 @@ int lua_ax_base_Scene_getPhysicsWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23008,7 +22996,7 @@ int lua_ax_base_Scene_initWithPhysics(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23055,7 +23043,7 @@ int lua_ax_base_Scene_initPhysicsWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23102,7 +23090,7 @@ int lua_ax_base_Scene_fixedUpdate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -23152,7 +23140,7 @@ int lua_ax_base_Scene_stepPhysicsAndNavigation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -23293,7 +23281,7 @@ int lua_ax_base_Scene_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23376,7 +23364,7 @@ int lua_ax_base_RenderView_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23423,7 +23411,7 @@ int lua_ax_base_RenderView_isGfxContextReady(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23470,7 +23458,7 @@ int lua_ax_base_RenderView_swapBuffers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23517,7 +23505,7 @@ int lua_ax_base_RenderView_setIMEKeyboardState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -23567,7 +23555,7 @@ int lua_ax_base_RenderView_windowShouldClose(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23614,7 +23602,7 @@ int lua_ax_base_RenderView_pollEvents(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23661,7 +23649,7 @@ int lua_ax_base_RenderView_getFrameSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23708,7 +23696,7 @@ int lua_ax_base_RenderView_setFrameSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -23761,7 +23749,7 @@ int lua_ax_base_RenderView_setFrameZoomFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -23811,7 +23799,7 @@ int lua_ax_base_RenderView_getFrameZoomFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23858,7 +23846,7 @@ int lua_ax_base_RenderView_setCursorVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -23908,7 +23896,7 @@ int lua_ax_base_RenderView_getRetinaFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23955,7 +23943,7 @@ int lua_ax_base_RenderView_setContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -24005,7 +23993,7 @@ int lua_ax_base_RenderView_getContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24052,7 +24040,7 @@ int lua_ax_base_RenderView_isRetinaDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24099,7 +24087,7 @@ int lua_ax_base_RenderView_getVisibleSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24146,7 +24134,7 @@ int lua_ax_base_RenderView_getVisibleOrigin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24193,7 +24181,7 @@ int lua_ax_base_RenderView_getVisibleRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24240,7 +24228,7 @@ int lua_ax_base_RenderView_getSafeAreaRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24287,7 +24275,7 @@ int lua_ax_base_RenderView_setDesignResolutionSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -24343,7 +24331,7 @@ int lua_ax_base_RenderView_getDesignResolutionSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24390,7 +24378,7 @@ int lua_ax_base_RenderView_setViewPortInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -24449,7 +24437,7 @@ int lua_ax_base_RenderView_setScissorInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -24508,7 +24496,7 @@ int lua_ax_base_RenderView_isScissorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24555,7 +24543,7 @@ int lua_ax_base_RenderView_getScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24602,7 +24590,7 @@ int lua_ax_base_RenderView_setViewName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -24652,7 +24640,7 @@ int lua_ax_base_RenderView_getViewName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24754,7 +24742,7 @@ int lua_ax_base_RenderView_setDefaultIcon(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24801,7 +24789,7 @@ int lua_ax_base_RenderView_getViewPortRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24848,7 +24836,7 @@ int lua_ax_base_RenderView_getScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24895,7 +24883,7 @@ int lua_ax_base_RenderView_getScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24942,7 +24930,7 @@ int lua_ax_base_RenderView_getResolutionPolicy(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24989,7 +24977,7 @@ int lua_ax_base_RenderView_renderScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Scene* arg0;
         ax::Renderer* arg1;
@@ -25042,7 +25030,7 @@ int lua_ax_base_RenderView_setInteractive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -25219,7 +25207,7 @@ int lua_ax_base_Director_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25266,7 +25254,7 @@ int lua_ax_base_Director_getRunningScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25313,7 +25301,7 @@ int lua_ax_base_Director_getNextScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25360,7 +25348,7 @@ int lua_ax_base_Director_getAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25407,7 +25395,7 @@ int lua_ax_base_Director_setAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -25457,7 +25445,7 @@ int lua_ax_base_Director_isStatsDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25504,7 +25492,7 @@ int lua_ax_base_Director_setStatsDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -25554,7 +25542,7 @@ int lua_ax_base_Director_getSecondsPerFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25601,7 +25589,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25612,7 +25600,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::AnchorPreset arg0;
 
@@ -25662,7 +25650,7 @@ int lua_ax_base_Director_getRenderView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25709,7 +25697,7 @@ int lua_ax_base_Director_setRenderView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::RenderView* arg0;
 
@@ -25759,7 +25747,7 @@ int lua_ax_base_Director_getTextureCache(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25806,7 +25794,7 @@ int lua_ax_base_Director_isNextDeltaTimeZero(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25853,7 +25841,7 @@ int lua_ax_base_Director_setNextDeltaTimeZero(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -25903,7 +25891,7 @@ int lua_ax_base_Director_isPaused(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25950,7 +25938,7 @@ int lua_ax_base_Director_getTotalFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25997,7 +25985,7 @@ int lua_ax_base_Director_setProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Director::Projection arg0;
 
@@ -26047,7 +26035,7 @@ int lua_ax_base_Director_setViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26094,7 +26082,7 @@ int lua_ax_base_Director_isSendCleanupToScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26141,7 +26129,7 @@ int lua_ax_base_Director_getNotificationNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26188,7 +26176,7 @@ int lua_ax_base_Director_setNotificationNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -26238,7 +26226,7 @@ int lua_ax_base_Director_getWinSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26285,7 +26273,7 @@ int lua_ax_base_Director_getWinSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26332,7 +26320,7 @@ int lua_ax_base_Director_getVisibleSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26379,7 +26367,7 @@ int lua_ax_base_Director_getVisibleOrigin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26426,7 +26414,7 @@ int lua_ax_base_Director_getSafeAreaRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26473,7 +26461,7 @@ int lua_ax_base_Director_convertToGL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -26523,7 +26511,7 @@ int lua_ax_base_Director_convertToUI(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -26573,7 +26561,7 @@ int lua_ax_base_Director_getZEye(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26620,7 +26608,7 @@ int lua_ax_base_Director_runWithScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -26670,7 +26658,7 @@ int lua_ax_base_Director_pushScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -26720,7 +26708,7 @@ int lua_ax_base_Director_popScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26767,7 +26755,7 @@ int lua_ax_base_Director_popToRootScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26814,7 +26802,7 @@ int lua_ax_base_Director_popToSceneStackLevel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -26864,7 +26852,7 @@ int lua_ax_base_Director_replaceScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -26914,7 +26902,7 @@ int lua_ax_base_Director_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26961,7 +26949,7 @@ int lua_ax_base_Director_pause(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27008,7 +26996,7 @@ int lua_ax_base_Director_resume(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27055,7 +27043,7 @@ int lua_ax_base_Director_restart(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27102,7 +27090,7 @@ int lua_ax_base_Director_stopAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27149,7 +27137,7 @@ int lua_ax_base_Director_startAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27196,7 +27184,7 @@ int lua_ax_base_Director_drawScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27243,7 +27231,7 @@ int lua_ax_base_Director_purgeCachedData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27290,7 +27278,7 @@ int lua_ax_base_Director_setDefaultValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27337,7 +27325,7 @@ int lua_ax_base_Director_setGLDefaultValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27384,7 +27372,7 @@ int lua_ax_base_Director_setClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -27485,7 +27473,7 @@ int lua_ax_base_Director_setContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -27535,7 +27523,7 @@ int lua_ax_base_Director_getContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27582,7 +27570,7 @@ int lua_ax_base_Director_getScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27629,7 +27617,7 @@ int lua_ax_base_Director_setScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scheduler* arg0;
 
@@ -27679,7 +27667,7 @@ int lua_ax_base_Director_getActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27726,7 +27714,7 @@ int lua_ax_base_Director_setActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionManager* arg0;
 
@@ -27776,7 +27764,7 @@ int lua_ax_base_Director_getEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27823,7 +27811,7 @@ int lua_ax_base_Director_setEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventDispatcher* arg0;
 
@@ -27873,7 +27861,7 @@ int lua_ax_base_Director_getRenderer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27920,7 +27908,7 @@ int lua_ax_base_Director_getDeltaTime(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27967,7 +27955,7 @@ int lua_ax_base_Director_getFrameRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28014,7 +28002,7 @@ int lua_ax_base_Director_pushMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28064,7 +28052,7 @@ int lua_ax_base_Director_popMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28114,7 +28102,7 @@ int lua_ax_base_Director_loadIdentityMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28164,7 +28152,7 @@ int lua_ax_base_Director_loadMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::MATRIX_STACK_TYPE arg0;
         ax::Mat4 arg1;
@@ -28217,7 +28205,7 @@ int lua_ax_base_Director_multiplyMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::MATRIX_STACK_TYPE arg0;
         ax::Mat4 arg1;
@@ -28270,7 +28258,7 @@ int lua_ax_base_Director_getMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28320,7 +28308,7 @@ int lua_ax_base_Director_resetMatrixStack(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28367,7 +28355,7 @@ int lua_ax_base_Director_getAxmolThreadId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28414,7 +28402,7 @@ int lua_ax_base_Director_setChildrenIndexerEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -28464,7 +28452,7 @@ int lua_ax_base_Director_isChildrenIndexerEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28511,7 +28499,7 @@ int lua_ax_base_Director_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28716,7 +28704,7 @@ int lua_ax_base_Properties_getNextProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28763,7 +28751,7 @@ int lua_ax_base_Properties_getNextNamespace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28810,7 +28798,7 @@ int lua_ax_base_Properties_rewind(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28944,7 +28932,7 @@ int lua_ax_base_Properties_getId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28991,7 +28979,7 @@ int lua_ax_base_Properties_exists(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29041,7 +29029,7 @@ int lua_ax_base_Properties_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29052,7 +29040,7 @@ int lua_ax_base_Properties_getType(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29102,7 +29090,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29113,7 +29101,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29127,7 +29115,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -29180,7 +29168,7 @@ int lua_ax_base_Properties_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -29233,7 +29221,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29244,7 +29232,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29258,7 +29246,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         bool arg1;
@@ -29311,7 +29299,7 @@ int lua_ax_base_Properties_getInt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29322,7 +29310,7 @@ int lua_ax_base_Properties_getInt(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29372,7 +29360,7 @@ int lua_ax_base_Properties_getFloat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29383,7 +29371,7 @@ int lua_ax_base_Properties_getFloat(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29433,7 +29421,7 @@ int lua_ax_base_Properties_getMat4(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Mat4* arg1;
@@ -29486,7 +29474,7 @@ int lua_ax_base_Properties_getVec2(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Vec2* arg1;
@@ -29539,7 +29527,7 @@ int lua_ax_base_Properties_getVec3(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Vec3* arg1;
@@ -29592,7 +29580,7 @@ int lua_ax_base_Properties_getVec4(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Vec4* arg1;
@@ -29645,7 +29633,7 @@ int lua_ax_base_Properties_getQuaternionFromAxisAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Quaternion* arg1;
@@ -29698,7 +29686,7 @@ int lua_ax_base_Properties_getColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Color* arg1;
@@ -29752,7 +29740,7 @@ int lua_ax_base_Properties_getPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         std::string* arg1;
@@ -29806,7 +29794,7 @@ int lua_ax_base_Properties_getVariable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29820,7 +29808,7 @@ int lua_ax_base_Properties_getVariable(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -29873,7 +29861,7 @@ int lua_ax_base_Properties_setVariable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -30162,7 +30150,7 @@ int lua_ax_base_Timer_setupTimerWithInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         unsigned int arg1;
@@ -30218,7 +30206,7 @@ int lua_ax_base_Timer_setAborted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30265,7 +30253,7 @@ int lua_ax_base_Timer_isAborted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30312,7 +30300,7 @@ int lua_ax_base_Timer_isExhausted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30359,7 +30347,7 @@ int lua_ax_base_Timer_trigger(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -30409,7 +30397,7 @@ int lua_ax_base_Timer_cancel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30456,7 +30444,7 @@ int lua_ax_base_Timer_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -30532,7 +30520,7 @@ int lua_ax_base_Scheduler_getTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30579,7 +30567,7 @@ int lua_ax_base_Scheduler_setTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -30629,7 +30617,7 @@ int lua_ax_base_Scheduler_runOnAxmolThread(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -30683,7 +30671,7 @@ int lua_ax_base_Scheduler_removeAllPendingActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30717,7 +30705,7 @@ int lua_ax_base_Scheduler_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -31145,7 +31133,7 @@ int lua_ax_base_UserDefault_setBoolForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         bool arg1;
@@ -31198,7 +31186,7 @@ int lua_ax_base_UserDefault_setIntegerForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         int arg1;
@@ -31251,7 +31239,7 @@ int lua_ax_base_UserDefault_setLargeIntForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         long long arg1;
@@ -31304,7 +31292,7 @@ int lua_ax_base_UserDefault_setFloatForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         double arg1;
@@ -31357,7 +31345,7 @@ int lua_ax_base_UserDefault_setDoubleForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         double arg1;
@@ -31410,7 +31398,7 @@ int lua_ax_base_UserDefault_setStringForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         std::string_view arg1;
@@ -31463,7 +31451,7 @@ int lua_ax_base_UserDefault_flush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -31510,7 +31498,7 @@ int lua_ax_base_UserDefault_deleteValueForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -31560,7 +31548,7 @@ int lua_ax_base_UserDefault_setEncryptEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         bool arg0;
         std::string_view arg1;
@@ -31733,7 +31721,7 @@ int lua_ax_base_FileUtils_purgeCachedEntries(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -31780,7 +31768,7 @@ int lua_ax_base_FileUtils_getStringFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -31830,7 +31818,7 @@ int lua_ax_base_FileUtils_fullPathForFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -31880,7 +31868,7 @@ int lua_ax_base_FileUtils_fullPathFromRelativeFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -31933,7 +31921,7 @@ int lua_ax_base_FileUtils_fullPathForDirectory(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -31983,7 +31971,7 @@ int lua_ax_base_FileUtils_setSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::vector<std::string> arg0;
 
@@ -32033,7 +32021,7 @@ int lua_ax_base_FileUtils_getDefaultResourceRootPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32080,7 +32068,7 @@ int lua_ax_base_FileUtils_setDefaultResourceRootPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32130,7 +32118,7 @@ int lua_ax_base_FileUtils_addSearchPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32144,7 +32132,7 @@ int lua_ax_base_FileUtils_addSearchPath(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -32197,7 +32185,7 @@ int lua_ax_base_FileUtils_getSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32244,7 +32232,7 @@ int lua_ax_base_FileUtils_getOriginalSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32291,7 +32279,7 @@ int lua_ax_base_FileUtils_getWritablePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32338,7 +32326,7 @@ int lua_ax_base_FileUtils_getNativeWritableAbsolutePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32385,7 +32373,7 @@ int lua_ax_base_FileUtils_setWritablePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32435,7 +32423,7 @@ int lua_ax_base_FileUtils_setPopupNotify(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -32485,7 +32473,7 @@ int lua_ax_base_FileUtils_isPopupNotify(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32532,7 +32520,7 @@ int lua_ax_base_FileUtils_getValueMapFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32582,7 +32570,7 @@ int lua_ax_base_FileUtils_getValueMapFromData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         int arg1;
@@ -32635,7 +32623,7 @@ int lua_ax_base_FileUtils_writeToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -32688,7 +32676,7 @@ int lua_ax_base_FileUtils_writeStringToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -32741,7 +32729,7 @@ int lua_ax_base_FileUtils_writeValueMapToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -32794,7 +32782,7 @@ int lua_ax_base_FileUtils_writeValueVectorToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueVector arg0;
         std::string_view arg1;
@@ -32847,7 +32835,7 @@ int lua_ax_base_FileUtils_getValueVectorFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32897,7 +32885,7 @@ int lua_ax_base_FileUtils_isFileExist(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32947,7 +32935,7 @@ int lua_ax_base_FileUtils_isAbsolutePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32997,7 +32985,7 @@ int lua_ax_base_FileUtils_isDirectoryExist(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33047,7 +33035,7 @@ int lua_ax_base_FileUtils_createDirectories(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33097,7 +33085,7 @@ int lua_ax_base_FileUtils_removeDirectory(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33147,7 +33135,7 @@ int lua_ax_base_FileUtils_removeFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33264,7 +33252,7 @@ int lua_ax_base_FileUtils_getFileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33314,7 +33302,7 @@ int lua_ax_base_FileUtils_listFiles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33364,7 +33352,7 @@ int lua_ax_base_FileUtils_listFilesRecursively(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::vector<std::string>* arg1;
@@ -33417,7 +33405,7 @@ int lua_ax_base_FileUtils_isFileExistInternal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33467,7 +33455,7 @@ int lua_ax_base_FileUtils_isDirectoryExistInternal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33887,7 +33875,7 @@ int lua_ax_base_EventCustom_getEventName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -33921,7 +33909,7 @@ int lua_ax_base_EventCustom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33995,7 +33983,7 @@ int lua_ax_base_EventDispatcher_addEventListenerWithSceneGraphPriority(lua_State
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventListener* arg0;
         ax::Node* arg1;
@@ -34048,7 +34036,7 @@ int lua_ax_base_EventDispatcher_addEventListenerWithFixedPriority(lua_State* tol
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventListener* arg0;
         int arg1;
@@ -34101,7 +34089,7 @@ int lua_ax_base_EventDispatcher_addCustomEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::function<void (ax::EventCustom *)> arg1;
@@ -34158,7 +34146,7 @@ int lua_ax_base_EventDispatcher_removeEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventListener* arg0;
 
@@ -34208,7 +34196,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventListener::Type arg0;
 
@@ -34258,7 +34246,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForTarget(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -34272,7 +34260,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForTarget(lua_State* tolua_S
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -34325,7 +34313,7 @@ int lua_ax_base_EventDispatcher_removeCustomEventListeners(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -34375,7 +34363,7 @@ int lua_ax_base_EventDispatcher_removeAllEventListeners(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -34422,7 +34410,7 @@ int lua_ax_base_EventDispatcher_pauseEventListenersForTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -34436,7 +34424,7 @@ int lua_ax_base_EventDispatcher_pauseEventListenersForTarget(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -34489,7 +34477,7 @@ int lua_ax_base_EventDispatcher_resumeEventListenersForTarget(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -34503,7 +34491,7 @@ int lua_ax_base_EventDispatcher_resumeEventListenersForTarget(lua_State* tolua_S
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -34556,7 +34544,7 @@ int lua_ax_base_EventDispatcher_setPriority(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventListener* arg0;
         int arg1;
@@ -34609,7 +34597,7 @@ int lua_ax_base_EventDispatcher_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -34659,7 +34647,7 @@ int lua_ax_base_EventDispatcher_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -34706,7 +34694,7 @@ int lua_ax_base_EventDispatcher_dispatchEvent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Event* arg0;
 
@@ -34720,7 +34708,7 @@ int lua_ax_base_EventDispatcher_dispatchEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Event* arg0;
         bool arg1;
@@ -34773,7 +34761,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -34787,7 +34775,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         void* arg1;
@@ -34805,7 +34793,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         std::string_view arg0;
         void* arg1;
@@ -34862,7 +34850,7 @@ int lua_ax_base_EventDispatcher_hasEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -34899,7 +34887,7 @@ int lua_ax_base_EventDispatcher_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -34972,7 +34960,7 @@ int lua_ax_base_EventFocus_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ui::Widget* arg0;
         ax::ui::Widget* arg1;
@@ -35048,7 +35036,7 @@ int lua_ax_base_EventListenerAcceleration_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void (ax::Acceleration *, ax::Event *)> arg0;
 
@@ -35089,7 +35077,7 @@ int lua_ax_base_EventListenerAcceleration_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35160,7 +35148,7 @@ int lua_ax_base_EventListenerFocus_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35194,7 +35182,7 @@ int lua_ax_base_EventListenerFocus_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35265,7 +35253,7 @@ int lua_ax_base_EventListenerKeyboard_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35299,7 +35287,7 @@ int lua_ax_base_EventListenerKeyboard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35370,7 +35358,7 @@ int lua_ax_base_EventMouse_getMouseEventType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35417,7 +35405,7 @@ int lua_ax_base_EventMouse_setScrollData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -35470,7 +35458,7 @@ int lua_ax_base_EventMouse_getScrollX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35517,7 +35505,7 @@ int lua_ax_base_EventMouse_getScrollY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35564,7 +35552,7 @@ int lua_ax_base_EventMouse_setMouseInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -35620,7 +35608,7 @@ int lua_ax_base_EventMouse_setMouseButton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventMouse::MouseButton arg0;
 
@@ -35670,7 +35658,7 @@ int lua_ax_base_EventMouse_getMouseButton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35717,7 +35705,7 @@ int lua_ax_base_EventMouse_getLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35764,7 +35752,7 @@ int lua_ax_base_EventMouse_getPreviousLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35811,7 +35799,7 @@ int lua_ax_base_EventMouse_getStartLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35858,7 +35846,7 @@ int lua_ax_base_EventMouse_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35905,7 +35893,7 @@ int lua_ax_base_EventMouse_getLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35952,7 +35940,7 @@ int lua_ax_base_EventMouse_getPreviousLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35999,7 +35987,7 @@ int lua_ax_base_EventMouse_getStartLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36033,7 +36021,7 @@ int lua_ax_base_EventMouse_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventMouse::MouseEventType arg0;
 
@@ -36120,7 +36108,7 @@ int lua_ax_base_EventListenerMouse_setSwallowMouse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -36170,7 +36158,7 @@ int lua_ax_base_EventListenerMouse_isSwallowMouse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36217,7 +36205,7 @@ int lua_ax_base_EventListenerMouse_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36251,7 +36239,7 @@ int lua_ax_base_EventListenerMouse_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36343,7 +36331,7 @@ int lua_ax_base_EventListenerTouchOneByOne_setSwallowTouches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -36393,7 +36381,7 @@ int lua_ax_base_EventListenerTouchOneByOne_isSwallowTouches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36440,7 +36428,7 @@ int lua_ax_base_EventListenerTouchOneByOne_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36474,7 +36462,7 @@ int lua_ax_base_EventListenerTouchOneByOne_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36547,7 +36535,7 @@ int lua_ax_base_EventListenerTouchAllAtOnce_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36581,7 +36569,7 @@ int lua_ax_base_EventListenerTouchAllAtOnce_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36652,7 +36640,7 @@ int lua_ax_base_EventController_getControllerEventType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36699,7 +36687,7 @@ int lua_ax_base_EventController_getController(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36746,7 +36734,7 @@ int lua_ax_base_EventController_getKeyCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36793,7 +36781,7 @@ int lua_ax_base_EventController_setKeyCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -36843,7 +36831,7 @@ int lua_ax_base_EventController_setConnectStatus(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -36893,7 +36881,7 @@ int lua_ax_base_EventController_isConnected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37095,7 +37083,7 @@ int lua_ax_base_ActionCamera_getEye(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37142,7 +37130,7 @@ int lua_ax_base_ActionCamera_setCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -37192,7 +37180,7 @@ int lua_ax_base_ActionCamera_getCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37239,7 +37227,7 @@ int lua_ax_base_ActionCamera_setUp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -37289,7 +37277,7 @@ int lua_ax_base_ActionCamera_getUp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37323,7 +37311,7 @@ int lua_ax_base_ActionCamera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37399,7 +37387,7 @@ int lua_ax_base_OrbitCamera_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 7)
+    if (argc == 7) 
     {
         double arg0;
         double arg1;
@@ -37502,7 +37490,7 @@ int lua_ax_base_OrbitCamera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37574,7 +37562,7 @@ int lua_ax_base_CardinalSplineTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::PointArray* arg1;
@@ -37630,7 +37618,7 @@ int lua_ax_base_CardinalSplineTo_updatePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -37680,7 +37668,7 @@ int lua_ax_base_CardinalSplineTo_getPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37714,7 +37702,7 @@ int lua_ax_base_CardinalSplineTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37774,7 +37762,7 @@ int lua_ax_base_CardinalSplineBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37844,7 +37832,7 @@ int lua_ax_base_CatmullRomTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::PointArray* arg1;
@@ -37917,7 +37905,7 @@ int lua_ax_base_CatmullRomBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::PointArray* arg1;
@@ -37990,7 +37978,7 @@ int lua_ax_base_ActionEase_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38037,7 +38025,7 @@ int lua_ax_base_ActionEase_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -38108,7 +38096,7 @@ int lua_ax_base_EaseRateAction_setRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -38158,7 +38146,7 @@ int lua_ax_base_EaseRateAction_getRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38205,7 +38193,7 @@ int lua_ax_base_EaseRateAction_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -38342,7 +38330,7 @@ int lua_ax_base_EaseExponentialIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38436,7 +38424,7 @@ int lua_ax_base_EaseExponentialOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38530,7 +38518,7 @@ int lua_ax_base_EaseExponentialInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38624,7 +38612,7 @@ int lua_ax_base_EaseSineIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38718,7 +38706,7 @@ int lua_ax_base_EaseSineOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38812,7 +38800,7 @@ int lua_ax_base_EaseSineInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38925,7 +38913,7 @@ int lua_ax_base_EaseBounceIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39019,7 +39007,7 @@ int lua_ax_base_EaseBounceOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39113,7 +39101,7 @@ int lua_ax_base_EaseBounceInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39207,7 +39195,7 @@ int lua_ax_base_EaseBackIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39301,7 +39289,7 @@ int lua_ax_base_EaseBackOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39395,7 +39383,7 @@ int lua_ax_base_EaseBackInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39489,7 +39477,7 @@ int lua_ax_base_EaseQuadraticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39583,7 +39571,7 @@ int lua_ax_base_EaseQuadraticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39677,7 +39665,7 @@ int lua_ax_base_EaseQuadraticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39771,7 +39759,7 @@ int lua_ax_base_EaseQuarticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39865,7 +39853,7 @@ int lua_ax_base_EaseQuarticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39959,7 +39947,7 @@ int lua_ax_base_EaseQuarticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40053,7 +40041,7 @@ int lua_ax_base_EaseQuinticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40147,7 +40135,7 @@ int lua_ax_base_EaseQuinticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40241,7 +40229,7 @@ int lua_ax_base_EaseQuinticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40335,7 +40323,7 @@ int lua_ax_base_EaseCircleActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40429,7 +40417,7 @@ int lua_ax_base_EaseCircleActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40523,7 +40511,7 @@ int lua_ax_base_EaseCircleActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40617,7 +40605,7 @@ int lua_ax_base_EaseCubicActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40711,7 +40699,7 @@ int lua_ax_base_EaseCubicActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40805,7 +40793,7 @@ int lua_ax_base_EaseCubicActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40901,7 +40889,7 @@ int lua_ax_base_EaseIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40997,7 +40985,7 @@ int lua_ax_base_EaseOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41093,7 +41081,7 @@ int lua_ax_base_EaseInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41164,7 +41152,7 @@ int lua_ax_base_EaseElastic_getPeriod(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41211,7 +41199,7 @@ int lua_ax_base_EaseElastic_setPeriod(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -41261,7 +41249,7 @@ int lua_ax_base_EaseElastic_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -41275,7 +41263,7 @@ int lua_ax_base_EaseElastic_initWithAction(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -41388,7 +41376,7 @@ int lua_ax_base_EaseElasticIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41497,7 +41485,7 @@ int lua_ax_base_EaseElasticOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41606,7 +41594,7 @@ int lua_ax_base_EaseElasticInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41677,7 +41665,7 @@ int lua_ax_base_EaseBezierAction_setBezierParamer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -41759,7 +41747,7 @@ int lua_ax_base_EaseBezierAction_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41871,7 +41859,7 @@ int lua_ax_base_Show_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41963,7 +41951,7 @@ int lua_ax_base_Hide_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42055,7 +42043,7 @@ int lua_ax_base_ToggleVisibility_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42126,7 +42114,7 @@ int lua_ax_base_RemoveSelf_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -42210,7 +42198,7 @@ int lua_ax_base_RemoveSelf_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42282,7 +42270,7 @@ int lua_ax_base_FlipX_initWithFlipX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -42355,7 +42343,7 @@ int lua_ax_base_FlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42427,7 +42415,7 @@ int lua_ax_base_FlipY_initWithFlipY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -42500,7 +42488,7 @@ int lua_ax_base_FlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42572,7 +42560,7 @@ int lua_ax_base_Place_initWithPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -42645,7 +42633,7 @@ int lua_ax_base_Place_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42717,7 +42705,7 @@ int lua_ax_base_CallFunc_execute(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42751,7 +42739,7 @@ int lua_ax_base_CallFunc_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42822,7 +42810,7 @@ int lua_ax_base_GridAction_getGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42869,7 +42857,7 @@ int lua_ax_base_GridAction_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -42943,7 +42931,7 @@ int lua_ax_base_Grid3DAction_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43050,7 +43038,7 @@ int lua_ax_base_StopGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43121,7 +43109,7 @@ int lua_ax_base_ReuseGrid_initWithTimes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -43194,7 +43182,7 @@ int lua_ax_base_ReuseGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43266,7 +43254,7 @@ int lua_ax_base_Waves3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43313,7 +43301,7 @@ int lua_ax_base_Waves3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -43363,7 +43351,7 @@ int lua_ax_base_Waves3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43410,7 +43398,7 @@ int lua_ax_base_Waves3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -43460,7 +43448,7 @@ int lua_ax_base_Waves3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -43548,7 +43536,7 @@ int lua_ax_base_Waves3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43624,7 +43612,7 @@ int lua_ax_base_FlipX3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -43674,7 +43662,7 @@ int lua_ax_base_FlipX3D_initWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -43750,7 +43738,7 @@ int lua_ax_base_FlipX3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43846,7 +43834,7 @@ int lua_ax_base_FlipY3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43917,7 +43905,7 @@ int lua_ax_base_Lens3D_getLensEffect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43964,7 +43952,7 @@ int lua_ax_base_Lens3D_setLensEffect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -44014,7 +44002,7 @@ int lua_ax_base_Lens3D_setConcave(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -44064,7 +44052,7 @@ int lua_ax_base_Lens3D_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44111,7 +44099,7 @@ int lua_ax_base_Lens3D_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -44161,7 +44149,7 @@ int lua_ax_base_Lens3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44249,7 +44237,7 @@ int lua_ax_base_Lens3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44326,7 +44314,7 @@ int lua_ax_base_Ripple3D_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44373,7 +44361,7 @@ int lua_ax_base_Ripple3D_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -44423,7 +44411,7 @@ int lua_ax_base_Ripple3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44470,7 +44458,7 @@ int lua_ax_base_Ripple3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -44520,7 +44508,7 @@ int lua_ax_base_Ripple3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44567,7 +44555,7 @@ int lua_ax_base_Ripple3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -44617,7 +44605,7 @@ int lua_ax_base_Ripple3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44715,7 +44703,7 @@ int lua_ax_base_Ripple3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44793,7 +44781,7 @@ int lua_ax_base_Shaky3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44881,7 +44869,7 @@ int lua_ax_base_Shaky3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44953,7 +44941,7 @@ int lua_ax_base_Liquid_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45000,7 +44988,7 @@ int lua_ax_base_Liquid_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45050,7 +45038,7 @@ int lua_ax_base_Liquid_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45097,7 +45085,7 @@ int lua_ax_base_Liquid_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45147,7 +45135,7 @@ int lua_ax_base_Liquid_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45235,7 +45223,7 @@ int lua_ax_base_Liquid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45311,7 +45299,7 @@ int lua_ax_base_Waves_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45358,7 +45346,7 @@ int lua_ax_base_Waves_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45408,7 +45396,7 @@ int lua_ax_base_Waves_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45455,7 +45443,7 @@ int lua_ax_base_Waves_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45505,7 +45493,7 @@ int lua_ax_base_Waves_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45603,7 +45591,7 @@ int lua_ax_base_Waves_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45679,7 +45667,7 @@ int lua_ax_base_Twirl_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45726,7 +45714,7 @@ int lua_ax_base_Twirl_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -45776,7 +45764,7 @@ int lua_ax_base_Twirl_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45823,7 +45811,7 @@ int lua_ax_base_Twirl_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45873,7 +45861,7 @@ int lua_ax_base_Twirl_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45920,7 +45908,7 @@ int lua_ax_base_Twirl_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45970,7 +45958,7 @@ int lua_ax_base_Twirl_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -46063,7 +46051,7 @@ int lua_ax_base_Twirl_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46141,7 +46129,7 @@ int lua_ax_base_ActionManager_addAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Action* arg0;
         ax::Node* arg1;
@@ -46197,7 +46185,7 @@ int lua_ax_base_ActionManager_removeAllActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46244,7 +46232,7 @@ int lua_ax_base_ActionManager_removeAllActionsFromTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -46294,7 +46282,7 @@ int lua_ax_base_ActionManager_removeAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Action* arg0;
 
@@ -46344,7 +46332,7 @@ int lua_ax_base_ActionManager_removeActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         ax::Node* arg1;
@@ -46397,7 +46385,7 @@ int lua_ax_base_ActionManager_removeAllActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         ax::Node* arg1;
@@ -46450,7 +46438,7 @@ int lua_ax_base_ActionManager_removeActionsByFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::Node* arg1;
@@ -46503,7 +46491,7 @@ int lua_ax_base_ActionManager_getActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         const ax::Node* arg1;
@@ -46556,7 +46544,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActionsInTarget(lua_State* tolua
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const ax::Node* arg0;
 
@@ -46606,7 +46594,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46653,7 +46641,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActionsInTargetByTag(lua_State* 
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const ax::Node* arg0;
         int arg1;
@@ -46706,7 +46694,7 @@ int lua_ax_base_ActionManager_pauseTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -46756,7 +46744,7 @@ int lua_ax_base_ActionManager_resumeTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -46806,7 +46794,7 @@ int lua_ax_base_ActionManager_pauseAllRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46853,7 +46841,7 @@ int lua_ax_base_ActionManager_resumeTargets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::Node *> arg0;
 
@@ -46903,7 +46891,7 @@ int lua_ax_base_ActionManager_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -46940,7 +46928,7 @@ int lua_ax_base_ActionManager_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47084,7 +47072,7 @@ int lua_ax_base_ProgressTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -47162,7 +47150,7 @@ int lua_ax_base_ProgressTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47234,7 +47222,7 @@ int lua_ax_base_ProgressFromTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -47317,7 +47305,7 @@ int lua_ax_base_ProgressFromTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47389,7 +47377,7 @@ int lua_ax_base_ShakyTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47477,7 +47465,7 @@ int lua_ax_base_ShakyTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47549,7 +47537,7 @@ int lua_ax_base_ShatteredTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47637,7 +47625,7 @@ int lua_ax_base_ShatteredTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47709,7 +47697,7 @@ int lua_ax_base_ShuffleTiles_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -47759,7 +47747,7 @@ int lua_ax_base_ShuffleTiles_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47842,7 +47830,7 @@ int lua_ax_base_ShuffleTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47915,7 +47903,7 @@ int lua_ax_base_FadeOutTRTiles_testFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -47968,7 +47956,7 @@ int lua_ax_base_FadeOutTRTiles_turnOnTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48018,7 +48006,7 @@ int lua_ax_base_FadeOutTRTiles_turnOffTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48068,7 +48056,7 @@ int lua_ax_base_FadeOutTRTiles_transformTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -48146,7 +48134,7 @@ int lua_ax_base_FadeOutTRTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48246,7 +48234,7 @@ int lua_ax_base_FadeOutBLTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48342,7 +48330,7 @@ int lua_ax_base_FadeOutUpTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48438,7 +48426,7 @@ int lua_ax_base_FadeOutDownTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48509,7 +48497,7 @@ int lua_ax_base_TurnOffTiles_turnOnTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48559,7 +48547,7 @@ int lua_ax_base_TurnOffTiles_turnOffTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48609,7 +48597,7 @@ int lua_ax_base_TurnOffTiles_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -48653,7 +48641,7 @@ int lua_ax_base_TurnOffTiles_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -48672,7 +48660,7 @@ int lua_ax_base_TurnOffTiles_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -48709,7 +48697,7 @@ int lua_ax_base_TurnOffTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48783,7 +48771,7 @@ int lua_ax_base_WavesTiles3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48830,7 +48818,7 @@ int lua_ax_base_WavesTiles3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -48880,7 +48868,7 @@ int lua_ax_base_WavesTiles3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48927,7 +48915,7 @@ int lua_ax_base_WavesTiles3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -48977,7 +48965,7 @@ int lua_ax_base_WavesTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -49065,7 +49053,7 @@ int lua_ax_base_WavesTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49141,7 +49129,7 @@ int lua_ax_base_JumpTiles3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49188,7 +49176,7 @@ int lua_ax_base_JumpTiles3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -49238,7 +49226,7 @@ int lua_ax_base_JumpTiles3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49285,7 +49273,7 @@ int lua_ax_base_JumpTiles3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -49335,7 +49323,7 @@ int lua_ax_base_JumpTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -49423,7 +49411,7 @@ int lua_ax_base_JumpTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49499,7 +49487,7 @@ int lua_ax_base_SplitRows_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         unsigned int arg1;
@@ -49577,7 +49565,7 @@ int lua_ax_base_SplitRows_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49649,7 +49637,7 @@ int lua_ax_base_SplitCols_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         unsigned int arg1;
@@ -49727,7 +49715,7 @@ int lua_ax_base_SplitCols_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49799,7 +49787,7 @@ int lua_ax_base_ActionTween_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         std::string_view arg1;
@@ -49921,7 +49909,7 @@ int lua_ax_base_ActionCoroutine_initWithCoroutine(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<ax::Coroutine ()> arg0;
 
@@ -50002,7 +49990,7 @@ int lua_ax_base_ActionCoroutine_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50074,7 +50062,7 @@ int lua_ax_base_AtlasNode_updateAtlasValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50121,7 +50109,7 @@ int lua_ax_base_AtlasNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50168,7 +50156,7 @@ int lua_ax_base_AtlasNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -50218,7 +50206,7 @@ int lua_ax_base_AtlasNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -50268,7 +50256,7 @@ int lua_ax_base_AtlasNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50315,7 +50303,7 @@ int lua_ax_base_AtlasNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -50365,7 +50353,7 @@ int lua_ax_base_AtlasNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50412,7 +50400,7 @@ int lua_ax_base_AtlasNode_setQuadsToDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -50462,7 +50450,7 @@ int lua_ax_base_AtlasNode_getQuadsToDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50509,7 +50497,7 @@ int lua_ax_base_AtlasNode_initWithTileFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         int arg1;
@@ -50568,7 +50556,7 @@ int lua_ax_base_AtlasNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Texture2D* arg0;
         int arg1;
@@ -50656,7 +50644,7 @@ int lua_ax_base_AtlasNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50738,7 +50726,7 @@ int lua_ax_base_ClippingNode_getStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50785,7 +50773,7 @@ int lua_ax_base_ClippingNode_setStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -50799,7 +50787,7 @@ int lua_ax_base_ClippingNode_setStencil(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -50852,7 +50840,7 @@ int lua_ax_base_ClippingNode_hasContent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50899,7 +50887,7 @@ int lua_ax_base_ClippingNode_getAlphaThreshold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50946,7 +50934,7 @@ int lua_ax_base_ClippingNode_setAlphaThreshold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -50996,7 +50984,7 @@ int lua_ax_base_ClippingNode_isInverted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51043,7 +51031,7 @@ int lua_ax_base_ClippingNode_setInverted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -51093,7 +51081,7 @@ int lua_ax_base_ClippingNode_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -51131,7 +51119,7 @@ int lua_ax_base_ClippingNode_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -51144,7 +51132,7 @@ int lua_ax_base_ClippingNode_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -51216,7 +51204,7 @@ int lua_ax_base_ClippingRectangleNode_getClippingRegion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51263,7 +51251,7 @@ int lua_ax_base_ClippingRectangleNode_setClippingRegion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -51313,7 +51301,7 @@ int lua_ax_base_ClippingRectangleNode_isClippingEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51360,7 +51348,7 @@ int lua_ax_base_ClippingRectangleNode_setClippingEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -51398,7 +51386,7 @@ int lua_ax_base_ClippingRectangleNode_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -51408,7 +51396,7 @@ int lua_ax_base_ClippingRectangleNode_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -51479,7 +51467,7 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -51499,7 +51487,7 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -51558,7 +51546,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51578,7 +51566,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51601,7 +51589,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51627,7 +51615,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52010,7 +51998,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52036,7 +52024,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52101,7 +52089,7 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52130,7 +52118,7 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 7)
+    if (argc == 7) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52198,7 +52186,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52224,7 +52212,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52289,7 +52277,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52318,7 +52306,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 7)
+    if (argc == 7) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52386,7 +52374,7 @@ int lua_ax_base_DrawNode_drawDot(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52442,7 +52430,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52462,7 +52450,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52485,7 +52473,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52993,7 +52981,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53016,7 +53004,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53042,7 +53030,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53107,7 +53095,7 @@ int lua_ax_base_DrawNode_drawColoredTriangle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const ax::Vec2* arg0;
         const ax::Color* arg1;
@@ -53367,7 +53355,7 @@ int lua_ax_base_DrawNode_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53414,7 +53402,7 @@ int lua_ax_base_DrawNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53461,7 +53449,7 @@ int lua_ax_base_DrawNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -53511,7 +53499,7 @@ int lua_ax_base_DrawNode_setIsolated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -53561,7 +53549,7 @@ int lua_ax_base_DrawNode_isIsolated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53629,7 +53617,7 @@ int lua_ax_base_DrawNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53721,7 +53709,7 @@ int lua_ax_base_Label_setTTFConfig(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::_ttfConfig arg0;
 
@@ -53771,7 +53759,7 @@ int lua_ax_base_Label_getTTFConfig(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53957,7 +53945,7 @@ int lua_ax_base_Label_getBMFontFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54095,7 +54083,7 @@ int lua_ax_base_Label_setSystemFontName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -54145,7 +54133,7 @@ int lua_ax_base_Label_getSystemFontName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54192,7 +54180,7 @@ int lua_ax_base_Label_setSystemFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -54242,7 +54230,7 @@ int lua_ax_base_Label_getSystemFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54289,7 +54277,7 @@ int lua_ax_base_Label_requestSystemFontRefresh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54336,7 +54324,7 @@ int lua_ax_base_Label_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -54386,7 +54374,7 @@ int lua_ax_base_Label_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54433,7 +54421,7 @@ int lua_ax_base_Label_getStringNumLines(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54480,7 +54468,7 @@ int lua_ax_base_Label_getStringLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54527,7 +54515,7 @@ int lua_ax_base_Label_setTextColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54577,7 +54565,7 @@ int lua_ax_base_Label_getTextColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54624,7 +54612,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54635,7 +54623,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54649,7 +54637,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -54666,7 +54654,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -54722,7 +54710,7 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54736,7 +54724,7 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Color32 arg0;
         int arg1;
@@ -54789,7 +54777,7 @@ int lua_ax_base_Label_enableGlow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54839,7 +54827,7 @@ int lua_ax_base_Label_enableItalics(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54886,7 +54874,7 @@ int lua_ax_base_Label_enableBold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54933,7 +54921,7 @@ int lua_ax_base_Label_enableUnderline(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54980,7 +54968,7 @@ int lua_ax_base_Label_enableStrikethrough(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55078,7 +55066,7 @@ int lua_ax_base_Label_isShadowEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55125,7 +55113,7 @@ int lua_ax_base_Label_getShadowOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55172,7 +55160,7 @@ int lua_ax_base_Label_getShadowBlurRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55219,7 +55207,7 @@ int lua_ax_base_Label_getShadowColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55266,7 +55254,7 @@ int lua_ax_base_Label_getOutlineSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55313,7 +55301,7 @@ int lua_ax_base_Label_getLabelEffectType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55360,7 +55348,7 @@ int lua_ax_base_Label_getEffectColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55466,7 +55454,7 @@ int lua_ax_base_Label_getTextAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55513,7 +55501,7 @@ int lua_ax_base_Label_setHorizontalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextHAlignment arg0;
 
@@ -55563,7 +55551,7 @@ int lua_ax_base_Label_getHorizontalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55610,7 +55598,7 @@ int lua_ax_base_Label_setVerticalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextVAlignment arg0;
 
@@ -55660,7 +55648,7 @@ int lua_ax_base_Label_getVerticalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55707,7 +55695,7 @@ int lua_ax_base_Label_setLineBreakWithoutSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -55757,7 +55745,7 @@ int lua_ax_base_Label_setMaxLineWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -55807,7 +55795,7 @@ int lua_ax_base_Label_getMaxLineWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55854,7 +55842,7 @@ int lua_ax_base_Label_setTTFFaceSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -55904,7 +55892,7 @@ int lua_ax_base_Label_getTTFFaceSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55951,7 +55939,7 @@ int lua_ax_base_Label_setBMFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56001,7 +55989,7 @@ int lua_ax_base_Label_getBMFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56048,7 +56036,7 @@ int lua_ax_base_Label_enableWrap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -56098,7 +56086,7 @@ int lua_ax_base_Label_isWrapEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56145,7 +56133,7 @@ int lua_ax_base_Label_setOverflow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Label::Overflow arg0;
 
@@ -56195,7 +56183,7 @@ int lua_ax_base_Label_getOverflow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56242,7 +56230,7 @@ int lua_ax_base_Label_setWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56292,7 +56280,7 @@ int lua_ax_base_Label_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56339,7 +56327,7 @@ int lua_ax_base_Label_setHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56389,7 +56377,7 @@ int lua_ax_base_Label_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56436,7 +56424,7 @@ int lua_ax_base_Label_setDimensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -56489,7 +56477,7 @@ int lua_ax_base_Label_getDimensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56536,7 +56524,7 @@ int lua_ax_base_Label_updateContent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56583,7 +56571,7 @@ int lua_ax_base_Label_getLetter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -56633,7 +56621,7 @@ int lua_ax_base_Label_setClipMarginEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -56683,7 +56671,7 @@ int lua_ax_base_Label_isClipMarginEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56730,7 +56718,7 @@ int lua_ax_base_Label_setLineHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56780,7 +56768,7 @@ int lua_ax_base_Label_getLineHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56827,7 +56815,7 @@ int lua_ax_base_Label_setLineSpacing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56877,7 +56865,7 @@ int lua_ax_base_Label_getLineSpacing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56924,7 +56912,7 @@ int lua_ax_base_Label_getLabelType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56971,7 +56959,7 @@ int lua_ax_base_Label_getRenderingFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57018,7 +57006,7 @@ int lua_ax_base_Label_setAdditionalKerning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -57068,7 +57056,7 @@ int lua_ax_base_Label_getAdditionalKerning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57115,7 +57103,7 @@ int lua_ax_base_Label_getFontAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57162,7 +57150,7 @@ int lua_ax_base_Label_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57209,7 +57197,7 @@ int lua_ax_base_Label_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -57259,7 +57247,7 @@ int lua_ax_base_Label_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -57629,7 +57617,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 6)
         {
@@ -57657,7 +57645,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -57673,7 +57661,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -57692,7 +57680,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -57714,7 +57702,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -57761,7 +57749,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -57783,7 +57771,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -57805,7 +57793,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -58049,7 +58037,7 @@ int lua_ax_base_LabelAtlas_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -58099,7 +58087,7 @@ int lua_ax_base_LabelAtlas_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58134,7 +58122,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -58150,7 +58138,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -58175,7 +58163,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -58221,7 +58209,7 @@ int lua_ax_base_LabelAtlas_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58295,7 +58283,7 @@ int lua_ax_base_Sprite_getBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58342,7 +58330,7 @@ int lua_ax_base_Sprite_setBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteBatchNode* arg0;
 
@@ -58447,7 +58435,7 @@ int lua_ax_base_Sprite_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58557,7 +58545,7 @@ int lua_ax_base_Sprite_setVertexRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -58607,7 +58595,7 @@ int lua_ax_base_Sprite_setCenterRectNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -58657,7 +58645,7 @@ int lua_ax_base_Sprite_getCenterRectNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58704,7 +58692,7 @@ int lua_ax_base_Sprite_setCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -58754,7 +58742,7 @@ int lua_ax_base_Sprite_getCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58856,7 +58844,7 @@ int lua_ax_base_Sprite_isFrameDisplayed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -58906,7 +58894,7 @@ int lua_ax_base_Sprite_getSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58953,7 +58941,7 @@ int lua_ax_base_Sprite_setDisplayFrameWithAnimationName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         unsigned int arg1;
@@ -59006,7 +58994,7 @@ int lua_ax_base_Sprite_isDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59053,7 +59041,7 @@ int lua_ax_base_Sprite_setDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59103,7 +59091,7 @@ int lua_ax_base_Sprite_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59153,7 +59141,7 @@ int lua_ax_base_Sprite_isTextureRectRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59200,7 +59188,7 @@ int lua_ax_base_Sprite_getAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59247,7 +59235,7 @@ int lua_ax_base_Sprite_setAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -59297,7 +59285,7 @@ int lua_ax_base_Sprite_getTextureRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59344,7 +59332,7 @@ int lua_ax_base_Sprite_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59391,7 +59379,7 @@ int lua_ax_base_Sprite_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -59441,7 +59429,7 @@ int lua_ax_base_Sprite_getOffsetPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59488,7 +59476,7 @@ int lua_ax_base_Sprite_isFlippedX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59535,7 +59523,7 @@ int lua_ax_base_Sprite_setFlippedX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59585,7 +59573,7 @@ int lua_ax_base_Sprite_isFlippedY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59632,7 +59620,7 @@ int lua_ax_base_Sprite_setFlippedY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59682,7 +59670,7 @@ int lua_ax_base_Sprite_setStretchEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59732,7 +59720,7 @@ int lua_ax_base_Sprite_isStretchEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59779,7 +59767,7 @@ int lua_ax_base_Sprite_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -59829,7 +59817,7 @@ int lua_ax_base_Sprite_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59876,7 +59864,7 @@ int lua_ax_base_Sprite_getResourceType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59923,7 +59911,7 @@ int lua_ax_base_Sprite_getResourceName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60049,7 +60037,7 @@ int lua_ax_base_Sprite_initWithSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -60099,7 +60087,7 @@ int lua_ax_base_Sprite_initWithSpriteFrameName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -60224,7 +60212,7 @@ int lua_ax_base_Sprite_initWithImageData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Data arg0;
         std::string_view arg1;
@@ -60277,7 +60265,7 @@ int lua_ax_base_Sprite_setVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60324,7 +60312,7 @@ int lua_ax_base_Sprite_setAutoUpdatePS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -60374,7 +60362,7 @@ int lua_ax_base_Sprite_setAutoSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -60412,7 +60400,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -60428,7 +60416,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -60447,7 +60435,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -60553,7 +60541,7 @@ int lua_ax_base_Sprite_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60722,7 +60710,7 @@ int lua_ax_base_LayerColor_changeWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -60772,7 +60760,7 @@ int lua_ax_base_LayerColor_changeHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -60822,7 +60810,7 @@ int lua_ax_base_LayerColor_changeWidthAndHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -60926,7 +60914,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -60945,7 +60933,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -60955,7 +60943,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -60989,7 +60977,7 @@ int lua_ax_base_LayerColor_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61064,7 +61052,7 @@ int lua_ax_base_LayerGradient_setCompressedInterpolation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -61114,7 +61102,7 @@ int lua_ax_base_LayerGradient_isCompressedInterpolation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61161,7 +61149,7 @@ int lua_ax_base_LayerGradient_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -61211,7 +61199,7 @@ int lua_ax_base_LayerGradient_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61258,7 +61246,7 @@ int lua_ax_base_LayerGradient_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -61308,7 +61296,7 @@ int lua_ax_base_LayerGradient_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61355,7 +61343,7 @@ int lua_ax_base_LayerGradient_setStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -61405,7 +61393,7 @@ int lua_ax_base_LayerGradient_getStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61452,7 +61440,7 @@ int lua_ax_base_LayerGradient_setEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -61502,7 +61490,7 @@ int lua_ax_base_LayerGradient_getEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61549,7 +61537,7 @@ int lua_ax_base_LayerGradient_setVector(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -61599,7 +61587,7 @@ int lua_ax_base_LayerGradient_getVector(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61701,7 +61689,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -61717,7 +61705,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -61727,7 +61715,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -61767,7 +61755,7 @@ int lua_ax_base_LayerGradient_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61851,7 +61839,7 @@ int lua_ax_base_LayerRadialGradient_setStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -61901,7 +61889,7 @@ int lua_ax_base_LayerRadialGradient_getStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61948,7 +61936,7 @@ int lua_ax_base_LayerRadialGradient_setEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -61998,7 +61986,7 @@ int lua_ax_base_LayerRadialGradient_getEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62045,7 +62033,7 @@ int lua_ax_base_LayerRadialGradient_setRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -62095,7 +62083,7 @@ int lua_ax_base_LayerRadialGradient_getRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62142,7 +62130,7 @@ int lua_ax_base_LayerRadialGradient_setCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -62192,7 +62180,7 @@ int lua_ax_base_LayerRadialGradient_getCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62239,7 +62227,7 @@ int lua_ax_base_LayerRadialGradient_setExpand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -62289,7 +62277,7 @@ int lua_ax_base_LayerRadialGradient_getExpand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62336,7 +62324,7 @@ int lua_ax_base_LayerRadialGradient_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -62386,7 +62374,7 @@ int lua_ax_base_LayerRadialGradient_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62433,7 +62421,7 @@ int lua_ax_base_LayerRadialGradient_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -62483,7 +62471,7 @@ int lua_ax_base_LayerRadialGradient_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62530,7 +62518,7 @@ int lua_ax_base_LayerRadialGradient_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -62580,7 +62568,7 @@ int lua_ax_base_LayerRadialGradient_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62627,7 +62615,7 @@ int lua_ax_base_LayerRadialGradient_initWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Color32 arg0;
         ax::Color32 arg1;
@@ -62677,7 +62665,7 @@ int lua_ax_base_LayerRadialGradient_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -62687,7 +62675,7 @@ int lua_ax_base_LayerRadialGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -62733,7 +62721,7 @@ int lua_ax_base_LayerRadialGradient_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62821,7 +62809,7 @@ int lua_ax_base_LayerMultiplex_addLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -62930,7 +62918,7 @@ int lua_ax_base_LayerMultiplex_switchToAndReleaseMe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -62980,7 +62968,7 @@ int lua_ax_base_LayerMultiplex_initWithArray(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::Node *> arg0;
 
@@ -63017,7 +63005,7 @@ int lua_ax_base_LayerMultiplex_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63091,7 +63079,7 @@ int lua_ax_base_MenuItem_rect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63138,7 +63126,7 @@ int lua_ax_base_MenuItem_activate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63185,7 +63173,7 @@ int lua_ax_base_MenuItem_selected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63232,7 +63220,7 @@ int lua_ax_base_MenuItem_unselected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63279,7 +63267,7 @@ int lua_ax_base_MenuItem_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63326,7 +63314,7 @@ int lua_ax_base_MenuItem_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -63376,7 +63364,7 @@ int lua_ax_base_MenuItem_isSelected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63410,7 +63398,7 @@ int lua_ax_base_MenuItem_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63487,7 +63475,7 @@ int lua_ax_base_MenuItemLabel_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -63537,7 +63525,7 @@ int lua_ax_base_MenuItemLabel_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63584,7 +63572,7 @@ int lua_ax_base_MenuItemLabel_getDisabledColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63631,7 +63619,7 @@ int lua_ax_base_MenuItemLabel_setDisabledColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -63681,7 +63669,7 @@ int lua_ax_base_MenuItemLabel_getLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63728,7 +63716,7 @@ int lua_ax_base_MenuItemLabel_setLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -63778,7 +63766,7 @@ int lua_ax_base_MenuItemLabel_initWithLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         std::function<void (ax::Object *)> arg1;
@@ -63822,7 +63810,7 @@ int lua_ax_base_MenuItemLabel_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63899,7 +63887,7 @@ int lua_ax_base_MenuItemAtlasFont_initWithString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -63955,7 +63943,7 @@ int lua_ax_base_MenuItemAtlasFont_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64026,7 +64014,7 @@ int lua_ax_base_MenuItemFont_setFontSizeObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -64076,7 +64064,7 @@ int lua_ax_base_MenuItemFont_getFontSizeObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64123,7 +64111,7 @@ int lua_ax_base_MenuItemFont_setFontNameObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -64173,7 +64161,7 @@ int lua_ax_base_MenuItemFont_getFontNameObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64220,7 +64208,7 @@ int lua_ax_base_MenuItemFont_initWithString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::function<void (ax::Object *)> arg1;
@@ -64404,7 +64392,7 @@ int lua_ax_base_MenuItemFont_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64483,7 +64471,7 @@ int lua_ax_base_MenuItemSprite_getNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64530,7 +64518,7 @@ int lua_ax_base_MenuItemSprite_setNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -64580,7 +64568,7 @@ int lua_ax_base_MenuItemSprite_getSelectedImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64627,7 +64615,7 @@ int lua_ax_base_MenuItemSprite_setSelectedImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -64677,7 +64665,7 @@ int lua_ax_base_MenuItemSprite_getDisabledImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64724,7 +64712,7 @@ int lua_ax_base_MenuItemSprite_setDisabledImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -64774,7 +64762,7 @@ int lua_ax_base_MenuItemSprite_selected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64821,7 +64809,7 @@ int lua_ax_base_MenuItemSprite_unselected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64868,7 +64856,7 @@ int lua_ax_base_MenuItemSprite_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -64918,7 +64906,7 @@ int lua_ax_base_MenuItemSprite_initWithNormalSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Node* arg0;
         ax::Node* arg1;
@@ -64968,7 +64956,7 @@ int lua_ax_base_MenuItemSprite_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65048,7 +65036,7 @@ int lua_ax_base_MenuItemImage_setNormalSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -65098,7 +65086,7 @@ int lua_ax_base_MenuItemImage_setSelectedSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -65148,7 +65136,7 @@ int lua_ax_base_MenuItemImage_setDisabledSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -65198,7 +65186,7 @@ int lua_ax_base_MenuItemImage_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65245,7 +65233,7 @@ int lua_ax_base_MenuItemImage_initWithNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -65295,7 +65283,7 @@ int lua_ax_base_MenuItemImage_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65370,7 +65358,7 @@ int lua_ax_base_MenuItemToggle_addSubItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MenuItem* arg0;
 
@@ -65420,7 +65408,7 @@ int lua_ax_base_MenuItemToggle_getSelectedItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65467,7 +65455,7 @@ int lua_ax_base_MenuItemToggle_getSelectedIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65514,7 +65502,7 @@ int lua_ax_base_MenuItemToggle_setSelectedIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -65564,7 +65552,7 @@ int lua_ax_base_MenuItemToggle_setSubItems(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::MenuItem *> arg0;
 
@@ -65614,7 +65602,7 @@ int lua_ax_base_MenuItemToggle_initWithItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MenuItem* arg0;
 
@@ -65651,7 +65639,7 @@ int lua_ax_base_MenuItemToggle_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65727,7 +65715,7 @@ int lua_ax_base_Menu_alignItemsVertically(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65774,7 +65762,7 @@ int lua_ax_base_Menu_alignItemsVerticallyWithPadding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -65824,7 +65812,7 @@ int lua_ax_base_Menu_alignItemsHorizontally(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65871,7 +65859,7 @@ int lua_ax_base_Menu_alignItemsHorizontallyWithPadding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -65921,7 +65909,7 @@ int lua_ax_base_Menu_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65968,7 +65956,7 @@ int lua_ax_base_Menu_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -66018,7 +66006,7 @@ int lua_ax_base_Menu_initWithArray(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::MenuItem *> arg0;
 
@@ -66055,7 +66043,7 @@ int lua_ax_base_Menu_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66132,7 +66120,7 @@ int lua_ax_base_MotionStreak_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66179,7 +66167,7 @@ int lua_ax_base_MotionStreak_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -66229,7 +66217,7 @@ int lua_ax_base_MotionStreak_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -66279,7 +66267,7 @@ int lua_ax_base_MotionStreak_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66326,7 +66314,7 @@ int lua_ax_base_MotionStreak_tintWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -66376,7 +66364,7 @@ int lua_ax_base_MotionStreak_reset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66423,7 +66411,7 @@ int lua_ax_base_MotionStreak_isFastMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66470,7 +66458,7 @@ int lua_ax_base_MotionStreak_setFastMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -66520,7 +66508,7 @@ int lua_ax_base_MotionStreak_getStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66567,7 +66555,7 @@ int lua_ax_base_MotionStreak_setStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -66617,7 +66605,7 @@ int lua_ax_base_MotionStreak_isStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66664,7 +66652,7 @@ int lua_ax_base_MotionStreak_setStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -66789,7 +66777,7 @@ int lua_ax_base_MotionStreak_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -66814,7 +66802,7 @@ int lua_ax_base_MotionStreak_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -66860,7 +66848,7 @@ int lua_ax_base_MotionStreak_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66991,7 +66979,7 @@ int lua_ax_base_NodeGrid_setGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::GridBase* arg0;
 
@@ -67041,7 +67029,7 @@ int lua_ax_base_NodeGrid_setTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -67091,7 +67079,7 @@ int lua_ax_base_NodeGrid_setGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -67141,7 +67129,7 @@ int lua_ax_base_NodeGrid_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67176,7 +67164,7 @@ int lua_ax_base_NodeGrid_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -67189,7 +67177,7 @@ int lua_ax_base_NodeGrid_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -67220,7 +67208,7 @@ int lua_ax_base_NodeGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67296,7 +67284,7 @@ int lua_ax_base_ParticleBatchNode_insertChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ParticleSystem* arg0;
         int arg1;
@@ -67349,7 +67337,7 @@ int lua_ax_base_ParticleBatchNode_removeChildAtIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         bool arg1;
@@ -67402,7 +67390,7 @@ int lua_ax_base_ParticleBatchNode_removeAllChildrenWithCleanup(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -67452,7 +67440,7 @@ int lua_ax_base_ParticleBatchNode_disableParticle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -67502,7 +67490,7 @@ int lua_ax_base_ParticleBatchNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67549,7 +67537,7 @@ int lua_ax_base_ParticleBatchNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -67599,7 +67587,7 @@ int lua_ax_base_ParticleBatchNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67646,7 +67634,7 @@ int lua_ax_base_ParticleBatchNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -67696,7 +67684,7 @@ int lua_ax_base_ParticleBatchNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -67746,7 +67734,7 @@ int lua_ax_base_ParticleBatchNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67793,7 +67781,7 @@ int lua_ax_base_ParticleBatchNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         int arg1;
@@ -67846,7 +67834,7 @@ int lua_ax_base_ParticleBatchNode_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         int arg1;
@@ -67988,7 +67976,7 @@ int lua_ax_base_ParticleBatchNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68091,7 +68079,7 @@ int lua_ax_base_SpriteFrameCache_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68269,7 +68257,7 @@ int lua_ax_base_SpriteFrameCache_addSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::SpriteFrame* arg0;
         std::string_view arg1;
@@ -68322,7 +68310,7 @@ int lua_ax_base_SpriteFrameCache_isSpriteFramesWithFileLoaded(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68372,7 +68360,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68419,7 +68407,7 @@ int lua_ax_base_SpriteFrameCache_removeUnusedSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68466,7 +68454,7 @@ int lua_ax_base_SpriteFrameCache_removeUnusedSpriteSheets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68513,7 +68501,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFrameByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68563,7 +68551,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68613,7 +68601,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromFileContent(lua_State* to
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68663,7 +68651,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromTexture(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -68713,7 +68701,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteFrameByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68763,7 +68751,7 @@ int lua_ax_base_SpriteFrameCache_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68813,7 +68801,7 @@ int lua_ax_base_SpriteFrameCache_findFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68863,7 +68851,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteFrameName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -68913,7 +68901,7 @@ int lua_ax_base_SpriteFrameCache_eraseFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68963,7 +68951,7 @@ int lua_ax_base_SpriteFrameCache_addSpriteFrameCapInset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::SpriteFrame* arg0;
         ax::Rect arg1;
@@ -69019,7 +69007,7 @@ int lua_ax_base_SpriteFrameCache_deregisterSpriteSheetLoader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -69069,7 +69057,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteSheetLoader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -69227,7 +69215,7 @@ int lua_ax_base_ParticleData_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -69277,7 +69265,7 @@ int lua_ax_base_ParticleData_release(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69324,7 +69312,7 @@ int lua_ax_base_ParticleData_getMaxCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69371,7 +69359,7 @@ int lua_ax_base_ParticleData_copyParticle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         int arg1;
@@ -69411,7 +69399,7 @@ int lua_ax_base_ParticleData_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69745,7 +69733,7 @@ int lua_ax_base_ParticleEmissionMaskCache_removeMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -69795,7 +69783,7 @@ int lua_ax_base_ParticleEmissionMaskCache_removeAllMasks(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69900,7 +69888,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -69914,7 +69902,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         int arg1;
@@ -69931,7 +69919,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         int arg0;
         int arg1;
@@ -69987,7 +69975,7 @@ int lua_ax_base_ParticleSystem_stopSystem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70034,7 +70022,7 @@ int lua_ax_base_ParticleSystem_resetSystem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70081,7 +70069,7 @@ int lua_ax_base_ParticleSystem_isFull(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70128,7 +70116,7 @@ int lua_ax_base_ParticleSystem_updateParticleQuads(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70175,7 +70163,7 @@ int lua_ax_base_ParticleSystem_postStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70222,7 +70210,7 @@ int lua_ax_base_ParticleSystem_updateWithNoTime(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70269,7 +70257,7 @@ int lua_ax_base_ParticleSystem_isAutoRemoveOnFinish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70316,7 +70304,7 @@ int lua_ax_base_ParticleSystem_setAutoRemoveOnFinish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -70366,7 +70354,7 @@ int lua_ax_base_ParticleSystem_getGravity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70413,7 +70401,7 @@ int lua_ax_base_ParticleSystem_setGravity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -70463,7 +70451,7 @@ int lua_ax_base_ParticleSystem_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70510,7 +70498,7 @@ int lua_ax_base_ParticleSystem_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70560,7 +70548,7 @@ int lua_ax_base_ParticleSystem_getSpeedVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70607,7 +70595,7 @@ int lua_ax_base_ParticleSystem_setSpeedVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70657,7 +70645,7 @@ int lua_ax_base_ParticleSystem_getTangentialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70704,7 +70692,7 @@ int lua_ax_base_ParticleSystem_setTangentialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70754,7 +70742,7 @@ int lua_ax_base_ParticleSystem_getTangentialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70801,7 +70789,7 @@ int lua_ax_base_ParticleSystem_setTangentialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70851,7 +70839,7 @@ int lua_ax_base_ParticleSystem_getRadialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70898,7 +70886,7 @@ int lua_ax_base_ParticleSystem_setRadialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70948,7 +70936,7 @@ int lua_ax_base_ParticleSystem_getRadialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70995,7 +70983,7 @@ int lua_ax_base_ParticleSystem_setRadialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71045,7 +71033,7 @@ int lua_ax_base_ParticleSystem_getRotationIsDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71092,7 +71080,7 @@ int lua_ax_base_ParticleSystem_setRotationIsDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -71142,7 +71130,7 @@ int lua_ax_base_ParticleSystem_getStartRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71189,7 +71177,7 @@ int lua_ax_base_ParticleSystem_setStartRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71239,7 +71227,7 @@ int lua_ax_base_ParticleSystem_getStartRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71286,7 +71274,7 @@ int lua_ax_base_ParticleSystem_setStartRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71336,7 +71324,7 @@ int lua_ax_base_ParticleSystem_getEndRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71383,7 +71371,7 @@ int lua_ax_base_ParticleSystem_setEndRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71433,7 +71421,7 @@ int lua_ax_base_ParticleSystem_getEndRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71480,7 +71468,7 @@ int lua_ax_base_ParticleSystem_setEndRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71530,7 +71518,7 @@ int lua_ax_base_ParticleSystem_getRotatePerSecond(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71577,7 +71565,7 @@ int lua_ax_base_ParticleSystem_setRotatePerSecond(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71627,7 +71615,7 @@ int lua_ax_base_ParticleSystem_getRotatePerSecondVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71674,7 +71662,7 @@ int lua_ax_base_ParticleSystem_setRotatePerSecondVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71724,7 +71712,7 @@ int lua_ax_base_ParticleSystem_isActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71771,7 +71759,7 @@ int lua_ax_base_ParticleSystem_isBlendAdditive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71818,7 +71806,7 @@ int lua_ax_base_ParticleSystem_setBlendAdditive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -71868,7 +71856,7 @@ int lua_ax_base_ParticleSystem_getBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71915,7 +71903,7 @@ int lua_ax_base_ParticleSystem_setBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ParticleBatchNode* arg0;
 
@@ -71965,7 +71953,7 @@ int lua_ax_base_ParticleSystem_getAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72012,7 +72000,7 @@ int lua_ax_base_ParticleSystem_setAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -72062,7 +72050,7 @@ int lua_ax_base_ParticleSystem_getParticleCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72109,7 +72097,7 @@ int lua_ax_base_ParticleSystem_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72156,7 +72144,7 @@ int lua_ax_base_ParticleSystem_setDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72206,7 +72194,7 @@ int lua_ax_base_ParticleSystem_getSourcePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72253,7 +72241,7 @@ int lua_ax_base_ParticleSystem_setSourcePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -72303,7 +72291,7 @@ int lua_ax_base_ParticleSystem_getPosVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72350,7 +72338,7 @@ int lua_ax_base_ParticleSystem_setPosVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -72400,7 +72388,7 @@ int lua_ax_base_ParticleSystem_getLife(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72447,7 +72435,7 @@ int lua_ax_base_ParticleSystem_setLife(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72497,7 +72485,7 @@ int lua_ax_base_ParticleSystem_getLifeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72544,7 +72532,7 @@ int lua_ax_base_ParticleSystem_setLifeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72594,7 +72582,7 @@ int lua_ax_base_ParticleSystem_getAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72641,7 +72629,7 @@ int lua_ax_base_ParticleSystem_setAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72691,7 +72679,7 @@ int lua_ax_base_ParticleSystem_getAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72738,7 +72726,7 @@ int lua_ax_base_ParticleSystem_setAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72788,7 +72776,7 @@ int lua_ax_base_ParticleSystem_getEmitterMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72835,7 +72823,7 @@ int lua_ax_base_ParticleSystem_setEmitterMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ParticleSystem::Mode arg0;
 
@@ -72885,7 +72873,7 @@ int lua_ax_base_ParticleSystem_getStartSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72932,7 +72920,7 @@ int lua_ax_base_ParticleSystem_setStartSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72982,7 +72970,7 @@ int lua_ax_base_ParticleSystem_getStartSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73029,7 +73017,7 @@ int lua_ax_base_ParticleSystem_setStartSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73079,7 +73067,7 @@ int lua_ax_base_ParticleSystem_getEndSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73126,7 +73114,7 @@ int lua_ax_base_ParticleSystem_setEndSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73176,7 +73164,7 @@ int lua_ax_base_ParticleSystem_getEndSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73223,7 +73211,7 @@ int lua_ax_base_ParticleSystem_setEndSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73273,7 +73261,7 @@ int lua_ax_base_ParticleSystem_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73320,7 +73308,7 @@ int lua_ax_base_ParticleSystem_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73370,7 +73358,7 @@ int lua_ax_base_ParticleSystem_getStartColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73417,7 +73405,7 @@ int lua_ax_base_ParticleSystem_setStartColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73467,7 +73455,7 @@ int lua_ax_base_ParticleSystem_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73514,7 +73502,7 @@ int lua_ax_base_ParticleSystem_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73564,7 +73552,7 @@ int lua_ax_base_ParticleSystem_getEndColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73611,7 +73599,7 @@ int lua_ax_base_ParticleSystem_setEndColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73661,7 +73649,7 @@ int lua_ax_base_ParticleSystem_useHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -73711,7 +73699,7 @@ int lua_ax_base_ParticleSystem_isHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73758,7 +73746,7 @@ int lua_ax_base_ParticleSystem_getHue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73805,7 +73793,7 @@ int lua_ax_base_ParticleSystem_setHue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73855,7 +73843,7 @@ int lua_ax_base_ParticleSystem_getHueVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73902,7 +73890,7 @@ int lua_ax_base_ParticleSystem_setHueVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73952,7 +73940,7 @@ int lua_ax_base_ParticleSystem_getHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73999,7 +73987,7 @@ int lua_ax_base_ParticleSystem_setHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::HSV arg0;
 
@@ -74050,7 +74038,7 @@ int lua_ax_base_ParticleSystem_getHSVVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74097,7 +74085,7 @@ int lua_ax_base_ParticleSystem_setHSVVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::HSV arg0;
 
@@ -74148,7 +74136,7 @@ int lua_ax_base_ParticleSystem_getStartSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74195,7 +74183,7 @@ int lua_ax_base_ParticleSystem_setStartSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74245,7 +74233,7 @@ int lua_ax_base_ParticleSystem_getStartSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74292,7 +74280,7 @@ int lua_ax_base_ParticleSystem_setStartSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74342,7 +74330,7 @@ int lua_ax_base_ParticleSystem_getEndSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74389,7 +74377,7 @@ int lua_ax_base_ParticleSystem_setEndSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74439,7 +74427,7 @@ int lua_ax_base_ParticleSystem_getEndSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74486,7 +74474,7 @@ int lua_ax_base_ParticleSystem_setEndSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74536,7 +74524,7 @@ int lua_ax_base_ParticleSystem_getSpawnAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74583,7 +74571,7 @@ int lua_ax_base_ParticleSystem_setSpawnAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74633,7 +74621,7 @@ int lua_ax_base_ParticleSystem_getSpawnAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74680,7 +74668,7 @@ int lua_ax_base_ParticleSystem_setSpawnAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74730,7 +74718,7 @@ int lua_ax_base_ParticleSystem_getSpawnFadeIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74777,7 +74765,7 @@ int lua_ax_base_ParticleSystem_setSpawnFadeIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74827,7 +74815,7 @@ int lua_ax_base_ParticleSystem_getSpawnFadeInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74874,7 +74862,7 @@ int lua_ax_base_ParticleSystem_setSpawnFadeInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74924,7 +74912,7 @@ int lua_ax_base_ParticleSystem_getSpawnScaleIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74971,7 +74959,7 @@ int lua_ax_base_ParticleSystem_setSpawnScaleIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75021,7 +75009,7 @@ int lua_ax_base_ParticleSystem_getSpawnScaleInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75068,7 +75056,7 @@ int lua_ax_base_ParticleSystem_setSpawnScaleInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75118,7 +75106,7 @@ int lua_ax_base_ParticleSystem_getEmissionRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75165,7 +75153,7 @@ int lua_ax_base_ParticleSystem_setEmissionRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75215,7 +75203,7 @@ int lua_ax_base_ParticleSystem_getTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75262,7 +75250,7 @@ int lua_ax_base_ParticleSystem_setTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -75312,7 +75300,7 @@ int lua_ax_base_ParticleSystem_setLifeAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75362,7 +75350,7 @@ int lua_ax_base_ParticleSystem_setEmitterAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75412,7 +75400,7 @@ int lua_ax_base_ParticleSystem_setLoopAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75462,7 +75450,7 @@ int lua_ax_base_ParticleSystem_isLifeAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75509,7 +75497,7 @@ int lua_ax_base_ParticleSystem_isEmitterAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75556,7 +75544,7 @@ int lua_ax_base_ParticleSystem_isLoopAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75603,7 +75591,7 @@ int lua_ax_base_ParticleSystem_getTotalAnimationIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75650,7 +75638,7 @@ int lua_ax_base_ParticleSystem_setAnimationReverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75700,7 +75688,7 @@ int lua_ax_base_ParticleSystem_isAnimationReversed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75747,7 +75735,7 @@ int lua_ax_base_ParticleSystem_resetAnimationIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75794,7 +75782,7 @@ int lua_ax_base_ParticleSystem_resetAnimationDescriptors(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75841,7 +75829,7 @@ int lua_ax_base_ParticleSystem_setMultiAnimationRandomSpecific(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::vector<unsigned short> arg0;
 
@@ -75891,7 +75879,7 @@ int lua_ax_base_ParticleSystem_setMultiAnimationRandom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76128,7 +76116,7 @@ int lua_ax_base_ParticleSystem_setRectForUndefinedIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -76289,7 +76277,7 @@ int lua_ax_base_ParticleSystem_setAnimationSpeedTimescaleIndependent(lua_State* 
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -76339,7 +76327,7 @@ int lua_ax_base_ParticleSystem_isAnimationSpeedTimescaleIndependent(lua_State* t
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76386,7 +76374,7 @@ int lua_ax_base_ParticleSystem_setEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -76436,7 +76424,7 @@ int lua_ax_base_ParticleSystem_isEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76483,7 +76471,7 @@ int lua_ax_base_ParticleSystem_resetEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76530,7 +76518,7 @@ int lua_ax_base_ParticleSystem_addEmissionShape(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EmissionShape arg0;
 
@@ -76581,7 +76569,7 @@ int lua_ax_base_ParticleSystem_setEmissionShape(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned short arg0;
         ax::EmissionShape arg1;
@@ -76635,7 +76623,7 @@ int lua_ax_base_ParticleSystem_getPositionType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76682,7 +76670,7 @@ int lua_ax_base_ParticleSystem_setPositionType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ParticleSystem::PositionType arg0;
 
@@ -76732,7 +76720,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76743,7 +76731,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -76757,7 +76745,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -76810,7 +76798,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76821,7 +76809,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -76835,7 +76823,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -76888,7 +76876,7 @@ int lua_ax_base_ParticleSystem_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76935,7 +76923,7 @@ int lua_ax_base_ParticleSystem_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -76985,7 +76973,7 @@ int lua_ax_base_ParticleSystem_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -77035,7 +77023,7 @@ int lua_ax_base_ParticleSystem_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77082,7 +77070,7 @@ int lua_ax_base_ParticleSystem_getResourceFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77129,7 +77117,7 @@ int lua_ax_base_ParticleSystem_start(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77176,7 +77164,7 @@ int lua_ax_base_ParticleSystem_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77223,7 +77211,7 @@ int lua_ax_base_ParticleSystem_setSourcePositionCompatible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -77273,7 +77261,7 @@ int lua_ax_base_ParticleSystem_isSourcePositionCompatible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77320,7 +77308,7 @@ int lua_ax_base_ParticleSystem_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -77429,7 +77417,7 @@ int lua_ax_base_ParticleSystem_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -77479,7 +77467,7 @@ int lua_ax_base_ParticleSystem_isPaused(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77526,7 +77514,7 @@ int lua_ax_base_ParticleSystem_pauseEmissions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77573,7 +77561,7 @@ int lua_ax_base_ParticleSystem_resumeEmissions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77620,7 +77608,7 @@ int lua_ax_base_ParticleSystem_getFixedFPS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77667,7 +77655,7 @@ int lua_ax_base_ParticleSystem_setFixedFPS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77678,7 +77666,7 @@ int lua_ax_base_ParticleSystem_setFixedFPS(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -77728,7 +77716,7 @@ int lua_ax_base_ParticleSystem_getTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77775,7 +77763,7 @@ int lua_ax_base_ParticleSystem_setTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77786,7 +77774,7 @@ int lua_ax_base_ParticleSystem_setTimeScale(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -78395,7 +78383,7 @@ int lua_ax_base_ParticleSystem_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -78634,7 +78622,7 @@ int lua_ax_base_ParticleSystemQuad_setDisplayFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -78684,7 +78672,7 @@ int lua_ax_base_ParticleSystemQuad_setTextureWithRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         ax::Rect arg1;
@@ -78737,7 +78725,7 @@ int lua_ax_base_ParticleSystemQuad_listenRendererRecreated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventCustom* arg0;
 
@@ -78775,7 +78763,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -78788,7 +78776,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -78798,7 +78786,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -78868,7 +78856,7 @@ int lua_ax_base_ParticleSystemQuad_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79000,7 +78988,7 @@ int lua_ax_base_ParticleFire_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79072,7 +79060,7 @@ int lua_ax_base_ParticleFireworks_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79119,7 +79107,7 @@ int lua_ax_base_ParticleFireworks_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79226,7 +79214,7 @@ int lua_ax_base_ParticleFireworks_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79300,7 +79288,7 @@ int lua_ax_base_ParticleSun_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79347,7 +79335,7 @@ int lua_ax_base_ParticleSun_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79454,7 +79442,7 @@ int lua_ax_base_ParticleSun_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79528,7 +79516,7 @@ int lua_ax_base_ParticleGalaxy_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79575,7 +79563,7 @@ int lua_ax_base_ParticleGalaxy_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79682,7 +79670,7 @@ int lua_ax_base_ParticleGalaxy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79756,7 +79744,7 @@ int lua_ax_base_ParticleFlower_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79803,7 +79791,7 @@ int lua_ax_base_ParticleFlower_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79910,7 +79898,7 @@ int lua_ax_base_ParticleFlower_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79984,7 +79972,7 @@ int lua_ax_base_ParticleMeteor_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80031,7 +80019,7 @@ int lua_ax_base_ParticleMeteor_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80138,7 +80126,7 @@ int lua_ax_base_ParticleMeteor_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80212,7 +80200,7 @@ int lua_ax_base_ParticleSpiral_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80259,7 +80247,7 @@ int lua_ax_base_ParticleSpiral_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80366,7 +80354,7 @@ int lua_ax_base_ParticleSpiral_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80440,7 +80428,7 @@ int lua_ax_base_ParticleExplosion_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80487,7 +80475,7 @@ int lua_ax_base_ParticleExplosion_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80594,7 +80582,7 @@ int lua_ax_base_ParticleExplosion_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80668,7 +80656,7 @@ int lua_ax_base_ParticleSmoke_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80715,7 +80703,7 @@ int lua_ax_base_ParticleSmoke_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80822,7 +80810,7 @@ int lua_ax_base_ParticleSmoke_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80896,7 +80884,7 @@ int lua_ax_base_ParticleSnow_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80943,7 +80931,7 @@ int lua_ax_base_ParticleSnow_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -81050,7 +81038,7 @@ int lua_ax_base_ParticleSnow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81124,7 +81112,7 @@ int lua_ax_base_ParticleRain_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81171,7 +81159,7 @@ int lua_ax_base_ParticleRain_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -81278,7 +81266,7 @@ int lua_ax_base_ParticleRain_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81352,7 +81340,7 @@ int lua_ax_base_ProgressTimer_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81399,7 +81387,7 @@ int lua_ax_base_ProgressTimer_getPercentage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81446,7 +81434,7 @@ int lua_ax_base_ProgressTimer_getSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81493,7 +81481,7 @@ int lua_ax_base_ProgressTimer_setPercentage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -81543,7 +81531,7 @@ int lua_ax_base_ProgressTimer_setSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -81593,7 +81581,7 @@ int lua_ax_base_ProgressTimer_setType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ProgressTimer::Type arg0;
 
@@ -81643,7 +81631,7 @@ int lua_ax_base_ProgressTimer_isReverseDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81690,7 +81678,7 @@ int lua_ax_base_ProgressTimer_setReverseDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -81740,7 +81728,7 @@ int lua_ax_base_ProgressTimer_setMidpoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -81790,7 +81778,7 @@ int lua_ax_base_ProgressTimer_getMidpoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81837,7 +81825,7 @@ int lua_ax_base_ProgressTimer_setBarChangeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -81887,7 +81875,7 @@ int lua_ax_base_ProgressTimer_getBarChangeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81934,7 +81922,7 @@ int lua_ax_base_ProgressTimer_initWithSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -82007,7 +81995,7 @@ int lua_ax_base_ProgressTimer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82170,7 +82158,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -82220,7 +82208,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -82270,7 +82258,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -82284,7 +82272,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -82337,7 +82325,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -82351,7 +82339,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChildByTag(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         bool arg1;
@@ -82404,7 +82392,7 @@ int lua_ax_base_ProtectedNode_removeAllProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82451,7 +82439,7 @@ int lua_ax_base_ProtectedNode_removeAllProtectedChildrenWithCleanup(lua_State* t
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -82501,7 +82489,7 @@ int lua_ax_base_ProtectedNode_reorderProtectedChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         int arg1;
@@ -82554,7 +82542,7 @@ int lua_ax_base_ProtectedNode_sortAllProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82601,7 +82589,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82648,7 +82636,7 @@ int lua_ax_base_ProtectedNode_disableCascadeColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82695,7 +82683,7 @@ int lua_ax_base_ProtectedNode_disableCascadeOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82763,7 +82751,7 @@ int lua_ax_base_ProtectedNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82846,7 +82834,7 @@ int lua_ax_base_RenderTexture_begin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83008,7 +82996,7 @@ int lua_ax_base_RenderTexture_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83055,7 +83043,7 @@ int lua_ax_base_RenderTexture_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -83114,7 +83102,7 @@ int lua_ax_base_RenderTexture_clearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -83164,7 +83152,7 @@ int lua_ax_base_RenderTexture_clearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -83472,7 +83460,7 @@ int lua_ax_base_RenderTexture_getClearFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83519,7 +83507,7 @@ int lua_ax_base_RenderTexture_setClearFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::TargetBufferFlags arg0;
 
@@ -83569,7 +83557,7 @@ int lua_ax_base_RenderTexture_getClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83616,7 +83604,7 @@ int lua_ax_base_RenderTexture_setClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -83666,7 +83654,7 @@ int lua_ax_base_RenderTexture_getClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83713,7 +83701,7 @@ int lua_ax_base_RenderTexture_setClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -83763,7 +83751,7 @@ int lua_ax_base_RenderTexture_getClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83810,7 +83798,7 @@ int lua_ax_base_RenderTexture_setClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -83860,7 +83848,7 @@ int lua_ax_base_RenderTexture_isAutoDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83907,7 +83895,7 @@ int lua_ax_base_RenderTexture_setAutoDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -83957,7 +83945,7 @@ int lua_ax_base_RenderTexture_getSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84004,7 +83992,7 @@ int lua_ax_base_RenderTexture_getRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84051,7 +84039,7 @@ int lua_ax_base_RenderTexture_setKeepMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -84101,7 +84089,7 @@ int lua_ax_base_RenderTexture_setVirtualViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         ax::Rect arg1;
@@ -84157,7 +84145,7 @@ int lua_ax_base_RenderTexture_isSharedRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84319,7 +84307,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -84338,7 +84326,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -84360,7 +84348,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -84382,7 +84370,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -84407,7 +84395,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -84423,7 +84411,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -84463,7 +84451,7 @@ int lua_ax_base_RenderTexture_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84558,7 +84546,7 @@ int lua_ax_base_TransitionEaseScene_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -84628,7 +84616,7 @@ int lua_ax_base_TransitionScene_finish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84675,7 +84663,7 @@ int lua_ax_base_TransitionScene_hideOutShowIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84722,7 +84710,7 @@ int lua_ax_base_TransitionScene_getInScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84769,7 +84757,7 @@ int lua_ax_base_TransitionScene_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84816,7 +84804,7 @@ int lua_ax_base_TransitionScene_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::Scene* arg1;
@@ -84894,7 +84882,7 @@ int lua_ax_base_TransitionScene_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84970,7 +84958,7 @@ int lua_ax_base_TransitionSceneOriented_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Scene* arg1;
@@ -85053,7 +85041,7 @@ int lua_ax_base_TransitionSceneOriented_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85150,7 +85138,7 @@ int lua_ax_base_TransitionRotoZoom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85246,7 +85234,7 @@ int lua_ax_base_TransitionJumpZoom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85317,7 +85305,7 @@ int lua_ax_base_TransitionMoveInL_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85364,7 +85352,7 @@ int lua_ax_base_TransitionMoveInL_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -85439,7 +85427,7 @@ int lua_ax_base_TransitionMoveInL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85537,7 +85525,7 @@ int lua_ax_base_TransitionMoveInR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85633,7 +85621,7 @@ int lua_ax_base_TransitionMoveInT_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85729,7 +85717,7 @@ int lua_ax_base_TransitionMoveInB_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85800,7 +85788,7 @@ int lua_ax_base_TransitionSlideInL_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -85850,7 +85838,7 @@ int lua_ax_base_TransitionSlideInL_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85922,7 +85910,7 @@ int lua_ax_base_TransitionSlideInL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86020,7 +86008,7 @@ int lua_ax_base_TransitionSlideInR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86116,7 +86104,7 @@ int lua_ax_base_TransitionSlideInB_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86212,7 +86200,7 @@ int lua_ax_base_TransitionSlideInT_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86283,7 +86271,7 @@ int lua_ax_base_TransitionShrinkGrow_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -86358,7 +86346,7 @@ int lua_ax_base_TransitionShrinkGrow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86418,7 +86406,7 @@ int lua_ax_base_TransitionFlipX_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86434,7 +86422,7 @@ int lua_ax_base_TransitionFlipX_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86474,7 +86462,7 @@ int lua_ax_base_TransitionFlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86533,7 +86521,7 @@ int lua_ax_base_TransitionFlipY_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86549,7 +86537,7 @@ int lua_ax_base_TransitionFlipY_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86589,7 +86577,7 @@ int lua_ax_base_TransitionFlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86648,7 +86636,7 @@ int lua_ax_base_TransitionFlipAngular_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86664,7 +86652,7 @@ int lua_ax_base_TransitionFlipAngular_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86704,7 +86692,7 @@ int lua_ax_base_TransitionFlipAngular_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86763,7 +86751,7 @@ int lua_ax_base_TransitionZoomFlipX_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86779,7 +86767,7 @@ int lua_ax_base_TransitionZoomFlipX_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86819,7 +86807,7 @@ int lua_ax_base_TransitionZoomFlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86878,7 +86866,7 @@ int lua_ax_base_TransitionZoomFlipY_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86894,7 +86882,7 @@ int lua_ax_base_TransitionZoomFlipY_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86934,7 +86922,7 @@ int lua_ax_base_TransitionZoomFlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86993,7 +86981,7 @@ int lua_ax_base_TransitionZoomFlipAngular_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -87009,7 +86997,7 @@ int lua_ax_base_TransitionZoomFlipAngular_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -87049,7 +87037,7 @@ int lua_ax_base_TransitionZoomFlipAngular_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87175,7 +87163,7 @@ int lua_ax_base_TransitionFade_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -87191,7 +87179,7 @@ int lua_ax_base_TransitionFade_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -87231,7 +87219,7 @@ int lua_ax_base_TransitionFade_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87328,7 +87316,7 @@ int lua_ax_base_TransitionCrossFade_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87399,7 +87387,7 @@ int lua_ax_base_TransitionTurnOffTiles_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -87474,7 +87462,7 @@ int lua_ax_base_TransitionTurnOffTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87546,7 +87534,7 @@ int lua_ax_base_TransitionSplitCols_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87593,7 +87581,7 @@ int lua_ax_base_TransitionSplitCols_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -87668,7 +87656,7 @@ int lua_ax_base_TransitionSplitCols_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87766,7 +87754,7 @@ int lua_ax_base_TransitionSplitRows_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87837,7 +87825,7 @@ int lua_ax_base_TransitionFadeTR_actionWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -87887,7 +87875,7 @@ int lua_ax_base_TransitionFadeTR_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -87962,7 +87950,7 @@ int lua_ax_base_TransitionFadeTR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88060,7 +88048,7 @@ int lua_ax_base_TransitionFadeBL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88156,7 +88144,7 @@ int lua_ax_base_TransitionFadeUp_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88252,7 +88240,7 @@ int lua_ax_base_TransitionFadeDown_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88323,7 +88311,7 @@ int lua_ax_base_TransitionPageTurn_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Scene* arg1;
@@ -88379,7 +88367,7 @@ int lua_ax_base_TransitionPageTurn_actionWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -88456,7 +88444,7 @@ int lua_ax_base_TransitionPageTurn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88554,7 +88542,7 @@ int lua_ax_base_TransitionProgress_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88650,7 +88638,7 @@ int lua_ax_base_TransitionProgressRadialCCW_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88746,7 +88734,7 @@ int lua_ax_base_TransitionProgressRadialCW_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88842,7 +88830,7 @@ int lua_ax_base_TransitionProgressHorizontal_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88938,7 +88926,7 @@ int lua_ax_base_TransitionProgressVertical_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89034,7 +89022,7 @@ int lua_ax_base_TransitionProgressInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89130,7 +89118,7 @@ int lua_ax_base_TransitionProgressOutIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89201,7 +89189,7 @@ int lua_ax_base_Camera_getCameraFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89248,7 +89236,7 @@ int lua_ax_base_Camera_setCameraFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::CameraFlag arg0;
 
@@ -89298,7 +89286,7 @@ int lua_ax_base_Camera_lookAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -89312,7 +89300,7 @@ int lua_ax_base_Camera_lookAt(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec3 arg0;
         ax::Vec3 arg1;
@@ -89365,7 +89353,7 @@ int lua_ax_base_Camera_getProjectionMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89412,7 +89400,7 @@ int lua_ax_base_Camera_getViewMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89459,7 +89447,7 @@ int lua_ax_base_Camera_getViewProjectionMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89506,7 +89494,7 @@ int lua_ax_base_Camera_project(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -89556,7 +89544,7 @@ int lua_ax_base_Camera_projectGL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -89606,7 +89594,7 @@ int lua_ax_base_Camera_isVisibleInFrustum(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const ax::AABB* arg0;
 
@@ -89656,7 +89644,7 @@ int lua_ax_base_Camera_getDepthInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -89706,7 +89694,7 @@ int lua_ax_base_Camera_setDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int32_t arg0;
 
@@ -89756,7 +89744,7 @@ int lua_ax_base_Camera_getDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89803,7 +89791,7 @@ int lua_ax_base_Camera_getRenderOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89850,7 +89838,7 @@ int lua_ax_base_Camera_getFOV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89897,7 +89885,7 @@ int lua_ax_base_Camera_setFOV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -89947,7 +89935,7 @@ int lua_ax_base_Camera_getFarPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89994,7 +89982,7 @@ int lua_ax_base_Camera_setFarPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90044,7 +90032,7 @@ int lua_ax_base_Camera_getNearPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90091,7 +90079,7 @@ int lua_ax_base_Camera_setNearPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90141,7 +90129,7 @@ int lua_ax_base_Camera_getZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90188,7 +90176,7 @@ int lua_ax_base_Camera_setZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90238,7 +90226,7 @@ int lua_ax_base_Camera_applyZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90285,7 +90273,7 @@ int lua_ax_base_Camera_clearBackground(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90332,7 +90320,7 @@ int lua_ax_base_Camera_apply(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90379,7 +90367,7 @@ int lua_ax_base_Camera_isViewProjectionUpdated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90426,7 +90414,7 @@ int lua_ax_base_Camera_setBackgroundBrush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::CameraBackgroundBrush* arg0;
 
@@ -90476,7 +90464,7 @@ int lua_ax_base_Camera_getBackgroundBrush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90523,7 +90511,7 @@ int lua_ax_base_Camera_isBrushValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90570,7 +90558,7 @@ int lua_ax_base_Camera_setScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -90620,7 +90608,7 @@ int lua_ax_base_Camera_setAdditionalProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -90670,7 +90658,7 @@ int lua_ax_base_Camera_initDefault(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90717,7 +90705,7 @@ int lua_ax_base_Camera_initPerspective(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -90776,7 +90764,7 @@ int lua_ax_base_Camera_initOrthographic(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -90835,7 +90823,7 @@ int lua_ax_base_Camera_applyViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91126,7 +91114,7 @@ int lua_ax_base_Camera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91237,7 +91225,7 @@ int lua_ax_base_CameraBackgroundBrush_getBrushType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91284,7 +91272,7 @@ int lua_ax_base_CameraBackgroundBrush_drawBackground(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Camera* arg0;
 
@@ -91334,7 +91322,7 @@ int lua_ax_base_CameraBackgroundBrush_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91381,7 +91369,7 @@ int lua_ax_base_CameraBackgroundBrush_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91580,7 +91568,7 @@ int lua_ax_base_CameraBackgroundBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91658,7 +91646,7 @@ int lua_ax_base_CameraBackgroundDepthBrush_setDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -91731,7 +91719,7 @@ int lua_ax_base_CameraBackgroundDepthBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91803,7 +91791,7 @@ int lua_ax_base_CameraBackgroundColorBrush_setColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -91878,7 +91866,7 @@ int lua_ax_base_CameraBackgroundColorBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91950,7 +91938,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureCube* arg0;
 
@@ -92000,7 +91988,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92047,7 +92035,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_isActived(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92094,7 +92082,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setActived(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -92144,7 +92132,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setTextureValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -92182,7 +92170,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -92192,7 +92180,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 6)
         {
@@ -92241,7 +92229,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92317,7 +92305,7 @@ int lua_ax_base_GridBase_beforeBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92364,7 +92352,7 @@ int lua_ax_base_GridBase_afterBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92411,7 +92399,7 @@ int lua_ax_base_GridBase_blit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92458,7 +92446,7 @@ int lua_ax_base_GridBase_reuse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92505,7 +92493,7 @@ int lua_ax_base_GridBase_calculateVertexPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92655,7 +92643,7 @@ int lua_ax_base_GridBase_isActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92702,7 +92690,7 @@ int lua_ax_base_GridBase_setActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -92752,7 +92740,7 @@ int lua_ax_base_GridBase_getReuseGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92799,7 +92787,7 @@ int lua_ax_base_GridBase_setReuseGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -92849,7 +92837,7 @@ int lua_ax_base_GridBase_getGridSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92896,7 +92884,7 @@ int lua_ax_base_GridBase_setGridSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -92946,7 +92934,7 @@ int lua_ax_base_GridBase_getStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92993,7 +92981,7 @@ int lua_ax_base_GridBase_setStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -93043,7 +93031,7 @@ int lua_ax_base_GridBase_isTextureFlipped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93090,7 +93078,7 @@ int lua_ax_base_GridBase_setTextureFlipped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -93140,7 +93128,7 @@ int lua_ax_base_GridBase_beforeDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93187,7 +93175,7 @@ int lua_ax_base_GridBase_afterDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -93237,7 +93225,7 @@ int lua_ax_base_GridBase_set2DProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93284,7 +93272,7 @@ int lua_ax_base_GridBase_setGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -93334,7 +93322,7 @@ int lua_ax_base_GridBase_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93421,7 +93409,7 @@ int lua_ax_base_Grid3D_setNeedDepthTestForBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -93471,7 +93459,7 @@ int lua_ax_base_Grid3D_getNeedDepthTestForBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93506,7 +93494,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -93522,7 +93510,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -93535,7 +93523,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -93554,7 +93542,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -93597,7 +93585,7 @@ int lua_ax_base_Grid3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93658,7 +93646,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -93674,7 +93662,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -93687,7 +93675,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -93706,7 +93694,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -93782,7 +93770,7 @@ int lua_ax_base_BaseLight_getLightType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93829,7 +93817,7 @@ int lua_ax_base_BaseLight_getIntensity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93876,7 +93864,7 @@ int lua_ax_base_BaseLight_setIntensity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -93926,7 +93914,7 @@ int lua_ax_base_BaseLight_getLightFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93973,7 +93961,7 @@ int lua_ax_base_BaseLight_setLightFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::LightFlag arg0;
 
@@ -94023,7 +94011,7 @@ int lua_ax_base_BaseLight_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -94073,7 +94061,7 @@ int lua_ax_base_BaseLight_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94146,7 +94134,7 @@ int lua_ax_base_DirectionLight_setDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -94196,7 +94184,7 @@ int lua_ax_base_DirectionLight_getDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94243,7 +94231,7 @@ int lua_ax_base_DirectionLight_getDirectionInWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94315,7 +94303,7 @@ int lua_ax_base_DirectionLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94389,7 +94377,7 @@ int lua_ax_base_PointLight_getRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94436,7 +94424,7 @@ int lua_ax_base_PointLight_setRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -94513,7 +94501,7 @@ int lua_ax_base_PointLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94586,7 +94574,7 @@ int lua_ax_base_SpotLight_setDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -94636,7 +94624,7 @@ int lua_ax_base_SpotLight_getDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94683,7 +94671,7 @@ int lua_ax_base_SpotLight_getDirectionInWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94730,7 +94718,7 @@ int lua_ax_base_SpotLight_setRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -94780,7 +94768,7 @@ int lua_ax_base_SpotLight_getRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94827,7 +94815,7 @@ int lua_ax_base_SpotLight_setInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -94877,7 +94865,7 @@ int lua_ax_base_SpotLight_getInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94924,7 +94912,7 @@ int lua_ax_base_SpotLight_getCosInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94971,7 +94959,7 @@ int lua_ax_base_SpotLight_setOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -95021,7 +95009,7 @@ int lua_ax_base_SpotLight_getOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95068,7 +95056,7 @@ int lua_ax_base_SpotLight_getCosOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95148,7 +95136,7 @@ int lua_ax_base_SpotLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95253,7 +95241,7 @@ int lua_ax_base_AmbientLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95324,7 +95312,7 @@ int lua_ax_base_RenderState_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95371,7 +95359,7 @@ int lua_ax_base_RenderState_bindPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Pass* arg0;
         ax::MeshCommand* arg1;
@@ -95445,7 +95433,7 @@ int lua_ax_base_Technique_addPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Pass* arg0;
 
@@ -95495,7 +95483,7 @@ int lua_ax_base_Technique_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95542,7 +95530,7 @@ int lua_ax_base_Technique_getPassByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -95592,7 +95580,7 @@ int lua_ax_base_Technique_getPassCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95639,7 +95627,7 @@ int lua_ax_base_Technique_getPasses(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95686,7 +95674,7 @@ int lua_ax_base_Technique_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95733,7 +95721,7 @@ int lua_ax_base_Technique_setMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Material* arg0;
 
@@ -95885,7 +95873,7 @@ int lua_ax_base_Material_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8)
+    if (argc == 8) 
     {
         ax::MeshCommand* arg0;
         double arg1;
@@ -95956,7 +95944,7 @@ int lua_ax_base_Material_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96003,7 +95991,7 @@ int lua_ax_base_Material_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -96053,7 +96041,7 @@ int lua_ax_base_Material_getTechniqueByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -96103,7 +96091,7 @@ int lua_ax_base_Material_getTechniqueByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -96153,7 +96141,7 @@ int lua_ax_base_Material_getTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96200,7 +96188,7 @@ int lua_ax_base_Material_getTechniques(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96247,7 +96235,7 @@ int lua_ax_base_Material_getTechniqueCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96294,7 +96282,7 @@ int lua_ax_base_Material_addTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Technique* arg0;
 
@@ -96344,7 +96332,7 @@ int lua_ax_base_Material_setTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -96394,7 +96382,7 @@ int lua_ax_base_Material_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96441,7 +96429,7 @@ int lua_ax_base_Material_getRenderState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96488,7 +96476,7 @@ int lua_ax_base_Material_setPrimitiveType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::PrimitiveType arg0;
 
@@ -96538,7 +96526,7 @@ int lua_ax_base_Material_getPrimitiveType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96585,7 +96573,7 @@ int lua_ax_base_Material_setTransparent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -96635,7 +96623,7 @@ int lua_ax_base_Material_isTransparent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96682,7 +96670,7 @@ int lua_ax_base_Material_setForce2DQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -96732,7 +96720,7 @@ int lua_ax_base_Material_isForce2DQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96927,7 +96915,7 @@ int lua_ax_base_Pass_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96974,7 +96962,7 @@ int lua_ax_base_Pass_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8)
+    if (argc == 8) 
     {
         ax::MeshCommand* arg0;
         double arg1;
@@ -97045,7 +97033,7 @@ int lua_ax_base_Pass_setVertexInputBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::VertexInputBinding* arg0;
 
@@ -97095,7 +97083,7 @@ int lua_ax_base_Pass_getVertexAttributeBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97142,7 +97130,7 @@ int lua_ax_base_Pass_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -97192,7 +97180,7 @@ int lua_ax_base_Pass_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97239,7 +97227,7 @@ int lua_ax_base_Pass_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97286,7 +97274,7 @@ int lua_ax_base_Pass_setTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Technique* arg0;
 
@@ -97336,7 +97324,7 @@ int lua_ax_base_Pass_updateMVPUniform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -97386,7 +97374,7 @@ int lua_ax_base_Pass_setUniformTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::rhi::Texture* arg1;
@@ -97439,7 +97427,7 @@ int lua_ax_base_Pass_setUniformNormTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::rhi::Texture* arg1;
@@ -97492,7 +97480,7 @@ int lua_ax_base_Pass_setUniformColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97546,7 +97534,7 @@ int lua_ax_base_Pass_setUniformMatrixPalette(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97600,7 +97588,7 @@ int lua_ax_base_Pass_setUniformDirLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97654,7 +97642,7 @@ int lua_ax_base_Pass_setUniformDirLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97708,7 +97696,7 @@ int lua_ax_base_Pass_setUniformPointLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97762,7 +97750,7 @@ int lua_ax_base_Pass_setUniformPointLightPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97816,7 +97804,7 @@ int lua_ax_base_Pass_setUniformPointLightRangeInverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97870,7 +97858,7 @@ int lua_ax_base_Pass_setUniformSpotLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97924,7 +97912,7 @@ int lua_ax_base_Pass_setUniformSpotLightPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97978,7 +97966,7 @@ int lua_ax_base_Pass_setUniformSpotLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98032,7 +98020,7 @@ int lua_ax_base_Pass_setUniformSpotLightInnerAngleCos(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98086,7 +98074,7 @@ int lua_ax_base_Pass_setUniformSpotLightOuterAngleCos(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98140,7 +98128,7 @@ int lua_ax_base_Pass_setUniformSpotLightRangeInverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98194,7 +98182,7 @@ int lua_ax_base_Pass_setUniformAmbientLigthColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98368,7 +98356,7 @@ int lua_ax_base_ProgramManager_getBuiltinProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -98418,7 +98406,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98435,7 +98423,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98455,7 +98443,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98593,7 +98581,7 @@ int lua_ax_base_ProgramManager_unloadProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::Program* arg0;
 
@@ -98643,7 +98631,7 @@ int lua_ax_base_ProgramManager_unloadUnusedPrograms(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -98690,7 +98678,7 @@ int lua_ax_base_ProgramManager_unloadAllPrograms(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -98869,7 +98857,7 @@ int lua_ax_base_Renderer_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -98916,7 +98904,7 @@ int lua_ax_base_Renderer_addCallbackCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -98934,7 +98922,7 @@ int lua_ax_base_Renderer_addCallbackCommand(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::function<void ()> arg0;
         double arg1;
@@ -99050,7 +99038,7 @@ int lua_ax_base_Renderer_getNextGroupCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99097,7 +99085,7 @@ int lua_ax_base_Renderer_pushGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -99147,7 +99135,7 @@ int lua_ax_base_Renderer_popGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99194,7 +99182,7 @@ int lua_ax_base_Renderer_createRenderQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99241,7 +99229,7 @@ int lua_ax_base_Renderer_render(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99288,7 +99276,7 @@ int lua_ax_base_Renderer_clean(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99335,7 +99323,7 @@ int lua_ax_base_Renderer_getDrawnBatches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99382,7 +99370,7 @@ int lua_ax_base_Renderer_addDrawnBatches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -99432,7 +99420,7 @@ int lua_ax_base_Renderer_getDrawnVertices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99479,7 +99467,7 @@ int lua_ax_base_Renderer_addDrawnVertices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -99529,7 +99517,7 @@ int lua_ax_base_Renderer_clearDrawStats(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99576,7 +99564,7 @@ int lua_ax_base_Renderer_getRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99623,7 +99611,7 @@ int lua_ax_base_Renderer_setRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::RenderTarget* arg0;
 
@@ -99673,7 +99661,7 @@ int lua_ax_base_Renderer_getDefaultRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99720,7 +99708,7 @@ int lua_ax_base_Renderer_getOffscreenRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99767,7 +99755,7 @@ int lua_ax_base_Renderer_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::rhi::TargetBufferFlags arg0;
         ax::Color arg1;
@@ -99829,7 +99817,7 @@ int lua_ax_base_Renderer_getClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99876,7 +99864,7 @@ int lua_ax_base_Renderer_getClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99923,7 +99911,7 @@ int lua_ax_base_Renderer_getClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99970,7 +99958,7 @@ int lua_ax_base_Renderer_getClearFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100017,7 +100005,7 @@ int lua_ax_base_Renderer_setDepthTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -100067,7 +100055,7 @@ int lua_ax_base_Renderer_setDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -100117,7 +100105,7 @@ int lua_ax_base_Renderer_setDepthCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::CompareFunc arg0;
 
@@ -100167,7 +100155,7 @@ int lua_ax_base_Renderer_getDepthTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100214,7 +100202,7 @@ int lua_ax_base_Renderer_getDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100261,7 +100249,7 @@ int lua_ax_base_Renderer_getDepthCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100308,7 +100296,7 @@ int lua_ax_base_Renderer_setStencilTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -100358,7 +100346,7 @@ int lua_ax_base_Renderer_setStencilCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::rhi::CompareFunc arg0;
         unsigned int arg1;
@@ -100414,7 +100402,7 @@ int lua_ax_base_Renderer_setStencilOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::rhi::StencilOp arg0;
         ax::rhi::StencilOp arg1;
@@ -100470,7 +100458,7 @@ int lua_ax_base_Renderer_setStencilWriteMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -100520,7 +100508,7 @@ int lua_ax_base_Renderer_getStencilTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100567,7 +100555,7 @@ int lua_ax_base_Renderer_getStencilFailureOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100614,7 +100602,7 @@ int lua_ax_base_Renderer_getStencilPassDepthFailureOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100661,7 +100649,7 @@ int lua_ax_base_Renderer_getStencilDepthPassOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100708,7 +100696,7 @@ int lua_ax_base_Renderer_getStencilCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100755,7 +100743,7 @@ int lua_ax_base_Renderer_getStencilReadMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100802,7 +100790,7 @@ int lua_ax_base_Renderer_getStencilWriteMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100849,7 +100837,7 @@ int lua_ax_base_Renderer_getStencilReferenceValue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100896,7 +100884,7 @@ int lua_ax_base_Renderer_setDepthStencilDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::DepthStencilDesc arg0;
 
@@ -100947,7 +100935,7 @@ int lua_ax_base_Renderer_getDepthStencilDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100994,7 +100982,7 @@ int lua_ax_base_Renderer_setCullMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::CullMode arg0;
 
@@ -101044,7 +101032,7 @@ int lua_ax_base_Renderer_getCullMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101091,7 +101079,7 @@ int lua_ax_base_Renderer_setWinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::Winding arg0;
 
@@ -101141,7 +101129,7 @@ int lua_ax_base_Renderer_getWinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101188,7 +101176,7 @@ int lua_ax_base_Renderer_setViewPort(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         int arg0;
         int arg1;
@@ -101247,7 +101235,7 @@ int lua_ax_base_Renderer_getViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101294,7 +101282,7 @@ int lua_ax_base_Renderer_setScissorTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -101344,7 +101332,7 @@ int lua_ax_base_Renderer_setScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -101403,7 +101391,7 @@ int lua_ax_base_Renderer_getScissorTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101450,7 +101438,7 @@ int lua_ax_base_Renderer_getScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101497,7 +101485,7 @@ int lua_ax_base_Renderer_checkVisibility(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Mat4 arg0;
         ax::Vec2 arg1;
@@ -101550,7 +101538,7 @@ int lua_ax_base_Renderer_readPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::rhi::RenderTarget* arg0;
         std::function<void (const ax::rhi::PixelBufferDesc &)> arg1;
@@ -101607,7 +101595,7 @@ int lua_ax_base_Renderer_beginRenderPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101654,7 +101642,7 @@ int lua_ax_base_Renderer_endRenderPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101701,7 +101689,7 @@ int lua_ax_base_Renderer_nextCallbackCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101748,7 +101736,7 @@ int lua_ax_base_Renderer_resizeSwapChain(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         unsigned int arg1;
@@ -101788,7 +101776,7 @@ int lua_ax_base_Renderer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101915,7 +101903,7 @@ int lua_ax_base_TextureCache_getDescription(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102017,7 +102005,7 @@ int lua_ax_base_TextureCache_getDummyTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102211,7 +102199,7 @@ int lua_ax_base_TextureCache_unbindImageAsync(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102261,7 +102249,7 @@ int lua_ax_base_TextureCache_unbindAllImageAsync(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102308,7 +102296,7 @@ int lua_ax_base_TextureCache_getTextureForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102358,7 +102346,7 @@ int lua_ax_base_TextureCache_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102408,7 +102396,7 @@ int lua_ax_base_TextureCache_removeAllTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102455,7 +102443,7 @@ int lua_ax_base_TextureCache_removeUnusedTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102502,7 +102490,7 @@ int lua_ax_base_TextureCache_removeTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -102552,7 +102540,7 @@ int lua_ax_base_TextureCache_removeTextureForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102602,7 +102590,7 @@ int lua_ax_base_TextureCache_getCachedTextureInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102649,7 +102637,7 @@ int lua_ax_base_TextureCache_waitForQuit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102696,7 +102684,7 @@ int lua_ax_base_TextureCache_getTextureFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -102746,7 +102734,7 @@ int lua_ax_base_TextureCache_renameTextureWithKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -102856,7 +102844,7 @@ int lua_ax_base_TextureCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103397,7 +103385,7 @@ int lua_ax_base_Application_setAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -103447,7 +103435,7 @@ int lua_ax_base_Application_getCurrentLanguage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103494,7 +103482,7 @@ int lua_ax_base_Application_getCurrentLanguageCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103541,7 +103529,7 @@ int lua_ax_base_Application_getTargetPlatform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103588,7 +103576,7 @@ int lua_ax_base_Application_getVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103635,7 +103623,7 @@ int lua_ax_base_Application_openURL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -103913,7 +103901,7 @@ int lua_ax_base_AnimationCache_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103960,7 +103948,7 @@ int lua_ax_base_AnimationCache_addAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Animation* arg0;
         std::string_view arg1;
@@ -104013,7 +104001,7 @@ int lua_ax_base_AnimationCache_removeAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104063,7 +104051,7 @@ int lua_ax_base_AnimationCache_getAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104113,7 +104101,7 @@ int lua_ax_base_AnimationCache_addAnimationsWithDictionary(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -104166,7 +104154,7 @@ int lua_ax_base_AnimationCache_addAnimationsWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104271,7 +104259,7 @@ int lua_ax_base_AnimationCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104347,7 +104335,7 @@ int lua_ax_base_SpriteBatchNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104394,7 +104382,7 @@ int lua_ax_base_SpriteBatchNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -104444,7 +104432,7 @@ int lua_ax_base_SpriteBatchNode_increaseAtlasCapacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104491,7 +104479,7 @@ int lua_ax_base_SpriteBatchNode_removeChildAtIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ssize_t arg0;
         bool arg1;
@@ -104544,7 +104532,7 @@ int lua_ax_base_SpriteBatchNode_appendChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104594,7 +104582,7 @@ int lua_ax_base_SpriteBatchNode_removeSpriteFromAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104644,7 +104632,7 @@ int lua_ax_base_SpriteBatchNode_rebuildIndexInOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Sprite* arg0;
         ssize_t arg1;
@@ -104697,7 +104685,7 @@ int lua_ax_base_SpriteBatchNode_highestAtlasIndexInChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104747,7 +104735,7 @@ int lua_ax_base_SpriteBatchNode_lowestAtlasIndexInChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104797,7 +104785,7 @@ int lua_ax_base_SpriteBatchNode_atlasIndexForChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Sprite* arg0;
         int arg1;
@@ -104850,7 +104838,7 @@ int lua_ax_base_SpriteBatchNode_reorderBatch(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -104900,7 +104888,7 @@ int lua_ax_base_SpriteBatchNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104947,7 +104935,7 @@ int lua_ax_base_SpriteBatchNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -104997,7 +104985,7 @@ int lua_ax_base_SpriteBatchNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -105047,7 +105035,7 @@ int lua_ax_base_SpriteBatchNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105094,7 +105082,7 @@ int lua_ax_base_SpriteBatchNode_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -105144,7 +105132,7 @@ int lua_ax_base_SpriteBatchNode_insertQuadFromSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Sprite* arg0;
         ssize_t arg1;
@@ -105197,7 +105185,7 @@ int lua_ax_base_SpriteBatchNode_addSpriteWithoutQuad(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Sprite* arg0;
         int arg1;
@@ -105253,7 +105241,7 @@ int lua_ax_base_SpriteBatchNode_reserveCapacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -105303,7 +105291,7 @@ int lua_ax_base_SpriteBatchNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -105317,7 +105305,7 @@ int lua_ax_base_SpriteBatchNode_initWithTexture(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         ssize_t arg1;
@@ -105370,7 +105358,7 @@ int lua_ax_base_SpriteBatchNode_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -105384,7 +105372,7 @@ int lua_ax_base_SpriteBatchNode_initWithFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         ssize_t arg1;
@@ -105526,7 +105514,7 @@ int lua_ax_base_SpriteBatchNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105619,7 +105607,7 @@ int lua_ax_base_ParallaxNode_addChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Node* arg0;
         int arg1;
@@ -105678,7 +105666,7 @@ int lua_ax_base_ParallaxNode_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -105749,7 +105737,7 @@ int lua_ax_base_ParallaxNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105822,7 +105810,7 @@ int lua_ax_base_TMXObjectGroup_getGroupName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105869,7 +105857,7 @@ int lua_ax_base_TMXObjectGroup_setGroupName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -105919,7 +105907,7 @@ int lua_ax_base_TMXObjectGroup_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -105969,7 +105957,7 @@ int lua_ax_base_TMXObjectGroup_getObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106019,7 +106007,7 @@ int lua_ax_base_TMXObjectGroup_getPositionOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106066,7 +106054,7 @@ int lua_ax_base_TMXObjectGroup_setPositionOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -106163,7 +106151,7 @@ int lua_ax_base_TMXObjectGroup_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -106260,7 +106248,7 @@ int lua_ax_base_TMXObjectGroup_setObjects(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueVector arg0;
 
@@ -106297,7 +106285,7 @@ int lua_ax_base_TMXObjectGroup_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106377,7 +106365,7 @@ int lua_ax_base_TMXLayerInfo_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -106427,7 +106415,7 @@ int lua_ax_base_TMXLayerInfo_getProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106461,7 +106449,7 @@ int lua_ax_base_TMXLayerInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106533,7 +106521,7 @@ int lua_ax_base_TMXTilesetInfo_getRectForGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -106570,7 +106558,7 @@ int lua_ax_base_TMXTilesetInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106641,7 +106629,7 @@ int lua_ax_base_TMXMapInfo_initWithTMXFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106691,7 +106679,7 @@ int lua_ax_base_TMXMapInfo_initWithXML(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -106744,7 +106732,7 @@ int lua_ax_base_TMXMapInfo_parseXMLFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106794,7 +106782,7 @@ int lua_ax_base_TMXMapInfo_parseXMLString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106844,7 +106832,7 @@ int lua_ax_base_TMXMapInfo_getTileProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106891,7 +106879,7 @@ int lua_ax_base_TMXMapInfo_setTileProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMapIntKey arg0;
 
@@ -106941,7 +106929,7 @@ int lua_ax_base_TMXMapInfo_getOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106988,7 +106976,7 @@ int lua_ax_base_TMXMapInfo_setOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107038,7 +107026,7 @@ int lua_ax_base_TMXMapInfo_getStaggerAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107085,7 +107073,7 @@ int lua_ax_base_TMXMapInfo_setStaggerAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107135,7 +107123,7 @@ int lua_ax_base_TMXMapInfo_getStaggerIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107182,7 +107170,7 @@ int lua_ax_base_TMXMapInfo_setStaggerIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107232,7 +107220,7 @@ int lua_ax_base_TMXMapInfo_getHexSideLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107279,7 +107267,7 @@ int lua_ax_base_TMXMapInfo_setHexSideLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107329,7 +107317,7 @@ int lua_ax_base_TMXMapInfo_getMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107376,7 +107364,7 @@ int lua_ax_base_TMXMapInfo_setMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -107426,7 +107414,7 @@ int lua_ax_base_TMXMapInfo_getTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107473,7 +107461,7 @@ int lua_ax_base_TMXMapInfo_setTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -107570,7 +107558,7 @@ int lua_ax_base_TMXMapInfo_setLayers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXLayerInfo *> arg0;
 
@@ -107667,7 +107655,7 @@ int lua_ax_base_TMXMapInfo_setTilesets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXTilesetInfo *> arg0;
 
@@ -107764,7 +107752,7 @@ int lua_ax_base_TMXMapInfo_setObjectGroups(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXObjectGroup *> arg0;
 
@@ -107814,7 +107802,7 @@ int lua_ax_base_TMXMapInfo_getParentElement(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107861,7 +107849,7 @@ int lua_ax_base_TMXMapInfo_setParentElement(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107911,7 +107899,7 @@ int lua_ax_base_TMXMapInfo_getParentGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107958,7 +107946,7 @@ int lua_ax_base_TMXMapInfo_setParentGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -108008,7 +107996,7 @@ int lua_ax_base_TMXMapInfo_getLayerAttribs(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108055,7 +108043,7 @@ int lua_ax_base_TMXMapInfo_setLayerAttribs(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -108105,7 +108093,7 @@ int lua_ax_base_TMXMapInfo_isStoringCharacters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108152,7 +108140,7 @@ int lua_ax_base_TMXMapInfo_setStoringCharacters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -108249,7 +108237,7 @@ int lua_ax_base_TMXMapInfo_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -108299,7 +108287,7 @@ int lua_ax_base_TMXMapInfo_getCurrentString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108346,7 +108334,7 @@ int lua_ax_base_TMXMapInfo_setCurrentString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -108396,7 +108384,7 @@ int lua_ax_base_TMXMapInfo_getTMXFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108443,7 +108431,7 @@ int lua_ax_base_TMXMapInfo_setTMXFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -108493,7 +108481,7 @@ int lua_ax_base_TMXMapInfo_getExternalTilesetFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108601,7 +108589,7 @@ int lua_ax_base_TMXMapInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108712,7 +108700,7 @@ int lua_ax_base_TileMapAtlas_initWithTileFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -108771,7 +108759,7 @@ int lua_ax_base_TileMapAtlas_getTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -108821,7 +108809,7 @@ int lua_ax_base_TileMapAtlas_setTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -108874,7 +108862,7 @@ int lua_ax_base_TileMapAtlas_releaseMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108950,7 +108938,7 @@ int lua_ax_base_TileMapAtlas_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109092,7 +109080,7 @@ int lua_ax_base_FastTMXLayer_removeTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109142,7 +109130,7 @@ int lua_ax_base_FastTMXLayer_getPositionAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109192,7 +109180,7 @@ int lua_ax_base_FastTMXLayer_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -109242,7 +109230,7 @@ int lua_ax_base_FastTMXLayer_setupTiles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109289,7 +109277,7 @@ int lua_ax_base_FastTMXLayer_getLayerName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109336,7 +109324,7 @@ int lua_ax_base_FastTMXLayer_setLayerName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -109386,7 +109374,7 @@ int lua_ax_base_FastTMXLayer_getLayerSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109433,7 +109421,7 @@ int lua_ax_base_FastTMXLayer_setLayerSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109483,7 +109471,7 @@ int lua_ax_base_FastTMXLayer_getMapTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109530,7 +109518,7 @@ int lua_ax_base_FastTMXLayer_setMapTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109580,7 +109568,7 @@ int lua_ax_base_FastTMXLayer_getTileSet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109627,7 +109615,7 @@ int lua_ax_base_FastTMXLayer_setTileSet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TMXTilesetInfo* arg0;
 
@@ -109677,7 +109665,7 @@ int lua_ax_base_FastTMXLayer_getLayerOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109724,7 +109712,7 @@ int lua_ax_base_FastTMXLayer_setLayerOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -109821,7 +109809,7 @@ int lua_ax_base_FastTMXLayer_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -109871,7 +109859,7 @@ int lua_ax_base_FastTMXLayer_getTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109921,7 +109909,7 @@ int lua_ax_base_FastTMXLayer_setupTileSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Sprite* arg0;
         ax::Vec2 arg1;
@@ -109977,7 +109965,7 @@ int lua_ax_base_FastTMXLayer_getAnimTileCoord(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110024,7 +110012,7 @@ int lua_ax_base_FastTMXLayer_hasTileAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110071,7 +110059,7 @@ int lua_ax_base_FastTMXLayer_getTileAnimManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110118,7 +110106,7 @@ int lua_ax_base_FastTMXLayer_initWithTilesetInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::TMXTilesetInfo* arg0;
         ax::TMXLayerInfo* arg1;
@@ -110201,7 +110189,7 @@ int lua_ax_base_FastTMXLayer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110295,7 +110283,7 @@ int lua_ax_base_TMXTileAnimTask_start(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110342,7 +110330,7 @@ int lua_ax_base_TMXTileAnimTask_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110389,7 +110377,7 @@ int lua_ax_base_TMXTileAnimTask_isRunning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110484,7 +110472,7 @@ int lua_ax_base_TMXTileAnimTask_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::FastTMXLayer* arg0;
         ax::TMXTileAnimInfo* arg1;
@@ -110508,7 +110496,7 @@ int lua_ax_base_TMXTileAnimTask_constructor(lua_State* tolua_S)
         toluafix_pushusertype_object(tolua_S, ID, luaID, (void*)cobj,"ax.TMXTileAnimTask");
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::FastTMXLayer* arg0;
         ax::TMXTileAnimInfo* arg1;
@@ -110595,7 +110583,7 @@ int lua_ax_base_TMXTileAnimManager_startAll(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110642,7 +110630,7 @@ int lua_ax_base_TMXTileAnimManager_stopAll(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110689,7 +110677,7 @@ int lua_ax_base_TMXTileAnimManager_getTasks(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110759,7 +110747,7 @@ int lua_ax_base_TMXTileAnimManager_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FastTMXLayer* arg0;
 
@@ -110836,7 +110824,7 @@ int lua_ax_base_FastTMXTiledMap_getLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -110886,7 +110874,7 @@ int lua_ax_base_FastTMXTiledMap_getObjectGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -110936,7 +110924,7 @@ int lua_ax_base_FastTMXTiledMap_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -110986,7 +110974,7 @@ int lua_ax_base_FastTMXTiledMap_getPropertiesForGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -111036,7 +111024,7 @@ int lua_ax_base_FastTMXTiledMap_getMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111083,7 +111071,7 @@ int lua_ax_base_FastTMXTiledMap_setMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -111133,7 +111121,7 @@ int lua_ax_base_FastTMXTiledMap_getTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111180,7 +111168,7 @@ int lua_ax_base_FastTMXTiledMap_setTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -111230,7 +111218,7 @@ int lua_ax_base_FastTMXTiledMap_getMapOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111277,7 +111265,7 @@ int lua_ax_base_FastTMXTiledMap_setMapOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -111374,7 +111362,7 @@ int lua_ax_base_FastTMXTiledMap_setObjectGroups(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXObjectGroup *> arg0;
 
@@ -111424,7 +111412,7 @@ int lua_ax_base_FastTMXTiledMap_getProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111471,7 +111459,7 @@ int lua_ax_base_FastTMXTiledMap_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -111521,7 +111509,7 @@ int lua_ax_base_FastTMXTiledMap_setTileAnimEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -111571,7 +111559,7 @@ int lua_ax_base_FastTMXTiledMap_getLayerCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111618,7 +111606,7 @@ int lua_ax_base_FastTMXTiledMap_getResourceFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111665,7 +111653,7 @@ int lua_ax_base_FastTMXTiledMap_getMapInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111712,7 +111700,7 @@ int lua_ax_base_FastTMXTiledMap_getTilesetInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -111762,7 +111750,7 @@ int lua_ax_base_FastTMXTiledMap_getLayers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111809,7 +111797,7 @@ int lua_ax_base_FastTMXTiledMap_initWithTMXFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -111823,7 +111811,7 @@ int lua_ax_base_FastTMXTiledMap_initWithTMXFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -111876,7 +111864,7 @@ int lua_ax_base_FastTMXTiledMap_initWithXML(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -111893,7 +111881,7 @@ int lua_ax_base_FastTMXTiledMap_initWithXML(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -112042,7 +112030,7 @@ int lua_ax_base_FastTMXTiledMap_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112136,7 +112124,7 @@ int lua_ax_base_MotionStreak3D_tintWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -112186,7 +112174,7 @@ int lua_ax_base_MotionStreak3D_reset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112233,7 +112221,7 @@ int lua_ax_base_MotionStreak3D_getStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112280,7 +112268,7 @@ int lua_ax_base_MotionStreak3D_setStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -112330,7 +112318,7 @@ int lua_ax_base_MotionStreak3D_isStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112377,7 +112365,7 @@ int lua_ax_base_MotionStreak3D_setStartingPositionInitialized(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -112427,7 +112415,7 @@ int lua_ax_base_MotionStreak3D_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112474,7 +112462,7 @@ int lua_ax_base_MotionStreak3D_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -112524,7 +112512,7 @@ int lua_ax_base_MotionStreak3D_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -112574,7 +112562,7 @@ int lua_ax_base_MotionStreak3D_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112621,7 +112609,7 @@ int lua_ax_base_MotionStreak3D_setSweepAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -112671,7 +112659,7 @@ int lua_ax_base_MotionStreak3D_getSweepAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112793,7 +112781,7 @@ int lua_ax_base_MotionStreak3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -112818,7 +112806,7 @@ int lua_ax_base_MotionStreak3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -112864,7 +112852,7 @@ int lua_ax_base_MotionStreak3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112948,7 +112936,7 @@ int lua_ax_base_ComponentLua_getScriptObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112995,7 +112983,7 @@ int lua_ax_base_ComponentLua_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -113068,7 +113056,7 @@ int lua_ax_base_ComponentLua_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -113120,7 +113108,7 @@ int lua_register_ax_base_ComponentLua(lua_State* tolua_S)
 TOLUA_API int register_all_ax_base(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-
+	
 	tolua_module(tolua_S,"ax",0);
 	tolua_beginmodule(tolua_S,"ax");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -35,7 +35,7 @@ int lua_ax_base_Object_retain(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82,7 +82,7 @@ int lua_ax_base_Object_release(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -129,7 +129,7 @@ int lua_ax_base_Object_getReferenceCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -198,7 +198,7 @@ int lua_ax_base_Touch_getLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -245,7 +245,7 @@ int lua_ax_base_Touch_getPreviousLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -292,7 +292,7 @@ int lua_ax_base_Touch_getStartLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -339,7 +339,7 @@ int lua_ax_base_Touch_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -386,7 +386,7 @@ int lua_ax_base_Touch_getLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -433,7 +433,7 @@ int lua_ax_base_Touch_getPreviousLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -480,7 +480,7 @@ int lua_ax_base_Touch_getStartLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -606,7 +606,7 @@ int lua_ax_base_Touch_getID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -653,7 +653,7 @@ int lua_ax_base_Touch_getCurrentForce(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -700,7 +700,7 @@ int lua_ax_base_Touch_getMaxForce(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -734,7 +734,7 @@ int lua_ax_base_Touch_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -815,7 +815,7 @@ int lua_ax_base_Event_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -862,7 +862,7 @@ int lua_ax_base_Event_stopPropagation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -909,7 +909,7 @@ int lua_ax_base_Event_isStopped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -956,7 +956,7 @@ int lua_ax_base_Event_getCurrentTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -990,7 +990,7 @@ int lua_ax_base_Event_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Event::Type arg0;
 
@@ -1067,7 +1067,7 @@ int lua_ax_base_EventTouch_getEventCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1114,7 +1114,7 @@ int lua_ax_base_EventTouch_setEventCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventTouch::EventCode arg0;
 
@@ -1151,7 +1151,7 @@ int lua_ax_base_EventTouch_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1210,7 +1210,7 @@ int lua_ax_base_EventKeyboard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::EventKeyboard::KeyCode arg0;
         bool arg1;
@@ -1286,7 +1286,7 @@ int lua_ax_base_Action_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1333,7 +1333,7 @@ int lua_ax_base_Action_reverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1380,7 +1380,7 @@ int lua_ax_base_Action_isDone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1427,7 +1427,7 @@ int lua_ax_base_Action_startWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -1477,7 +1477,7 @@ int lua_ax_base_Action_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1524,7 +1524,7 @@ int lua_ax_base_Action_step(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -1574,7 +1574,7 @@ int lua_ax_base_Action_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -1624,7 +1624,7 @@ int lua_ax_base_Action_getTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1671,7 +1671,7 @@ int lua_ax_base_Action_setTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -1721,7 +1721,7 @@ int lua_ax_base_Action_getOriginalTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1768,7 +1768,7 @@ int lua_ax_base_Action_setOriginalTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -1818,7 +1818,7 @@ int lua_ax_base_Action_getTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1865,7 +1865,7 @@ int lua_ax_base_Action_setTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -1915,7 +1915,7 @@ int lua_ax_base_Action_getFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1962,7 +1962,7 @@ int lua_ax_base_Action_setFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -2046,7 +2046,7 @@ int lua_ax_base_FiniteTimeAction_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2093,7 +2093,7 @@ int lua_ax_base_FiniteTimeAction_setDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -2164,7 +2164,7 @@ int lua_ax_base_Speed_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2211,7 +2211,7 @@ int lua_ax_base_Speed_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -2261,7 +2261,7 @@ int lua_ax_base_Speed_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -2311,7 +2311,7 @@ int lua_ax_base_Speed_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2358,7 +2358,7 @@ int lua_ax_base_Speed_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -2436,7 +2436,7 @@ int lua_ax_base_Speed_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2512,7 +2512,7 @@ int lua_ax_base_Follow_isBoundarySet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2559,7 +2559,7 @@ int lua_ax_base_Follow_setBoundarySet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -2609,7 +2609,7 @@ int lua_ax_base_Follow_initWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -2623,7 +2623,7 @@ int lua_ax_base_Follow_initWithTarget(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         ax::Rect arg1;
@@ -2676,7 +2676,7 @@ int lua_ax_base_Follow_initWithTargetAndOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Node* arg0;
         double arg1;
@@ -2696,7 +2696,7 @@ int lua_ax_base_Follow_initWithTargetAndOffset(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Node* arg0;
         double arg1;
@@ -2852,7 +2852,7 @@ int lua_ax_base_Follow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2928,7 +2928,7 @@ int lua_ax_base_EventListener_checkAvailable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2975,7 +2975,7 @@ int lua_ax_base_EventListener_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3022,7 +3022,7 @@ int lua_ax_base_EventListener_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -3072,7 +3072,7 @@ int lua_ax_base_EventListener_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3129,7 +3129,7 @@ int lua_ax_base_EventListenerCustom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3199,7 +3199,7 @@ int lua_ax_base_ShaderCache_purge(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3246,7 +3246,7 @@ int lua_ax_base_ShaderCache_acquireVertexShaderModule(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -3296,7 +3296,7 @@ int lua_ax_base_ShaderCache_acquireFragmentShaderModule(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -3346,7 +3346,7 @@ int lua_ax_base_ShaderCache_removeUnusedShader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3486,7 +3486,7 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Image* arg0;
 
@@ -3500,7 +3500,7 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Image* arg0;
         ax::rhi::PixelFormat arg1;
@@ -3514,6 +3514,26 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
             return 0;
         }
         auto&& ret = cobj->initWithImage(arg0, arg1);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 3)
+    {
+        ax::Image* arg0;
+        ax::rhi::PixelFormat arg1;
+        bool arg2;
+
+        ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:initWithImage");
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:initWithImage");
+
+        ok &= luaval_to_boolean(tolua_S, 4,&arg2, "ax.Texture2D:initWithImage");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_initWithImage'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->initWithImage(arg0, arg1, arg2);
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
@@ -3780,7 +3800,7 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
+    if (argc == 5)
     {
         const void* arg0;
         int arg1;
@@ -3807,7 +3827,7 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 6) 
+    if (argc == 6)
     {
         const void* arg0;
         int arg1;
@@ -3837,7 +3857,7 @@ int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 7) 
+    if (argc == 7)
     {
         const void* arg0;
         int arg1;
@@ -3906,7 +3926,7 @@ int lua_ax_base_Texture2D_drawAtPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -3959,7 +3979,7 @@ int lua_ax_base_Texture2D_drawInRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Rect arg0;
         double arg1;
@@ -4012,7 +4032,7 @@ int lua_ax_base_Texture2D_updateTextureDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::TextureDesc arg0;
 
@@ -4027,7 +4047,7 @@ int lua_ax_base_Texture2D_updateTextureDesc(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::rhi::TextureDesc arg0;
         bool arg1;
@@ -4081,7 +4101,7 @@ int lua_ax_base_Texture2D_setRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -4131,7 +4151,7 @@ int lua_ax_base_Texture2D_isRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4148,53 +4168,6 @@ int lua_ax_base_Texture2D_isRenderTarget(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_isRenderTarget'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_generateMipmap(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_generateMipmap'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_generateMipmap'", nullptr);
-            return 0;
-        }
-        cobj->generateMipmap();
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:generateMipmap",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_generateMipmap'.",&tolua_err);
 #endif
 
     return 0;
@@ -4225,7 +4198,7 @@ int lua_ax_base_Texture2D_setAntiAliasTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4272,7 +4245,7 @@ int lua_ax_base_Texture2D_setAliasTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4319,7 +4292,7 @@ int lua_ax_base_Texture2D_getStringForFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4417,7 +4390,7 @@ int lua_ax_base_Texture2D_getContentSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4464,7 +4437,7 @@ int lua_ax_base_Texture2D_hasPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4511,7 +4484,7 @@ int lua_ax_base_Texture2D_setPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -4561,7 +4534,7 @@ int lua_ax_base_Texture2D_hasMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4608,7 +4581,7 @@ int lua_ax_base_Texture2D_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4655,7 +4628,7 @@ int lua_ax_base_Texture2D_getSamplerFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4702,7 +4675,7 @@ int lua_ax_base_Texture2D_getPixelsWide(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4749,7 +4722,7 @@ int lua_ax_base_Texture2D_getPixelsHigh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4770,7 +4743,7 @@ int lua_ax_base_Texture2D_getPixelsHigh(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Texture2D_getBackendTexture(lua_State* tolua_S)
+int lua_ax_base_Texture2D_getRHITexture(lua_State* tolua_S)
 {
     int argc = 0;
     ax::Texture2D* cobj = nullptr;
@@ -4790,29 +4763,29 @@ int lua_ax_base_Texture2D_getBackendTexture(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_getBackendTexture'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_getRHITexture'", nullptr);
         return 0;
     }
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_getBackendTexture'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_getRHITexture'", nullptr);
             return 0;
         }
-        auto&& ret = cobj->getBackendTexture();
+        auto&& ret = cobj->getRHITexture();
         object_to_luaval<ax::rhi::Texture>(tolua_S, "axrhi.Texture",(ax::rhi::Texture*)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:getBackendTexture",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:getRHITexture",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_getBackendTexture'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_getRHITexture'.",&tolua_err);
 #endif
 
     return 0;
@@ -4843,7 +4816,7 @@ int lua_ax_base_Texture2D_getMaxS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4890,7 +4863,7 @@ int lua_ax_base_Texture2D_setMaxS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -4940,7 +4913,7 @@ int lua_ax_base_Texture2D_getMaxT(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -4987,7 +4960,7 @@ int lua_ax_base_Texture2D_setMaxT(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -5037,7 +5010,7 @@ int lua_ax_base_Texture2D_getContentSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5084,7 +5057,7 @@ int lua_ax_base_Texture2D_getPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5105,44 +5078,6 @@ int lua_ax_base_Texture2D_getPath(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Texture2D_chooseSamplerDesc(lua_State* tolua_S)
-{
-    int argc = 0;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    argc = lua_gettop(tolua_S) - 1;
-
-    if (argc == 2)
-    {
-        bool arg0;
-        bool arg1;
-        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.Texture2D:chooseSamplerDesc");
-        ok &= luaval_to_boolean(tolua_S, 3,&arg1, "ax.Texture2D:chooseSamplerDesc");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_chooseSamplerDesc'", nullptr);
-            return 0;
-        }
-        auto&& ret = ax::Texture2D::chooseSamplerDesc(arg0, arg1);
-        #pragma warning NO CONVERSION FROM NATIVE FOR SamplerDesc;
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.Texture2D:chooseSamplerDesc",argc, 2);
-    return 0;
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_chooseSamplerDesc'.",&tolua_err);
-#endif
-    return 0;
-}
 int lua_ax_base_Texture2D_constructor(lua_State* tolua_S)
 {
     int argc = 0;
@@ -5156,7 +5091,7 @@ int lua_ax_base_Texture2D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5201,7 +5136,6 @@ int lua_register_ax_base_Texture2D(lua_State* tolua_S)
         tolua_function(tolua_S,"updateTextureDesc",lua_ax_base_Texture2D_updateTextureDesc);
         tolua_function(tolua_S,"setRenderTarget",lua_ax_base_Texture2D_setRenderTarget);
         tolua_function(tolua_S,"isRenderTarget",lua_ax_base_Texture2D_isRenderTarget);
-        tolua_function(tolua_S,"generateMipmap",lua_ax_base_Texture2D_generateMipmap);
         tolua_function(tolua_S,"setAntiAliasTexParameters",lua_ax_base_Texture2D_setAntiAliasTexParameters);
         tolua_function(tolua_S,"setAliasTexParameters",lua_ax_base_Texture2D_setAliasTexParameters);
         tolua_function(tolua_S,"getStringForFormat",lua_ax_base_Texture2D_getStringForFormat);
@@ -5214,14 +5148,13 @@ int lua_register_ax_base_Texture2D(lua_State* tolua_S)
         tolua_function(tolua_S,"getSamplerFlags",lua_ax_base_Texture2D_getSamplerFlags);
         tolua_function(tolua_S,"getPixelsWide",lua_ax_base_Texture2D_getPixelsWide);
         tolua_function(tolua_S,"getPixelsHigh",lua_ax_base_Texture2D_getPixelsHigh);
-        tolua_function(tolua_S,"getBackendTexture",lua_ax_base_Texture2D_getBackendTexture);
+        tolua_function(tolua_S,"getRHITexture",lua_ax_base_Texture2D_getRHITexture);
         tolua_function(tolua_S,"getMaxS",lua_ax_base_Texture2D_getMaxS);
         tolua_function(tolua_S,"setMaxS",lua_ax_base_Texture2D_setMaxS);
         tolua_function(tolua_S,"getMaxT",lua_ax_base_Texture2D_getMaxT);
         tolua_function(tolua_S,"setMaxT",lua_ax_base_Texture2D_setMaxT);
         tolua_function(tolua_S,"getContentSize",lua_ax_base_Texture2D_getContentSize);
         tolua_function(tolua_S,"getPath",lua_ax_base_Texture2D_getPath);
-        tolua_function(tolua_S,"chooseSamplerDesc", lua_ax_base_Texture2D_chooseSamplerDesc);
     tolua_endmodule(tolua_S);
     auto typeName = typeid(ax::Texture2D).name(); // rtti is literal storage
     g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.Texture2D";
@@ -5255,7 +5188,7 @@ int lua_ax_base_Component_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5302,7 +5235,7 @@ int lua_ax_base_Component_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5349,7 +5282,7 @@ int lua_ax_base_Component_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -5399,7 +5332,7 @@ int lua_ax_base_Component_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5446,7 +5379,7 @@ int lua_ax_base_Component_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -5496,7 +5429,7 @@ int lua_ax_base_Component_getOwner(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5543,7 +5476,7 @@ int lua_ax_base_Component_setOwner(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -5593,7 +5526,7 @@ int lua_ax_base_Component_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -5643,7 +5576,7 @@ int lua_ax_base_Component_onAdd(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5690,7 +5623,7 @@ int lua_ax_base_Component_onRemove(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5801,7 +5734,7 @@ int lua_ax_base_Node_getDescription(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5848,7 +5781,7 @@ int lua_ax_base_Node_setLocalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -5898,7 +5831,7 @@ int lua_ax_base_Node_updateOrderOfArrival(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5945,7 +5878,7 @@ int lua_ax_base_Node_getLocalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -5992,7 +5925,7 @@ int lua_ax_base_Node_setGlobalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6042,7 +5975,7 @@ int lua_ax_base_Node_getGlobalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6089,7 +6022,7 @@ int lua_ax_base_Node_setScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6139,7 +6072,7 @@ int lua_ax_base_Node_getScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6186,7 +6119,7 @@ int lua_ax_base_Node_setScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6236,7 +6169,7 @@ int lua_ax_base_Node_getScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6283,7 +6216,7 @@ int lua_ax_base_Node_setScaleZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6333,7 +6266,7 @@ int lua_ax_base_Node_getScaleZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6439,7 +6372,7 @@ int lua_ax_base_Node_getScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6545,7 +6478,7 @@ int lua_ax_base_Node_setPositionNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -6595,7 +6528,7 @@ int lua_ax_base_Node_setNormalizedPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -6645,7 +6578,7 @@ int lua_ax_base_Node_getPositionNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6692,7 +6625,7 @@ int lua_ax_base_Node_getNormalizedPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6739,7 +6672,7 @@ int lua_ax_base_Node_setPositionX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6789,7 +6722,7 @@ int lua_ax_base_Node_getPositionX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6836,7 +6769,7 @@ int lua_ax_base_Node_setPositionY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -6886,7 +6819,7 @@ int lua_ax_base_Node_getPositionY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -6933,7 +6866,7 @@ int lua_ax_base_Node_setPosition3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -6983,7 +6916,7 @@ int lua_ax_base_Node_getPosition3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7030,7 +6963,7 @@ int lua_ax_base_Node_setPositionZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -7080,7 +7013,7 @@ int lua_ax_base_Node_getPositionZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7127,7 +7060,7 @@ int lua_ax_base_Node_setSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -7177,7 +7110,7 @@ int lua_ax_base_Node_getSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7224,7 +7157,7 @@ int lua_ax_base_Node_setSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -7274,7 +7207,7 @@ int lua_ax_base_Node_getSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7321,7 +7254,7 @@ int lua_ax_base_Node_getAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7368,7 +7301,7 @@ int lua_ax_base_Node_getAnchorPointInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7415,7 +7348,7 @@ int lua_ax_base_Node_getContentSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7462,7 +7395,7 @@ int lua_ax_base_Node_hitTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -7512,7 +7445,7 @@ int lua_ax_base_Node_setVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -7562,7 +7495,7 @@ int lua_ax_base_Node_isVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7609,7 +7542,7 @@ int lua_ax_base_Node_setRotation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -7659,7 +7592,7 @@ int lua_ax_base_Node_getRotation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7706,7 +7639,7 @@ int lua_ax_base_Node_setRotation3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -7756,7 +7689,7 @@ int lua_ax_base_Node_getRotation3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7803,7 +7736,7 @@ int lua_ax_base_Node_setRotationSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -7853,7 +7786,7 @@ int lua_ax_base_Node_getRotationSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7900,7 +7833,7 @@ int lua_ax_base_Node_setRotationSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -7950,7 +7883,7 @@ int lua_ax_base_Node_getRotationSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -7997,7 +7930,7 @@ int lua_ax_base_Node_setIgnoreAnchorPointForPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -8047,7 +7980,7 @@ int lua_ax_base_Node_isIgnoreAnchorPointForPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -8193,7 +8126,7 @@ int lua_ax_base_Node_getChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -8243,7 +8176,7 @@ int lua_ax_base_Node_getChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -8340,7 +8273,7 @@ int lua_ax_base_Node_getChildrenCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -8387,7 +8320,7 @@ int lua_ax_base_Node_setParent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -8535,7 +8468,7 @@ int lua_ax_base_Node_removeChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -8549,7 +8482,7 @@ int lua_ax_base_Node_removeChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -8602,7 +8535,7 @@ int lua_ax_base_Node_removeChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -8616,7 +8549,7 @@ int lua_ax_base_Node_removeChildByTag(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         bool arg1;
@@ -8669,7 +8602,7 @@ int lua_ax_base_Node_removeChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -8683,7 +8616,7 @@ int lua_ax_base_Node_removeChildByName(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         bool arg1;
@@ -8787,7 +8720,7 @@ int lua_ax_base_Node_reorderChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         int arg1;
@@ -8840,7 +8773,7 @@ int lua_ax_base_Node_sortAllChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -8887,7 +8820,7 @@ int lua_ax_base_Node_getTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -8934,7 +8867,7 @@ int lua_ax_base_Node_setTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -8984,7 +8917,7 @@ int lua_ax_base_Node_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9031,7 +8964,7 @@ int lua_ax_base_Node_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -9081,7 +9014,7 @@ int lua_ax_base_Node_setUserObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Object* arg0;
 
@@ -9131,7 +9064,7 @@ int lua_ax_base_Node_isRunning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9178,7 +9111,7 @@ int lua_ax_base_Node_cleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9343,7 +9276,7 @@ int lua_ax_base_Node_getScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9390,7 +9323,7 @@ int lua_ax_base_Node_getBoundingBox(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9437,7 +9370,7 @@ int lua_ax_base_Node_setEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventDispatcher* arg0;
 
@@ -9487,7 +9420,7 @@ int lua_ax_base_Node_getEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9534,7 +9467,7 @@ int lua_ax_base_Node_setActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionManager* arg0;
 
@@ -9631,7 +9564,7 @@ int lua_ax_base_Node_runAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Action* arg0;
 
@@ -9681,7 +9614,7 @@ int lua_ax_base_Node_stopAllActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -9728,7 +9661,7 @@ int lua_ax_base_Node_stopAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Action* arg0;
 
@@ -9778,7 +9711,7 @@ int lua_ax_base_Node_stopActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -9828,7 +9761,7 @@ int lua_ax_base_Node_stopAllActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -9878,7 +9811,7 @@ int lua_ax_base_Node_stopActionsByFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -9928,7 +9861,7 @@ int lua_ax_base_Node_getActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -9978,7 +9911,7 @@ int lua_ax_base_Node_getNumberOfRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10025,7 +9958,7 @@ int lua_ax_base_Node_getNumberOfRunningActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -10075,7 +10008,7 @@ int lua_ax_base_Node_setScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Scheduler* arg0;
 
@@ -10172,7 +10105,7 @@ int lua_ax_base_Node_isScheduled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -10222,7 +10155,7 @@ int lua_ax_base_Node_resume(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10269,7 +10202,7 @@ int lua_ax_base_Node_pause(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10316,7 +10249,7 @@ int lua_ax_base_Node_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -10366,7 +10299,7 @@ int lua_ax_base_Node_updateTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10515,7 +10448,7 @@ int lua_ax_base_Node_setNodeToParentTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Mat4 arg0;
 
@@ -10565,7 +10498,7 @@ int lua_ax_base_Node_getParentToNodeTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10612,7 +10545,7 @@ int lua_ax_base_Node_getParentToNodeAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10659,7 +10592,7 @@ int lua_ax_base_Node_getNodeToWorldTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10706,7 +10639,7 @@ int lua_ax_base_Node_getNodeToWorldAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10753,7 +10686,7 @@ int lua_ax_base_Node_getWorldToNodeTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10800,7 +10733,7 @@ int lua_ax_base_Node_getWorldToNodeAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -10847,7 +10780,7 @@ int lua_ax_base_Node_convertToNodeSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -10897,7 +10830,7 @@ int lua_ax_base_Node_convertToWorldSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -10947,7 +10880,7 @@ int lua_ax_base_Node_convertToNodeSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -10997,7 +10930,7 @@ int lua_ax_base_Node_convertToWorldSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -11047,7 +10980,7 @@ int lua_ax_base_Node_convertTouchToNodeSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Touch* arg0;
 
@@ -11097,7 +11030,7 @@ int lua_ax_base_Node_convertTouchToNodeSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Touch* arg0;
 
@@ -11147,7 +11080,7 @@ int lua_ax_base_Node_getWorldPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11194,7 +11127,7 @@ int lua_ax_base_Node_setWorldPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -11244,7 +11177,7 @@ int lua_ax_base_Node_getComponent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -11294,7 +11227,7 @@ int lua_ax_base_Node_addComponent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Component* arg0;
 
@@ -11399,7 +11332,7 @@ int lua_ax_base_Node_removeAllComponents(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11446,7 +11379,7 @@ int lua_ax_base_Node_getOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11493,7 +11426,7 @@ int lua_ax_base_Node_getDisplayedOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11540,7 +11473,7 @@ int lua_ax_base_Node_setOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         uint16_t arg0;
 
@@ -11590,7 +11523,7 @@ int lua_ax_base_Node_updateDisplayedOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         uint16_t arg0;
 
@@ -11640,7 +11573,7 @@ int lua_ax_base_Node_isCascadeOpacityEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11687,7 +11620,7 @@ int lua_ax_base_Node_setCascadeOpacityEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -11737,7 +11670,7 @@ int lua_ax_base_Node_getColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11784,7 +11717,7 @@ int lua_ax_base_Node_getDisplayedColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11831,7 +11764,7 @@ int lua_ax_base_Node_setColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -11881,7 +11814,7 @@ int lua_ax_base_Node_updateDisplayedColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -11931,7 +11864,7 @@ int lua_ax_base_Node_isCascadeColorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -11978,7 +11911,7 @@ int lua_ax_base_Node_setCascadeColorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -12028,7 +11961,7 @@ int lua_ax_base_Node_setOpacityModifyRGB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -12078,7 +12011,7 @@ int lua_ax_base_Node_isOpacityModifyRGB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -12125,7 +12058,7 @@ int lua_ax_base_Node_setOnEnterCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void ()> arg0;
 
@@ -12179,7 +12112,7 @@ int lua_ax_base_Node_setOnExitCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void ()> arg0;
 
@@ -12233,7 +12166,7 @@ int lua_ax_base_Node_setOnEnterTransitionDidFinishCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void ()> arg0;
 
@@ -12287,7 +12220,7 @@ int lua_ax_base_Node_getOnEnterTransitionDidFinishCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -12334,7 +12267,7 @@ int lua_ax_base_Node_setOnExitTransitionDidStartCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void ()> arg0;
 
@@ -12388,7 +12321,7 @@ int lua_ax_base_Node_getOnExitTransitionDidStartCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -12435,7 +12368,7 @@ int lua_ax_base_Node_getCameraMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -12482,7 +12415,7 @@ int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned short arg0;
 
@@ -12496,7 +12429,7 @@ int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned short arg0;
         bool arg1;
@@ -12549,7 +12482,7 @@ int lua_ax_base_Node_applyMaskOnEnter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -12670,7 +12603,7 @@ int lua_ax_base_Node_setProgramStateWithRegistry(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned int arg0;
         ax::Texture2D* arg1;
@@ -12723,7 +12656,7 @@ int lua_ax_base_Node_setProgramStateByProgramId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned long long arg0;
 
@@ -12773,7 +12706,7 @@ int lua_ax_base_Node_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -12820,7 +12753,7 @@ int lua_ax_base_Node_updateProgramStateTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -12870,7 +12803,7 @@ int lua_ax_base_Node_resetChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -12923,7 +12856,7 @@ int lua_ax_base_Node_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -12970,7 +12903,7 @@ int lua_ax_base_Node_initLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13017,7 +12950,7 @@ int lua_ax_base_Node_setPhysicsBody(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::PhysicsBody* arg0;
 
@@ -13067,7 +13000,7 @@ int lua_ax_base_Node_getPhysicsBody(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13169,7 +13102,7 @@ int lua_ax_base_Node_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13387,7 +13320,7 @@ int lua_ax_base_Image_initWithImageFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -13437,7 +13370,7 @@ int lua_ax_base_Image_flipRawData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13484,7 +13417,7 @@ int lua_ax_base_Image_getFileType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13531,7 +13464,7 @@ int lua_ax_base_Image_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13578,7 +13511,7 @@ int lua_ax_base_Image_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13625,7 +13558,7 @@ int lua_ax_base_Image_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13672,7 +13605,7 @@ int lua_ax_base_Image_getNumberOfMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13719,7 +13652,7 @@ int lua_ax_base_Image_hasPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13766,7 +13699,7 @@ int lua_ax_base_Image_getFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13813,7 +13746,7 @@ int lua_ax_base_Image_getBitPerPixel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13860,7 +13793,7 @@ int lua_ax_base_Image_hasAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13907,7 +13840,7 @@ int lua_ax_base_Image_isCompressed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -13954,7 +13887,7 @@ int lua_ax_base_Image_saveToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -13968,7 +13901,7 @@ int lua_ax_base_Image_saveToFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         bool arg1;
@@ -14021,7 +13954,7 @@ int lua_ax_base_Image_premultiplyAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14068,7 +14001,7 @@ int lua_ax_base_Image_reversePremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14212,7 +14145,7 @@ int lua_ax_base_Image_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14300,7 +14233,7 @@ int lua_ax_base_PolygonInfo_setQuad(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::V3F_T2F_C4B_Quad* arg0;
 
@@ -14351,7 +14284,7 @@ int lua_ax_base_PolygonInfo_setQuads(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::V3F_T2F_C4B_Quad* arg0;
         int arg1;
@@ -14405,7 +14338,7 @@ int lua_ax_base_PolygonInfo_setTriangles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TrianglesCommand::Triangles arg0;
 
@@ -14456,7 +14389,7 @@ int lua_ax_base_PolygonInfo_getVertCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14503,7 +14436,7 @@ int lua_ax_base_PolygonInfo_getTrianglesCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14550,7 +14483,7 @@ int lua_ax_base_PolygonInfo_getArea(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14597,7 +14530,7 @@ int lua_ax_base_PolygonInfo_getRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14644,7 +14577,7 @@ int lua_ax_base_PolygonInfo_setRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -14694,7 +14627,7 @@ int lua_ax_base_PolygonInfo_getFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14741,7 +14674,7 @@ int lua_ax_base_PolygonInfo_setFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -14778,7 +14711,7 @@ int lua_ax_base_PolygonInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14843,7 +14776,7 @@ int lua_ax_base_AutoPolygon_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -14914,7 +14847,7 @@ int lua_ax_base_SpriteFrame_getRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -14961,7 +14894,7 @@ int lua_ax_base_SpriteFrame_setRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -15011,7 +14944,7 @@ int lua_ax_base_SpriteFrame_isRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15058,7 +14991,7 @@ int lua_ax_base_SpriteFrame_setRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -15108,7 +15041,7 @@ int lua_ax_base_SpriteFrame_getRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15155,7 +15088,7 @@ int lua_ax_base_SpriteFrame_setRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -15205,7 +15138,7 @@ int lua_ax_base_SpriteFrame_getCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15252,7 +15185,7 @@ int lua_ax_base_SpriteFrame_setCenterRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -15302,7 +15235,7 @@ int lua_ax_base_SpriteFrame_hasCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15349,7 +15282,7 @@ int lua_ax_base_SpriteFrame_getOffsetInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15396,7 +15329,7 @@ int lua_ax_base_SpriteFrame_setOffsetInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -15446,7 +15379,7 @@ int lua_ax_base_SpriteFrame_getOriginalSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15493,7 +15426,7 @@ int lua_ax_base_SpriteFrame_setOriginalSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -15543,7 +15476,7 @@ int lua_ax_base_SpriteFrame_getOriginalSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15590,7 +15523,7 @@ int lua_ax_base_SpriteFrame_setOriginalSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -15640,7 +15573,7 @@ int lua_ax_base_SpriteFrame_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15687,7 +15620,7 @@ int lua_ax_base_SpriteFrame_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -15737,7 +15670,7 @@ int lua_ax_base_SpriteFrame_getOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15784,7 +15717,7 @@ int lua_ax_base_SpriteFrame_setOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -15834,7 +15767,7 @@ int lua_ax_base_SpriteFrame_getAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15881,7 +15814,7 @@ int lua_ax_base_SpriteFrame_setAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -15931,7 +15864,7 @@ int lua_ax_base_SpriteFrame_hasAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -15978,7 +15911,7 @@ int lua_ax_base_SpriteFrame_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16175,7 +16108,7 @@ int lua_ax_base_SpriteFrame_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16210,7 +16143,7 @@ int lua_ax_base_SpriteFrame_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -16235,7 +16168,7 @@ int lua_ax_base_SpriteFrame_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -16273,7 +16206,7 @@ int lua_ax_base_SpriteFrame_createWithTexture(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -16298,7 +16231,7 @@ int lua_ax_base_SpriteFrame_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -16335,7 +16268,7 @@ int lua_ax_base_SpriteFrame_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16433,7 +16366,7 @@ int lua_ax_base_AnimationFrame_getSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16480,7 +16413,7 @@ int lua_ax_base_AnimationFrame_setSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -16530,7 +16463,7 @@ int lua_ax_base_AnimationFrame_getDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16577,7 +16510,7 @@ int lua_ax_base_AnimationFrame_setDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -16674,7 +16607,7 @@ int lua_ax_base_AnimationFrame_setUserInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMap arg0;
 
@@ -16724,7 +16657,7 @@ int lua_ax_base_AnimationFrame_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16771,7 +16704,7 @@ int lua_ax_base_AnimationFrame_initWithSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::SpriteFrame* arg0;
         double arg1;
@@ -16854,7 +16787,7 @@ int lua_ax_base_AnimationFrame_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -16933,7 +16866,7 @@ int lua_ax_base_Animation_addSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -16983,7 +16916,7 @@ int lua_ax_base_Animation_addSpriteFrameWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -17033,7 +16966,7 @@ int lua_ax_base_Animation_addSpriteFrameWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Texture2D* arg0;
         ax::Rect arg1;
@@ -17086,7 +17019,7 @@ int lua_ax_base_Animation_getTotalDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17133,7 +17066,7 @@ int lua_ax_base_Animation_setDelayPerUnit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -17183,7 +17116,7 @@ int lua_ax_base_Animation_getDelayPerUnit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17230,7 +17163,7 @@ int lua_ax_base_Animation_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17277,7 +17210,7 @@ int lua_ax_base_Animation_getFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17324,7 +17257,7 @@ int lua_ax_base_Animation_setFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::AnimationFrame *> arg0;
 
@@ -17374,7 +17307,7 @@ int lua_ax_base_Animation_getRestoreOriginalFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17421,7 +17354,7 @@ int lua_ax_base_Animation_setRestoreOriginalFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -17471,7 +17404,7 @@ int lua_ax_base_Animation_getLoops(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17518,7 +17451,7 @@ int lua_ax_base_Animation_setLoops(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -17568,7 +17501,7 @@ int lua_ax_base_Animation_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17615,7 +17548,7 @@ int lua_ax_base_Animation_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -17662,7 +17595,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::SpriteFrame *> arg0;
 
@@ -17676,7 +17609,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Vector<ax::SpriteFrame *> arg0;
         double arg1;
@@ -17693,7 +17626,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vector<ax::SpriteFrame *> arg0;
         double arg1;
@@ -17749,7 +17682,7 @@ int lua_ax_base_Animation_initWithAnimationFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vector<ax::AnimationFrame *> arg0;
         double arg1;
@@ -17793,7 +17726,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -17809,7 +17742,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -17828,7 +17761,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -17927,7 +17860,7 @@ int lua_ax_base_Animation_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18016,7 +17949,7 @@ int lua_ax_base_ActionInterval_getElapsed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18063,7 +17996,7 @@ int lua_ax_base_ActionInterval_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -18113,7 +18046,7 @@ int lua_ax_base_ActionInterval_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18160,7 +18093,7 @@ int lua_ax_base_ActionInterval_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -18233,7 +18166,7 @@ int lua_ax_base_Sequence_initWithTwoActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::FiniteTimeAction* arg0;
         ax::FiniteTimeAction* arg1;
@@ -18286,7 +18219,7 @@ int lua_ax_base_Sequence_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::FiniteTimeAction *> arg0;
 
@@ -18323,7 +18256,7 @@ int lua_ax_base_Sequence_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18395,7 +18328,7 @@ int lua_ax_base_Repeat_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::FiniteTimeAction* arg0;
 
@@ -18445,7 +18378,7 @@ int lua_ax_base_Repeat_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18492,7 +18425,7 @@ int lua_ax_base_Repeat_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::FiniteTimeAction* arg0;
         unsigned int arg1;
@@ -18570,7 +18503,7 @@ int lua_ax_base_Repeat_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18644,7 +18577,7 @@ int lua_ax_base_RepeatForever_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -18694,7 +18627,7 @@ int lua_ax_base_RepeatForever_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18741,7 +18674,7 @@ int lua_ax_base_RepeatForever_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -18814,7 +18747,7 @@ int lua_ax_base_RepeatForever_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -18888,7 +18821,7 @@ int lua_ax_base_Spawn_initWithTwoActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::FiniteTimeAction* arg0;
         ax::FiniteTimeAction* arg1;
@@ -18941,7 +18874,7 @@ int lua_ax_base_Spawn_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::FiniteTimeAction *> arg0;
 
@@ -18978,7 +18911,7 @@ int lua_ax_base_Spawn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -19105,7 +19038,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19121,7 +19054,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -19140,7 +19073,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19177,7 +19110,7 @@ int lua_ax_base_RotateTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -19320,7 +19253,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -19339,7 +19272,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19355,7 +19288,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19392,7 +19325,7 @@ int lua_ax_base_RotateBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -19515,7 +19448,7 @@ int lua_ax_base_MoveBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19531,7 +19464,7 @@ int lua_ax_base_MoveBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19568,7 +19501,7 @@ int lua_ax_base_MoveBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -19691,7 +19624,7 @@ int lua_ax_base_MoveTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19707,7 +19640,7 @@ int lua_ax_base_MoveTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -19744,7 +19677,7 @@ int lua_ax_base_MoveTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -19816,7 +19749,7 @@ int lua_ax_base_SkewTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         double arg1;
@@ -19899,7 +19832,7 @@ int lua_ax_base_SkewTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -19971,7 +19904,7 @@ int lua_ax_base_SkewBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         double arg1;
@@ -20054,7 +19987,7 @@ int lua_ax_base_SkewBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -20126,7 +20059,7 @@ int lua_ax_base_JumpBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -20214,7 +20147,7 @@ int lua_ax_base_JumpBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -20286,7 +20219,7 @@ int lua_ax_base_JumpTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -20374,7 +20307,7 @@ int lua_ax_base_JumpTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -20446,7 +20379,7 @@ int lua_ax_base_BezierBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::BezierConfig arg1;
@@ -20487,7 +20420,7 @@ int lua_ax_base_BezierBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -20558,7 +20491,7 @@ int lua_ax_base_BezierTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::BezierConfig arg1;
@@ -20599,7 +20532,7 @@ int lua_ax_base_BezierTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -20749,7 +20682,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -20768,7 +20701,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -20784,7 +20717,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -20827,7 +20760,7 @@ int lua_ax_base_ScaleTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -20887,7 +20820,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -20906,7 +20839,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -20922,7 +20855,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -20965,7 +20898,7 @@ int lua_ax_base_ScaleBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21036,7 +20969,7 @@ int lua_ax_base_Blink_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         int arg1;
@@ -21114,7 +21047,7 @@ int lua_ax_base_Blink_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21186,7 +21119,7 @@ int lua_ax_base_FadeTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         uint16_t arg1;
@@ -21264,7 +21197,7 @@ int lua_ax_base_FadeTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21336,7 +21269,7 @@ int lua_ax_base_FadeIn_setReverseAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::FadeTo* arg0;
 
@@ -21409,7 +21342,7 @@ int lua_ax_base_FadeIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21481,7 +21414,7 @@ int lua_ax_base_FadeOut_setReverseAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::FadeTo* arg0;
 
@@ -21554,7 +21487,7 @@ int lua_ax_base_FadeOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21626,7 +21559,7 @@ int lua_ax_base_TintTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::Color32 arg1;
@@ -21667,7 +21600,7 @@ int lua_ax_base_TintTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -21683,7 +21616,7 @@ int lua_ax_base_TintTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -21726,7 +21659,7 @@ int lua_ax_base_TintTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21798,7 +21731,7 @@ int lua_ax_base_TintBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         int32_t arg1;
@@ -21886,7 +21819,7 @@ int lua_ax_base_TintBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -21981,7 +21914,7 @@ int lua_ax_base_DelayTime_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22052,7 +21985,7 @@ int lua_ax_base_Animate_setAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Animation* arg0;
 
@@ -22149,7 +22082,7 @@ int lua_ax_base_Animate_getCurrentFrameIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22196,7 +22129,7 @@ int lua_ax_base_Animate_initWithAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Animation* arg0;
 
@@ -22269,7 +22202,7 @@ int lua_ax_base_Animate_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22344,7 +22277,7 @@ int lua_ax_base_TargetedAction_setForcedTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -22441,7 +22374,7 @@ int lua_ax_base_TargetedAction_initWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         ax::FiniteTimeAction* arg1;
@@ -22519,7 +22452,7 @@ int lua_ax_base_TargetedAction_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22593,7 +22526,7 @@ int lua_ax_base_ActionFloat_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -22689,7 +22622,7 @@ int lua_ax_base_ActionFloat_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22761,7 +22694,7 @@ int lua_ax_base_Scene_getDefaultCamera(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22808,7 +22741,7 @@ int lua_ax_base_Scene_render(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Renderer* arg0;
         ax::Mat4 arg1;
@@ -22825,7 +22758,7 @@ int lua_ax_base_Scene_render(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Renderer* arg0;
         ax::Mat4 arg1;
@@ -22881,7 +22814,7 @@ int lua_ax_base_Scene_initWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -22931,7 +22864,7 @@ int lua_ax_base_Scene_setCameraOrderDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -22978,7 +22911,7 @@ int lua_ax_base_Scene_onProjectionChanged(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventCustom* arg0;
 
@@ -23028,7 +22961,7 @@ int lua_ax_base_Scene_getPhysicsWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23075,7 +23008,7 @@ int lua_ax_base_Scene_initWithPhysics(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23122,7 +23055,7 @@ int lua_ax_base_Scene_initPhysicsWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23169,7 +23102,7 @@ int lua_ax_base_Scene_fixedUpdate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -23219,7 +23152,7 @@ int lua_ax_base_Scene_stepPhysicsAndNavigation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -23360,7 +23293,7 @@ int lua_ax_base_Scene_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23443,7 +23376,7 @@ int lua_ax_base_RenderView_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23490,7 +23423,7 @@ int lua_ax_base_RenderView_isGfxContextReady(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23537,7 +23470,7 @@ int lua_ax_base_RenderView_swapBuffers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23584,7 +23517,7 @@ int lua_ax_base_RenderView_setIMEKeyboardState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -23634,7 +23567,7 @@ int lua_ax_base_RenderView_windowShouldClose(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23681,7 +23614,7 @@ int lua_ax_base_RenderView_pollEvents(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23728,7 +23661,7 @@ int lua_ax_base_RenderView_getFrameSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23775,7 +23708,7 @@ int lua_ax_base_RenderView_setFrameSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -23828,7 +23761,7 @@ int lua_ax_base_RenderView_setFrameZoomFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -23878,7 +23811,7 @@ int lua_ax_base_RenderView_getFrameZoomFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -23925,7 +23858,7 @@ int lua_ax_base_RenderView_setCursorVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -23975,7 +23908,7 @@ int lua_ax_base_RenderView_getRetinaFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24022,7 +23955,7 @@ int lua_ax_base_RenderView_setContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -24072,7 +24005,7 @@ int lua_ax_base_RenderView_getContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24119,7 +24052,7 @@ int lua_ax_base_RenderView_isRetinaDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24166,7 +24099,7 @@ int lua_ax_base_RenderView_getVisibleSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24213,7 +24146,7 @@ int lua_ax_base_RenderView_getVisibleOrigin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24260,7 +24193,7 @@ int lua_ax_base_RenderView_getVisibleRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24307,7 +24240,7 @@ int lua_ax_base_RenderView_getSafeAreaRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24354,7 +24287,7 @@ int lua_ax_base_RenderView_setDesignResolutionSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         double arg1;
@@ -24410,7 +24343,7 @@ int lua_ax_base_RenderView_getDesignResolutionSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24457,7 +24390,7 @@ int lua_ax_base_RenderView_setViewPortInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -24516,7 +24449,7 @@ int lua_ax_base_RenderView_setScissorInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -24575,7 +24508,7 @@ int lua_ax_base_RenderView_isScissorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24622,7 +24555,7 @@ int lua_ax_base_RenderView_getScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24669,7 +24602,7 @@ int lua_ax_base_RenderView_setViewName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -24719,7 +24652,7 @@ int lua_ax_base_RenderView_getViewName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24821,7 +24754,7 @@ int lua_ax_base_RenderView_setDefaultIcon(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24868,7 +24801,7 @@ int lua_ax_base_RenderView_getViewPortRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24915,7 +24848,7 @@ int lua_ax_base_RenderView_getScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -24962,7 +24895,7 @@ int lua_ax_base_RenderView_getScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25009,7 +24942,7 @@ int lua_ax_base_RenderView_getResolutionPolicy(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25056,7 +24989,7 @@ int lua_ax_base_RenderView_renderScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Scene* arg0;
         ax::Renderer* arg1;
@@ -25109,7 +25042,7 @@ int lua_ax_base_RenderView_setInteractive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -25286,7 +25219,7 @@ int lua_ax_base_Director_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25333,7 +25266,7 @@ int lua_ax_base_Director_getRunningScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25380,7 +25313,7 @@ int lua_ax_base_Director_getNextScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25427,7 +25360,7 @@ int lua_ax_base_Director_getAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25474,7 +25407,7 @@ int lua_ax_base_Director_setAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -25524,7 +25457,7 @@ int lua_ax_base_Director_isStatsDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25571,7 +25504,7 @@ int lua_ax_base_Director_setStatsDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -25621,7 +25554,7 @@ int lua_ax_base_Director_getSecondsPerFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25668,7 +25601,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25679,7 +25612,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::AnchorPreset arg0;
 
@@ -25729,7 +25662,7 @@ int lua_ax_base_Director_getRenderView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25776,7 +25709,7 @@ int lua_ax_base_Director_setRenderView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::RenderView* arg0;
 
@@ -25826,7 +25759,7 @@ int lua_ax_base_Director_getTextureCache(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25873,7 +25806,7 @@ int lua_ax_base_Director_isNextDeltaTimeZero(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -25920,7 +25853,7 @@ int lua_ax_base_Director_setNextDeltaTimeZero(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -25970,7 +25903,7 @@ int lua_ax_base_Director_isPaused(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26017,7 +25950,7 @@ int lua_ax_base_Director_getTotalFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26064,7 +25997,7 @@ int lua_ax_base_Director_setProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Director::Projection arg0;
 
@@ -26114,7 +26047,7 @@ int lua_ax_base_Director_setViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26161,7 +26094,7 @@ int lua_ax_base_Director_isSendCleanupToScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26208,7 +26141,7 @@ int lua_ax_base_Director_getNotificationNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26255,7 +26188,7 @@ int lua_ax_base_Director_setNotificationNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -26305,7 +26238,7 @@ int lua_ax_base_Director_getWinSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26352,7 +26285,7 @@ int lua_ax_base_Director_getWinSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26399,7 +26332,7 @@ int lua_ax_base_Director_getVisibleSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26446,7 +26379,7 @@ int lua_ax_base_Director_getVisibleOrigin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26493,7 +26426,7 @@ int lua_ax_base_Director_getSafeAreaRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26540,7 +26473,7 @@ int lua_ax_base_Director_convertToGL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -26590,7 +26523,7 @@ int lua_ax_base_Director_convertToUI(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -26640,7 +26573,7 @@ int lua_ax_base_Director_getZEye(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26687,7 +26620,7 @@ int lua_ax_base_Director_runWithScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Scene* arg0;
 
@@ -26737,7 +26670,7 @@ int lua_ax_base_Director_pushScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Scene* arg0;
 
@@ -26787,7 +26720,7 @@ int lua_ax_base_Director_popScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26834,7 +26767,7 @@ int lua_ax_base_Director_popToRootScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -26881,7 +26814,7 @@ int lua_ax_base_Director_popToSceneStackLevel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -26931,7 +26864,7 @@ int lua_ax_base_Director_replaceScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Scene* arg0;
 
@@ -26981,7 +26914,7 @@ int lua_ax_base_Director_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27028,7 +26961,7 @@ int lua_ax_base_Director_pause(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27075,7 +27008,7 @@ int lua_ax_base_Director_resume(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27122,7 +27055,7 @@ int lua_ax_base_Director_restart(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27169,7 +27102,7 @@ int lua_ax_base_Director_stopAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27216,7 +27149,7 @@ int lua_ax_base_Director_startAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27263,7 +27196,7 @@ int lua_ax_base_Director_drawScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27310,7 +27243,7 @@ int lua_ax_base_Director_purgeCachedData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27357,7 +27290,7 @@ int lua_ax_base_Director_setDefaultValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27404,7 +27337,7 @@ int lua_ax_base_Director_setGLDefaultValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27451,7 +27384,7 @@ int lua_ax_base_Director_setClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -27552,7 +27485,7 @@ int lua_ax_base_Director_setContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -27602,7 +27535,7 @@ int lua_ax_base_Director_getContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27649,7 +27582,7 @@ int lua_ax_base_Director_getScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27696,7 +27629,7 @@ int lua_ax_base_Director_setScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Scheduler* arg0;
 
@@ -27746,7 +27679,7 @@ int lua_ax_base_Director_getActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27793,7 +27726,7 @@ int lua_ax_base_Director_setActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionManager* arg0;
 
@@ -27843,7 +27776,7 @@ int lua_ax_base_Director_getEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27890,7 +27823,7 @@ int lua_ax_base_Director_setEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventDispatcher* arg0;
 
@@ -27940,7 +27873,7 @@ int lua_ax_base_Director_getRenderer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -27987,7 +27920,7 @@ int lua_ax_base_Director_getDeltaTime(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28034,7 +27967,7 @@ int lua_ax_base_Director_getFrameRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28081,7 +28014,7 @@ int lua_ax_base_Director_pushMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28131,7 +28064,7 @@ int lua_ax_base_Director_popMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28181,7 +28114,7 @@ int lua_ax_base_Director_loadIdentityMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28231,7 +28164,7 @@ int lua_ax_base_Director_loadMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::MATRIX_STACK_TYPE arg0;
         ax::Mat4 arg1;
@@ -28284,7 +28217,7 @@ int lua_ax_base_Director_multiplyMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::MATRIX_STACK_TYPE arg0;
         ax::Mat4 arg1;
@@ -28337,7 +28270,7 @@ int lua_ax_base_Director_getMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28387,7 +28320,7 @@ int lua_ax_base_Director_resetMatrixStack(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28434,7 +28367,7 @@ int lua_ax_base_Director_getAxmolThreadId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28481,7 +28414,7 @@ int lua_ax_base_Director_setChildrenIndexerEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -28531,7 +28464,7 @@ int lua_ax_base_Director_isChildrenIndexerEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28578,7 +28511,7 @@ int lua_ax_base_Director_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28783,7 +28716,7 @@ int lua_ax_base_Properties_getNextProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28830,7 +28763,7 @@ int lua_ax_base_Properties_getNextNamespace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -28877,7 +28810,7 @@ int lua_ax_base_Properties_rewind(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29011,7 +28944,7 @@ int lua_ax_base_Properties_getId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29058,7 +28991,7 @@ int lua_ax_base_Properties_exists(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29108,7 +29041,7 @@ int lua_ax_base_Properties_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29119,7 +29052,7 @@ int lua_ax_base_Properties_getType(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29169,7 +29102,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29180,7 +29113,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29194,7 +29127,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         const char* arg1;
@@ -29247,7 +29180,7 @@ int lua_ax_base_Properties_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         const char* arg1;
@@ -29300,7 +29233,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29311,7 +29244,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29325,7 +29258,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         bool arg1;
@@ -29378,7 +29311,7 @@ int lua_ax_base_Properties_getInt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29389,7 +29322,7 @@ int lua_ax_base_Properties_getInt(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29439,7 +29372,7 @@ int lua_ax_base_Properties_getFloat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -29450,7 +29383,7 @@ int lua_ax_base_Properties_getFloat(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29500,7 +29433,7 @@ int lua_ax_base_Properties_getMat4(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         ax::Mat4* arg1;
@@ -29553,7 +29486,7 @@ int lua_ax_base_Properties_getVec2(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         ax::Vec2* arg1;
@@ -29606,7 +29539,7 @@ int lua_ax_base_Properties_getVec3(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         ax::Vec3* arg1;
@@ -29659,7 +29592,7 @@ int lua_ax_base_Properties_getVec4(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         ax::Vec4* arg1;
@@ -29712,7 +29645,7 @@ int lua_ax_base_Properties_getQuaternionFromAxisAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         ax::Quaternion* arg1;
@@ -29765,7 +29698,7 @@ int lua_ax_base_Properties_getColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         ax::Color* arg1;
@@ -29819,7 +29752,7 @@ int lua_ax_base_Properties_getPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         std::string* arg1;
@@ -29873,7 +29806,7 @@ int lua_ax_base_Properties_getVariable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -29887,7 +29820,7 @@ int lua_ax_base_Properties_getVariable(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         const char* arg1;
@@ -29940,7 +29873,7 @@ int lua_ax_base_Properties_setVariable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         const char* arg1;
@@ -30229,7 +30162,7 @@ int lua_ax_base_Timer_setupTimerWithInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         unsigned int arg1;
@@ -30285,7 +30218,7 @@ int lua_ax_base_Timer_setAborted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -30332,7 +30265,7 @@ int lua_ax_base_Timer_isAborted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -30379,7 +30312,7 @@ int lua_ax_base_Timer_isExhausted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -30426,7 +30359,7 @@ int lua_ax_base_Timer_trigger(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -30476,7 +30409,7 @@ int lua_ax_base_Timer_cancel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -30523,7 +30456,7 @@ int lua_ax_base_Timer_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -30599,7 +30532,7 @@ int lua_ax_base_Scheduler_getTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -30646,7 +30579,7 @@ int lua_ax_base_Scheduler_setTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -30696,7 +30629,7 @@ int lua_ax_base_Scheduler_runOnAxmolThread(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void ()> arg0;
 
@@ -30750,7 +30683,7 @@ int lua_ax_base_Scheduler_removeAllPendingActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -30784,7 +30717,7 @@ int lua_ax_base_Scheduler_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -31212,7 +31145,7 @@ int lua_ax_base_UserDefault_setBoolForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         bool arg1;
@@ -31265,7 +31198,7 @@ int lua_ax_base_UserDefault_setIntegerForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         int arg1;
@@ -31318,7 +31251,7 @@ int lua_ax_base_UserDefault_setLargeIntForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         long long arg1;
@@ -31371,7 +31304,7 @@ int lua_ax_base_UserDefault_setFloatForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         double arg1;
@@ -31424,7 +31357,7 @@ int lua_ax_base_UserDefault_setDoubleForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         double arg1;
@@ -31477,7 +31410,7 @@ int lua_ax_base_UserDefault_setStringForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         std::string_view arg1;
@@ -31530,7 +31463,7 @@ int lua_ax_base_UserDefault_flush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -31577,7 +31510,7 @@ int lua_ax_base_UserDefault_deleteValueForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         const char* arg0;
 
@@ -31627,7 +31560,7 @@ int lua_ax_base_UserDefault_setEncryptEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         bool arg0;
         std::string_view arg1;
@@ -31800,7 +31733,7 @@ int lua_ax_base_FileUtils_purgeCachedEntries(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -31847,7 +31780,7 @@ int lua_ax_base_FileUtils_getStringFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -31897,7 +31830,7 @@ int lua_ax_base_FileUtils_fullPathForFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -31947,7 +31880,7 @@ int lua_ax_base_FileUtils_fullPathFromRelativeFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -32000,7 +31933,7 @@ int lua_ax_base_FileUtils_fullPathForDirectory(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -32050,7 +31983,7 @@ int lua_ax_base_FileUtils_setSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::vector<std::string> arg0;
 
@@ -32100,7 +32033,7 @@ int lua_ax_base_FileUtils_getDefaultResourceRootPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -32147,7 +32080,7 @@ int lua_ax_base_FileUtils_setDefaultResourceRootPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -32197,7 +32130,7 @@ int lua_ax_base_FileUtils_addSearchPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -32211,7 +32144,7 @@ int lua_ax_base_FileUtils_addSearchPath(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         bool arg1;
@@ -32264,7 +32197,7 @@ int lua_ax_base_FileUtils_getSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -32311,7 +32244,7 @@ int lua_ax_base_FileUtils_getOriginalSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -32358,7 +32291,7 @@ int lua_ax_base_FileUtils_getWritablePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -32405,7 +32338,7 @@ int lua_ax_base_FileUtils_getNativeWritableAbsolutePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -32452,7 +32385,7 @@ int lua_ax_base_FileUtils_setWritablePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -32502,7 +32435,7 @@ int lua_ax_base_FileUtils_setPopupNotify(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -32552,7 +32485,7 @@ int lua_ax_base_FileUtils_isPopupNotify(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -32599,7 +32532,7 @@ int lua_ax_base_FileUtils_getValueMapFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -32649,7 +32582,7 @@ int lua_ax_base_FileUtils_getValueMapFromData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const char* arg0;
         int arg1;
@@ -32702,7 +32635,7 @@ int lua_ax_base_FileUtils_writeToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -32755,7 +32688,7 @@ int lua_ax_base_FileUtils_writeStringToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -32808,7 +32741,7 @@ int lua_ax_base_FileUtils_writeValueMapToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -32861,7 +32794,7 @@ int lua_ax_base_FileUtils_writeValueVectorToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ValueVector arg0;
         std::string_view arg1;
@@ -32914,7 +32847,7 @@ int lua_ax_base_FileUtils_getValueVectorFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -32964,7 +32897,7 @@ int lua_ax_base_FileUtils_isFileExist(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33014,7 +32947,7 @@ int lua_ax_base_FileUtils_isAbsolutePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33064,7 +32997,7 @@ int lua_ax_base_FileUtils_isDirectoryExist(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33114,7 +33047,7 @@ int lua_ax_base_FileUtils_createDirectories(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33164,7 +33097,7 @@ int lua_ax_base_FileUtils_removeDirectory(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33214,7 +33147,7 @@ int lua_ax_base_FileUtils_removeFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33331,7 +33264,7 @@ int lua_ax_base_FileUtils_getFileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33381,7 +33314,7 @@ int lua_ax_base_FileUtils_listFiles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33431,7 +33364,7 @@ int lua_ax_base_FileUtils_listFilesRecursively(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::vector<std::string>* arg1;
@@ -33484,7 +33417,7 @@ int lua_ax_base_FileUtils_isFileExistInternal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33534,7 +33467,7 @@ int lua_ax_base_FileUtils_isDirectoryExistInternal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -33954,7 +33887,7 @@ int lua_ax_base_EventCustom_getEventName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -33988,7 +33921,7 @@ int lua_ax_base_EventCustom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -34062,7 +33995,7 @@ int lua_ax_base_EventDispatcher_addEventListenerWithSceneGraphPriority(lua_State
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::EventListener* arg0;
         ax::Node* arg1;
@@ -34115,7 +34048,7 @@ int lua_ax_base_EventDispatcher_addEventListenerWithFixedPriority(lua_State* tol
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::EventListener* arg0;
         int arg1;
@@ -34168,7 +34101,7 @@ int lua_ax_base_EventDispatcher_addCustomEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::function<void (ax::EventCustom *)> arg1;
@@ -34225,7 +34158,7 @@ int lua_ax_base_EventDispatcher_removeEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventListener* arg0;
 
@@ -34275,7 +34208,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventListener::Type arg0;
 
@@ -34325,7 +34258,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForTarget(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -34339,7 +34272,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForTarget(lua_State* tolua_S
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -34392,7 +34325,7 @@ int lua_ax_base_EventDispatcher_removeCustomEventListeners(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -34442,7 +34375,7 @@ int lua_ax_base_EventDispatcher_removeAllEventListeners(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -34489,7 +34422,7 @@ int lua_ax_base_EventDispatcher_pauseEventListenersForTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -34503,7 +34436,7 @@ int lua_ax_base_EventDispatcher_pauseEventListenersForTarget(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -34556,7 +34489,7 @@ int lua_ax_base_EventDispatcher_resumeEventListenersForTarget(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -34570,7 +34503,7 @@ int lua_ax_base_EventDispatcher_resumeEventListenersForTarget(lua_State* tolua_S
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -34623,7 +34556,7 @@ int lua_ax_base_EventDispatcher_setPriority(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::EventListener* arg0;
         int arg1;
@@ -34676,7 +34609,7 @@ int lua_ax_base_EventDispatcher_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -34726,7 +34659,7 @@ int lua_ax_base_EventDispatcher_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -34773,7 +34706,7 @@ int lua_ax_base_EventDispatcher_dispatchEvent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Event* arg0;
 
@@ -34787,7 +34720,7 @@ int lua_ax_base_EventDispatcher_dispatchEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Event* arg0;
         bool arg1;
@@ -34840,7 +34773,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -34854,7 +34787,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         void* arg1;
@@ -34872,7 +34805,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         std::string_view arg0;
         void* arg1;
@@ -34929,7 +34862,7 @@ int lua_ax_base_EventDispatcher_hasEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -34966,7 +34899,7 @@ int lua_ax_base_EventDispatcher_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35039,7 +34972,7 @@ int lua_ax_base_EventFocus_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ui::Widget* arg0;
         ax::ui::Widget* arg1;
@@ -35115,7 +35048,7 @@ int lua_ax_base_EventListenerAcceleration_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void (ax::Acceleration *, ax::Event *)> arg0;
 
@@ -35156,7 +35089,7 @@ int lua_ax_base_EventListenerAcceleration_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35227,7 +35160,7 @@ int lua_ax_base_EventListenerFocus_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35261,7 +35194,7 @@ int lua_ax_base_EventListenerFocus_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35332,7 +35265,7 @@ int lua_ax_base_EventListenerKeyboard_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35366,7 +35299,7 @@ int lua_ax_base_EventListenerKeyboard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35437,7 +35370,7 @@ int lua_ax_base_EventMouse_getMouseEventType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35484,7 +35417,7 @@ int lua_ax_base_EventMouse_setScrollData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -35537,7 +35470,7 @@ int lua_ax_base_EventMouse_getScrollX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35584,7 +35517,7 @@ int lua_ax_base_EventMouse_getScrollY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35631,7 +35564,7 @@ int lua_ax_base_EventMouse_setMouseInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         double arg1;
@@ -35687,7 +35620,7 @@ int lua_ax_base_EventMouse_setMouseButton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventMouse::MouseButton arg0;
 
@@ -35737,7 +35670,7 @@ int lua_ax_base_EventMouse_getMouseButton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35784,7 +35717,7 @@ int lua_ax_base_EventMouse_getLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35831,7 +35764,7 @@ int lua_ax_base_EventMouse_getPreviousLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35878,7 +35811,7 @@ int lua_ax_base_EventMouse_getStartLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35925,7 +35858,7 @@ int lua_ax_base_EventMouse_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -35972,7 +35905,7 @@ int lua_ax_base_EventMouse_getLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36019,7 +35952,7 @@ int lua_ax_base_EventMouse_getPreviousLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36066,7 +35999,7 @@ int lua_ax_base_EventMouse_getStartLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36100,7 +36033,7 @@ int lua_ax_base_EventMouse_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventMouse::MouseEventType arg0;
 
@@ -36187,7 +36120,7 @@ int lua_ax_base_EventListenerMouse_setSwallowMouse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -36237,7 +36170,7 @@ int lua_ax_base_EventListenerMouse_isSwallowMouse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36284,7 +36217,7 @@ int lua_ax_base_EventListenerMouse_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36318,7 +36251,7 @@ int lua_ax_base_EventListenerMouse_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36410,7 +36343,7 @@ int lua_ax_base_EventListenerTouchOneByOne_setSwallowTouches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -36460,7 +36393,7 @@ int lua_ax_base_EventListenerTouchOneByOne_isSwallowTouches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36507,7 +36440,7 @@ int lua_ax_base_EventListenerTouchOneByOne_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36541,7 +36474,7 @@ int lua_ax_base_EventListenerTouchOneByOne_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36614,7 +36547,7 @@ int lua_ax_base_EventListenerTouchAllAtOnce_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36648,7 +36581,7 @@ int lua_ax_base_EventListenerTouchAllAtOnce_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36719,7 +36652,7 @@ int lua_ax_base_EventController_getControllerEventType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36766,7 +36699,7 @@ int lua_ax_base_EventController_getController(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36813,7 +36746,7 @@ int lua_ax_base_EventController_getKeyCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -36860,7 +36793,7 @@ int lua_ax_base_EventController_setKeyCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -36910,7 +36843,7 @@ int lua_ax_base_EventController_setConnectStatus(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -36960,7 +36893,7 @@ int lua_ax_base_EventController_isConnected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37162,7 +37095,7 @@ int lua_ax_base_ActionCamera_getEye(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37209,7 +37142,7 @@ int lua_ax_base_ActionCamera_setCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -37259,7 +37192,7 @@ int lua_ax_base_ActionCamera_getCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37306,7 +37239,7 @@ int lua_ax_base_ActionCamera_setUp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -37356,7 +37289,7 @@ int lua_ax_base_ActionCamera_getUp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37390,7 +37323,7 @@ int lua_ax_base_ActionCamera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37466,7 +37399,7 @@ int lua_ax_base_OrbitCamera_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 7) 
+    if (argc == 7)
     {
         double arg0;
         double arg1;
@@ -37569,7 +37502,7 @@ int lua_ax_base_OrbitCamera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37641,7 +37574,7 @@ int lua_ax_base_CardinalSplineTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         ax::PointArray* arg1;
@@ -37697,7 +37630,7 @@ int lua_ax_base_CardinalSplineTo_updatePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -37747,7 +37680,7 @@ int lua_ax_base_CardinalSplineTo_getPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37781,7 +37714,7 @@ int lua_ax_base_CardinalSplineTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37841,7 +37774,7 @@ int lua_ax_base_CardinalSplineBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -37911,7 +37844,7 @@ int lua_ax_base_CatmullRomTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::PointArray* arg1;
@@ -37984,7 +37917,7 @@ int lua_ax_base_CatmullRomBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::PointArray* arg1;
@@ -38057,7 +37990,7 @@ int lua_ax_base_ActionEase_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38104,7 +38037,7 @@ int lua_ax_base_ActionEase_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -38175,7 +38108,7 @@ int lua_ax_base_EaseRateAction_setRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -38225,7 +38158,7 @@ int lua_ax_base_EaseRateAction_getRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38272,7 +38205,7 @@ int lua_ax_base_EaseRateAction_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -38409,7 +38342,7 @@ int lua_ax_base_EaseExponentialIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38503,7 +38436,7 @@ int lua_ax_base_EaseExponentialOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38597,7 +38530,7 @@ int lua_ax_base_EaseExponentialInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38691,7 +38624,7 @@ int lua_ax_base_EaseSineIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38785,7 +38718,7 @@ int lua_ax_base_EaseSineOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38879,7 +38812,7 @@ int lua_ax_base_EaseSineInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -38992,7 +38925,7 @@ int lua_ax_base_EaseBounceIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39086,7 +39019,7 @@ int lua_ax_base_EaseBounceOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39180,7 +39113,7 @@ int lua_ax_base_EaseBounceInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39274,7 +39207,7 @@ int lua_ax_base_EaseBackIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39368,7 +39301,7 @@ int lua_ax_base_EaseBackOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39462,7 +39395,7 @@ int lua_ax_base_EaseBackInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39556,7 +39489,7 @@ int lua_ax_base_EaseQuadraticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39650,7 +39583,7 @@ int lua_ax_base_EaseQuadraticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39744,7 +39677,7 @@ int lua_ax_base_EaseQuadraticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39838,7 +39771,7 @@ int lua_ax_base_EaseQuarticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -39932,7 +39865,7 @@ int lua_ax_base_EaseQuarticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40026,7 +39959,7 @@ int lua_ax_base_EaseQuarticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40120,7 +40053,7 @@ int lua_ax_base_EaseQuinticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40214,7 +40147,7 @@ int lua_ax_base_EaseQuinticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40308,7 +40241,7 @@ int lua_ax_base_EaseQuinticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40402,7 +40335,7 @@ int lua_ax_base_EaseCircleActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40496,7 +40429,7 @@ int lua_ax_base_EaseCircleActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40590,7 +40523,7 @@ int lua_ax_base_EaseCircleActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40684,7 +40617,7 @@ int lua_ax_base_EaseCubicActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40778,7 +40711,7 @@ int lua_ax_base_EaseCubicActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40872,7 +40805,7 @@ int lua_ax_base_EaseCubicActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -40968,7 +40901,7 @@ int lua_ax_base_EaseIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41064,7 +40997,7 @@ int lua_ax_base_EaseOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41160,7 +41093,7 @@ int lua_ax_base_EaseInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41231,7 +41164,7 @@ int lua_ax_base_EaseElastic_getPeriod(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41278,7 +41211,7 @@ int lua_ax_base_EaseElastic_setPeriod(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -41328,7 +41261,7 @@ int lua_ax_base_EaseElastic_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -41342,7 +41275,7 @@ int lua_ax_base_EaseElastic_initWithAction(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -41455,7 +41388,7 @@ int lua_ax_base_EaseElasticIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41564,7 +41497,7 @@ int lua_ax_base_EaseElasticOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41673,7 +41606,7 @@ int lua_ax_base_EaseElasticInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41744,7 +41677,7 @@ int lua_ax_base_EaseBezierAction_setBezierParamer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -41826,7 +41759,7 @@ int lua_ax_base_EaseBezierAction_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -41938,7 +41871,7 @@ int lua_ax_base_Show_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42030,7 +41963,7 @@ int lua_ax_base_Hide_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42122,7 +42055,7 @@ int lua_ax_base_ToggleVisibility_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42193,7 +42126,7 @@ int lua_ax_base_RemoveSelf_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -42277,7 +42210,7 @@ int lua_ax_base_RemoveSelf_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42349,7 +42282,7 @@ int lua_ax_base_FlipX_initWithFlipX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -42422,7 +42355,7 @@ int lua_ax_base_FlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42494,7 +42427,7 @@ int lua_ax_base_FlipY_initWithFlipY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -42567,7 +42500,7 @@ int lua_ax_base_FlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42639,7 +42572,7 @@ int lua_ax_base_Place_initWithPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -42712,7 +42645,7 @@ int lua_ax_base_Place_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42784,7 +42717,7 @@ int lua_ax_base_CallFunc_execute(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42818,7 +42751,7 @@ int lua_ax_base_CallFunc_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42889,7 +42822,7 @@ int lua_ax_base_GridAction_getGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -42936,7 +42869,7 @@ int lua_ax_base_GridAction_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -43010,7 +42943,7 @@ int lua_ax_base_Grid3DAction_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43117,7 +43050,7 @@ int lua_ax_base_StopGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43188,7 +43121,7 @@ int lua_ax_base_ReuseGrid_initWithTimes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -43261,7 +43194,7 @@ int lua_ax_base_ReuseGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43333,7 +43266,7 @@ int lua_ax_base_Waves3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43380,7 +43313,7 @@ int lua_ax_base_Waves3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -43430,7 +43363,7 @@ int lua_ax_base_Waves3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43477,7 +43410,7 @@ int lua_ax_base_Waves3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -43527,7 +43460,7 @@ int lua_ax_base_Waves3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -43615,7 +43548,7 @@ int lua_ax_base_Waves3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43691,7 +43624,7 @@ int lua_ax_base_FlipX3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -43741,7 +43674,7 @@ int lua_ax_base_FlipX3D_initWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -43817,7 +43750,7 @@ int lua_ax_base_FlipX3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43913,7 +43846,7 @@ int lua_ax_base_FlipY3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -43984,7 +43917,7 @@ int lua_ax_base_Lens3D_getLensEffect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44031,7 +43964,7 @@ int lua_ax_base_Lens3D_setLensEffect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -44081,7 +44014,7 @@ int lua_ax_base_Lens3D_setConcave(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -44131,7 +44064,7 @@ int lua_ax_base_Lens3D_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44178,7 +44111,7 @@ int lua_ax_base_Lens3D_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -44228,7 +44161,7 @@ int lua_ax_base_Lens3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44316,7 +44249,7 @@ int lua_ax_base_Lens3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44393,7 +44326,7 @@ int lua_ax_base_Ripple3D_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44440,7 +44373,7 @@ int lua_ax_base_Ripple3D_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -44490,7 +44423,7 @@ int lua_ax_base_Ripple3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44537,7 +44470,7 @@ int lua_ax_base_Ripple3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -44587,7 +44520,7 @@ int lua_ax_base_Ripple3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44634,7 +44567,7 @@ int lua_ax_base_Ripple3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -44684,7 +44617,7 @@ int lua_ax_base_Ripple3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
+    if (argc == 6)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44782,7 +44715,7 @@ int lua_ax_base_Ripple3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -44860,7 +44793,7 @@ int lua_ax_base_Shaky3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44948,7 +44881,7 @@ int lua_ax_base_Shaky3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45020,7 +44953,7 @@ int lua_ax_base_Liquid_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45067,7 +45000,7 @@ int lua_ax_base_Liquid_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -45117,7 +45050,7 @@ int lua_ax_base_Liquid_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45164,7 +45097,7 @@ int lua_ax_base_Liquid_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -45214,7 +45147,7 @@ int lua_ax_base_Liquid_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45302,7 +45235,7 @@ int lua_ax_base_Liquid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45378,7 +45311,7 @@ int lua_ax_base_Waves_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45425,7 +45358,7 @@ int lua_ax_base_Waves_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -45475,7 +45408,7 @@ int lua_ax_base_Waves_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45522,7 +45455,7 @@ int lua_ax_base_Waves_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -45572,7 +45505,7 @@ int lua_ax_base_Waves_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
+    if (argc == 6)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45670,7 +45603,7 @@ int lua_ax_base_Waves_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45746,7 +45679,7 @@ int lua_ax_base_Twirl_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45793,7 +45726,7 @@ int lua_ax_base_Twirl_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -45843,7 +45776,7 @@ int lua_ax_base_Twirl_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45890,7 +45823,7 @@ int lua_ax_base_Twirl_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -45940,7 +45873,7 @@ int lua_ax_base_Twirl_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -45987,7 +45920,7 @@ int lua_ax_base_Twirl_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -46037,7 +45970,7 @@ int lua_ax_base_Twirl_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
+    if (argc == 5)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -46130,7 +46063,7 @@ int lua_ax_base_Twirl_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -46208,7 +46141,7 @@ int lua_ax_base_ActionManager_addAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Action* arg0;
         ax::Node* arg1;
@@ -46264,7 +46197,7 @@ int lua_ax_base_ActionManager_removeAllActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -46311,7 +46244,7 @@ int lua_ax_base_ActionManager_removeAllActionsFromTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -46361,7 +46294,7 @@ int lua_ax_base_ActionManager_removeAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Action* arg0;
 
@@ -46411,7 +46344,7 @@ int lua_ax_base_ActionManager_removeActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         ax::Node* arg1;
@@ -46464,7 +46397,7 @@ int lua_ax_base_ActionManager_removeAllActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         ax::Node* arg1;
@@ -46517,7 +46450,7 @@ int lua_ax_base_ActionManager_removeActionsByFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned int arg0;
         ax::Node* arg1;
@@ -46570,7 +46503,7 @@ int lua_ax_base_ActionManager_getActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         const ax::Node* arg1;
@@ -46623,7 +46556,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActionsInTarget(lua_State* tolua
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         const ax::Node* arg0;
 
@@ -46673,7 +46606,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -46720,7 +46653,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActionsInTargetByTag(lua_State* 
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const ax::Node* arg0;
         int arg1;
@@ -46773,7 +46706,7 @@ int lua_ax_base_ActionManager_pauseTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -46823,7 +46756,7 @@ int lua_ax_base_ActionManager_resumeTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -46873,7 +46806,7 @@ int lua_ax_base_ActionManager_pauseAllRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -46920,7 +46853,7 @@ int lua_ax_base_ActionManager_resumeTargets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::Node *> arg0;
 
@@ -46970,7 +46903,7 @@ int lua_ax_base_ActionManager_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -47007,7 +46940,7 @@ int lua_ax_base_ActionManager_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -47151,7 +47084,7 @@ int lua_ax_base_ProgressTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -47229,7 +47162,7 @@ int lua_ax_base_ProgressTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -47301,7 +47234,7 @@ int lua_ax_base_ProgressFromTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         double arg1;
@@ -47384,7 +47317,7 @@ int lua_ax_base_ProgressFromTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -47456,7 +47389,7 @@ int lua_ax_base_ShakyTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47544,7 +47477,7 @@ int lua_ax_base_ShakyTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -47616,7 +47549,7 @@ int lua_ax_base_ShatteredTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47704,7 +47637,7 @@ int lua_ax_base_ShatteredTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -47776,7 +47709,7 @@ int lua_ax_base_ShuffleTiles_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -47826,7 +47759,7 @@ int lua_ax_base_ShuffleTiles_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47909,7 +47842,7 @@ int lua_ax_base_ShuffleTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -47982,7 +47915,7 @@ int lua_ax_base_FadeOutTRTiles_testFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -48035,7 +47968,7 @@ int lua_ax_base_FadeOutTRTiles_turnOnTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -48085,7 +48018,7 @@ int lua_ax_base_FadeOutTRTiles_turnOffTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -48135,7 +48068,7 @@ int lua_ax_base_FadeOutTRTiles_transformTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -48213,7 +48146,7 @@ int lua_ax_base_FadeOutTRTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48313,7 +48246,7 @@ int lua_ax_base_FadeOutBLTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48409,7 +48342,7 @@ int lua_ax_base_FadeOutUpTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48505,7 +48438,7 @@ int lua_ax_base_FadeOutDownTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48576,7 +48509,7 @@ int lua_ax_base_TurnOffTiles_turnOnTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -48626,7 +48559,7 @@ int lua_ax_base_TurnOffTiles_turnOffTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -48676,7 +48609,7 @@ int lua_ax_base_TurnOffTiles_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -48720,7 +48653,7 @@ int lua_ax_base_TurnOffTiles_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -48739,7 +48672,7 @@ int lua_ax_base_TurnOffTiles_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -48776,7 +48709,7 @@ int lua_ax_base_TurnOffTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48850,7 +48783,7 @@ int lua_ax_base_WavesTiles3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48897,7 +48830,7 @@ int lua_ax_base_WavesTiles3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -48947,7 +48880,7 @@ int lua_ax_base_WavesTiles3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -48994,7 +48927,7 @@ int lua_ax_base_WavesTiles3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -49044,7 +48977,7 @@ int lua_ax_base_WavesTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -49132,7 +49065,7 @@ int lua_ax_base_WavesTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -49208,7 +49141,7 @@ int lua_ax_base_JumpTiles3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -49255,7 +49188,7 @@ int lua_ax_base_JumpTiles3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -49305,7 +49238,7 @@ int lua_ax_base_JumpTiles3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -49352,7 +49285,7 @@ int lua_ax_base_JumpTiles3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -49402,7 +49335,7 @@ int lua_ax_base_JumpTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         ax::Vec2 arg1;
@@ -49490,7 +49423,7 @@ int lua_ax_base_JumpTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -49566,7 +49499,7 @@ int lua_ax_base_SplitRows_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         unsigned int arg1;
@@ -49644,7 +49577,7 @@ int lua_ax_base_SplitRows_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -49716,7 +49649,7 @@ int lua_ax_base_SplitCols_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         unsigned int arg1;
@@ -49794,7 +49727,7 @@ int lua_ax_base_SplitCols_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -49866,7 +49799,7 @@ int lua_ax_base_ActionTween_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         std::string_view arg1;
@@ -49988,7 +49921,7 @@ int lua_ax_base_ActionCoroutine_initWithCoroutine(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<ax::Coroutine ()> arg0;
 
@@ -50069,7 +50002,7 @@ int lua_ax_base_ActionCoroutine_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50141,7 +50074,7 @@ int lua_ax_base_AtlasNode_updateAtlasValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50188,7 +50121,7 @@ int lua_ax_base_AtlasNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50235,7 +50168,7 @@ int lua_ax_base_AtlasNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -50285,7 +50218,7 @@ int lua_ax_base_AtlasNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -50335,7 +50268,7 @@ int lua_ax_base_AtlasNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50382,7 +50315,7 @@ int lua_ax_base_AtlasNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextureAtlas* arg0;
 
@@ -50432,7 +50365,7 @@ int lua_ax_base_AtlasNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50479,7 +50412,7 @@ int lua_ax_base_AtlasNode_setQuadsToDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ssize_t arg0;
 
@@ -50529,7 +50462,7 @@ int lua_ax_base_AtlasNode_getQuadsToDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50576,7 +50509,7 @@ int lua_ax_base_AtlasNode_initWithTileFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         std::string_view arg0;
         int arg1;
@@ -50635,7 +50568,7 @@ int lua_ax_base_AtlasNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Texture2D* arg0;
         int arg1;
@@ -50723,7 +50656,7 @@ int lua_ax_base_AtlasNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50805,7 +50738,7 @@ int lua_ax_base_ClippingNode_getStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50852,7 +50785,7 @@ int lua_ax_base_ClippingNode_setStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -50866,7 +50799,7 @@ int lua_ax_base_ClippingNode_setStencil(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -50919,7 +50852,7 @@ int lua_ax_base_ClippingNode_hasContent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -50966,7 +50899,7 @@ int lua_ax_base_ClippingNode_getAlphaThreshold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -51013,7 +50946,7 @@ int lua_ax_base_ClippingNode_setAlphaThreshold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -51063,7 +50996,7 @@ int lua_ax_base_ClippingNode_isInverted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -51110,7 +51043,7 @@ int lua_ax_base_ClippingNode_setInverted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -51160,7 +51093,7 @@ int lua_ax_base_ClippingNode_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -51198,7 +51131,7 @@ int lua_ax_base_ClippingNode_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -51211,7 +51144,7 @@ int lua_ax_base_ClippingNode_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -51283,7 +51216,7 @@ int lua_ax_base_ClippingRectangleNode_getClippingRegion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -51330,7 +51263,7 @@ int lua_ax_base_ClippingRectangleNode_setClippingRegion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -51380,7 +51313,7 @@ int lua_ax_base_ClippingRectangleNode_isClippingEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -51427,7 +51360,7 @@ int lua_ax_base_ClippingRectangleNode_setClippingEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -51465,7 +51398,7 @@ int lua_ax_base_ClippingRectangleNode_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -51475,7 +51408,7 @@ int lua_ax_base_ClippingRectangleNode_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -51546,7 +51479,7 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -51566,7 +51499,7 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -51625,7 +51558,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51645,7 +51578,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51668,7 +51601,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51694,7 +51627,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6) 
+    if (argc == 6)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52077,7 +52010,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52103,7 +52036,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6) 
+    if (argc == 6)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52168,7 +52101,7 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
+    if (argc == 6)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52197,7 +52130,7 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 7) 
+    if (argc == 7)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52265,7 +52198,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52291,7 +52224,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6) 
+    if (argc == 6)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52356,7 +52289,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
+    if (argc == 6)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52385,7 +52318,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 7) 
+    if (argc == 7)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52453,7 +52386,7 @@ int lua_ax_base_DrawNode_drawDot(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52509,7 +52442,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52529,7 +52462,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52552,7 +52485,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53060,7 +52993,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53083,7 +53016,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53109,7 +53042,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6) 
+    if (argc == 6)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53174,7 +53107,7 @@ int lua_ax_base_DrawNode_drawColoredTriangle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const ax::Vec2* arg0;
         const ax::Color* arg1;
@@ -53434,7 +53367,7 @@ int lua_ax_base_DrawNode_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -53481,7 +53414,7 @@ int lua_ax_base_DrawNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -53528,7 +53461,7 @@ int lua_ax_base_DrawNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -53578,7 +53511,7 @@ int lua_ax_base_DrawNode_setIsolated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -53628,7 +53561,7 @@ int lua_ax_base_DrawNode_isIsolated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -53696,7 +53629,7 @@ int lua_ax_base_DrawNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -53788,7 +53721,7 @@ int lua_ax_base_Label_setTTFConfig(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::_ttfConfig arg0;
 
@@ -53838,7 +53771,7 @@ int lua_ax_base_Label_getTTFConfig(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54024,7 +53957,7 @@ int lua_ax_base_Label_getBMFontFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54162,7 +54095,7 @@ int lua_ax_base_Label_setSystemFontName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -54212,7 +54145,7 @@ int lua_ax_base_Label_getSystemFontName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54259,7 +54192,7 @@ int lua_ax_base_Label_setSystemFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -54309,7 +54242,7 @@ int lua_ax_base_Label_getSystemFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54356,7 +54289,7 @@ int lua_ax_base_Label_requestSystemFontRefresh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54403,7 +54336,7 @@ int lua_ax_base_Label_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -54453,7 +54386,7 @@ int lua_ax_base_Label_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54500,7 +54433,7 @@ int lua_ax_base_Label_getStringNumLines(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54547,7 +54480,7 @@ int lua_ax_base_Label_getStringLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54594,7 +54527,7 @@ int lua_ax_base_Label_setTextColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -54644,7 +54577,7 @@ int lua_ax_base_Label_getTextColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54691,7 +54624,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54702,7 +54635,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -54716,7 +54649,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -54733,7 +54666,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -54789,7 +54722,7 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -54803,7 +54736,7 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Color32 arg0;
         int arg1;
@@ -54856,7 +54789,7 @@ int lua_ax_base_Label_enableGlow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -54906,7 +54839,7 @@ int lua_ax_base_Label_enableItalics(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -54953,7 +54886,7 @@ int lua_ax_base_Label_enableBold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55000,7 +54933,7 @@ int lua_ax_base_Label_enableUnderline(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55047,7 +54980,7 @@ int lua_ax_base_Label_enableStrikethrough(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55145,7 +55078,7 @@ int lua_ax_base_Label_isShadowEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55192,7 +55125,7 @@ int lua_ax_base_Label_getShadowOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55239,7 +55172,7 @@ int lua_ax_base_Label_getShadowBlurRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55286,7 +55219,7 @@ int lua_ax_base_Label_getShadowColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55333,7 +55266,7 @@ int lua_ax_base_Label_getOutlineSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55380,7 +55313,7 @@ int lua_ax_base_Label_getLabelEffectType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55427,7 +55360,7 @@ int lua_ax_base_Label_getEffectColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55533,7 +55466,7 @@ int lua_ax_base_Label_getTextAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55580,7 +55513,7 @@ int lua_ax_base_Label_setHorizontalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextHAlignment arg0;
 
@@ -55630,7 +55563,7 @@ int lua_ax_base_Label_getHorizontalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55677,7 +55610,7 @@ int lua_ax_base_Label_setVerticalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextVAlignment arg0;
 
@@ -55727,7 +55660,7 @@ int lua_ax_base_Label_getVerticalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55774,7 +55707,7 @@ int lua_ax_base_Label_setLineBreakWithoutSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -55824,7 +55757,7 @@ int lua_ax_base_Label_setMaxLineWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -55874,7 +55807,7 @@ int lua_ax_base_Label_getMaxLineWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -55921,7 +55854,7 @@ int lua_ax_base_Label_setTTFFaceSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -55971,7 +55904,7 @@ int lua_ax_base_Label_getTTFFaceSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56018,7 +55951,7 @@ int lua_ax_base_Label_setBMFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -56068,7 +56001,7 @@ int lua_ax_base_Label_getBMFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56115,7 +56048,7 @@ int lua_ax_base_Label_enableWrap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -56165,7 +56098,7 @@ int lua_ax_base_Label_isWrapEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56212,7 +56145,7 @@ int lua_ax_base_Label_setOverflow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Label::Overflow arg0;
 
@@ -56262,7 +56195,7 @@ int lua_ax_base_Label_getOverflow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56309,7 +56242,7 @@ int lua_ax_base_Label_setWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -56359,7 +56292,7 @@ int lua_ax_base_Label_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56406,7 +56339,7 @@ int lua_ax_base_Label_setHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -56456,7 +56389,7 @@ int lua_ax_base_Label_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56503,7 +56436,7 @@ int lua_ax_base_Label_setDimensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -56556,7 +56489,7 @@ int lua_ax_base_Label_getDimensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56603,7 +56536,7 @@ int lua_ax_base_Label_updateContent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56650,7 +56583,7 @@ int lua_ax_base_Label_getLetter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -56700,7 +56633,7 @@ int lua_ax_base_Label_setClipMarginEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -56750,7 +56683,7 @@ int lua_ax_base_Label_isClipMarginEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56797,7 +56730,7 @@ int lua_ax_base_Label_setLineHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -56847,7 +56780,7 @@ int lua_ax_base_Label_getLineHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56894,7 +56827,7 @@ int lua_ax_base_Label_setLineSpacing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -56944,7 +56877,7 @@ int lua_ax_base_Label_getLineSpacing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -56991,7 +56924,7 @@ int lua_ax_base_Label_getLabelType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -57038,7 +56971,7 @@ int lua_ax_base_Label_getRenderingFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -57085,7 +57018,7 @@ int lua_ax_base_Label_setAdditionalKerning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -57135,7 +57068,7 @@ int lua_ax_base_Label_getAdditionalKerning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -57182,7 +57115,7 @@ int lua_ax_base_Label_getFontAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -57229,7 +57162,7 @@ int lua_ax_base_Label_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -57276,7 +57209,7 @@ int lua_ax_base_Label_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -57326,7 +57259,7 @@ int lua_ax_base_Label_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -57696,7 +57629,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 6)
         {
@@ -57724,7 +57657,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -57740,7 +57673,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -57759,7 +57692,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -57781,7 +57714,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -57828,7 +57761,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -57850,7 +57783,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -57872,7 +57805,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -58116,7 +58049,7 @@ int lua_ax_base_LabelAtlas_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -58166,7 +58099,7 @@ int lua_ax_base_LabelAtlas_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -58201,7 +58134,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -58217,7 +58150,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -58242,7 +58175,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -58288,7 +58221,7 @@ int lua_ax_base_LabelAtlas_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -58362,7 +58295,7 @@ int lua_ax_base_Sprite_getBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -58409,7 +58342,7 @@ int lua_ax_base_Sprite_setBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteBatchNode* arg0;
 
@@ -58514,7 +58447,7 @@ int lua_ax_base_Sprite_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -58624,7 +58557,7 @@ int lua_ax_base_Sprite_setVertexRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -58674,7 +58607,7 @@ int lua_ax_base_Sprite_setCenterRectNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -58724,7 +58657,7 @@ int lua_ax_base_Sprite_getCenterRectNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -58771,7 +58704,7 @@ int lua_ax_base_Sprite_setCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -58821,7 +58754,7 @@ int lua_ax_base_Sprite_getCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -58923,7 +58856,7 @@ int lua_ax_base_Sprite_isFrameDisplayed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -58973,7 +58906,7 @@ int lua_ax_base_Sprite_getSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59020,7 +58953,7 @@ int lua_ax_base_Sprite_setDisplayFrameWithAnimationName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         unsigned int arg1;
@@ -59073,7 +59006,7 @@ int lua_ax_base_Sprite_isDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59120,7 +59053,7 @@ int lua_ax_base_Sprite_setDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -59170,7 +59103,7 @@ int lua_ax_base_Sprite_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -59220,7 +59153,7 @@ int lua_ax_base_Sprite_isTextureRectRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59267,7 +59200,7 @@ int lua_ax_base_Sprite_getAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59314,7 +59247,7 @@ int lua_ax_base_Sprite_setAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -59364,7 +59297,7 @@ int lua_ax_base_Sprite_getTextureRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59411,7 +59344,7 @@ int lua_ax_base_Sprite_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59458,7 +59391,7 @@ int lua_ax_base_Sprite_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextureAtlas* arg0;
 
@@ -59508,7 +59441,7 @@ int lua_ax_base_Sprite_getOffsetPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59555,7 +59488,7 @@ int lua_ax_base_Sprite_isFlippedX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59602,7 +59535,7 @@ int lua_ax_base_Sprite_setFlippedX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -59652,7 +59585,7 @@ int lua_ax_base_Sprite_isFlippedY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59699,7 +59632,7 @@ int lua_ax_base_Sprite_setFlippedY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -59749,7 +59682,7 @@ int lua_ax_base_Sprite_setStretchEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -59799,7 +59732,7 @@ int lua_ax_base_Sprite_isStretchEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59846,7 +59779,7 @@ int lua_ax_base_Sprite_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -59896,7 +59829,7 @@ int lua_ax_base_Sprite_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59943,7 +59876,7 @@ int lua_ax_base_Sprite_getResourceType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -59990,7 +59923,7 @@ int lua_ax_base_Sprite_getResourceName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -60116,7 +60049,7 @@ int lua_ax_base_Sprite_initWithSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -60166,7 +60099,7 @@ int lua_ax_base_Sprite_initWithSpriteFrameName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -60291,7 +60224,7 @@ int lua_ax_base_Sprite_initWithImageData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Data arg0;
         std::string_view arg1;
@@ -60344,7 +60277,7 @@ int lua_ax_base_Sprite_setVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -60391,7 +60324,7 @@ int lua_ax_base_Sprite_setAutoUpdatePS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -60441,7 +60374,7 @@ int lua_ax_base_Sprite_setAutoSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -60479,7 +60412,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -60495,7 +60428,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -60514,7 +60447,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -60620,7 +60553,7 @@ int lua_ax_base_Sprite_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -60789,7 +60722,7 @@ int lua_ax_base_LayerColor_changeWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -60839,7 +60772,7 @@ int lua_ax_base_LayerColor_changeHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -60889,7 +60822,7 @@ int lua_ax_base_LayerColor_changeWidthAndHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -60993,7 +60926,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -61012,7 +60945,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -61022,7 +60955,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -61056,7 +60989,7 @@ int lua_ax_base_LayerColor_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61131,7 +61064,7 @@ int lua_ax_base_LayerGradient_setCompressedInterpolation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -61181,7 +61114,7 @@ int lua_ax_base_LayerGradient_isCompressedInterpolation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61228,7 +61161,7 @@ int lua_ax_base_LayerGradient_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -61278,7 +61211,7 @@ int lua_ax_base_LayerGradient_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61325,7 +61258,7 @@ int lua_ax_base_LayerGradient_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -61375,7 +61308,7 @@ int lua_ax_base_LayerGradient_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61422,7 +61355,7 @@ int lua_ax_base_LayerGradient_setStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         uint16_t arg0;
 
@@ -61472,7 +61405,7 @@ int lua_ax_base_LayerGradient_getStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61519,7 +61452,7 @@ int lua_ax_base_LayerGradient_setEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         uint16_t arg0;
 
@@ -61569,7 +61502,7 @@ int lua_ax_base_LayerGradient_getEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61616,7 +61549,7 @@ int lua_ax_base_LayerGradient_setVector(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -61666,7 +61599,7 @@ int lua_ax_base_LayerGradient_getVector(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61768,7 +61701,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -61784,7 +61717,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -61794,7 +61727,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -61834,7 +61767,7 @@ int lua_ax_base_LayerGradient_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -61918,7 +61851,7 @@ int lua_ax_base_LayerRadialGradient_setStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         uint16_t arg0;
 
@@ -61968,7 +61901,7 @@ int lua_ax_base_LayerRadialGradient_getStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62015,7 +61948,7 @@ int lua_ax_base_LayerRadialGradient_setEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         uint16_t arg0;
 
@@ -62065,7 +61998,7 @@ int lua_ax_base_LayerRadialGradient_getEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62112,7 +62045,7 @@ int lua_ax_base_LayerRadialGradient_setRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -62162,7 +62095,7 @@ int lua_ax_base_LayerRadialGradient_getRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62209,7 +62142,7 @@ int lua_ax_base_LayerRadialGradient_setCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -62259,7 +62192,7 @@ int lua_ax_base_LayerRadialGradient_getCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62306,7 +62239,7 @@ int lua_ax_base_LayerRadialGradient_setExpand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -62356,7 +62289,7 @@ int lua_ax_base_LayerRadialGradient_getExpand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62403,7 +62336,7 @@ int lua_ax_base_LayerRadialGradient_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -62453,7 +62386,7 @@ int lua_ax_base_LayerRadialGradient_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62500,7 +62433,7 @@ int lua_ax_base_LayerRadialGradient_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -62550,7 +62483,7 @@ int lua_ax_base_LayerRadialGradient_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62597,7 +62530,7 @@ int lua_ax_base_LayerRadialGradient_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -62647,7 +62580,7 @@ int lua_ax_base_LayerRadialGradient_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62694,7 +62627,7 @@ int lua_ax_base_LayerRadialGradient_initWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::Color32 arg0;
         ax::Color32 arg1;
@@ -62744,7 +62677,7 @@ int lua_ax_base_LayerRadialGradient_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -62754,7 +62687,7 @@ int lua_ax_base_LayerRadialGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -62800,7 +62733,7 @@ int lua_ax_base_LayerRadialGradient_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -62888,7 +62821,7 @@ int lua_ax_base_LayerMultiplex_addLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -62997,7 +62930,7 @@ int lua_ax_base_LayerMultiplex_switchToAndReleaseMe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -63047,7 +62980,7 @@ int lua_ax_base_LayerMultiplex_initWithArray(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::Node *> arg0;
 
@@ -63084,7 +63017,7 @@ int lua_ax_base_LayerMultiplex_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63158,7 +63091,7 @@ int lua_ax_base_MenuItem_rect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63205,7 +63138,7 @@ int lua_ax_base_MenuItem_activate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63252,7 +63185,7 @@ int lua_ax_base_MenuItem_selected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63299,7 +63232,7 @@ int lua_ax_base_MenuItem_unselected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63346,7 +63279,7 @@ int lua_ax_base_MenuItem_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63393,7 +63326,7 @@ int lua_ax_base_MenuItem_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -63443,7 +63376,7 @@ int lua_ax_base_MenuItem_isSelected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63477,7 +63410,7 @@ int lua_ax_base_MenuItem_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63554,7 +63487,7 @@ int lua_ax_base_MenuItemLabel_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -63604,7 +63537,7 @@ int lua_ax_base_MenuItemLabel_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63651,7 +63584,7 @@ int lua_ax_base_MenuItemLabel_getDisabledColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63698,7 +63631,7 @@ int lua_ax_base_MenuItemLabel_setDisabledColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -63748,7 +63681,7 @@ int lua_ax_base_MenuItemLabel_getLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63795,7 +63728,7 @@ int lua_ax_base_MenuItemLabel_setLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -63845,7 +63778,7 @@ int lua_ax_base_MenuItemLabel_initWithLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         std::function<void (ax::Object *)> arg1;
@@ -63889,7 +63822,7 @@ int lua_ax_base_MenuItemLabel_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -63966,7 +63899,7 @@ int lua_ax_base_MenuItemAtlasFont_initWithString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
+    if (argc == 6)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -64022,7 +63955,7 @@ int lua_ax_base_MenuItemAtlasFont_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64093,7 +64026,7 @@ int lua_ax_base_MenuItemFont_setFontSizeObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -64143,7 +64076,7 @@ int lua_ax_base_MenuItemFont_getFontSizeObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64190,7 +64123,7 @@ int lua_ax_base_MenuItemFont_setFontNameObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -64240,7 +64173,7 @@ int lua_ax_base_MenuItemFont_getFontNameObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64287,7 +64220,7 @@ int lua_ax_base_MenuItemFont_initWithString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::function<void (ax::Object *)> arg1;
@@ -64471,7 +64404,7 @@ int lua_ax_base_MenuItemFont_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64550,7 +64483,7 @@ int lua_ax_base_MenuItemSprite_getNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64597,7 +64530,7 @@ int lua_ax_base_MenuItemSprite_setNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -64647,7 +64580,7 @@ int lua_ax_base_MenuItemSprite_getSelectedImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64694,7 +64627,7 @@ int lua_ax_base_MenuItemSprite_setSelectedImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -64744,7 +64677,7 @@ int lua_ax_base_MenuItemSprite_getDisabledImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64791,7 +64724,7 @@ int lua_ax_base_MenuItemSprite_setDisabledImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -64841,7 +64774,7 @@ int lua_ax_base_MenuItemSprite_selected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64888,7 +64821,7 @@ int lua_ax_base_MenuItemSprite_unselected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -64935,7 +64868,7 @@ int lua_ax_base_MenuItemSprite_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -64985,7 +64918,7 @@ int lua_ax_base_MenuItemSprite_initWithNormalSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Node* arg0;
         ax::Node* arg1;
@@ -65035,7 +64968,7 @@ int lua_ax_base_MenuItemSprite_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65115,7 +65048,7 @@ int lua_ax_base_MenuItemImage_setNormalSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -65165,7 +65098,7 @@ int lua_ax_base_MenuItemImage_setSelectedSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -65215,7 +65148,7 @@ int lua_ax_base_MenuItemImage_setDisabledSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -65265,7 +65198,7 @@ int lua_ax_base_MenuItemImage_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65312,7 +65245,7 @@ int lua_ax_base_MenuItemImage_initWithNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -65362,7 +65295,7 @@ int lua_ax_base_MenuItemImage_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65437,7 +65370,7 @@ int lua_ax_base_MenuItemToggle_addSubItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MenuItem* arg0;
 
@@ -65487,7 +65420,7 @@ int lua_ax_base_MenuItemToggle_getSelectedItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65534,7 +65467,7 @@ int lua_ax_base_MenuItemToggle_getSelectedIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65581,7 +65514,7 @@ int lua_ax_base_MenuItemToggle_setSelectedIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -65631,7 +65564,7 @@ int lua_ax_base_MenuItemToggle_setSubItems(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::MenuItem *> arg0;
 
@@ -65681,7 +65614,7 @@ int lua_ax_base_MenuItemToggle_initWithItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::MenuItem* arg0;
 
@@ -65718,7 +65651,7 @@ int lua_ax_base_MenuItemToggle_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65794,7 +65727,7 @@ int lua_ax_base_Menu_alignItemsVertically(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65841,7 +65774,7 @@ int lua_ax_base_Menu_alignItemsVerticallyWithPadding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -65891,7 +65824,7 @@ int lua_ax_base_Menu_alignItemsHorizontally(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -65938,7 +65871,7 @@ int lua_ax_base_Menu_alignItemsHorizontallyWithPadding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -65988,7 +65921,7 @@ int lua_ax_base_Menu_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66035,7 +65968,7 @@ int lua_ax_base_Menu_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -66085,7 +66018,7 @@ int lua_ax_base_Menu_initWithArray(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::MenuItem *> arg0;
 
@@ -66122,7 +66055,7 @@ int lua_ax_base_Menu_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66199,7 +66132,7 @@ int lua_ax_base_MotionStreak_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66246,7 +66179,7 @@ int lua_ax_base_MotionStreak_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -66296,7 +66229,7 @@ int lua_ax_base_MotionStreak_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -66346,7 +66279,7 @@ int lua_ax_base_MotionStreak_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66393,7 +66326,7 @@ int lua_ax_base_MotionStreak_tintWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -66443,7 +66376,7 @@ int lua_ax_base_MotionStreak_reset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66490,7 +66423,7 @@ int lua_ax_base_MotionStreak_isFastMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66537,7 +66470,7 @@ int lua_ax_base_MotionStreak_setFastMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -66587,7 +66520,7 @@ int lua_ax_base_MotionStreak_getStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66634,7 +66567,7 @@ int lua_ax_base_MotionStreak_setStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -66684,7 +66617,7 @@ int lua_ax_base_MotionStreak_isStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -66731,7 +66664,7 @@ int lua_ax_base_MotionStreak_setStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -66856,7 +66789,7 @@ int lua_ax_base_MotionStreak_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -66881,7 +66814,7 @@ int lua_ax_base_MotionStreak_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -66927,7 +66860,7 @@ int lua_ax_base_MotionStreak_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -67058,7 +66991,7 @@ int lua_ax_base_NodeGrid_setGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::GridBase* arg0;
 
@@ -67108,7 +67041,7 @@ int lua_ax_base_NodeGrid_setTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -67158,7 +67091,7 @@ int lua_ax_base_NodeGrid_setGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -67208,7 +67141,7 @@ int lua_ax_base_NodeGrid_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -67243,7 +67176,7 @@ int lua_ax_base_NodeGrid_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -67256,7 +67189,7 @@ int lua_ax_base_NodeGrid_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -67287,7 +67220,7 @@ int lua_ax_base_NodeGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -67363,7 +67296,7 @@ int lua_ax_base_ParticleBatchNode_insertChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ParticleSystem* arg0;
         int arg1;
@@ -67416,7 +67349,7 @@ int lua_ax_base_ParticleBatchNode_removeChildAtIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         bool arg1;
@@ -67469,7 +67402,7 @@ int lua_ax_base_ParticleBatchNode_removeAllChildrenWithCleanup(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -67519,7 +67452,7 @@ int lua_ax_base_ParticleBatchNode_disableParticle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -67569,7 +67502,7 @@ int lua_ax_base_ParticleBatchNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -67616,7 +67549,7 @@ int lua_ax_base_ParticleBatchNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextureAtlas* arg0;
 
@@ -67666,7 +67599,7 @@ int lua_ax_base_ParticleBatchNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -67713,7 +67646,7 @@ int lua_ax_base_ParticleBatchNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -67763,7 +67696,7 @@ int lua_ax_base_ParticleBatchNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -67813,7 +67746,7 @@ int lua_ax_base_ParticleBatchNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -67860,7 +67793,7 @@ int lua_ax_base_ParticleBatchNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Texture2D* arg0;
         int arg1;
@@ -67913,7 +67846,7 @@ int lua_ax_base_ParticleBatchNode_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         int arg1;
@@ -68055,7 +67988,7 @@ int lua_ax_base_ParticleBatchNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -68158,7 +68091,7 @@ int lua_ax_base_SpriteFrameCache_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -68336,7 +68269,7 @@ int lua_ax_base_SpriteFrameCache_addSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::SpriteFrame* arg0;
         std::string_view arg1;
@@ -68389,7 +68322,7 @@ int lua_ax_base_SpriteFrameCache_isSpriteFramesWithFileLoaded(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68439,7 +68372,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -68486,7 +68419,7 @@ int lua_ax_base_SpriteFrameCache_removeUnusedSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -68533,7 +68466,7 @@ int lua_ax_base_SpriteFrameCache_removeUnusedSpriteSheets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -68580,7 +68513,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFrameByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68630,7 +68563,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68680,7 +68613,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromFileContent(lua_State* to
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68730,7 +68663,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromTexture(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -68780,7 +68713,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteFrameByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68830,7 +68763,7 @@ int lua_ax_base_SpriteFrameCache_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68880,7 +68813,7 @@ int lua_ax_base_SpriteFrameCache_findFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -68930,7 +68863,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteFrameName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -68980,7 +68913,7 @@ int lua_ax_base_SpriteFrameCache_eraseFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -69030,7 +68963,7 @@ int lua_ax_base_SpriteFrameCache_addSpriteFrameCapInset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::SpriteFrame* arg0;
         ax::Rect arg1;
@@ -69086,7 +69019,7 @@ int lua_ax_base_SpriteFrameCache_deregisterSpriteSheetLoader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -69136,7 +69069,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteSheetLoader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -69294,7 +69227,7 @@ int lua_ax_base_ParticleData_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -69344,7 +69277,7 @@ int lua_ax_base_ParticleData_release(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -69391,7 +69324,7 @@ int lua_ax_base_ParticleData_getMaxCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -69438,7 +69371,7 @@ int lua_ax_base_ParticleData_copyParticle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         int arg1;
@@ -69478,7 +69411,7 @@ int lua_ax_base_ParticleData_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -69812,7 +69745,7 @@ int lua_ax_base_ParticleEmissionMaskCache_removeMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -69862,7 +69795,7 @@ int lua_ax_base_ParticleEmissionMaskCache_removeAllMasks(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -69967,7 +69900,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -69981,7 +69914,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         int arg1;
@@ -69998,7 +69931,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         int arg0;
         int arg1;
@@ -70054,7 +69987,7 @@ int lua_ax_base_ParticleSystem_stopSystem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70101,7 +70034,7 @@ int lua_ax_base_ParticleSystem_resetSystem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70148,7 +70081,7 @@ int lua_ax_base_ParticleSystem_isFull(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70195,7 +70128,7 @@ int lua_ax_base_ParticleSystem_updateParticleQuads(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70242,7 +70175,7 @@ int lua_ax_base_ParticleSystem_postStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70289,7 +70222,7 @@ int lua_ax_base_ParticleSystem_updateWithNoTime(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70336,7 +70269,7 @@ int lua_ax_base_ParticleSystem_isAutoRemoveOnFinish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70383,7 +70316,7 @@ int lua_ax_base_ParticleSystem_setAutoRemoveOnFinish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -70433,7 +70366,7 @@ int lua_ax_base_ParticleSystem_getGravity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70480,7 +70413,7 @@ int lua_ax_base_ParticleSystem_setGravity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -70530,7 +70463,7 @@ int lua_ax_base_ParticleSystem_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70577,7 +70510,7 @@ int lua_ax_base_ParticleSystem_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -70627,7 +70560,7 @@ int lua_ax_base_ParticleSystem_getSpeedVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70674,7 +70607,7 @@ int lua_ax_base_ParticleSystem_setSpeedVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -70724,7 +70657,7 @@ int lua_ax_base_ParticleSystem_getTangentialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70771,7 +70704,7 @@ int lua_ax_base_ParticleSystem_setTangentialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -70821,7 +70754,7 @@ int lua_ax_base_ParticleSystem_getTangentialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70868,7 +70801,7 @@ int lua_ax_base_ParticleSystem_setTangentialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -70918,7 +70851,7 @@ int lua_ax_base_ParticleSystem_getRadialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -70965,7 +70898,7 @@ int lua_ax_base_ParticleSystem_setRadialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71015,7 +70948,7 @@ int lua_ax_base_ParticleSystem_getRadialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71062,7 +70995,7 @@ int lua_ax_base_ParticleSystem_setRadialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71112,7 +71045,7 @@ int lua_ax_base_ParticleSystem_getRotationIsDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71159,7 +71092,7 @@ int lua_ax_base_ParticleSystem_setRotationIsDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -71209,7 +71142,7 @@ int lua_ax_base_ParticleSystem_getStartRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71256,7 +71189,7 @@ int lua_ax_base_ParticleSystem_setStartRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71306,7 +71239,7 @@ int lua_ax_base_ParticleSystem_getStartRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71353,7 +71286,7 @@ int lua_ax_base_ParticleSystem_setStartRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71403,7 +71336,7 @@ int lua_ax_base_ParticleSystem_getEndRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71450,7 +71383,7 @@ int lua_ax_base_ParticleSystem_setEndRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71500,7 +71433,7 @@ int lua_ax_base_ParticleSystem_getEndRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71547,7 +71480,7 @@ int lua_ax_base_ParticleSystem_setEndRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71597,7 +71530,7 @@ int lua_ax_base_ParticleSystem_getRotatePerSecond(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71644,7 +71577,7 @@ int lua_ax_base_ParticleSystem_setRotatePerSecond(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71694,7 +71627,7 @@ int lua_ax_base_ParticleSystem_getRotatePerSecondVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71741,7 +71674,7 @@ int lua_ax_base_ParticleSystem_setRotatePerSecondVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -71791,7 +71724,7 @@ int lua_ax_base_ParticleSystem_isActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71838,7 +71771,7 @@ int lua_ax_base_ParticleSystem_isBlendAdditive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71885,7 +71818,7 @@ int lua_ax_base_ParticleSystem_setBlendAdditive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -71935,7 +71868,7 @@ int lua_ax_base_ParticleSystem_getBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -71982,7 +71915,7 @@ int lua_ax_base_ParticleSystem_setBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ParticleBatchNode* arg0;
 
@@ -72032,7 +71965,7 @@ int lua_ax_base_ParticleSystem_getAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72079,7 +72012,7 @@ int lua_ax_base_ParticleSystem_setAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -72129,7 +72062,7 @@ int lua_ax_base_ParticleSystem_getParticleCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72176,7 +72109,7 @@ int lua_ax_base_ParticleSystem_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72223,7 +72156,7 @@ int lua_ax_base_ParticleSystem_setDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -72273,7 +72206,7 @@ int lua_ax_base_ParticleSystem_getSourcePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72320,7 +72253,7 @@ int lua_ax_base_ParticleSystem_setSourcePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -72370,7 +72303,7 @@ int lua_ax_base_ParticleSystem_getPosVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72417,7 +72350,7 @@ int lua_ax_base_ParticleSystem_setPosVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -72467,7 +72400,7 @@ int lua_ax_base_ParticleSystem_getLife(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72514,7 +72447,7 @@ int lua_ax_base_ParticleSystem_setLife(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -72564,7 +72497,7 @@ int lua_ax_base_ParticleSystem_getLifeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72611,7 +72544,7 @@ int lua_ax_base_ParticleSystem_setLifeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -72661,7 +72594,7 @@ int lua_ax_base_ParticleSystem_getAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72708,7 +72641,7 @@ int lua_ax_base_ParticleSystem_setAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -72758,7 +72691,7 @@ int lua_ax_base_ParticleSystem_getAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72805,7 +72738,7 @@ int lua_ax_base_ParticleSystem_setAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -72855,7 +72788,7 @@ int lua_ax_base_ParticleSystem_getEmitterMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72902,7 +72835,7 @@ int lua_ax_base_ParticleSystem_setEmitterMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ParticleSystem::Mode arg0;
 
@@ -72952,7 +72885,7 @@ int lua_ax_base_ParticleSystem_getStartSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -72999,7 +72932,7 @@ int lua_ax_base_ParticleSystem_setStartSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -73049,7 +72982,7 @@ int lua_ax_base_ParticleSystem_getStartSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73096,7 +73029,7 @@ int lua_ax_base_ParticleSystem_setStartSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -73146,7 +73079,7 @@ int lua_ax_base_ParticleSystem_getEndSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73193,7 +73126,7 @@ int lua_ax_base_ParticleSystem_setEndSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -73243,7 +73176,7 @@ int lua_ax_base_ParticleSystem_getEndSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73290,7 +73223,7 @@ int lua_ax_base_ParticleSystem_setEndSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -73340,7 +73273,7 @@ int lua_ax_base_ParticleSystem_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73387,7 +73320,7 @@ int lua_ax_base_ParticleSystem_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -73437,7 +73370,7 @@ int lua_ax_base_ParticleSystem_getStartColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73484,7 +73417,7 @@ int lua_ax_base_ParticleSystem_setStartColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -73534,7 +73467,7 @@ int lua_ax_base_ParticleSystem_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73581,7 +73514,7 @@ int lua_ax_base_ParticleSystem_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -73631,7 +73564,7 @@ int lua_ax_base_ParticleSystem_getEndColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73678,7 +73611,7 @@ int lua_ax_base_ParticleSystem_setEndColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -73728,7 +73661,7 @@ int lua_ax_base_ParticleSystem_useHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -73778,7 +73711,7 @@ int lua_ax_base_ParticleSystem_isHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73825,7 +73758,7 @@ int lua_ax_base_ParticleSystem_getHue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73872,7 +73805,7 @@ int lua_ax_base_ParticleSystem_setHue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -73922,7 +73855,7 @@ int lua_ax_base_ParticleSystem_getHueVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -73969,7 +73902,7 @@ int lua_ax_base_ParticleSystem_setHueVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74019,7 +73952,7 @@ int lua_ax_base_ParticleSystem_getHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74066,7 +73999,7 @@ int lua_ax_base_ParticleSystem_setHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::HSV arg0;
 
@@ -74117,7 +74050,7 @@ int lua_ax_base_ParticleSystem_getHSVVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74164,7 +74097,7 @@ int lua_ax_base_ParticleSystem_setHSVVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::HSV arg0;
 
@@ -74215,7 +74148,7 @@ int lua_ax_base_ParticleSystem_getStartSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74262,7 +74195,7 @@ int lua_ax_base_ParticleSystem_setStartSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74312,7 +74245,7 @@ int lua_ax_base_ParticleSystem_getStartSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74359,7 +74292,7 @@ int lua_ax_base_ParticleSystem_setStartSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74409,7 +74342,7 @@ int lua_ax_base_ParticleSystem_getEndSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74456,7 +74389,7 @@ int lua_ax_base_ParticleSystem_setEndSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74506,7 +74439,7 @@ int lua_ax_base_ParticleSystem_getEndSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74553,7 +74486,7 @@ int lua_ax_base_ParticleSystem_setEndSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74603,7 +74536,7 @@ int lua_ax_base_ParticleSystem_getSpawnAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74650,7 +74583,7 @@ int lua_ax_base_ParticleSystem_setSpawnAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74700,7 +74633,7 @@ int lua_ax_base_ParticleSystem_getSpawnAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74747,7 +74680,7 @@ int lua_ax_base_ParticleSystem_setSpawnAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74797,7 +74730,7 @@ int lua_ax_base_ParticleSystem_getSpawnFadeIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74844,7 +74777,7 @@ int lua_ax_base_ParticleSystem_setSpawnFadeIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74894,7 +74827,7 @@ int lua_ax_base_ParticleSystem_getSpawnFadeInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -74941,7 +74874,7 @@ int lua_ax_base_ParticleSystem_setSpawnFadeInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -74991,7 +74924,7 @@ int lua_ax_base_ParticleSystem_getSpawnScaleIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75038,7 +74971,7 @@ int lua_ax_base_ParticleSystem_setSpawnScaleIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -75088,7 +75021,7 @@ int lua_ax_base_ParticleSystem_getSpawnScaleInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75135,7 +75068,7 @@ int lua_ax_base_ParticleSystem_setSpawnScaleInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -75185,7 +75118,7 @@ int lua_ax_base_ParticleSystem_getEmissionRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75232,7 +75165,7 @@ int lua_ax_base_ParticleSystem_setEmissionRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -75282,7 +75215,7 @@ int lua_ax_base_ParticleSystem_getTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75329,7 +75262,7 @@ int lua_ax_base_ParticleSystem_setTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -75379,7 +75312,7 @@ int lua_ax_base_ParticleSystem_setLifeAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -75429,7 +75362,7 @@ int lua_ax_base_ParticleSystem_setEmitterAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -75479,7 +75412,7 @@ int lua_ax_base_ParticleSystem_setLoopAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -75529,7 +75462,7 @@ int lua_ax_base_ParticleSystem_isLifeAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75576,7 +75509,7 @@ int lua_ax_base_ParticleSystem_isEmitterAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75623,7 +75556,7 @@ int lua_ax_base_ParticleSystem_isLoopAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75670,7 +75603,7 @@ int lua_ax_base_ParticleSystem_getTotalAnimationIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75717,7 +75650,7 @@ int lua_ax_base_ParticleSystem_setAnimationReverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -75767,7 +75700,7 @@ int lua_ax_base_ParticleSystem_isAnimationReversed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75814,7 +75747,7 @@ int lua_ax_base_ParticleSystem_resetAnimationIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75861,7 +75794,7 @@ int lua_ax_base_ParticleSystem_resetAnimationDescriptors(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -75908,7 +75841,7 @@ int lua_ax_base_ParticleSystem_setMultiAnimationRandomSpecific(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::vector<unsigned short> arg0;
 
@@ -75958,7 +75891,7 @@ int lua_ax_base_ParticleSystem_setMultiAnimationRandom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76195,7 +76128,7 @@ int lua_ax_base_ParticleSystem_setRectForUndefinedIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -76356,7 +76289,7 @@ int lua_ax_base_ParticleSystem_setAnimationSpeedTimescaleIndependent(lua_State* 
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -76406,7 +76339,7 @@ int lua_ax_base_ParticleSystem_isAnimationSpeedTimescaleIndependent(lua_State* t
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76453,7 +76386,7 @@ int lua_ax_base_ParticleSystem_setEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -76503,7 +76436,7 @@ int lua_ax_base_ParticleSystem_isEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76550,7 +76483,7 @@ int lua_ax_base_ParticleSystem_resetEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76597,7 +76530,7 @@ int lua_ax_base_ParticleSystem_addEmissionShape(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EmissionShape arg0;
 
@@ -76648,7 +76581,7 @@ int lua_ax_base_ParticleSystem_setEmissionShape(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned short arg0;
         ax::EmissionShape arg1;
@@ -76702,7 +76635,7 @@ int lua_ax_base_ParticleSystem_getPositionType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76749,7 +76682,7 @@ int lua_ax_base_ParticleSystem_setPositionType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ParticleSystem::PositionType arg0;
 
@@ -76799,7 +76732,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76810,7 +76743,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -76824,7 +76757,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -76877,7 +76810,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -76888,7 +76821,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -76902,7 +76835,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         double arg1;
@@ -76955,7 +76888,7 @@ int lua_ax_base_ParticleSystem_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77002,7 +76935,7 @@ int lua_ax_base_ParticleSystem_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -77052,7 +76985,7 @@ int lua_ax_base_ParticleSystem_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -77102,7 +77035,7 @@ int lua_ax_base_ParticleSystem_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77149,7 +77082,7 @@ int lua_ax_base_ParticleSystem_getResourceFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77196,7 +77129,7 @@ int lua_ax_base_ParticleSystem_start(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77243,7 +77176,7 @@ int lua_ax_base_ParticleSystem_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77290,7 +77223,7 @@ int lua_ax_base_ParticleSystem_setSourcePositionCompatible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -77340,7 +77273,7 @@ int lua_ax_base_ParticleSystem_isSourcePositionCompatible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77387,7 +77320,7 @@ int lua_ax_base_ParticleSystem_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -77496,7 +77429,7 @@ int lua_ax_base_ParticleSystem_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -77546,7 +77479,7 @@ int lua_ax_base_ParticleSystem_isPaused(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77593,7 +77526,7 @@ int lua_ax_base_ParticleSystem_pauseEmissions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77640,7 +77573,7 @@ int lua_ax_base_ParticleSystem_resumeEmissions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77687,7 +77620,7 @@ int lua_ax_base_ParticleSystem_getFixedFPS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77734,7 +77667,7 @@ int lua_ax_base_ParticleSystem_setFixedFPS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77745,7 +77678,7 @@ int lua_ax_base_ParticleSystem_setFixedFPS(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -77795,7 +77728,7 @@ int lua_ax_base_ParticleSystem_getTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77842,7 +77775,7 @@ int lua_ax_base_ParticleSystem_setTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -77853,7 +77786,7 @@ int lua_ax_base_ParticleSystem_setTimeScale(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -78462,7 +78395,7 @@ int lua_ax_base_ParticleSystem_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -78701,7 +78634,7 @@ int lua_ax_base_ParticleSystemQuad_setDisplayFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::SpriteFrame* arg0;
 
@@ -78751,7 +78684,7 @@ int lua_ax_base_ParticleSystemQuad_setTextureWithRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Texture2D* arg0;
         ax::Rect arg1;
@@ -78804,7 +78737,7 @@ int lua_ax_base_ParticleSystemQuad_listenRendererRecreated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::EventCustom* arg0;
 
@@ -78842,7 +78775,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -78855,7 +78788,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -78865,7 +78798,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -78935,7 +78868,7 @@ int lua_ax_base_ParticleSystemQuad_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79067,7 +79000,7 @@ int lua_ax_base_ParticleFire_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79139,7 +79072,7 @@ int lua_ax_base_ParticleFireworks_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79186,7 +79119,7 @@ int lua_ax_base_ParticleFireworks_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -79293,7 +79226,7 @@ int lua_ax_base_ParticleFireworks_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79367,7 +79300,7 @@ int lua_ax_base_ParticleSun_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79414,7 +79347,7 @@ int lua_ax_base_ParticleSun_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -79521,7 +79454,7 @@ int lua_ax_base_ParticleSun_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79595,7 +79528,7 @@ int lua_ax_base_ParticleGalaxy_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79642,7 +79575,7 @@ int lua_ax_base_ParticleGalaxy_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -79749,7 +79682,7 @@ int lua_ax_base_ParticleGalaxy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79823,7 +79756,7 @@ int lua_ax_base_ParticleFlower_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -79870,7 +79803,7 @@ int lua_ax_base_ParticleFlower_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -79977,7 +79910,7 @@ int lua_ax_base_ParticleFlower_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80051,7 +79984,7 @@ int lua_ax_base_ParticleMeteor_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80098,7 +80031,7 @@ int lua_ax_base_ParticleMeteor_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -80205,7 +80138,7 @@ int lua_ax_base_ParticleMeteor_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80279,7 +80212,7 @@ int lua_ax_base_ParticleSpiral_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80326,7 +80259,7 @@ int lua_ax_base_ParticleSpiral_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -80433,7 +80366,7 @@ int lua_ax_base_ParticleSpiral_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80507,7 +80440,7 @@ int lua_ax_base_ParticleExplosion_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80554,7 +80487,7 @@ int lua_ax_base_ParticleExplosion_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -80661,7 +80594,7 @@ int lua_ax_base_ParticleExplosion_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80735,7 +80668,7 @@ int lua_ax_base_ParticleSmoke_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80782,7 +80715,7 @@ int lua_ax_base_ParticleSmoke_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -80889,7 +80822,7 @@ int lua_ax_base_ParticleSmoke_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -80963,7 +80896,7 @@ int lua_ax_base_ParticleSnow_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81010,7 +80943,7 @@ int lua_ax_base_ParticleSnow_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -81117,7 +81050,7 @@ int lua_ax_base_ParticleSnow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81191,7 +81124,7 @@ int lua_ax_base_ParticleRain_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81238,7 +81171,7 @@ int lua_ax_base_ParticleRain_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -81345,7 +81278,7 @@ int lua_ax_base_ParticleRain_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81419,7 +81352,7 @@ int lua_ax_base_ProgressTimer_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81466,7 +81399,7 @@ int lua_ax_base_ProgressTimer_getPercentage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81513,7 +81446,7 @@ int lua_ax_base_ProgressTimer_getSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81560,7 +81493,7 @@ int lua_ax_base_ProgressTimer_setPercentage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -81610,7 +81543,7 @@ int lua_ax_base_ProgressTimer_setSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Sprite* arg0;
 
@@ -81660,7 +81593,7 @@ int lua_ax_base_ProgressTimer_setType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ProgressTimer::Type arg0;
 
@@ -81710,7 +81643,7 @@ int lua_ax_base_ProgressTimer_isReverseDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81757,7 +81690,7 @@ int lua_ax_base_ProgressTimer_setReverseDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -81807,7 +81740,7 @@ int lua_ax_base_ProgressTimer_setMidpoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -81857,7 +81790,7 @@ int lua_ax_base_ProgressTimer_getMidpoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -81904,7 +81837,7 @@ int lua_ax_base_ProgressTimer_setBarChangeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -81954,7 +81887,7 @@ int lua_ax_base_ProgressTimer_getBarChangeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82001,7 +81934,7 @@ int lua_ax_base_ProgressTimer_initWithSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Sprite* arg0;
 
@@ -82074,7 +82007,7 @@ int lua_ax_base_ProgressTimer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82237,7 +82170,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -82287,7 +82220,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -82337,7 +82270,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -82351,7 +82284,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         bool arg1;
@@ -82404,7 +82337,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -82418,7 +82351,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChildByTag(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         int arg0;
         bool arg1;
@@ -82471,7 +82404,7 @@ int lua_ax_base_ProtectedNode_removeAllProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82518,7 +82451,7 @@ int lua_ax_base_ProtectedNode_removeAllProtectedChildrenWithCleanup(lua_State* t
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -82568,7 +82501,7 @@ int lua_ax_base_ProtectedNode_reorderProtectedChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Node* arg0;
         int arg1;
@@ -82621,7 +82554,7 @@ int lua_ax_base_ProtectedNode_sortAllProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82668,7 +82601,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82715,7 +82648,7 @@ int lua_ax_base_ProtectedNode_disableCascadeColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82762,7 +82695,7 @@ int lua_ax_base_ProtectedNode_disableCascadeOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82830,7 +82763,7 @@ int lua_ax_base_ProtectedNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -82913,7 +82846,7 @@ int lua_ax_base_RenderTexture_begin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83075,7 +83008,7 @@ int lua_ax_base_RenderTexture_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83122,7 +83055,7 @@ int lua_ax_base_RenderTexture_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -83181,7 +83114,7 @@ int lua_ax_base_RenderTexture_clearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -83231,7 +83164,7 @@ int lua_ax_base_RenderTexture_clearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -83539,7 +83472,7 @@ int lua_ax_base_RenderTexture_getClearFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83586,7 +83519,7 @@ int lua_ax_base_RenderTexture_setClearFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::TargetBufferFlags arg0;
 
@@ -83636,7 +83569,7 @@ int lua_ax_base_RenderTexture_getClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83683,7 +83616,7 @@ int lua_ax_base_RenderTexture_setClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -83733,7 +83666,7 @@ int lua_ax_base_RenderTexture_getClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83780,7 +83713,7 @@ int lua_ax_base_RenderTexture_setClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -83830,7 +83763,7 @@ int lua_ax_base_RenderTexture_getClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83877,7 +83810,7 @@ int lua_ax_base_RenderTexture_setClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -83927,7 +83860,7 @@ int lua_ax_base_RenderTexture_isAutoDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -83974,7 +83907,7 @@ int lua_ax_base_RenderTexture_setAutoDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -84024,7 +83957,7 @@ int lua_ax_base_RenderTexture_getSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84071,7 +84004,7 @@ int lua_ax_base_RenderTexture_getRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84118,7 +84051,7 @@ int lua_ax_base_RenderTexture_setKeepMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -84168,7 +84101,7 @@ int lua_ax_base_RenderTexture_setVirtualViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Vec2 arg0;
         ax::Rect arg1;
@@ -84224,7 +84157,7 @@ int lua_ax_base_RenderTexture_isSharedRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84386,7 +84319,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -84405,7 +84338,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -84427,7 +84360,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -84449,7 +84382,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -84474,7 +84407,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -84490,7 +84423,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -84530,7 +84463,7 @@ int lua_ax_base_RenderTexture_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84625,7 +84558,7 @@ int lua_ax_base_TransitionEaseScene_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -84695,7 +84628,7 @@ int lua_ax_base_TransitionScene_finish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84742,7 +84675,7 @@ int lua_ax_base_TransitionScene_hideOutShowIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84789,7 +84722,7 @@ int lua_ax_base_TransitionScene_getInScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84836,7 +84769,7 @@ int lua_ax_base_TransitionScene_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -84883,7 +84816,7 @@ int lua_ax_base_TransitionScene_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         double arg0;
         ax::Scene* arg1;
@@ -84961,7 +84894,7 @@ int lua_ax_base_TransitionScene_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85037,7 +84970,7 @@ int lua_ax_base_TransitionSceneOriented_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         ax::Scene* arg1;
@@ -85120,7 +85053,7 @@ int lua_ax_base_TransitionSceneOriented_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85217,7 +85150,7 @@ int lua_ax_base_TransitionRotoZoom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85313,7 +85246,7 @@ int lua_ax_base_TransitionJumpZoom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85384,7 +85317,7 @@ int lua_ax_base_TransitionMoveInL_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85431,7 +85364,7 @@ int lua_ax_base_TransitionMoveInL_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -85506,7 +85439,7 @@ int lua_ax_base_TransitionMoveInL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85604,7 +85537,7 @@ int lua_ax_base_TransitionMoveInR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85700,7 +85633,7 @@ int lua_ax_base_TransitionMoveInT_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85796,7 +85729,7 @@ int lua_ax_base_TransitionMoveInB_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85867,7 +85800,7 @@ int lua_ax_base_TransitionSlideInL_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -85917,7 +85850,7 @@ int lua_ax_base_TransitionSlideInL_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -85989,7 +85922,7 @@ int lua_ax_base_TransitionSlideInL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86087,7 +86020,7 @@ int lua_ax_base_TransitionSlideInR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86183,7 +86116,7 @@ int lua_ax_base_TransitionSlideInB_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86279,7 +86212,7 @@ int lua_ax_base_TransitionSlideInT_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86350,7 +86283,7 @@ int lua_ax_base_TransitionShrinkGrow_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -86425,7 +86358,7 @@ int lua_ax_base_TransitionShrinkGrow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86485,7 +86418,7 @@ int lua_ax_base_TransitionFlipX_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -86501,7 +86434,7 @@ int lua_ax_base_TransitionFlipX_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -86541,7 +86474,7 @@ int lua_ax_base_TransitionFlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86600,7 +86533,7 @@ int lua_ax_base_TransitionFlipY_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -86616,7 +86549,7 @@ int lua_ax_base_TransitionFlipY_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -86656,7 +86589,7 @@ int lua_ax_base_TransitionFlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86715,7 +86648,7 @@ int lua_ax_base_TransitionFlipAngular_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -86731,7 +86664,7 @@ int lua_ax_base_TransitionFlipAngular_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -86771,7 +86704,7 @@ int lua_ax_base_TransitionFlipAngular_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86830,7 +86763,7 @@ int lua_ax_base_TransitionZoomFlipX_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -86846,7 +86779,7 @@ int lua_ax_base_TransitionZoomFlipX_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -86886,7 +86819,7 @@ int lua_ax_base_TransitionZoomFlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -86945,7 +86878,7 @@ int lua_ax_base_TransitionZoomFlipY_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -86961,7 +86894,7 @@ int lua_ax_base_TransitionZoomFlipY_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -87001,7 +86934,7 @@ int lua_ax_base_TransitionZoomFlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87060,7 +86993,7 @@ int lua_ax_base_TransitionZoomFlipAngular_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -87076,7 +87009,7 @@ int lua_ax_base_TransitionZoomFlipAngular_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -87116,7 +87049,7 @@ int lua_ax_base_TransitionZoomFlipAngular_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87242,7 +87175,7 @@ int lua_ax_base_TransitionFade_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -87258,7 +87191,7 @@ int lua_ax_base_TransitionFade_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -87298,7 +87231,7 @@ int lua_ax_base_TransitionFade_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87395,7 +87328,7 @@ int lua_ax_base_TransitionCrossFade_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87466,7 +87399,7 @@ int lua_ax_base_TransitionTurnOffTiles_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -87541,7 +87474,7 @@ int lua_ax_base_TransitionTurnOffTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87613,7 +87546,7 @@ int lua_ax_base_TransitionSplitCols_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87660,7 +87593,7 @@ int lua_ax_base_TransitionSplitCols_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -87735,7 +87668,7 @@ int lua_ax_base_TransitionSplitCols_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87833,7 +87766,7 @@ int lua_ax_base_TransitionSplitRows_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -87904,7 +87837,7 @@ int lua_ax_base_TransitionFadeTR_actionWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -87954,7 +87887,7 @@ int lua_ax_base_TransitionFadeTR_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ActionInterval* arg0;
 
@@ -88029,7 +87962,7 @@ int lua_ax_base_TransitionFadeTR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88127,7 +88060,7 @@ int lua_ax_base_TransitionFadeBL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88223,7 +88156,7 @@ int lua_ax_base_TransitionFadeUp_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88319,7 +88252,7 @@ int lua_ax_base_TransitionFadeDown_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88390,7 +88323,7 @@ int lua_ax_base_TransitionPageTurn_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         double arg0;
         ax::Scene* arg1;
@@ -88446,7 +88379,7 @@ int lua_ax_base_TransitionPageTurn_actionWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -88523,7 +88456,7 @@ int lua_ax_base_TransitionPageTurn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88621,7 +88554,7 @@ int lua_ax_base_TransitionProgress_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88717,7 +88650,7 @@ int lua_ax_base_TransitionProgressRadialCCW_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88813,7 +88746,7 @@ int lua_ax_base_TransitionProgressRadialCW_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -88909,7 +88842,7 @@ int lua_ax_base_TransitionProgressHorizontal_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89005,7 +88938,7 @@ int lua_ax_base_TransitionProgressVertical_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89101,7 +89034,7 @@ int lua_ax_base_TransitionProgressInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89197,7 +89130,7 @@ int lua_ax_base_TransitionProgressOutIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89268,7 +89201,7 @@ int lua_ax_base_Camera_getCameraFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89315,7 +89248,7 @@ int lua_ax_base_Camera_setCameraFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::CameraFlag arg0;
 
@@ -89365,7 +89298,7 @@ int lua_ax_base_Camera_lookAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -89379,7 +89312,7 @@ int lua_ax_base_Camera_lookAt(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Vec3 arg0;
         ax::Vec3 arg1;
@@ -89432,7 +89365,7 @@ int lua_ax_base_Camera_getProjectionMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89479,7 +89412,7 @@ int lua_ax_base_Camera_getViewMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89526,7 +89459,7 @@ int lua_ax_base_Camera_getViewProjectionMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89573,7 +89506,7 @@ int lua_ax_base_Camera_project(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -89623,7 +89556,7 @@ int lua_ax_base_Camera_projectGL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -89673,7 +89606,7 @@ int lua_ax_base_Camera_isVisibleInFrustum(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         const ax::AABB* arg0;
 
@@ -89723,7 +89656,7 @@ int lua_ax_base_Camera_getDepthInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Mat4 arg0;
 
@@ -89773,7 +89706,7 @@ int lua_ax_base_Camera_setDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int32_t arg0;
 
@@ -89823,7 +89756,7 @@ int lua_ax_base_Camera_getDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89870,7 +89803,7 @@ int lua_ax_base_Camera_getRenderOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89917,7 +89850,7 @@ int lua_ax_base_Camera_getFOV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -89964,7 +89897,7 @@ int lua_ax_base_Camera_setFOV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -90014,7 +89947,7 @@ int lua_ax_base_Camera_getFarPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90061,7 +89994,7 @@ int lua_ax_base_Camera_setFarPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -90111,7 +90044,7 @@ int lua_ax_base_Camera_getNearPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90158,7 +90091,7 @@ int lua_ax_base_Camera_setNearPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -90208,7 +90141,7 @@ int lua_ax_base_Camera_getZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90255,7 +90188,7 @@ int lua_ax_base_Camera_setZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -90305,7 +90238,7 @@ int lua_ax_base_Camera_applyZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90352,7 +90285,7 @@ int lua_ax_base_Camera_clearBackground(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90399,7 +90332,7 @@ int lua_ax_base_Camera_apply(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90446,7 +90379,7 @@ int lua_ax_base_Camera_isViewProjectionUpdated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90493,7 +90426,7 @@ int lua_ax_base_Camera_setBackgroundBrush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::CameraBackgroundBrush* arg0;
 
@@ -90543,7 +90476,7 @@ int lua_ax_base_Camera_getBackgroundBrush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90590,7 +90523,7 @@ int lua_ax_base_Camera_isBrushValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90637,7 +90570,7 @@ int lua_ax_base_Camera_setScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Scene* arg0;
 
@@ -90687,7 +90620,7 @@ int lua_ax_base_Camera_setAdditionalProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Mat4 arg0;
 
@@ -90737,7 +90670,7 @@ int lua_ax_base_Camera_initDefault(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -90784,7 +90717,7 @@ int lua_ax_base_Camera_initPerspective(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -90843,7 +90776,7 @@ int lua_ax_base_Camera_initOrthographic(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -90902,7 +90835,7 @@ int lua_ax_base_Camera_applyViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91193,7 +91126,7 @@ int lua_ax_base_Camera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91304,7 +91237,7 @@ int lua_ax_base_CameraBackgroundBrush_getBrushType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91351,7 +91284,7 @@ int lua_ax_base_CameraBackgroundBrush_drawBackground(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Camera* arg0;
 
@@ -91401,7 +91334,7 @@ int lua_ax_base_CameraBackgroundBrush_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91448,7 +91381,7 @@ int lua_ax_base_CameraBackgroundBrush_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91647,7 +91580,7 @@ int lua_ax_base_CameraBackgroundBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91725,7 +91658,7 @@ int lua_ax_base_CameraBackgroundDepthBrush_setDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -91798,7 +91731,7 @@ int lua_ax_base_CameraBackgroundDepthBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -91870,7 +91803,7 @@ int lua_ax_base_CameraBackgroundColorBrush_setColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color arg0;
 
@@ -91945,7 +91878,7 @@ int lua_ax_base_CameraBackgroundColorBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92017,7 +91950,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextureCube* arg0;
 
@@ -92067,7 +92000,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92114,7 +92047,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_isActived(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92161,7 +92094,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setActived(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -92211,7 +92144,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setTextureValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -92249,7 +92182,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 0)
         {
@@ -92259,7 +92192,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 6)
         {
@@ -92308,7 +92241,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92384,7 +92317,7 @@ int lua_ax_base_GridBase_beforeBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92431,7 +92364,7 @@ int lua_ax_base_GridBase_afterBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92478,7 +92411,7 @@ int lua_ax_base_GridBase_blit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92525,7 +92458,7 @@ int lua_ax_base_GridBase_reuse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92572,7 +92505,7 @@ int lua_ax_base_GridBase_calculateVertexPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92722,7 +92655,7 @@ int lua_ax_base_GridBase_isActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92769,7 +92702,7 @@ int lua_ax_base_GridBase_setActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -92819,7 +92752,7 @@ int lua_ax_base_GridBase_getReuseGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92866,7 +92799,7 @@ int lua_ax_base_GridBase_setReuseGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -92916,7 +92849,7 @@ int lua_ax_base_GridBase_getGridSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -92963,7 +92896,7 @@ int lua_ax_base_GridBase_setGridSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -93013,7 +92946,7 @@ int lua_ax_base_GridBase_getStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93060,7 +92993,7 @@ int lua_ax_base_GridBase_setStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -93110,7 +93043,7 @@ int lua_ax_base_GridBase_isTextureFlipped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93157,7 +93090,7 @@ int lua_ax_base_GridBase_setTextureFlipped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -93207,7 +93140,7 @@ int lua_ax_base_GridBase_beforeDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93254,7 +93187,7 @@ int lua_ax_base_GridBase_afterDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Node* arg0;
 
@@ -93304,7 +93237,7 @@ int lua_ax_base_GridBase_set2DProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93351,7 +93284,7 @@ int lua_ax_base_GridBase_setGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Rect arg0;
 
@@ -93401,7 +93334,7 @@ int lua_ax_base_GridBase_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93488,7 +93421,7 @@ int lua_ax_base_Grid3D_setNeedDepthTestForBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -93538,7 +93471,7 @@ int lua_ax_base_Grid3D_getNeedDepthTestForBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93573,7 +93506,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -93589,7 +93522,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -93602,7 +93535,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -93621,7 +93554,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -93664,7 +93597,7 @@ int lua_ax_base_Grid3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93725,7 +93658,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 2)
         {
@@ -93741,7 +93674,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 1)
         {
@@ -93754,7 +93687,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 3)
         {
@@ -93773,7 +93706,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 4)
         {
@@ -93849,7 +93782,7 @@ int lua_ax_base_BaseLight_getLightType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93896,7 +93829,7 @@ int lua_ax_base_BaseLight_getIntensity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -93943,7 +93876,7 @@ int lua_ax_base_BaseLight_setIntensity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -93993,7 +93926,7 @@ int lua_ax_base_BaseLight_getLightFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94040,7 +93973,7 @@ int lua_ax_base_BaseLight_setLightFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::LightFlag arg0;
 
@@ -94090,7 +94023,7 @@ int lua_ax_base_BaseLight_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -94140,7 +94073,7 @@ int lua_ax_base_BaseLight_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94213,7 +94146,7 @@ int lua_ax_base_DirectionLight_setDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -94263,7 +94196,7 @@ int lua_ax_base_DirectionLight_getDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94310,7 +94243,7 @@ int lua_ax_base_DirectionLight_getDirectionInWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94382,7 +94315,7 @@ int lua_ax_base_DirectionLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94456,7 +94389,7 @@ int lua_ax_base_PointLight_getRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94503,7 +94436,7 @@ int lua_ax_base_PointLight_setRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -94580,7 +94513,7 @@ int lua_ax_base_PointLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94653,7 +94586,7 @@ int lua_ax_base_SpotLight_setDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -94703,7 +94636,7 @@ int lua_ax_base_SpotLight_getDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94750,7 +94683,7 @@ int lua_ax_base_SpotLight_getDirectionInWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94797,7 +94730,7 @@ int lua_ax_base_SpotLight_setRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -94847,7 +94780,7 @@ int lua_ax_base_SpotLight_getRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94894,7 +94827,7 @@ int lua_ax_base_SpotLight_setInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -94944,7 +94877,7 @@ int lua_ax_base_SpotLight_getInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -94991,7 +94924,7 @@ int lua_ax_base_SpotLight_getCosInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95038,7 +94971,7 @@ int lua_ax_base_SpotLight_setOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -95088,7 +95021,7 @@ int lua_ax_base_SpotLight_getOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95135,7 +95068,7 @@ int lua_ax_base_SpotLight_getCosOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95215,7 +95148,7 @@ int lua_ax_base_SpotLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95320,7 +95253,7 @@ int lua_ax_base_AmbientLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95391,7 +95324,7 @@ int lua_ax_base_RenderState_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95438,7 +95371,7 @@ int lua_ax_base_RenderState_bindPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Pass* arg0;
         ax::MeshCommand* arg1;
@@ -95512,7 +95445,7 @@ int lua_ax_base_Technique_addPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Pass* arg0;
 
@@ -95562,7 +95495,7 @@ int lua_ax_base_Technique_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95609,7 +95542,7 @@ int lua_ax_base_Technique_getPassByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ssize_t arg0;
 
@@ -95659,7 +95592,7 @@ int lua_ax_base_Technique_getPassCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95706,7 +95639,7 @@ int lua_ax_base_Technique_getPasses(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95753,7 +95686,7 @@ int lua_ax_base_Technique_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -95800,7 +95733,7 @@ int lua_ax_base_Technique_setMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Material* arg0;
 
@@ -95952,7 +95885,7 @@ int lua_ax_base_Material_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8) 
+    if (argc == 8)
     {
         ax::MeshCommand* arg0;
         double arg1;
@@ -96023,7 +95956,7 @@ int lua_ax_base_Material_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96070,7 +96003,7 @@ int lua_ax_base_Material_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -96120,7 +96053,7 @@ int lua_ax_base_Material_getTechniqueByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -96170,7 +96103,7 @@ int lua_ax_base_Material_getTechniqueByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ssize_t arg0;
 
@@ -96220,7 +96153,7 @@ int lua_ax_base_Material_getTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96267,7 +96200,7 @@ int lua_ax_base_Material_getTechniques(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96314,7 +96247,7 @@ int lua_ax_base_Material_getTechniqueCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96361,7 +96294,7 @@ int lua_ax_base_Material_addTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Technique* arg0;
 
@@ -96411,7 +96344,7 @@ int lua_ax_base_Material_setTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -96461,7 +96394,7 @@ int lua_ax_base_Material_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96508,7 +96441,7 @@ int lua_ax_base_Material_getRenderState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96555,7 +96488,7 @@ int lua_ax_base_Material_setPrimitiveType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::PrimitiveType arg0;
 
@@ -96605,7 +96538,7 @@ int lua_ax_base_Material_getPrimitiveType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96652,7 +96585,7 @@ int lua_ax_base_Material_setTransparent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -96702,7 +96635,7 @@ int lua_ax_base_Material_isTransparent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96749,7 +96682,7 @@ int lua_ax_base_Material_setForce2DQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -96799,7 +96732,7 @@ int lua_ax_base_Material_isForce2DQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -96994,7 +96927,7 @@ int lua_ax_base_Pass_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -97041,7 +96974,7 @@ int lua_ax_base_Pass_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8) 
+    if (argc == 8)
     {
         ax::MeshCommand* arg0;
         double arg1;
@@ -97112,7 +97045,7 @@ int lua_ax_base_Pass_setVertexInputBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::VertexInputBinding* arg0;
 
@@ -97162,7 +97095,7 @@ int lua_ax_base_Pass_getVertexAttributeBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -97209,7 +97142,7 @@ int lua_ax_base_Pass_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -97259,7 +97192,7 @@ int lua_ax_base_Pass_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -97306,7 +97239,7 @@ int lua_ax_base_Pass_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -97353,7 +97286,7 @@ int lua_ax_base_Pass_setTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Technique* arg0;
 
@@ -97403,7 +97336,7 @@ int lua_ax_base_Pass_updateMVPUniform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Mat4 arg0;
 
@@ -97453,7 +97386,7 @@ int lua_ax_base_Pass_setUniformTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned int arg0;
         ax::rhi::Texture* arg1;
@@ -97506,7 +97439,7 @@ int lua_ax_base_Pass_setUniformNormTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned int arg0;
         ax::rhi::Texture* arg1;
@@ -97559,7 +97492,7 @@ int lua_ax_base_Pass_setUniformColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97613,7 +97546,7 @@ int lua_ax_base_Pass_setUniformMatrixPalette(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97667,7 +97600,7 @@ int lua_ax_base_Pass_setUniformDirLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97721,7 +97654,7 @@ int lua_ax_base_Pass_setUniformDirLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97775,7 +97708,7 @@ int lua_ax_base_Pass_setUniformPointLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97829,7 +97762,7 @@ int lua_ax_base_Pass_setUniformPointLightPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97883,7 +97816,7 @@ int lua_ax_base_Pass_setUniformPointLightRangeInverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97937,7 +97870,7 @@ int lua_ax_base_Pass_setUniformSpotLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -97991,7 +97924,7 @@ int lua_ax_base_Pass_setUniformSpotLightPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -98045,7 +97978,7 @@ int lua_ax_base_Pass_setUniformSpotLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -98099,7 +98032,7 @@ int lua_ax_base_Pass_setUniformSpotLightInnerAngleCos(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -98153,7 +98086,7 @@ int lua_ax_base_Pass_setUniformSpotLightOuterAngleCos(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -98207,7 +98140,7 @@ int lua_ax_base_Pass_setUniformSpotLightRangeInverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -98261,7 +98194,7 @@ int lua_ax_base_Pass_setUniformAmbientLigthColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         const void* arg0;
         unsigned int arg1;
@@ -98435,7 +98368,7 @@ int lua_ax_base_ProgramManager_getBuiltinProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -98485,7 +98418,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98502,7 +98435,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98522,7 +98455,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 4) 
+    if (argc == 4)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98660,7 +98593,7 @@ int lua_ax_base_ProgramManager_unloadProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::Program* arg0;
 
@@ -98710,7 +98643,7 @@ int lua_ax_base_ProgramManager_unloadUnusedPrograms(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -98757,7 +98690,7 @@ int lua_ax_base_ProgramManager_unloadAllPrograms(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -98936,7 +98869,7 @@ int lua_ax_base_Renderer_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -98983,7 +98916,7 @@ int lua_ax_base_Renderer_addCallbackCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::function<void ()> arg0;
 
@@ -99001,7 +98934,7 @@ int lua_ax_base_Renderer_addCallbackCommand(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::function<void ()> arg0;
         double arg1;
@@ -99117,7 +99050,7 @@ int lua_ax_base_Renderer_getNextGroupCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99164,7 +99097,7 @@ int lua_ax_base_Renderer_pushGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -99214,7 +99147,7 @@ int lua_ax_base_Renderer_popGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99261,7 +99194,7 @@ int lua_ax_base_Renderer_createRenderQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99308,7 +99241,7 @@ int lua_ax_base_Renderer_render(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99355,7 +99288,7 @@ int lua_ax_base_Renderer_clean(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99402,7 +99335,7 @@ int lua_ax_base_Renderer_getDrawnBatches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99449,7 +99382,7 @@ int lua_ax_base_Renderer_addDrawnBatches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ssize_t arg0;
 
@@ -99499,7 +99432,7 @@ int lua_ax_base_Renderer_getDrawnVertices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99546,7 +99479,7 @@ int lua_ax_base_Renderer_addDrawnVertices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ssize_t arg0;
 
@@ -99596,7 +99529,7 @@ int lua_ax_base_Renderer_clearDrawStats(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99643,7 +99576,7 @@ int lua_ax_base_Renderer_getRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99690,7 +99623,7 @@ int lua_ax_base_Renderer_setRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::RenderTarget* arg0;
 
@@ -99740,7 +99673,7 @@ int lua_ax_base_Renderer_getDefaultRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99787,7 +99720,7 @@ int lua_ax_base_Renderer_getOffscreenRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99834,7 +99767,7 @@ int lua_ax_base_Renderer_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
+    if (argc == 5)
     {
         ax::rhi::TargetBufferFlags arg0;
         ax::Color arg1;
@@ -99896,7 +99829,7 @@ int lua_ax_base_Renderer_getClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99943,7 +99876,7 @@ int lua_ax_base_Renderer_getClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -99990,7 +99923,7 @@ int lua_ax_base_Renderer_getClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100037,7 +99970,7 @@ int lua_ax_base_Renderer_getClearFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100084,7 +100017,7 @@ int lua_ax_base_Renderer_setDepthTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -100134,7 +100067,7 @@ int lua_ax_base_Renderer_setDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -100184,7 +100117,7 @@ int lua_ax_base_Renderer_setDepthCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::CompareFunc arg0;
 
@@ -100234,7 +100167,7 @@ int lua_ax_base_Renderer_getDepthTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100281,7 +100214,7 @@ int lua_ax_base_Renderer_getDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100328,7 +100261,7 @@ int lua_ax_base_Renderer_getDepthCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100375,7 +100308,7 @@ int lua_ax_base_Renderer_setStencilTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -100425,7 +100358,7 @@ int lua_ax_base_Renderer_setStencilCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::rhi::CompareFunc arg0;
         unsigned int arg1;
@@ -100481,7 +100414,7 @@ int lua_ax_base_Renderer_setStencilOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::rhi::StencilOp arg0;
         ax::rhi::StencilOp arg1;
@@ -100537,7 +100470,7 @@ int lua_ax_base_Renderer_setStencilWriteMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -100587,7 +100520,7 @@ int lua_ax_base_Renderer_getStencilTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100634,7 +100567,7 @@ int lua_ax_base_Renderer_getStencilFailureOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100681,7 +100614,7 @@ int lua_ax_base_Renderer_getStencilPassDepthFailureOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100728,7 +100661,7 @@ int lua_ax_base_Renderer_getStencilDepthPassOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100775,7 +100708,7 @@ int lua_ax_base_Renderer_getStencilCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100822,7 +100755,7 @@ int lua_ax_base_Renderer_getStencilReadMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100869,7 +100802,7 @@ int lua_ax_base_Renderer_getStencilWriteMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100916,7 +100849,7 @@ int lua_ax_base_Renderer_getStencilReferenceValue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -100963,7 +100896,7 @@ int lua_ax_base_Renderer_setDepthStencilDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::DepthStencilDesc arg0;
 
@@ -101014,7 +100947,7 @@ int lua_ax_base_Renderer_getDepthStencilDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101061,7 +100994,7 @@ int lua_ax_base_Renderer_setCullMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::CullMode arg0;
 
@@ -101111,7 +101044,7 @@ int lua_ax_base_Renderer_getCullMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101158,7 +101091,7 @@ int lua_ax_base_Renderer_setWinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::Winding arg0;
 
@@ -101208,7 +101141,7 @@ int lua_ax_base_Renderer_getWinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101255,7 +101188,7 @@ int lua_ax_base_Renderer_setViewPort(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         int arg0;
         int arg1;
@@ -101314,7 +101247,7 @@ int lua_ax_base_Renderer_getViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101361,7 +101294,7 @@ int lua_ax_base_Renderer_setScissorTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -101411,7 +101344,7 @@ int lua_ax_base_Renderer_setScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         double arg0;
         double arg1;
@@ -101470,7 +101403,7 @@ int lua_ax_base_Renderer_getScissorTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101517,7 +101450,7 @@ int lua_ax_base_Renderer_getScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101564,7 +101497,7 @@ int lua_ax_base_Renderer_checkVisibility(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Mat4 arg0;
         ax::Vec2 arg1;
@@ -101617,7 +101550,7 @@ int lua_ax_base_Renderer_readPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::rhi::RenderTarget* arg0;
         std::function<void (const ax::rhi::PixelBufferDesc &)> arg1;
@@ -101674,7 +101607,7 @@ int lua_ax_base_Renderer_beginRenderPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101721,7 +101654,7 @@ int lua_ax_base_Renderer_endRenderPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101768,7 +101701,7 @@ int lua_ax_base_Renderer_nextCallbackCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101815,7 +101748,7 @@ int lua_ax_base_Renderer_resizeSwapChain(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         unsigned int arg0;
         unsigned int arg1;
@@ -101855,7 +101788,7 @@ int lua_ax_base_Renderer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -101982,7 +101915,7 @@ int lua_ax_base_TextureCache_getDescription(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102084,7 +102017,7 @@ int lua_ax_base_TextureCache_getDummyTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102143,12 +102076,48 @@ int lua_ax_base_TextureCache_addImage(lua_State* tolua_S)
     }while(0);
     ok  = true;
     do{
+        if (argc == 3) {
+            std::string_view arg0;
+            ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.TextureCache:addImage");
+
+            if (!ok) { break; }
+            ax::rhi::PixelFormat arg1;
+            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.TextureCache:addImage");
+
+            if (!ok) { break; }
+            bool arg2;
+            ok &= luaval_to_boolean(tolua_S, 4,&arg2, "ax.TextureCache:addImage");
+
+            if (!ok) { break; }
+            ax::Texture2D* ret = cobj->addImage(arg0, arg1, arg2);
+            object_to_luaval<ax::Texture2D>(tolua_S, "ax.Texture2D",(ax::Texture2D*)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
         if (argc == 1) {
             std::string_view arg0;
             ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.TextureCache:addImage");
 
             if (!ok) { break; }
             ax::Texture2D* ret = cobj->addImage(arg0);
+            object_to_luaval<ax::Texture2D>(tolua_S, "ax.Texture2D",(ax::Texture2D*)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 2) {
+            std::string_view arg0;
+            ok &= luaval_to_std_string_view(tolua_S, 2,&arg0, "ax.TextureCache:addImage");
+
+            if (!ok) { break; }
+            bool arg1;
+            ok &= luaval_to_boolean(tolua_S, 3,&arg1, "ax.TextureCache:addImage");
+
+            if (!ok) { break; }
+            ax::Texture2D* ret = cobj->addImage(arg0, arg1);
             object_to_luaval<ax::Texture2D>(tolua_S, "ax.Texture2D",(ax::Texture2D*)ret);
             return 1;
         }
@@ -102242,7 +102211,7 @@ int lua_ax_base_TextureCache_unbindImageAsync(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -102292,7 +102261,7 @@ int lua_ax_base_TextureCache_unbindAllImageAsync(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102339,7 +102308,7 @@ int lua_ax_base_TextureCache_getTextureForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -102389,7 +102358,7 @@ int lua_ax_base_TextureCache_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -102439,7 +102408,7 @@ int lua_ax_base_TextureCache_removeAllTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102486,7 +102455,7 @@ int lua_ax_base_TextureCache_removeUnusedTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102533,7 +102502,7 @@ int lua_ax_base_TextureCache_removeTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -102583,7 +102552,7 @@ int lua_ax_base_TextureCache_removeTextureForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -102633,7 +102602,7 @@ int lua_ax_base_TextureCache_getCachedTextureInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102680,7 +102649,7 @@ int lua_ax_base_TextureCache_waitForQuit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -102727,7 +102696,7 @@ int lua_ax_base_TextureCache_getTextureFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -102777,7 +102746,7 @@ int lua_ax_base_TextureCache_renameTextureWithKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -102887,7 +102856,7 @@ int lua_ax_base_TextureCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -103428,7 +103397,7 @@ int lua_ax_base_Application_setAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -103478,7 +103447,7 @@ int lua_ax_base_Application_getCurrentLanguage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -103525,7 +103494,7 @@ int lua_ax_base_Application_getCurrentLanguageCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -103572,7 +103541,7 @@ int lua_ax_base_Application_getTargetPlatform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -103619,7 +103588,7 @@ int lua_ax_base_Application_getVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -103666,7 +103635,7 @@ int lua_ax_base_Application_openURL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -103944,7 +103913,7 @@ int lua_ax_base_AnimationCache_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -103991,7 +103960,7 @@ int lua_ax_base_AnimationCache_addAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Animation* arg0;
         std::string_view arg1;
@@ -104044,7 +104013,7 @@ int lua_ax_base_AnimationCache_removeAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -104094,7 +104063,7 @@ int lua_ax_base_AnimationCache_getAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -104144,7 +104113,7 @@ int lua_ax_base_AnimationCache_addAnimationsWithDictionary(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -104197,7 +104166,7 @@ int lua_ax_base_AnimationCache_addAnimationsWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -104302,7 +104271,7 @@ int lua_ax_base_AnimationCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -104378,7 +104347,7 @@ int lua_ax_base_SpriteBatchNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -104425,7 +104394,7 @@ int lua_ax_base_SpriteBatchNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TextureAtlas* arg0;
 
@@ -104475,7 +104444,7 @@ int lua_ax_base_SpriteBatchNode_increaseAtlasCapacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -104522,7 +104491,7 @@ int lua_ax_base_SpriteBatchNode_removeChildAtIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ssize_t arg0;
         bool arg1;
@@ -104575,7 +104544,7 @@ int lua_ax_base_SpriteBatchNode_appendChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Sprite* arg0;
 
@@ -104625,7 +104594,7 @@ int lua_ax_base_SpriteBatchNode_removeSpriteFromAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Sprite* arg0;
 
@@ -104675,7 +104644,7 @@ int lua_ax_base_SpriteBatchNode_rebuildIndexInOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Sprite* arg0;
         ssize_t arg1;
@@ -104728,7 +104697,7 @@ int lua_ax_base_SpriteBatchNode_highestAtlasIndexInChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Sprite* arg0;
 
@@ -104778,7 +104747,7 @@ int lua_ax_base_SpriteBatchNode_lowestAtlasIndexInChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Sprite* arg0;
 
@@ -104828,7 +104797,7 @@ int lua_ax_base_SpriteBatchNode_atlasIndexForChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Sprite* arg0;
         int arg1;
@@ -104881,7 +104850,7 @@ int lua_ax_base_SpriteBatchNode_reorderBatch(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -104931,7 +104900,7 @@ int lua_ax_base_SpriteBatchNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -104978,7 +104947,7 @@ int lua_ax_base_SpriteBatchNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -105028,7 +104997,7 @@ int lua_ax_base_SpriteBatchNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -105078,7 +105047,7 @@ int lua_ax_base_SpriteBatchNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -105125,7 +105094,7 @@ int lua_ax_base_SpriteBatchNode_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -105175,7 +105144,7 @@ int lua_ax_base_SpriteBatchNode_insertQuadFromSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Sprite* arg0;
         ssize_t arg1;
@@ -105228,7 +105197,7 @@ int lua_ax_base_SpriteBatchNode_addSpriteWithoutQuad(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Sprite* arg0;
         int arg1;
@@ -105284,7 +105253,7 @@ int lua_ax_base_SpriteBatchNode_reserveCapacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ssize_t arg0;
 
@@ -105334,7 +105303,7 @@ int lua_ax_base_SpriteBatchNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -105348,7 +105317,7 @@ int lua_ax_base_SpriteBatchNode_initWithTexture(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Texture2D* arg0;
         ssize_t arg1;
@@ -105401,7 +105370,7 @@ int lua_ax_base_SpriteBatchNode_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -105415,7 +105384,7 @@ int lua_ax_base_SpriteBatchNode_initWithFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         ssize_t arg1;
@@ -105557,7 +105526,7 @@ int lua_ax_base_SpriteBatchNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -105650,7 +105619,7 @@ int lua_ax_base_ParallaxNode_addChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::Node* arg0;
         int arg1;
@@ -105709,7 +105678,7 @@ int lua_ax_base_ParallaxNode_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -105780,7 +105749,7 @@ int lua_ax_base_ParallaxNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -105853,7 +105822,7 @@ int lua_ax_base_TMXObjectGroup_getGroupName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -105900,7 +105869,7 @@ int lua_ax_base_TMXObjectGroup_setGroupName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -105950,7 +105919,7 @@ int lua_ax_base_TMXObjectGroup_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -106000,7 +105969,7 @@ int lua_ax_base_TMXObjectGroup_getObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -106050,7 +106019,7 @@ int lua_ax_base_TMXObjectGroup_getPositionOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -106097,7 +106066,7 @@ int lua_ax_base_TMXObjectGroup_setPositionOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -106194,7 +106163,7 @@ int lua_ax_base_TMXObjectGroup_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMap arg0;
 
@@ -106291,7 +106260,7 @@ int lua_ax_base_TMXObjectGroup_setObjects(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueVector arg0;
 
@@ -106328,7 +106297,7 @@ int lua_ax_base_TMXObjectGroup_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -106408,7 +106377,7 @@ int lua_ax_base_TMXLayerInfo_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMap arg0;
 
@@ -106458,7 +106427,7 @@ int lua_ax_base_TMXLayerInfo_getProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -106492,7 +106461,7 @@ int lua_ax_base_TMXLayerInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -106564,7 +106533,7 @@ int lua_ax_base_TMXTilesetInfo_getRectForGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         unsigned int arg0;
 
@@ -106601,7 +106570,7 @@ int lua_ax_base_TMXTilesetInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -106672,7 +106641,7 @@ int lua_ax_base_TMXMapInfo_initWithTMXFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -106722,7 +106691,7 @@ int lua_ax_base_TMXMapInfo_initWithXML(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -106775,7 +106744,7 @@ int lua_ax_base_TMXMapInfo_parseXMLFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -106825,7 +106794,7 @@ int lua_ax_base_TMXMapInfo_parseXMLString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -106875,7 +106844,7 @@ int lua_ax_base_TMXMapInfo_getTileProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -106922,7 +106891,7 @@ int lua_ax_base_TMXMapInfo_setTileProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMapIntKey arg0;
 
@@ -106972,7 +106941,7 @@ int lua_ax_base_TMXMapInfo_getOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107019,7 +106988,7 @@ int lua_ax_base_TMXMapInfo_setOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -107069,7 +107038,7 @@ int lua_ax_base_TMXMapInfo_getStaggerAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107116,7 +107085,7 @@ int lua_ax_base_TMXMapInfo_setStaggerAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -107166,7 +107135,7 @@ int lua_ax_base_TMXMapInfo_getStaggerIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107213,7 +107182,7 @@ int lua_ax_base_TMXMapInfo_setStaggerIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -107263,7 +107232,7 @@ int lua_ax_base_TMXMapInfo_getHexSideLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107310,7 +107279,7 @@ int lua_ax_base_TMXMapInfo_setHexSideLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -107360,7 +107329,7 @@ int lua_ax_base_TMXMapInfo_getMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107407,7 +107376,7 @@ int lua_ax_base_TMXMapInfo_setMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -107457,7 +107426,7 @@ int lua_ax_base_TMXMapInfo_getTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107504,7 +107473,7 @@ int lua_ax_base_TMXMapInfo_setTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -107601,7 +107570,7 @@ int lua_ax_base_TMXMapInfo_setLayers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::TMXLayerInfo *> arg0;
 
@@ -107698,7 +107667,7 @@ int lua_ax_base_TMXMapInfo_setTilesets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::TMXTilesetInfo *> arg0;
 
@@ -107795,7 +107764,7 @@ int lua_ax_base_TMXMapInfo_setObjectGroups(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::TMXObjectGroup *> arg0;
 
@@ -107845,7 +107814,7 @@ int lua_ax_base_TMXMapInfo_getParentElement(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107892,7 +107861,7 @@ int lua_ax_base_TMXMapInfo_setParentElement(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -107942,7 +107911,7 @@ int lua_ax_base_TMXMapInfo_getParentGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -107989,7 +107958,7 @@ int lua_ax_base_TMXMapInfo_setParentGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -108039,7 +108008,7 @@ int lua_ax_base_TMXMapInfo_getLayerAttribs(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108086,7 +108055,7 @@ int lua_ax_base_TMXMapInfo_setLayerAttribs(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -108136,7 +108105,7 @@ int lua_ax_base_TMXMapInfo_isStoringCharacters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108183,7 +108152,7 @@ int lua_ax_base_TMXMapInfo_setStoringCharacters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -108280,7 +108249,7 @@ int lua_ax_base_TMXMapInfo_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMap arg0;
 
@@ -108330,7 +108299,7 @@ int lua_ax_base_TMXMapInfo_getCurrentString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108377,7 +108346,7 @@ int lua_ax_base_TMXMapInfo_setCurrentString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -108427,7 +108396,7 @@ int lua_ax_base_TMXMapInfo_getTMXFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108474,7 +108443,7 @@ int lua_ax_base_TMXMapInfo_setTMXFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -108524,7 +108493,7 @@ int lua_ax_base_TMXMapInfo_getExternalTilesetFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108632,7 +108601,7 @@ int lua_ax_base_TMXMapInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108743,7 +108712,7 @@ int lua_ax_base_TileMapAtlas_initWithTileFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
+    if (argc == 4)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -108802,7 +108771,7 @@ int lua_ax_base_TileMapAtlas_getTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -108852,7 +108821,7 @@ int lua_ax_base_TileMapAtlas_setTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -108905,7 +108874,7 @@ int lua_ax_base_TileMapAtlas_releaseMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -108981,7 +108950,7 @@ int lua_ax_base_TileMapAtlas_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109123,7 +109092,7 @@ int lua_ax_base_FastTMXLayer_removeTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -109173,7 +109142,7 @@ int lua_ax_base_FastTMXLayer_getPositionAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -109223,7 +109192,7 @@ int lua_ax_base_FastTMXLayer_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -109273,7 +109242,7 @@ int lua_ax_base_FastTMXLayer_setupTiles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109320,7 +109289,7 @@ int lua_ax_base_FastTMXLayer_getLayerName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109367,7 +109336,7 @@ int lua_ax_base_FastTMXLayer_setLayerName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -109417,7 +109386,7 @@ int lua_ax_base_FastTMXLayer_getLayerSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109464,7 +109433,7 @@ int lua_ax_base_FastTMXLayer_setLayerSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -109514,7 +109483,7 @@ int lua_ax_base_FastTMXLayer_getMapTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109561,7 +109530,7 @@ int lua_ax_base_FastTMXLayer_setMapTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -109611,7 +109580,7 @@ int lua_ax_base_FastTMXLayer_getTileSet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109658,7 +109627,7 @@ int lua_ax_base_FastTMXLayer_setTileSet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::TMXTilesetInfo* arg0;
 
@@ -109708,7 +109677,7 @@ int lua_ax_base_FastTMXLayer_getLayerOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -109755,7 +109724,7 @@ int lua_ax_base_FastTMXLayer_setLayerOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -109852,7 +109821,7 @@ int lua_ax_base_FastTMXLayer_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMap arg0;
 
@@ -109902,7 +109871,7 @@ int lua_ax_base_FastTMXLayer_getTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -109952,7 +109921,7 @@ int lua_ax_base_FastTMXLayer_setupTileSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::Sprite* arg0;
         ax::Vec2 arg1;
@@ -110008,7 +109977,7 @@ int lua_ax_base_FastTMXLayer_getAnimTileCoord(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110055,7 +110024,7 @@ int lua_ax_base_FastTMXLayer_hasTileAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110102,7 +110071,7 @@ int lua_ax_base_FastTMXLayer_getTileAnimManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110149,7 +110118,7 @@ int lua_ax_base_FastTMXLayer_initWithTilesetInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::TMXTilesetInfo* arg0;
         ax::TMXLayerInfo* arg1;
@@ -110232,7 +110201,7 @@ int lua_ax_base_FastTMXLayer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110326,7 +110295,7 @@ int lua_ax_base_TMXTileAnimTask_start(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110373,7 +110342,7 @@ int lua_ax_base_TMXTileAnimTask_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110420,7 +110389,7 @@ int lua_ax_base_TMXTileAnimTask_isRunning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110515,7 +110484,7 @@ int lua_ax_base_TMXTileAnimTask_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3) 
+    if (argc == 3)
     {
         ax::FastTMXLayer* arg0;
         ax::TMXTileAnimInfo* arg1;
@@ -110539,7 +110508,7 @@ int lua_ax_base_TMXTileAnimTask_constructor(lua_State* tolua_S)
         toluafix_pushusertype_object(tolua_S, ID, luaID, (void*)cobj,"ax.TMXTileAnimTask");
         return 1;
     }
-    if (argc == 4) 
+    if (argc == 4)
     {
         ax::FastTMXLayer* arg0;
         ax::TMXTileAnimInfo* arg1;
@@ -110626,7 +110595,7 @@ int lua_ax_base_TMXTileAnimManager_startAll(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110673,7 +110642,7 @@ int lua_ax_base_TMXTileAnimManager_stopAll(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110720,7 +110689,7 @@ int lua_ax_base_TMXTileAnimManager_getTasks(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -110790,7 +110759,7 @@ int lua_ax_base_TMXTileAnimManager_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::FastTMXLayer* arg0;
 
@@ -110867,7 +110836,7 @@ int lua_ax_base_FastTMXTiledMap_getLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -110917,7 +110886,7 @@ int lua_ax_base_FastTMXTiledMap_getObjectGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -110967,7 +110936,7 @@ int lua_ax_base_FastTMXTiledMap_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -111017,7 +110986,7 @@ int lua_ax_base_FastTMXTiledMap_getPropertiesForGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -111067,7 +111036,7 @@ int lua_ax_base_FastTMXTiledMap_getMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111114,7 +111083,7 @@ int lua_ax_base_FastTMXTiledMap_setMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -111164,7 +111133,7 @@ int lua_ax_base_FastTMXTiledMap_getTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111211,7 +111180,7 @@ int lua_ax_base_FastTMXTiledMap_setTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec2 arg0;
 
@@ -111261,7 +111230,7 @@ int lua_ax_base_FastTMXTiledMap_getMapOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111308,7 +111277,7 @@ int lua_ax_base_FastTMXTiledMap_setMapOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         int arg0;
 
@@ -111405,7 +111374,7 @@ int lua_ax_base_FastTMXTiledMap_setObjectGroups(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vector<ax::TMXObjectGroup *> arg0;
 
@@ -111455,7 +111424,7 @@ int lua_ax_base_FastTMXTiledMap_getProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111502,7 +111471,7 @@ int lua_ax_base_FastTMXTiledMap_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::ValueMap arg0;
 
@@ -111552,7 +111521,7 @@ int lua_ax_base_FastTMXTiledMap_setTileAnimEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -111602,7 +111571,7 @@ int lua_ax_base_FastTMXTiledMap_getLayerCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111649,7 +111618,7 @@ int lua_ax_base_FastTMXTiledMap_getResourceFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111696,7 +111665,7 @@ int lua_ax_base_FastTMXTiledMap_getMapInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111743,7 +111712,7 @@ int lua_ax_base_FastTMXTiledMap_getTilesetInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -111793,7 +111762,7 @@ int lua_ax_base_FastTMXTiledMap_getLayers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -111840,7 +111809,7 @@ int lua_ax_base_FastTMXTiledMap_initWithTMXFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -111854,7 +111823,7 @@ int lua_ax_base_FastTMXTiledMap_initWithTMXFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         bool arg1;
@@ -111907,7 +111876,7 @@ int lua_ax_base_FastTMXTiledMap_initWithXML(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -111924,7 +111893,7 @@ int lua_ax_base_FastTMXTiledMap_initWithXML(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3) 
+    if (argc == 3)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -112073,7 +112042,7 @@ int lua_ax_base_FastTMXTiledMap_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112167,7 +112136,7 @@ int lua_ax_base_MotionStreak3D_tintWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Color32 arg0;
 
@@ -112217,7 +112186,7 @@ int lua_ax_base_MotionStreak3D_reset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112264,7 +112233,7 @@ int lua_ax_base_MotionStreak3D_getStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112311,7 +112280,7 @@ int lua_ax_base_MotionStreak3D_setStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -112361,7 +112330,7 @@ int lua_ax_base_MotionStreak3D_isStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112408,7 +112377,7 @@ int lua_ax_base_MotionStreak3D_setStartingPositionInitialized(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         bool arg0;
 
@@ -112458,7 +112427,7 @@ int lua_ax_base_MotionStreak3D_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112505,7 +112474,7 @@ int lua_ax_base_MotionStreak3D_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Texture2D* arg0;
 
@@ -112555,7 +112524,7 @@ int lua_ax_base_MotionStreak3D_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::BlendFunc arg0;
 
@@ -112605,7 +112574,7 @@ int lua_ax_base_MotionStreak3D_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112652,7 +112621,7 @@ int lua_ax_base_MotionStreak3D_setSweepAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::Vec3 arg0;
 
@@ -112702,7 +112671,7 @@ int lua_ax_base_MotionStreak3D_getSweepAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112824,7 +112793,7 @@ int lua_ax_base_MotionStreak3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -112849,7 +112818,7 @@ int lua_ax_base_MotionStreak3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do 
+    do
     {
         if (argc == 5)
         {
@@ -112895,7 +112864,7 @@ int lua_ax_base_MotionStreak3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -112979,7 +112948,7 @@ int lua_ax_base_ComponentLua_getScriptObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -113026,7 +112995,7 @@ int lua_ax_base_ComponentLua_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         double arg0;
 
@@ -113099,7 +113068,7 @@ int lua_ax_base_ComponentLua_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -113151,7 +113120,7 @@ int lua_register_ax_base_ComponentLua(lua_State* tolua_S)
 TOLUA_API int register_all_ax_base(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-	
+
 	tolua_module(tolua_S,"ax",0);
 	tolua_beginmodule(tolua_S,"ax");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -35,7 +35,7 @@ int lua_ax_base_Object_retain(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82,7 +82,7 @@ int lua_ax_base_Object_release(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -129,7 +129,7 @@ int lua_ax_base_Object_getReferenceCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -198,7 +198,7 @@ int lua_ax_base_Touch_getLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -245,7 +245,7 @@ int lua_ax_base_Touch_getPreviousLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -292,7 +292,7 @@ int lua_ax_base_Touch_getStartLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -339,7 +339,7 @@ int lua_ax_base_Touch_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -386,7 +386,7 @@ int lua_ax_base_Touch_getLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -433,7 +433,7 @@ int lua_ax_base_Touch_getPreviousLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -480,7 +480,7 @@ int lua_ax_base_Touch_getStartLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -606,7 +606,7 @@ int lua_ax_base_Touch_getID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -653,7 +653,7 @@ int lua_ax_base_Touch_getCurrentForce(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -700,7 +700,7 @@ int lua_ax_base_Touch_getMaxForce(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -734,7 +734,7 @@ int lua_ax_base_Touch_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -815,7 +815,7 @@ int lua_ax_base_Event_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -862,7 +862,7 @@ int lua_ax_base_Event_stopPropagation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -909,7 +909,7 @@ int lua_ax_base_Event_isStopped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -956,7 +956,7 @@ int lua_ax_base_Event_getCurrentTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -990,7 +990,7 @@ int lua_ax_base_Event_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Event::Type arg0;
 
@@ -1067,7 +1067,7 @@ int lua_ax_base_EventTouch_getEventCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1114,7 +1114,7 @@ int lua_ax_base_EventTouch_setEventCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventTouch::EventCode arg0;
 
@@ -1151,7 +1151,7 @@ int lua_ax_base_EventTouch_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1210,7 +1210,7 @@ int lua_ax_base_EventKeyboard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventKeyboard::KeyCode arg0;
         bool arg1;
@@ -1286,7 +1286,7 @@ int lua_ax_base_Action_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1333,7 +1333,7 @@ int lua_ax_base_Action_reverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1380,7 +1380,7 @@ int lua_ax_base_Action_isDone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1427,7 +1427,7 @@ int lua_ax_base_Action_startWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -1477,7 +1477,7 @@ int lua_ax_base_Action_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1524,7 +1524,7 @@ int lua_ax_base_Action_step(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -1574,7 +1574,7 @@ int lua_ax_base_Action_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -1624,7 +1624,7 @@ int lua_ax_base_Action_getTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1671,7 +1671,7 @@ int lua_ax_base_Action_setTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -1721,7 +1721,7 @@ int lua_ax_base_Action_getOriginalTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1768,7 +1768,7 @@ int lua_ax_base_Action_setOriginalTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -1818,7 +1818,7 @@ int lua_ax_base_Action_getTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1865,7 +1865,7 @@ int lua_ax_base_Action_setTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -1915,7 +1915,7 @@ int lua_ax_base_Action_getFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1962,7 +1962,7 @@ int lua_ax_base_Action_setFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -2046,7 +2046,7 @@ int lua_ax_base_FiniteTimeAction_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2093,7 +2093,7 @@ int lua_ax_base_FiniteTimeAction_setDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -2164,7 +2164,7 @@ int lua_ax_base_Speed_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2211,7 +2211,7 @@ int lua_ax_base_Speed_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -2261,7 +2261,7 @@ int lua_ax_base_Speed_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -2311,7 +2311,7 @@ int lua_ax_base_Speed_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2358,7 +2358,7 @@ int lua_ax_base_Speed_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -2436,7 +2436,7 @@ int lua_ax_base_Speed_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2512,7 +2512,7 @@ int lua_ax_base_Follow_isBoundarySet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2559,7 +2559,7 @@ int lua_ax_base_Follow_setBoundarySet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -2609,7 +2609,7 @@ int lua_ax_base_Follow_initWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -2623,7 +2623,7 @@ int lua_ax_base_Follow_initWithTarget(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         ax::Rect arg1;
@@ -2676,7 +2676,7 @@ int lua_ax_base_Follow_initWithTargetAndOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Node* arg0;
         double arg1;
@@ -2696,7 +2696,7 @@ int lua_ax_base_Follow_initWithTargetAndOffset(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Node* arg0;
         double arg1;
@@ -2852,7 +2852,7 @@ int lua_ax_base_Follow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2928,7 +2928,7 @@ int lua_ax_base_EventListener_checkAvailable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2975,7 +2975,7 @@ int lua_ax_base_EventListener_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3022,7 +3022,7 @@ int lua_ax_base_EventListener_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -3072,7 +3072,7 @@ int lua_ax_base_EventListener_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3129,7 +3129,7 @@ int lua_ax_base_EventListenerCustom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3199,7 +3199,7 @@ int lua_ax_base_ShaderCache_purge(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3246,7 +3246,7 @@ int lua_ax_base_ShaderCache_acquireVertexShaderModule(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -3296,7 +3296,7 @@ int lua_ax_base_ShaderCache_acquireFragmentShaderModule(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -3346,7 +3346,7 @@ int lua_ax_base_ShaderCache_removeUnusedShader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3460,448 +3460,23 @@ int lua_register_ax_base_ShaderCache(lua_State* tolua_S)
     return 1;
 }
 
-int lua_ax_base_Texture2D_updateWithImage(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateWithImage'", nullptr);
-        return 0;
-    }
-#endif
-    argc = lua_gettop(tolua_S)-1;
-    do{
-        if (argc == 2) {
-            ax::Image* arg0;
-            ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            ax::rhi::PixelFormat arg1;
-            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            bool ret = cobj->updateWithImage(arg0, arg1);
-            tolua_pushboolean(tolua_S,(bool)ret);
-            return 1;
-        }
-    }while(0);
-    ok  = true;
-    do{
-        if (argc == 3) {
-            ax::Image* arg0;
-            ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            ax::rhi::PixelFormat arg1;
-            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            int arg2;
-            ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            bool ret = cobj->updateWithImage(arg0, arg1, arg2);
-            tolua_pushboolean(tolua_S,(bool)ret);
-            return 1;
-        }
-    }while(0);
-    ok  = true;
-    do{
-        if (argc == 1) {
-            ax::Image* arg0;
-            ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            bool ret = cobj->updateWithImage(arg0);
-            tolua_pushboolean(tolua_S,(bool)ret);
-            return 1;
-        }
-    }while(0);
-    ok  = true;
-    do{
-        if (argc == 2) {
-            ax::Image* arg0;
-            ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            int arg1;
-            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithImage");
-
-            if (!ok) { break; }
-            bool ret = cobj->updateWithImage(arg0, arg1);
-            tolua_pushboolean(tolua_S,(bool)ret);
-            return 1;
-        }
-    }while(0);
-    ok  = true;
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.Texture2D:updateWithImage",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateWithImage'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_updateWithMipmaps(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateWithMipmaps'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
-    {
-        ax::_MipmapInfo* arg0;
-        int arg1;
-        ax::rhi::PixelFormat arg2;
-        ax::rhi::PixelFormat arg3;
-        int arg4;
-        int arg5;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR _MipmapInfo*
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithMipmaps");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithMipmaps'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateWithMipmaps(arg0, arg1, arg2, arg3, arg4, arg5);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    if (argc == 7)
-    {
-        ax::_MipmapInfo* arg0;
-        int arg1;
-        ax::rhi::PixelFormat arg2;
-        ax::rhi::PixelFormat arg3;
-        int arg4;
-        int arg5;
-        bool arg6;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR _MipmapInfo*
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_boolean(tolua_S, 8,&arg6, "ax.Texture2D:updateWithMipmaps");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithMipmaps'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateWithMipmaps(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    if (argc == 8)
-    {
-        ax::_MipmapInfo* arg0;
-        int arg1;
-        ax::rhi::PixelFormat arg2;
-        ax::rhi::PixelFormat arg3;
-        int arg4;
-        int arg5;
-        bool arg6;
-        int arg7;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR _MipmapInfo*
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_boolean(tolua_S, 8,&arg6, "ax.Texture2D:updateWithMipmaps");
-
-        ok &= luaval_to_int32(tolua_S, 9,(int *)&arg7, "ax.Texture2D:updateWithMipmaps");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithMipmaps'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateWithMipmaps(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateWithMipmaps",argc, 6);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateWithMipmaps'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
-    {
-        void* arg0;
-        int arg1;
-        int arg2;
-        int arg3;
-        int arg4;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR void*
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    if (argc == 6)
-    {
-        void* arg0;
-        int arg1;
-        int arg2;
-        int arg3;
-        int arg4;
-        int arg5;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR void*
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
-
-        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithSubData");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4, arg5);
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateWithSubData",argc, 5);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateWithSubData'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_drawAtPoint(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_drawAtPoint'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
-    {
-        ax::Vec2 arg0;
-        double arg1;
-
-        ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.Texture2D:drawAtPoint");
-
-        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.Texture2D:drawAtPoint");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_drawAtPoint'", nullptr);
-            return 0;
-        }
-        cobj->drawAtPoint(arg0, arg1);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:drawAtPoint",argc, 2);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_drawAtPoint'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Texture2D_drawInRect(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_drawInRect'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
-    {
-        ax::Rect arg0;
-        double arg1;
-
-        ok &= luaval_to_rect(tolua_S, 2, &arg0, "ax.Texture2D:drawInRect");
-
-        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.Texture2D:drawInRect");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_drawInRect'", nullptr);
-            return 0;
-        }
-        cobj->drawInRect(arg0, arg1);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:drawInRect",argc, 2);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_drawInRect'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
 {
     int argc = 0;
     ax::Texture2D* cobj = nullptr;
     bool ok  = true;
+
 #if _AX_DEBUG >= 1
     tolua_Error tolua_err;
 #endif
 
+
 #if _AX_DEBUG >= 1
     if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
 #endif
+
     cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
@@ -3909,36 +3484,40 @@ int lua_ax_base_Texture2D_initWithImage(lua_State* tolua_S)
         return 0;
     }
 #endif
+
     argc = lua_gettop(tolua_S)-1;
-    do{
-        if (argc == 2) {
-            ax::Image* arg0;
-            ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:initWithImage");
+    if (argc == 1) 
+    {
+        ax::Image* arg0;
 
-            if (!ok) { break; }
-            ax::rhi::PixelFormat arg1;
-            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:initWithImage");
-
-            if (!ok) { break; }
-            bool ret = cobj->initWithImage(arg0, arg1);
-            tolua_pushboolean(tolua_S,(bool)ret);
-            return 1;
+        ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:initWithImage");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_initWithImage'", nullptr);
+            return 0;
         }
-    }while(0);
-    ok  = true;
-    do{
-        if (argc == 1) {
-            ax::Image* arg0;
-            ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:initWithImage");
+        auto&& ret = cobj->initWithImage(arg0);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 2) 
+    {
+        ax::Image* arg0;
+        ax::rhi::PixelFormat arg1;
 
-            if (!ok) { break; }
-            bool ret = cobj->initWithImage(arg0);
-            tolua_pushboolean(tolua_S,(bool)ret);
-            return 1;
+        ok &= luaval_to_object<ax::Image>(tolua_S, 2, "ax.Image",&arg0, "ax.Texture2D:initWithImage");
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:initWithImage");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_initWithImage'", nullptr);
+            return 0;
         }
-    }while(0);
-    ok  = true;
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.Texture2D:initWithImage",argc, 1);
+        auto&& ret = cobj->initWithImage(arg0, arg1);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:initWithImage",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -4175,6 +3754,238 @@ int lua_ax_base_Texture2D_initWithString(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_base_Texture2D_updateWithSubData(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 5) 
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+        int arg4;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 6) 
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+        int arg4;
+        int arg5;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithSubData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4, arg5);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 7) 
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+        int arg4;
+        int arg5;
+        int arg6;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "ax.Texture2D:updateWithSubData");
+
+        ok &= luaval_to_int32(tolua_S, 8,(int *)&arg6, "ax.Texture2D:updateWithSubData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_updateWithSubData'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->updateWithSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:updateWithSubData",argc, 5);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_updateWithSubData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Texture2D_drawAtPoint(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_drawAtPoint'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 2) 
+    {
+        ax::Vec2 arg0;
+        double arg1;
+
+        ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.Texture2D:drawAtPoint");
+
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.Texture2D:drawAtPoint");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_drawAtPoint'", nullptr);
+            return 0;
+        }
+        cobj->drawAtPoint(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:drawAtPoint",argc, 2);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_drawAtPoint'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Texture2D_drawInRect(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Texture2D_drawInRect'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 2) 
+    {
+        ax::Rect arg0;
+        double arg1;
+
+        ok &= luaval_to_rect(tolua_S, 2, &arg0, "ax.Texture2D:drawInRect");
+
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.Texture2D:drawInRect");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_drawInRect'", nullptr);
+            return 0;
+        }
+        cobj->drawInRect(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Texture2D:drawInRect",argc, 2);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_drawInRect'.",&tolua_err);
+#endif
+
+    return 0;
+}
 int lua_ax_base_Texture2D_updateTextureDesc(lua_State* tolua_S)
 {
     int argc = 0;
@@ -4201,7 +4012,7 @@ int lua_ax_base_Texture2D_updateTextureDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::TextureDesc arg0;
 
@@ -4216,7 +4027,7 @@ int lua_ax_base_Texture2D_updateTextureDesc(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::rhi::TextureDesc arg0;
         bool arg1;
@@ -4270,7 +4081,7 @@ int lua_ax_base_Texture2D_setRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -4320,7 +4131,7 @@ int lua_ax_base_Texture2D_isRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4367,7 +4178,7 @@ int lua_ax_base_Texture2D_generateMipmap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4414,7 +4225,7 @@ int lua_ax_base_Texture2D_setAntiAliasTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4461,7 +4272,7 @@ int lua_ax_base_Texture2D_setAliasTexParameters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4508,7 +4319,7 @@ int lua_ax_base_Texture2D_getStringForFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4606,7 +4417,7 @@ int lua_ax_base_Texture2D_getContentSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4653,7 +4464,7 @@ int lua_ax_base_Texture2D_hasPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4700,7 +4511,7 @@ int lua_ax_base_Texture2D_setPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -4750,7 +4561,7 @@ int lua_ax_base_Texture2D_hasMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4797,7 +4608,7 @@ int lua_ax_base_Texture2D_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4844,7 +4655,7 @@ int lua_ax_base_Texture2D_getSamplerFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4891,7 +4702,7 @@ int lua_ax_base_Texture2D_getPixelsWide(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4938,7 +4749,7 @@ int lua_ax_base_Texture2D_getPixelsHigh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -4985,7 +4796,7 @@ int lua_ax_base_Texture2D_getBackendTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5032,7 +4843,7 @@ int lua_ax_base_Texture2D_getMaxS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5079,7 +4890,7 @@ int lua_ax_base_Texture2D_setMaxS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -5129,7 +4940,7 @@ int lua_ax_base_Texture2D_getMaxT(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5176,7 +4987,7 @@ int lua_ax_base_Texture2D_setMaxT(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -5226,7 +5037,7 @@ int lua_ax_base_Texture2D_getContentSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5273,7 +5084,7 @@ int lua_ax_base_Texture2D_getPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5294,6 +5105,44 @@ int lua_ax_base_Texture2D_getPath(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_base_Texture2D_chooseSamplerDesc(lua_State* tolua_S)
+{
+    int argc = 0;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertable(tolua_S,1,"ax.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    argc = lua_gettop(tolua_S) - 1;
+
+    if (argc == 2)
+    {
+        bool arg0;
+        bool arg1;
+        ok &= luaval_to_boolean(tolua_S, 2,&arg0, "ax.Texture2D:chooseSamplerDesc");
+        ok &= luaval_to_boolean(tolua_S, 3,&arg1, "ax.Texture2D:chooseSamplerDesc");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Texture2D_chooseSamplerDesc'", nullptr);
+            return 0;
+        }
+        auto&& ret = ax::Texture2D::chooseSamplerDesc(arg0, arg1);
+        #pragma warning NO CONVERSION FROM NATIVE FOR SamplerDesc;
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.Texture2D:chooseSamplerDesc",argc, 2);
+    return 0;
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Texture2D_chooseSamplerDesc'.",&tolua_err);
+#endif
+    return 0;
+}
 int lua_ax_base_Texture2D_constructor(lua_State* tolua_S)
 {
     int argc = 0;
@@ -5307,7 +5156,7 @@ int lua_ax_base_Texture2D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5344,13 +5193,11 @@ int lua_register_ax_base_Texture2D(lua_State* tolua_S)
 
     tolua_beginmodule(tolua_S,"Texture2D");
         tolua_function(tolua_S,"new",lua_ax_base_Texture2D_constructor);
-        tolua_function(tolua_S,"updateWithImage",lua_ax_base_Texture2D_updateWithImage);
-        tolua_function(tolua_S,"updateWithMipmaps",lua_ax_base_Texture2D_updateWithMipmaps);
+        tolua_function(tolua_S,"initWithImage",lua_ax_base_Texture2D_initWithImage);
+        tolua_function(tolua_S,"initWithString",lua_ax_base_Texture2D_initWithString);
         tolua_function(tolua_S,"updateWithSubData",lua_ax_base_Texture2D_updateWithSubData);
         tolua_function(tolua_S,"drawAtPoint",lua_ax_base_Texture2D_drawAtPoint);
         tolua_function(tolua_S,"drawInRect",lua_ax_base_Texture2D_drawInRect);
-        tolua_function(tolua_S,"initWithImage",lua_ax_base_Texture2D_initWithImage);
-        tolua_function(tolua_S,"initWithString",lua_ax_base_Texture2D_initWithString);
         tolua_function(tolua_S,"updateTextureDesc",lua_ax_base_Texture2D_updateTextureDesc);
         tolua_function(tolua_S,"setRenderTarget",lua_ax_base_Texture2D_setRenderTarget);
         tolua_function(tolua_S,"isRenderTarget",lua_ax_base_Texture2D_isRenderTarget);
@@ -5374,6 +5221,7 @@ int lua_register_ax_base_Texture2D(lua_State* tolua_S)
         tolua_function(tolua_S,"setMaxT",lua_ax_base_Texture2D_setMaxT);
         tolua_function(tolua_S,"getContentSize",lua_ax_base_Texture2D_getContentSize);
         tolua_function(tolua_S,"getPath",lua_ax_base_Texture2D_getPath);
+        tolua_function(tolua_S,"chooseSamplerDesc", lua_ax_base_Texture2D_chooseSamplerDesc);
     tolua_endmodule(tolua_S);
     auto typeName = typeid(ax::Texture2D).name(); // rtti is literal storage
     g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.Texture2D";
@@ -5407,7 +5255,7 @@ int lua_ax_base_Component_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5454,7 +5302,7 @@ int lua_ax_base_Component_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5501,7 +5349,7 @@ int lua_ax_base_Component_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -5551,7 +5399,7 @@ int lua_ax_base_Component_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5598,7 +5446,7 @@ int lua_ax_base_Component_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -5648,7 +5496,7 @@ int lua_ax_base_Component_getOwner(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5695,7 +5543,7 @@ int lua_ax_base_Component_setOwner(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -5745,7 +5593,7 @@ int lua_ax_base_Component_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -5795,7 +5643,7 @@ int lua_ax_base_Component_onAdd(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5842,7 +5690,7 @@ int lua_ax_base_Component_onRemove(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -5953,7 +5801,7 @@ int lua_ax_base_Node_getDescription(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6000,7 +5848,7 @@ int lua_ax_base_Node_setLocalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -6050,7 +5898,7 @@ int lua_ax_base_Node_updateOrderOfArrival(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6097,7 +5945,7 @@ int lua_ax_base_Node_getLocalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6144,7 +5992,7 @@ int lua_ax_base_Node_setGlobalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6194,7 +6042,7 @@ int lua_ax_base_Node_getGlobalZOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6241,7 +6089,7 @@ int lua_ax_base_Node_setScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6291,7 +6139,7 @@ int lua_ax_base_Node_getScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6338,7 +6186,7 @@ int lua_ax_base_Node_setScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6388,7 +6236,7 @@ int lua_ax_base_Node_getScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6435,7 +6283,7 @@ int lua_ax_base_Node_setScaleZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6485,7 +6333,7 @@ int lua_ax_base_Node_getScaleZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6591,7 +6439,7 @@ int lua_ax_base_Node_getScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6697,7 +6545,7 @@ int lua_ax_base_Node_setPositionNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -6747,7 +6595,7 @@ int lua_ax_base_Node_setNormalizedPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -6797,7 +6645,7 @@ int lua_ax_base_Node_getPositionNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6844,7 +6692,7 @@ int lua_ax_base_Node_getNormalizedPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6891,7 +6739,7 @@ int lua_ax_base_Node_setPositionX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -6941,7 +6789,7 @@ int lua_ax_base_Node_getPositionX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -6988,7 +6836,7 @@ int lua_ax_base_Node_setPositionY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7038,7 +6886,7 @@ int lua_ax_base_Node_getPositionY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7085,7 +6933,7 @@ int lua_ax_base_Node_setPosition3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -7135,7 +6983,7 @@ int lua_ax_base_Node_getPosition3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7182,7 +7030,7 @@ int lua_ax_base_Node_setPositionZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7232,7 +7080,7 @@ int lua_ax_base_Node_getPositionZ(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7279,7 +7127,7 @@ int lua_ax_base_Node_setSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7329,7 +7177,7 @@ int lua_ax_base_Node_getSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7376,7 +7224,7 @@ int lua_ax_base_Node_setSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7426,7 +7274,7 @@ int lua_ax_base_Node_getSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7473,7 +7321,7 @@ int lua_ax_base_Node_getAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7520,7 +7368,7 @@ int lua_ax_base_Node_getAnchorPointInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7567,7 +7415,7 @@ int lua_ax_base_Node_getContentSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7614,7 +7462,7 @@ int lua_ax_base_Node_hitTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -7664,7 +7512,7 @@ int lua_ax_base_Node_setVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -7714,7 +7562,7 @@ int lua_ax_base_Node_isVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7761,7 +7609,7 @@ int lua_ax_base_Node_setRotation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -7811,7 +7659,7 @@ int lua_ax_base_Node_getRotation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7858,7 +7706,7 @@ int lua_ax_base_Node_setRotation3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -7908,7 +7756,7 @@ int lua_ax_base_Node_getRotation3D(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -7955,7 +7803,7 @@ int lua_ax_base_Node_setRotationSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -8005,7 +7853,7 @@ int lua_ax_base_Node_getRotationSkewX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8052,7 +7900,7 @@ int lua_ax_base_Node_setRotationSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -8102,7 +7950,7 @@ int lua_ax_base_Node_getRotationSkewY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8149,7 +7997,7 @@ int lua_ax_base_Node_setIgnoreAnchorPointForPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -8199,7 +8047,7 @@ int lua_ax_base_Node_isIgnoreAnchorPointForPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8345,7 +8193,7 @@ int lua_ax_base_Node_getChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -8395,7 +8243,7 @@ int lua_ax_base_Node_getChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -8492,7 +8340,7 @@ int lua_ax_base_Node_getChildrenCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -8539,7 +8387,7 @@ int lua_ax_base_Node_setParent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -8687,7 +8535,7 @@ int lua_ax_base_Node_removeChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -8701,7 +8549,7 @@ int lua_ax_base_Node_removeChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -8754,7 +8602,7 @@ int lua_ax_base_Node_removeChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -8768,7 +8616,7 @@ int lua_ax_base_Node_removeChildByTag(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         bool arg1;
@@ -8821,7 +8669,7 @@ int lua_ax_base_Node_removeChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -8835,7 +8683,7 @@ int lua_ax_base_Node_removeChildByName(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -8939,7 +8787,7 @@ int lua_ax_base_Node_reorderChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         int arg1;
@@ -8992,7 +8840,7 @@ int lua_ax_base_Node_sortAllChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9039,7 +8887,7 @@ int lua_ax_base_Node_getTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9086,7 +8934,7 @@ int lua_ax_base_Node_setTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -9136,7 +8984,7 @@ int lua_ax_base_Node_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9183,7 +9031,7 @@ int lua_ax_base_Node_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -9233,7 +9081,7 @@ int lua_ax_base_Node_setUserObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Object* arg0;
 
@@ -9283,7 +9131,7 @@ int lua_ax_base_Node_isRunning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9330,7 +9178,7 @@ int lua_ax_base_Node_cleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9495,7 +9343,7 @@ int lua_ax_base_Node_getScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9542,7 +9390,7 @@ int lua_ax_base_Node_getBoundingBox(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9589,7 +9437,7 @@ int lua_ax_base_Node_setEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventDispatcher* arg0;
 
@@ -9639,7 +9487,7 @@ int lua_ax_base_Node_getEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9686,7 +9534,7 @@ int lua_ax_base_Node_setActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionManager* arg0;
 
@@ -9783,7 +9631,7 @@ int lua_ax_base_Node_runAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Action* arg0;
 
@@ -9833,7 +9681,7 @@ int lua_ax_base_Node_stopAllActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -9880,7 +9728,7 @@ int lua_ax_base_Node_stopAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Action* arg0;
 
@@ -9930,7 +9778,7 @@ int lua_ax_base_Node_stopActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -9980,7 +9828,7 @@ int lua_ax_base_Node_stopAllActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -10030,7 +9878,7 @@ int lua_ax_base_Node_stopActionsByFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -10080,7 +9928,7 @@ int lua_ax_base_Node_getActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -10130,7 +9978,7 @@ int lua_ax_base_Node_getNumberOfRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10177,7 +10025,7 @@ int lua_ax_base_Node_getNumberOfRunningActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -10227,7 +10075,7 @@ int lua_ax_base_Node_setScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scheduler* arg0;
 
@@ -10324,7 +10172,7 @@ int lua_ax_base_Node_isScheduled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -10374,7 +10222,7 @@ int lua_ax_base_Node_resume(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10421,7 +10269,7 @@ int lua_ax_base_Node_pause(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10468,7 +10316,7 @@ int lua_ax_base_Node_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -10518,7 +10366,7 @@ int lua_ax_base_Node_updateTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10667,7 +10515,7 @@ int lua_ax_base_Node_setNodeToParentTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -10717,7 +10565,7 @@ int lua_ax_base_Node_getParentToNodeTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10764,7 +10612,7 @@ int lua_ax_base_Node_getParentToNodeAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10811,7 +10659,7 @@ int lua_ax_base_Node_getNodeToWorldTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10858,7 +10706,7 @@ int lua_ax_base_Node_getNodeToWorldAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10905,7 +10753,7 @@ int lua_ax_base_Node_getWorldToNodeTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10952,7 +10800,7 @@ int lua_ax_base_Node_getWorldToNodeAffineTransform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -10999,7 +10847,7 @@ int lua_ax_base_Node_convertToNodeSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -11049,7 +10897,7 @@ int lua_ax_base_Node_convertToWorldSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -11099,7 +10947,7 @@ int lua_ax_base_Node_convertToNodeSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -11149,7 +10997,7 @@ int lua_ax_base_Node_convertToWorldSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -11199,7 +11047,7 @@ int lua_ax_base_Node_convertTouchToNodeSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Touch* arg0;
 
@@ -11249,7 +11097,7 @@ int lua_ax_base_Node_convertTouchToNodeSpaceAR(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Touch* arg0;
 
@@ -11299,7 +11147,7 @@ int lua_ax_base_Node_getWorldPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11346,7 +11194,7 @@ int lua_ax_base_Node_setWorldPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -11396,7 +11244,7 @@ int lua_ax_base_Node_getComponent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -11446,7 +11294,7 @@ int lua_ax_base_Node_addComponent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Component* arg0;
 
@@ -11551,7 +11399,7 @@ int lua_ax_base_Node_removeAllComponents(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11598,7 +11446,7 @@ int lua_ax_base_Node_getOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11645,7 +11493,7 @@ int lua_ax_base_Node_getDisplayedOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11692,7 +11540,7 @@ int lua_ax_base_Node_setOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -11742,7 +11590,7 @@ int lua_ax_base_Node_updateDisplayedOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -11792,7 +11640,7 @@ int lua_ax_base_Node_isCascadeOpacityEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11839,7 +11687,7 @@ int lua_ax_base_Node_setCascadeOpacityEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -11889,7 +11737,7 @@ int lua_ax_base_Node_getColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11936,7 +11784,7 @@ int lua_ax_base_Node_getDisplayedColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -11983,7 +11831,7 @@ int lua_ax_base_Node_setColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -12033,7 +11881,7 @@ int lua_ax_base_Node_updateDisplayedColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -12083,7 +11931,7 @@ int lua_ax_base_Node_isCascadeColorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12130,7 +11978,7 @@ int lua_ax_base_Node_setCascadeColorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -12180,7 +12028,7 @@ int lua_ax_base_Node_setOpacityModifyRGB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -12230,7 +12078,7 @@ int lua_ax_base_Node_isOpacityModifyRGB(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12277,7 +12125,7 @@ int lua_ax_base_Node_setOnEnterCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12331,7 +12179,7 @@ int lua_ax_base_Node_setOnExitCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12385,7 +12233,7 @@ int lua_ax_base_Node_setOnEnterTransitionDidFinishCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12439,7 +12287,7 @@ int lua_ax_base_Node_getOnEnterTransitionDidFinishCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12486,7 +12334,7 @@ int lua_ax_base_Node_setOnExitTransitionDidStartCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -12540,7 +12388,7 @@ int lua_ax_base_Node_getOnExitTransitionDidStartCallback(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12587,7 +12435,7 @@ int lua_ax_base_Node_getCameraMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12634,7 +12482,7 @@ int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned short arg0;
 
@@ -12648,7 +12496,7 @@ int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned short arg0;
         bool arg1;
@@ -12701,7 +12549,7 @@ int lua_ax_base_Node_applyMaskOnEnter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -12822,7 +12670,7 @@ int lua_ax_base_Node_setProgramStateWithRegistry(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::Texture2D* arg1;
@@ -12875,7 +12723,7 @@ int lua_ax_base_Node_setProgramStateByProgramId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned long long arg0;
 
@@ -12925,7 +12773,7 @@ int lua_ax_base_Node_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -12972,7 +12820,7 @@ int lua_ax_base_Node_updateProgramStateTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -13022,7 +12870,7 @@ int lua_ax_base_Node_resetChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -13075,7 +12923,7 @@ int lua_ax_base_Node_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13122,7 +12970,7 @@ int lua_ax_base_Node_initLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13169,7 +13017,7 @@ int lua_ax_base_Node_setPhysicsBody(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::PhysicsBody* arg0;
 
@@ -13219,7 +13067,7 @@ int lua_ax_base_Node_getPhysicsBody(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13321,7 +13169,7 @@ int lua_ax_base_Node_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13539,7 +13387,7 @@ int lua_ax_base_Image_initWithImageFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -13589,7 +13437,7 @@ int lua_ax_base_Image_flipRawData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13636,7 +13484,7 @@ int lua_ax_base_Image_getFileType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13683,7 +13531,7 @@ int lua_ax_base_Image_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13730,7 +13578,7 @@ int lua_ax_base_Image_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13777,7 +13625,7 @@ int lua_ax_base_Image_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13824,7 +13672,7 @@ int lua_ax_base_Image_getNumberOfMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13871,7 +13719,7 @@ int lua_ax_base_Image_hasPremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13918,7 +13766,7 @@ int lua_ax_base_Image_getFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -13965,7 +13813,7 @@ int lua_ax_base_Image_getBitPerPixel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14012,7 +13860,7 @@ int lua_ax_base_Image_hasAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14059,7 +13907,7 @@ int lua_ax_base_Image_isCompressed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14106,7 +13954,7 @@ int lua_ax_base_Image_saveToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -14120,7 +13968,7 @@ int lua_ax_base_Image_saveToFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -14173,7 +14021,7 @@ int lua_ax_base_Image_premultiplyAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14220,7 +14068,7 @@ int lua_ax_base_Image_reversePremultipliedAlpha(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14364,7 +14212,7 @@ int lua_ax_base_Image_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14452,7 +14300,7 @@ int lua_ax_base_PolygonInfo_setQuad(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::V3F_T2F_C4B_Quad* arg0;
 
@@ -14503,7 +14351,7 @@ int lua_ax_base_PolygonInfo_setQuads(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::V3F_T2F_C4B_Quad* arg0;
         int arg1;
@@ -14557,7 +14405,7 @@ int lua_ax_base_PolygonInfo_setTriangles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TrianglesCommand::Triangles arg0;
 
@@ -14608,7 +14456,7 @@ int lua_ax_base_PolygonInfo_getVertCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14655,7 +14503,7 @@ int lua_ax_base_PolygonInfo_getTrianglesCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14702,7 +14550,7 @@ int lua_ax_base_PolygonInfo_getArea(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14749,7 +14597,7 @@ int lua_ax_base_PolygonInfo_getRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14796,7 +14644,7 @@ int lua_ax_base_PolygonInfo_setRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -14846,7 +14694,7 @@ int lua_ax_base_PolygonInfo_getFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14893,7 +14741,7 @@ int lua_ax_base_PolygonInfo_setFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -14930,7 +14778,7 @@ int lua_ax_base_PolygonInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -14995,7 +14843,7 @@ int lua_ax_base_AutoPolygon_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -15066,7 +14914,7 @@ int lua_ax_base_SpriteFrame_getRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15113,7 +14961,7 @@ int lua_ax_base_SpriteFrame_setRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -15163,7 +15011,7 @@ int lua_ax_base_SpriteFrame_isRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15210,7 +15058,7 @@ int lua_ax_base_SpriteFrame_setRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -15260,7 +15108,7 @@ int lua_ax_base_SpriteFrame_getRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15307,7 +15155,7 @@ int lua_ax_base_SpriteFrame_setRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -15357,7 +15205,7 @@ int lua_ax_base_SpriteFrame_getCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15404,7 +15252,7 @@ int lua_ax_base_SpriteFrame_setCenterRectInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -15454,7 +15302,7 @@ int lua_ax_base_SpriteFrame_hasCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15501,7 +15349,7 @@ int lua_ax_base_SpriteFrame_getOffsetInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15548,7 +15396,7 @@ int lua_ax_base_SpriteFrame_setOffsetInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15598,7 +15446,7 @@ int lua_ax_base_SpriteFrame_getOriginalSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15645,7 +15493,7 @@ int lua_ax_base_SpriteFrame_setOriginalSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15695,7 +15543,7 @@ int lua_ax_base_SpriteFrame_getOriginalSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15742,7 +15590,7 @@ int lua_ax_base_SpriteFrame_setOriginalSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15792,7 +15640,7 @@ int lua_ax_base_SpriteFrame_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15839,7 +15687,7 @@ int lua_ax_base_SpriteFrame_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -15889,7 +15737,7 @@ int lua_ax_base_SpriteFrame_getOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -15936,7 +15784,7 @@ int lua_ax_base_SpriteFrame_setOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -15986,7 +15834,7 @@ int lua_ax_base_SpriteFrame_getAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16033,7 +15881,7 @@ int lua_ax_base_SpriteFrame_setAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -16083,7 +15931,7 @@ int lua_ax_base_SpriteFrame_hasAnchorPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16130,7 +15978,7 @@ int lua_ax_base_SpriteFrame_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16327,7 +16175,7 @@ int lua_ax_base_SpriteFrame_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16362,7 +16210,7 @@ int lua_ax_base_SpriteFrame_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -16387,7 +16235,7 @@ int lua_ax_base_SpriteFrame_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -16425,7 +16273,7 @@ int lua_ax_base_SpriteFrame_createWithTexture(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -16450,7 +16298,7 @@ int lua_ax_base_SpriteFrame_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -16487,7 +16335,7 @@ int lua_ax_base_SpriteFrame_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16585,7 +16433,7 @@ int lua_ax_base_AnimationFrame_getSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16632,7 +16480,7 @@ int lua_ax_base_AnimationFrame_setSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -16682,7 +16530,7 @@ int lua_ax_base_AnimationFrame_getDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16729,7 +16577,7 @@ int lua_ax_base_AnimationFrame_setDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -16826,7 +16674,7 @@ int lua_ax_base_AnimationFrame_setUserInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -16876,7 +16724,7 @@ int lua_ax_base_AnimationFrame_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -16923,7 +16771,7 @@ int lua_ax_base_AnimationFrame_initWithSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::SpriteFrame* arg0;
         double arg1;
@@ -17006,7 +16854,7 @@ int lua_ax_base_AnimationFrame_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17085,7 +16933,7 @@ int lua_ax_base_Animation_addSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -17135,7 +16983,7 @@ int lua_ax_base_Animation_addSpriteFrameWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -17185,7 +17033,7 @@ int lua_ax_base_Animation_addSpriteFrameWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         ax::Rect arg1;
@@ -17238,7 +17086,7 @@ int lua_ax_base_Animation_getTotalDelayUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17285,7 +17133,7 @@ int lua_ax_base_Animation_setDelayPerUnit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -17335,7 +17183,7 @@ int lua_ax_base_Animation_getDelayPerUnit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17382,7 +17230,7 @@ int lua_ax_base_Animation_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17429,7 +17277,7 @@ int lua_ax_base_Animation_getFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17476,7 +17324,7 @@ int lua_ax_base_Animation_setFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::AnimationFrame *> arg0;
 
@@ -17526,7 +17374,7 @@ int lua_ax_base_Animation_getRestoreOriginalFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17573,7 +17421,7 @@ int lua_ax_base_Animation_setRestoreOriginalFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -17623,7 +17471,7 @@ int lua_ax_base_Animation_getLoops(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17670,7 +17518,7 @@ int lua_ax_base_Animation_setLoops(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -17720,7 +17568,7 @@ int lua_ax_base_Animation_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17767,7 +17615,7 @@ int lua_ax_base_Animation_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -17814,7 +17662,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::SpriteFrame *> arg0;
 
@@ -17828,7 +17676,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vector<ax::SpriteFrame *> arg0;
         double arg1;
@@ -17845,7 +17693,7 @@ int lua_ax_base_Animation_initWithSpriteFrames(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vector<ax::SpriteFrame *> arg0;
         double arg1;
@@ -17901,7 +17749,7 @@ int lua_ax_base_Animation_initWithAnimationFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vector<ax::AnimationFrame *> arg0;
         double arg1;
@@ -17945,7 +17793,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -17961,7 +17809,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -17980,7 +17828,7 @@ int lua_ax_base_Animation_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -18079,7 +17927,7 @@ int lua_ax_base_Animation_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18168,7 +18016,7 @@ int lua_ax_base_ActionInterval_getElapsed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18215,7 +18063,7 @@ int lua_ax_base_ActionInterval_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -18265,7 +18113,7 @@ int lua_ax_base_ActionInterval_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18312,7 +18160,7 @@ int lua_ax_base_ActionInterval_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -18385,7 +18233,7 @@ int lua_ax_base_Sequence_initWithTwoActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::FiniteTimeAction* arg0;
         ax::FiniteTimeAction* arg1;
@@ -18438,7 +18286,7 @@ int lua_ax_base_Sequence_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::FiniteTimeAction *> arg0;
 
@@ -18475,7 +18323,7 @@ int lua_ax_base_Sequence_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18547,7 +18395,7 @@ int lua_ax_base_Repeat_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FiniteTimeAction* arg0;
 
@@ -18597,7 +18445,7 @@ int lua_ax_base_Repeat_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18644,7 +18492,7 @@ int lua_ax_base_Repeat_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::FiniteTimeAction* arg0;
         unsigned int arg1;
@@ -18722,7 +18570,7 @@ int lua_ax_base_Repeat_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18796,7 +18644,7 @@ int lua_ax_base_RepeatForever_setInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -18846,7 +18694,7 @@ int lua_ax_base_RepeatForever_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -18893,7 +18741,7 @@ int lua_ax_base_RepeatForever_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -18966,7 +18814,7 @@ int lua_ax_base_RepeatForever_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19040,7 +18888,7 @@ int lua_ax_base_Spawn_initWithTwoActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::FiniteTimeAction* arg0;
         ax::FiniteTimeAction* arg1;
@@ -19093,7 +18941,7 @@ int lua_ax_base_Spawn_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::FiniteTimeAction *> arg0;
 
@@ -19130,7 +18978,7 @@ int lua_ax_base_Spawn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19257,7 +19105,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19273,7 +19121,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -19292,7 +19140,7 @@ int lua_ax_base_RotateTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19329,7 +19177,7 @@ int lua_ax_base_RotateTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19472,7 +19320,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -19491,7 +19339,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19507,7 +19355,7 @@ int lua_ax_base_RotateBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19544,7 +19392,7 @@ int lua_ax_base_RotateBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19667,7 +19515,7 @@ int lua_ax_base_MoveBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19683,7 +19531,7 @@ int lua_ax_base_MoveBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19720,7 +19568,7 @@ int lua_ax_base_MoveBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19843,7 +19691,7 @@ int lua_ax_base_MoveTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19859,7 +19707,7 @@ int lua_ax_base_MoveTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -19896,7 +19744,7 @@ int lua_ax_base_MoveTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -19968,7 +19816,7 @@ int lua_ax_base_SkewTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -20051,7 +19899,7 @@ int lua_ax_base_SkewTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20123,7 +19971,7 @@ int lua_ax_base_SkewBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -20206,7 +20054,7 @@ int lua_ax_base_SkewBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20278,7 +20126,7 @@ int lua_ax_base_JumpBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -20366,7 +20214,7 @@ int lua_ax_base_JumpBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20438,7 +20286,7 @@ int lua_ax_base_JumpTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -20526,7 +20374,7 @@ int lua_ax_base_JumpTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20598,7 +20446,7 @@ int lua_ax_base_BezierBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::BezierConfig arg1;
@@ -20639,7 +20487,7 @@ int lua_ax_base_BezierBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20710,7 +20558,7 @@ int lua_ax_base_BezierTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::BezierConfig arg1;
@@ -20751,7 +20599,7 @@ int lua_ax_base_BezierTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -20901,7 +20749,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -20920,7 +20768,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -20936,7 +20784,7 @@ int lua_ax_base_ScaleTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -20979,7 +20827,7 @@ int lua_ax_base_ScaleTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21039,7 +20887,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -21058,7 +20906,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -21074,7 +20922,7 @@ int lua_ax_base_ScaleBy_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -21117,7 +20965,7 @@ int lua_ax_base_ScaleBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21188,7 +21036,7 @@ int lua_ax_base_Blink_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         int arg1;
@@ -21266,7 +21114,7 @@ int lua_ax_base_Blink_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21338,7 +21186,7 @@ int lua_ax_base_FadeTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         uint16_t arg1;
@@ -21416,7 +21264,7 @@ int lua_ax_base_FadeTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21488,7 +21336,7 @@ int lua_ax_base_FadeIn_setReverseAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FadeTo* arg0;
 
@@ -21561,7 +21409,7 @@ int lua_ax_base_FadeIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21633,7 +21481,7 @@ int lua_ax_base_FadeOut_setReverseAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FadeTo* arg0;
 
@@ -21706,7 +21554,7 @@ int lua_ax_base_FadeOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21778,7 +21626,7 @@ int lua_ax_base_TintTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::Color32 arg1;
@@ -21819,7 +21667,7 @@ int lua_ax_base_TintTo_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -21835,7 +21683,7 @@ int lua_ax_base_TintTo_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -21878,7 +21726,7 @@ int lua_ax_base_TintTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -21950,7 +21798,7 @@ int lua_ax_base_TintBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         int32_t arg1;
@@ -22038,7 +21886,7 @@ int lua_ax_base_TintBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22133,7 +21981,7 @@ int lua_ax_base_DelayTime_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22204,7 +22052,7 @@ int lua_ax_base_Animate_setAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Animation* arg0;
 
@@ -22301,7 +22149,7 @@ int lua_ax_base_Animate_getCurrentFrameIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22348,7 +22196,7 @@ int lua_ax_base_Animate_initWithAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Animation* arg0;
 
@@ -22421,7 +22269,7 @@ int lua_ax_base_Animate_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22496,7 +22344,7 @@ int lua_ax_base_TargetedAction_setForcedTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -22593,7 +22441,7 @@ int lua_ax_base_TargetedAction_initWithTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         ax::FiniteTimeAction* arg1;
@@ -22671,7 +22519,7 @@ int lua_ax_base_TargetedAction_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22745,7 +22593,7 @@ int lua_ax_base_ActionFloat_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -22841,7 +22689,7 @@ int lua_ax_base_ActionFloat_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22913,7 +22761,7 @@ int lua_ax_base_Scene_getDefaultCamera(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -22960,7 +22808,7 @@ int lua_ax_base_Scene_render(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Renderer* arg0;
         ax::Mat4 arg1;
@@ -22977,7 +22825,7 @@ int lua_ax_base_Scene_render(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Renderer* arg0;
         ax::Mat4 arg1;
@@ -23033,7 +22881,7 @@ int lua_ax_base_Scene_initWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -23083,7 +22931,7 @@ int lua_ax_base_Scene_setCameraOrderDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23130,7 +22978,7 @@ int lua_ax_base_Scene_onProjectionChanged(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventCustom* arg0;
 
@@ -23180,7 +23028,7 @@ int lua_ax_base_Scene_getPhysicsWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23227,7 +23075,7 @@ int lua_ax_base_Scene_initWithPhysics(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23274,7 +23122,7 @@ int lua_ax_base_Scene_initPhysicsWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23321,7 +23169,7 @@ int lua_ax_base_Scene_fixedUpdate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -23371,7 +23219,7 @@ int lua_ax_base_Scene_stepPhysicsAndNavigation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -23512,7 +23360,7 @@ int lua_ax_base_Scene_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23595,7 +23443,7 @@ int lua_ax_base_RenderView_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23642,7 +23490,7 @@ int lua_ax_base_RenderView_isGfxContextReady(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23689,7 +23537,7 @@ int lua_ax_base_RenderView_swapBuffers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23736,7 +23584,7 @@ int lua_ax_base_RenderView_setIMEKeyboardState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -23786,7 +23634,7 @@ int lua_ax_base_RenderView_windowShouldClose(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23833,7 +23681,7 @@ int lua_ax_base_RenderView_pollEvents(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23880,7 +23728,7 @@ int lua_ax_base_RenderView_getFrameSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -23927,7 +23775,7 @@ int lua_ax_base_RenderView_setFrameSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -23980,7 +23828,7 @@ int lua_ax_base_RenderView_setFrameZoomFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -24030,7 +23878,7 @@ int lua_ax_base_RenderView_getFrameZoomFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24077,7 +23925,7 @@ int lua_ax_base_RenderView_setCursorVisible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -24127,7 +23975,7 @@ int lua_ax_base_RenderView_getRetinaFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24174,7 +24022,7 @@ int lua_ax_base_RenderView_setContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -24224,7 +24072,7 @@ int lua_ax_base_RenderView_getContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24271,7 +24119,7 @@ int lua_ax_base_RenderView_isRetinaDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24318,7 +24166,7 @@ int lua_ax_base_RenderView_getVisibleSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24365,7 +24213,7 @@ int lua_ax_base_RenderView_getVisibleOrigin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24412,7 +24260,7 @@ int lua_ax_base_RenderView_getVisibleRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24459,7 +24307,7 @@ int lua_ax_base_RenderView_getSafeAreaRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24506,7 +24354,7 @@ int lua_ax_base_RenderView_setDesignResolutionSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -24562,7 +24410,7 @@ int lua_ax_base_RenderView_getDesignResolutionSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24609,7 +24457,7 @@ int lua_ax_base_RenderView_setViewPortInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -24668,7 +24516,7 @@ int lua_ax_base_RenderView_setScissorInPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -24727,7 +24575,7 @@ int lua_ax_base_RenderView_isScissorEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24774,7 +24622,7 @@ int lua_ax_base_RenderView_getScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24821,7 +24669,7 @@ int lua_ax_base_RenderView_setViewName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -24871,7 +24719,7 @@ int lua_ax_base_RenderView_getViewName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -24973,7 +24821,7 @@ int lua_ax_base_RenderView_setDefaultIcon(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25020,7 +24868,7 @@ int lua_ax_base_RenderView_getViewPortRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25067,7 +24915,7 @@ int lua_ax_base_RenderView_getScaleX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25114,7 +24962,7 @@ int lua_ax_base_RenderView_getScaleY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25161,7 +25009,7 @@ int lua_ax_base_RenderView_getResolutionPolicy(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25208,7 +25056,7 @@ int lua_ax_base_RenderView_renderScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Scene* arg0;
         ax::Renderer* arg1;
@@ -25261,7 +25109,7 @@ int lua_ax_base_RenderView_setInteractive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -25438,7 +25286,7 @@ int lua_ax_base_Director_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25485,7 +25333,7 @@ int lua_ax_base_Director_getRunningScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25532,7 +25380,7 @@ int lua_ax_base_Director_getNextScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25579,7 +25427,7 @@ int lua_ax_base_Director_getAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25626,7 +25474,7 @@ int lua_ax_base_Director_setAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -25676,7 +25524,7 @@ int lua_ax_base_Director_isStatsDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25723,7 +25571,7 @@ int lua_ax_base_Director_setStatsDisplay(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -25773,7 +25621,7 @@ int lua_ax_base_Director_getSecondsPerFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25820,7 +25668,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25831,7 +25679,7 @@ int lua_ax_base_Director_setStatsAnchor(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::AnchorPreset arg0;
 
@@ -25881,7 +25729,7 @@ int lua_ax_base_Director_getRenderView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -25928,7 +25776,7 @@ int lua_ax_base_Director_setRenderView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::RenderView* arg0;
 
@@ -25978,7 +25826,7 @@ int lua_ax_base_Director_getTextureCache(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26025,7 +25873,7 @@ int lua_ax_base_Director_isNextDeltaTimeZero(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26072,7 +25920,7 @@ int lua_ax_base_Director_setNextDeltaTimeZero(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -26122,7 +25970,7 @@ int lua_ax_base_Director_isPaused(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26169,7 +26017,7 @@ int lua_ax_base_Director_getTotalFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26216,7 +26064,7 @@ int lua_ax_base_Director_setProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Director::Projection arg0;
 
@@ -26266,7 +26114,7 @@ int lua_ax_base_Director_setViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26313,7 +26161,7 @@ int lua_ax_base_Director_isSendCleanupToScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26360,7 +26208,7 @@ int lua_ax_base_Director_getNotificationNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26407,7 +26255,7 @@ int lua_ax_base_Director_setNotificationNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -26457,7 +26305,7 @@ int lua_ax_base_Director_getWinSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26504,7 +26352,7 @@ int lua_ax_base_Director_getWinSizeInPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26551,7 +26399,7 @@ int lua_ax_base_Director_getVisibleSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26598,7 +26446,7 @@ int lua_ax_base_Director_getVisibleOrigin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26645,7 +26493,7 @@ int lua_ax_base_Director_getSafeAreaRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26692,7 +26540,7 @@ int lua_ax_base_Director_convertToGL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -26742,7 +26590,7 @@ int lua_ax_base_Director_convertToUI(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -26792,7 +26640,7 @@ int lua_ax_base_Director_getZEye(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26839,7 +26687,7 @@ int lua_ax_base_Director_runWithScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -26889,7 +26737,7 @@ int lua_ax_base_Director_pushScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -26939,7 +26787,7 @@ int lua_ax_base_Director_popScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -26986,7 +26834,7 @@ int lua_ax_base_Director_popToRootScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27033,7 +26881,7 @@ int lua_ax_base_Director_popToSceneStackLevel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -27083,7 +26931,7 @@ int lua_ax_base_Director_replaceScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -27133,7 +26981,7 @@ int lua_ax_base_Director_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27180,7 +27028,7 @@ int lua_ax_base_Director_pause(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27227,7 +27075,7 @@ int lua_ax_base_Director_resume(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27274,7 +27122,7 @@ int lua_ax_base_Director_restart(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27321,7 +27169,7 @@ int lua_ax_base_Director_stopAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27368,7 +27216,7 @@ int lua_ax_base_Director_startAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27415,7 +27263,7 @@ int lua_ax_base_Director_drawScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27462,7 +27310,7 @@ int lua_ax_base_Director_purgeCachedData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27509,7 +27357,7 @@ int lua_ax_base_Director_setDefaultValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27556,7 +27404,7 @@ int lua_ax_base_Director_setGLDefaultValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27603,7 +27451,7 @@ int lua_ax_base_Director_setClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -27704,7 +27552,7 @@ int lua_ax_base_Director_setContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -27754,7 +27602,7 @@ int lua_ax_base_Director_getContentScaleFactor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27801,7 +27649,7 @@ int lua_ax_base_Director_getScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27848,7 +27696,7 @@ int lua_ax_base_Director_setScheduler(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scheduler* arg0;
 
@@ -27898,7 +27746,7 @@ int lua_ax_base_Director_getActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -27945,7 +27793,7 @@ int lua_ax_base_Director_setActionManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionManager* arg0;
 
@@ -27995,7 +27843,7 @@ int lua_ax_base_Director_getEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28042,7 +27890,7 @@ int lua_ax_base_Director_setEventDispatcher(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventDispatcher* arg0;
 
@@ -28092,7 +27940,7 @@ int lua_ax_base_Director_getRenderer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28139,7 +27987,7 @@ int lua_ax_base_Director_getDeltaTime(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28186,7 +28034,7 @@ int lua_ax_base_Director_getFrameRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28233,7 +28081,7 @@ int lua_ax_base_Director_pushMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28283,7 +28131,7 @@ int lua_ax_base_Director_popMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28333,7 +28181,7 @@ int lua_ax_base_Director_loadIdentityMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28383,7 +28231,7 @@ int lua_ax_base_Director_loadMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::MATRIX_STACK_TYPE arg0;
         ax::Mat4 arg1;
@@ -28436,7 +28284,7 @@ int lua_ax_base_Director_multiplyMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::MATRIX_STACK_TYPE arg0;
         ax::Mat4 arg1;
@@ -28489,7 +28337,7 @@ int lua_ax_base_Director_getMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MATRIX_STACK_TYPE arg0;
 
@@ -28539,7 +28387,7 @@ int lua_ax_base_Director_resetMatrixStack(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28586,7 +28434,7 @@ int lua_ax_base_Director_getAxmolThreadId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28633,7 +28481,7 @@ int lua_ax_base_Director_setChildrenIndexerEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -28683,7 +28531,7 @@ int lua_ax_base_Director_isChildrenIndexerEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28730,7 +28578,7 @@ int lua_ax_base_Director_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28935,7 +28783,7 @@ int lua_ax_base_Properties_getNextProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -28982,7 +28830,7 @@ int lua_ax_base_Properties_getNextNamespace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29029,7 +28877,7 @@ int lua_ax_base_Properties_rewind(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29163,7 +29011,7 @@ int lua_ax_base_Properties_getId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29210,7 +29058,7 @@ int lua_ax_base_Properties_exists(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29260,7 +29108,7 @@ int lua_ax_base_Properties_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29271,7 +29119,7 @@ int lua_ax_base_Properties_getType(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29321,7 +29169,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29332,7 +29180,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29346,7 +29194,7 @@ int lua_ax_base_Properties_getString(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -29399,7 +29247,7 @@ int lua_ax_base_Properties_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -29452,7 +29300,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29463,7 +29311,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29477,7 +29325,7 @@ int lua_ax_base_Properties_getBool(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         bool arg1;
@@ -29530,7 +29378,7 @@ int lua_ax_base_Properties_getInt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29541,7 +29389,7 @@ int lua_ax_base_Properties_getInt(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29591,7 +29439,7 @@ int lua_ax_base_Properties_getFloat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -29602,7 +29450,7 @@ int lua_ax_base_Properties_getFloat(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -29652,7 +29500,7 @@ int lua_ax_base_Properties_getMat4(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Mat4* arg1;
@@ -29705,7 +29553,7 @@ int lua_ax_base_Properties_getVec2(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Vec2* arg1;
@@ -29758,7 +29606,7 @@ int lua_ax_base_Properties_getVec3(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Vec3* arg1;
@@ -29811,7 +29659,7 @@ int lua_ax_base_Properties_getVec4(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Vec4* arg1;
@@ -29864,7 +29712,7 @@ int lua_ax_base_Properties_getQuaternionFromAxisAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Quaternion* arg1;
@@ -29917,7 +29765,7 @@ int lua_ax_base_Properties_getColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         ax::Color* arg1;
@@ -29971,7 +29819,7 @@ int lua_ax_base_Properties_getPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         std::string* arg1;
@@ -30025,7 +29873,7 @@ int lua_ax_base_Properties_getVariable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -30039,7 +29887,7 @@ int lua_ax_base_Properties_getVariable(lua_State* tolua_S)
         tolua_pushstring(tolua_S,(const char*)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -30092,7 +29940,7 @@ int lua_ax_base_Properties_setVariable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         const char* arg1;
@@ -30381,7 +30229,7 @@ int lua_ax_base_Timer_setupTimerWithInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         unsigned int arg1;
@@ -30437,7 +30285,7 @@ int lua_ax_base_Timer_setAborted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30484,7 +30332,7 @@ int lua_ax_base_Timer_isAborted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30531,7 +30379,7 @@ int lua_ax_base_Timer_isExhausted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30578,7 +30426,7 @@ int lua_ax_base_Timer_trigger(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -30628,7 +30476,7 @@ int lua_ax_base_Timer_cancel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30675,7 +30523,7 @@ int lua_ax_base_Timer_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -30751,7 +30599,7 @@ int lua_ax_base_Scheduler_getTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30798,7 +30646,7 @@ int lua_ax_base_Scheduler_setTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -30848,7 +30696,7 @@ int lua_ax_base_Scheduler_runOnAxmolThread(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -30902,7 +30750,7 @@ int lua_ax_base_Scheduler_removeAllPendingActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -30936,7 +30784,7 @@ int lua_ax_base_Scheduler_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -31364,7 +31212,7 @@ int lua_ax_base_UserDefault_setBoolForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         bool arg1;
@@ -31417,7 +31265,7 @@ int lua_ax_base_UserDefault_setIntegerForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         int arg1;
@@ -31470,7 +31318,7 @@ int lua_ax_base_UserDefault_setLargeIntForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         long long arg1;
@@ -31523,7 +31371,7 @@ int lua_ax_base_UserDefault_setFloatForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         double arg1;
@@ -31576,7 +31424,7 @@ int lua_ax_base_UserDefault_setDoubleForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         double arg1;
@@ -31629,7 +31477,7 @@ int lua_ax_base_UserDefault_setStringForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         std::string_view arg1;
@@ -31682,7 +31530,7 @@ int lua_ax_base_UserDefault_flush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -31729,7 +31577,7 @@ int lua_ax_base_UserDefault_deleteValueForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const char* arg0;
 
@@ -31779,7 +31627,7 @@ int lua_ax_base_UserDefault_setEncryptEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         bool arg0;
         std::string_view arg1;
@@ -31952,7 +31800,7 @@ int lua_ax_base_FileUtils_purgeCachedEntries(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -31999,7 +31847,7 @@ int lua_ax_base_FileUtils_getStringFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32049,7 +31897,7 @@ int lua_ax_base_FileUtils_fullPathForFilename(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32099,7 +31947,7 @@ int lua_ax_base_FileUtils_fullPathFromRelativeFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -32152,7 +32000,7 @@ int lua_ax_base_FileUtils_fullPathForDirectory(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32202,7 +32050,7 @@ int lua_ax_base_FileUtils_setSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::vector<std::string> arg0;
 
@@ -32252,7 +32100,7 @@ int lua_ax_base_FileUtils_getDefaultResourceRootPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32299,7 +32147,7 @@ int lua_ax_base_FileUtils_setDefaultResourceRootPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32349,7 +32197,7 @@ int lua_ax_base_FileUtils_addSearchPath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32363,7 +32211,7 @@ int lua_ax_base_FileUtils_addSearchPath(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -32416,7 +32264,7 @@ int lua_ax_base_FileUtils_getSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32463,7 +32311,7 @@ int lua_ax_base_FileUtils_getOriginalSearchPaths(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32510,7 +32358,7 @@ int lua_ax_base_FileUtils_getWritablePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32557,7 +32405,7 @@ int lua_ax_base_FileUtils_getNativeWritableAbsolutePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32604,7 +32452,7 @@ int lua_ax_base_FileUtils_setWritablePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32654,7 +32502,7 @@ int lua_ax_base_FileUtils_setPopupNotify(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -32704,7 +32552,7 @@ int lua_ax_base_FileUtils_isPopupNotify(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -32751,7 +32599,7 @@ int lua_ax_base_FileUtils_getValueMapFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -32801,7 +32649,7 @@ int lua_ax_base_FileUtils_getValueMapFromData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const char* arg0;
         int arg1;
@@ -32854,7 +32702,7 @@ int lua_ax_base_FileUtils_writeToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -32907,7 +32755,7 @@ int lua_ax_base_FileUtils_writeStringToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -32960,7 +32808,7 @@ int lua_ax_base_FileUtils_writeValueMapToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -33013,7 +32861,7 @@ int lua_ax_base_FileUtils_writeValueVectorToFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueVector arg0;
         std::string_view arg1;
@@ -33066,7 +32914,7 @@ int lua_ax_base_FileUtils_getValueVectorFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33116,7 +32964,7 @@ int lua_ax_base_FileUtils_isFileExist(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33166,7 +33014,7 @@ int lua_ax_base_FileUtils_isAbsolutePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33216,7 +33064,7 @@ int lua_ax_base_FileUtils_isDirectoryExist(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33266,7 +33114,7 @@ int lua_ax_base_FileUtils_createDirectories(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33316,7 +33164,7 @@ int lua_ax_base_FileUtils_removeDirectory(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33366,7 +33214,7 @@ int lua_ax_base_FileUtils_removeFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33483,7 +33331,7 @@ int lua_ax_base_FileUtils_getFileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33533,7 +33381,7 @@ int lua_ax_base_FileUtils_listFiles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33583,7 +33431,7 @@ int lua_ax_base_FileUtils_listFilesRecursively(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::vector<std::string>* arg1;
@@ -33636,7 +33484,7 @@ int lua_ax_base_FileUtils_isFileExistInternal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -33686,7 +33534,7 @@ int lua_ax_base_FileUtils_isDirectoryExistInternal(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -34106,7 +33954,7 @@ int lua_ax_base_EventCustom_getEventName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -34140,7 +33988,7 @@ int lua_ax_base_EventCustom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -34214,7 +34062,7 @@ int lua_ax_base_EventDispatcher_addEventListenerWithSceneGraphPriority(lua_State
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventListener* arg0;
         ax::Node* arg1;
@@ -34267,7 +34115,7 @@ int lua_ax_base_EventDispatcher_addEventListenerWithFixedPriority(lua_State* tol
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventListener* arg0;
         int arg1;
@@ -34320,7 +34168,7 @@ int lua_ax_base_EventDispatcher_addCustomEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::function<void (ax::EventCustom *)> arg1;
@@ -34377,7 +34225,7 @@ int lua_ax_base_EventDispatcher_removeEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventListener* arg0;
 
@@ -34427,7 +34275,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventListener::Type arg0;
 
@@ -34477,7 +34325,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForTarget(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -34491,7 +34339,7 @@ int lua_ax_base_EventDispatcher_removeEventListenersForTarget(lua_State* tolua_S
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -34544,7 +34392,7 @@ int lua_ax_base_EventDispatcher_removeCustomEventListeners(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -34594,7 +34442,7 @@ int lua_ax_base_EventDispatcher_removeAllEventListeners(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -34641,7 +34489,7 @@ int lua_ax_base_EventDispatcher_pauseEventListenersForTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -34655,7 +34503,7 @@ int lua_ax_base_EventDispatcher_pauseEventListenersForTarget(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -34708,7 +34556,7 @@ int lua_ax_base_EventDispatcher_resumeEventListenersForTarget(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -34722,7 +34570,7 @@ int lua_ax_base_EventDispatcher_resumeEventListenersForTarget(lua_State* tolua_S
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -34775,7 +34623,7 @@ int lua_ax_base_EventDispatcher_setPriority(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::EventListener* arg0;
         int arg1;
@@ -34828,7 +34676,7 @@ int lua_ax_base_EventDispatcher_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -34878,7 +34726,7 @@ int lua_ax_base_EventDispatcher_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -34925,7 +34773,7 @@ int lua_ax_base_EventDispatcher_dispatchEvent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Event* arg0;
 
@@ -34939,7 +34787,7 @@ int lua_ax_base_EventDispatcher_dispatchEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Event* arg0;
         bool arg1;
@@ -34992,7 +34840,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -35006,7 +34854,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         void* arg1;
@@ -35024,7 +34872,7 @@ int lua_ax_base_EventDispatcher_dispatchCustomEvent(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         std::string_view arg0;
         void* arg1;
@@ -35081,7 +34929,7 @@ int lua_ax_base_EventDispatcher_hasEventListener(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -35118,7 +34966,7 @@ int lua_ax_base_EventDispatcher_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35191,7 +35039,7 @@ int lua_ax_base_EventFocus_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ui::Widget* arg0;
         ax::ui::Widget* arg1;
@@ -35267,7 +35115,7 @@ int lua_ax_base_EventListenerAcceleration_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void (ax::Acceleration *, ax::Event *)> arg0;
 
@@ -35308,7 +35156,7 @@ int lua_ax_base_EventListenerAcceleration_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35379,7 +35227,7 @@ int lua_ax_base_EventListenerFocus_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35413,7 +35261,7 @@ int lua_ax_base_EventListenerFocus_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35484,7 +35332,7 @@ int lua_ax_base_EventListenerKeyboard_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35518,7 +35366,7 @@ int lua_ax_base_EventListenerKeyboard_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35589,7 +35437,7 @@ int lua_ax_base_EventMouse_getMouseEventType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35636,7 +35484,7 @@ int lua_ax_base_EventMouse_setScrollData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -35689,7 +35537,7 @@ int lua_ax_base_EventMouse_getScrollX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35736,7 +35584,7 @@ int lua_ax_base_EventMouse_getScrollY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35783,7 +35631,7 @@ int lua_ax_base_EventMouse_setMouseInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -35839,7 +35687,7 @@ int lua_ax_base_EventMouse_setMouseButton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventMouse::MouseButton arg0;
 
@@ -35889,7 +35737,7 @@ int lua_ax_base_EventMouse_getMouseButton(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35936,7 +35784,7 @@ int lua_ax_base_EventMouse_getLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -35983,7 +35831,7 @@ int lua_ax_base_EventMouse_getPreviousLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36030,7 +35878,7 @@ int lua_ax_base_EventMouse_getStartLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36077,7 +35925,7 @@ int lua_ax_base_EventMouse_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36124,7 +35972,7 @@ int lua_ax_base_EventMouse_getLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36171,7 +36019,7 @@ int lua_ax_base_EventMouse_getPreviousLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36218,7 +36066,7 @@ int lua_ax_base_EventMouse_getStartLocationInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36252,7 +36100,7 @@ int lua_ax_base_EventMouse_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventMouse::MouseEventType arg0;
 
@@ -36339,7 +36187,7 @@ int lua_ax_base_EventListenerMouse_setSwallowMouse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -36389,7 +36237,7 @@ int lua_ax_base_EventListenerMouse_isSwallowMouse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36436,7 +36284,7 @@ int lua_ax_base_EventListenerMouse_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36470,7 +36318,7 @@ int lua_ax_base_EventListenerMouse_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36562,7 +36410,7 @@ int lua_ax_base_EventListenerTouchOneByOne_setSwallowTouches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -36612,7 +36460,7 @@ int lua_ax_base_EventListenerTouchOneByOne_isSwallowTouches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36659,7 +36507,7 @@ int lua_ax_base_EventListenerTouchOneByOne_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36693,7 +36541,7 @@ int lua_ax_base_EventListenerTouchOneByOne_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36766,7 +36614,7 @@ int lua_ax_base_EventListenerTouchAllAtOnce_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36800,7 +36648,7 @@ int lua_ax_base_EventListenerTouchAllAtOnce_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36871,7 +36719,7 @@ int lua_ax_base_EventController_getControllerEventType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36918,7 +36766,7 @@ int lua_ax_base_EventController_getController(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -36965,7 +36813,7 @@ int lua_ax_base_EventController_getKeyCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37012,7 +36860,7 @@ int lua_ax_base_EventController_setKeyCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -37062,7 +36910,7 @@ int lua_ax_base_EventController_setConnectStatus(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -37112,7 +36960,7 @@ int lua_ax_base_EventController_isConnected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37314,7 +37162,7 @@ int lua_ax_base_ActionCamera_getEye(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37361,7 +37209,7 @@ int lua_ax_base_ActionCamera_setCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -37411,7 +37259,7 @@ int lua_ax_base_ActionCamera_getCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37458,7 +37306,7 @@ int lua_ax_base_ActionCamera_setUp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -37508,7 +37356,7 @@ int lua_ax_base_ActionCamera_getUp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37542,7 +37390,7 @@ int lua_ax_base_ActionCamera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37618,7 +37466,7 @@ int lua_ax_base_OrbitCamera_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 7)
+    if (argc == 7) 
     {
         double arg0;
         double arg1;
@@ -37721,7 +37569,7 @@ int lua_ax_base_OrbitCamera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37793,7 +37641,7 @@ int lua_ax_base_CardinalSplineTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::PointArray* arg1;
@@ -37849,7 +37697,7 @@ int lua_ax_base_CardinalSplineTo_updatePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -37899,7 +37747,7 @@ int lua_ax_base_CardinalSplineTo_getPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37933,7 +37781,7 @@ int lua_ax_base_CardinalSplineTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -37993,7 +37841,7 @@ int lua_ax_base_CardinalSplineBy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38063,7 +37911,7 @@ int lua_ax_base_CatmullRomTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::PointArray* arg1;
@@ -38136,7 +37984,7 @@ int lua_ax_base_CatmullRomBy_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::PointArray* arg1;
@@ -38209,7 +38057,7 @@ int lua_ax_base_ActionEase_getInnerAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38256,7 +38104,7 @@ int lua_ax_base_ActionEase_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -38327,7 +38175,7 @@ int lua_ax_base_EaseRateAction_setRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -38377,7 +38225,7 @@ int lua_ax_base_EaseRateAction_getRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38424,7 +38272,7 @@ int lua_ax_base_EaseRateAction_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -38561,7 +38409,7 @@ int lua_ax_base_EaseExponentialIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38655,7 +38503,7 @@ int lua_ax_base_EaseExponentialOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38749,7 +38597,7 @@ int lua_ax_base_EaseExponentialInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38843,7 +38691,7 @@ int lua_ax_base_EaseSineIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -38937,7 +38785,7 @@ int lua_ax_base_EaseSineOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39031,7 +38879,7 @@ int lua_ax_base_EaseSineInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39144,7 +38992,7 @@ int lua_ax_base_EaseBounceIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39238,7 +39086,7 @@ int lua_ax_base_EaseBounceOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39332,7 +39180,7 @@ int lua_ax_base_EaseBounceInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39426,7 +39274,7 @@ int lua_ax_base_EaseBackIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39520,7 +39368,7 @@ int lua_ax_base_EaseBackOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39614,7 +39462,7 @@ int lua_ax_base_EaseBackInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39708,7 +39556,7 @@ int lua_ax_base_EaseQuadraticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39802,7 +39650,7 @@ int lua_ax_base_EaseQuadraticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39896,7 +39744,7 @@ int lua_ax_base_EaseQuadraticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -39990,7 +39838,7 @@ int lua_ax_base_EaseQuarticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40084,7 +39932,7 @@ int lua_ax_base_EaseQuarticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40178,7 +40026,7 @@ int lua_ax_base_EaseQuarticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40272,7 +40120,7 @@ int lua_ax_base_EaseQuinticActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40366,7 +40214,7 @@ int lua_ax_base_EaseQuinticActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40460,7 +40308,7 @@ int lua_ax_base_EaseQuinticActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40554,7 +40402,7 @@ int lua_ax_base_EaseCircleActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40648,7 +40496,7 @@ int lua_ax_base_EaseCircleActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40742,7 +40590,7 @@ int lua_ax_base_EaseCircleActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40836,7 +40684,7 @@ int lua_ax_base_EaseCubicActionIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -40930,7 +40778,7 @@ int lua_ax_base_EaseCubicActionOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41024,7 +40872,7 @@ int lua_ax_base_EaseCubicActionInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41120,7 +40968,7 @@ int lua_ax_base_EaseIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41216,7 +41064,7 @@ int lua_ax_base_EaseOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41312,7 +41160,7 @@ int lua_ax_base_EaseInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41383,7 +41231,7 @@ int lua_ax_base_EaseElastic_getPeriod(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41430,7 +41278,7 @@ int lua_ax_base_EaseElastic_setPeriod(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -41480,7 +41328,7 @@ int lua_ax_base_EaseElastic_initWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -41494,7 +41342,7 @@ int lua_ax_base_EaseElastic_initWithAction(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ActionInterval* arg0;
         double arg1;
@@ -41607,7 +41455,7 @@ int lua_ax_base_EaseElasticIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41716,7 +41564,7 @@ int lua_ax_base_EaseElasticOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41825,7 +41673,7 @@ int lua_ax_base_EaseElasticInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -41896,7 +41744,7 @@ int lua_ax_base_EaseBezierAction_setBezierParamer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -41978,7 +41826,7 @@ int lua_ax_base_EaseBezierAction_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42090,7 +41938,7 @@ int lua_ax_base_Show_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42182,7 +42030,7 @@ int lua_ax_base_Hide_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42274,7 +42122,7 @@ int lua_ax_base_ToggleVisibility_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42345,7 +42193,7 @@ int lua_ax_base_RemoveSelf_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -42429,7 +42277,7 @@ int lua_ax_base_RemoveSelf_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42501,7 +42349,7 @@ int lua_ax_base_FlipX_initWithFlipX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -42574,7 +42422,7 @@ int lua_ax_base_FlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42646,7 +42494,7 @@ int lua_ax_base_FlipY_initWithFlipY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -42719,7 +42567,7 @@ int lua_ax_base_FlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42791,7 +42639,7 @@ int lua_ax_base_Place_initWithPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -42864,7 +42712,7 @@ int lua_ax_base_Place_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42936,7 +42784,7 @@ int lua_ax_base_CallFunc_execute(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -42970,7 +42818,7 @@ int lua_ax_base_CallFunc_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43041,7 +42889,7 @@ int lua_ax_base_GridAction_getGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43088,7 +42936,7 @@ int lua_ax_base_GridAction_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -43162,7 +43010,7 @@ int lua_ax_base_Grid3DAction_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43269,7 +43117,7 @@ int lua_ax_base_StopGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43340,7 +43188,7 @@ int lua_ax_base_ReuseGrid_initWithTimes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -43413,7 +43261,7 @@ int lua_ax_base_ReuseGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43485,7 +43333,7 @@ int lua_ax_base_Waves3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43532,7 +43380,7 @@ int lua_ax_base_Waves3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -43582,7 +43430,7 @@ int lua_ax_base_Waves3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43629,7 +43477,7 @@ int lua_ax_base_Waves3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -43679,7 +43527,7 @@ int lua_ax_base_Waves3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -43767,7 +43615,7 @@ int lua_ax_base_Waves3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -43843,7 +43691,7 @@ int lua_ax_base_FlipX3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -43893,7 +43741,7 @@ int lua_ax_base_FlipX3D_initWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -43969,7 +43817,7 @@ int lua_ax_base_FlipX3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44065,7 +43913,7 @@ int lua_ax_base_FlipY3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44136,7 +43984,7 @@ int lua_ax_base_Lens3D_getLensEffect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44183,7 +44031,7 @@ int lua_ax_base_Lens3D_setLensEffect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -44233,7 +44081,7 @@ int lua_ax_base_Lens3D_setConcave(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -44283,7 +44131,7 @@ int lua_ax_base_Lens3D_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44330,7 +44178,7 @@ int lua_ax_base_Lens3D_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -44380,7 +44228,7 @@ int lua_ax_base_Lens3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44468,7 +44316,7 @@ int lua_ax_base_Lens3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44545,7 +44393,7 @@ int lua_ax_base_Ripple3D_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44592,7 +44440,7 @@ int lua_ax_base_Ripple3D_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -44642,7 +44490,7 @@ int lua_ax_base_Ripple3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44689,7 +44537,7 @@ int lua_ax_base_Ripple3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -44739,7 +44587,7 @@ int lua_ax_base_Ripple3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -44786,7 +44634,7 @@ int lua_ax_base_Ripple3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -44836,7 +44684,7 @@ int lua_ax_base_Ripple3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -44934,7 +44782,7 @@ int lua_ax_base_Ripple3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45012,7 +44860,7 @@ int lua_ax_base_Shaky3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45100,7 +44948,7 @@ int lua_ax_base_Shaky3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45172,7 +45020,7 @@ int lua_ax_base_Liquid_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45219,7 +45067,7 @@ int lua_ax_base_Liquid_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45269,7 +45117,7 @@ int lua_ax_base_Liquid_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45316,7 +45164,7 @@ int lua_ax_base_Liquid_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45366,7 +45214,7 @@ int lua_ax_base_Liquid_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45454,7 +45302,7 @@ int lua_ax_base_Liquid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45530,7 +45378,7 @@ int lua_ax_base_Waves_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45577,7 +45425,7 @@ int lua_ax_base_Waves_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45627,7 +45475,7 @@ int lua_ax_base_Waves_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45674,7 +45522,7 @@ int lua_ax_base_Waves_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -45724,7 +45572,7 @@ int lua_ax_base_Waves_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -45822,7 +45670,7 @@ int lua_ax_base_Waves_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45898,7 +45746,7 @@ int lua_ax_base_Twirl_getPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -45945,7 +45793,7 @@ int lua_ax_base_Twirl_setPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -45995,7 +45843,7 @@ int lua_ax_base_Twirl_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46042,7 +45890,7 @@ int lua_ax_base_Twirl_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -46092,7 +45940,7 @@ int lua_ax_base_Twirl_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46139,7 +45987,7 @@ int lua_ax_base_Twirl_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -46189,7 +46037,7 @@ int lua_ax_base_Twirl_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -46282,7 +46130,7 @@ int lua_ax_base_Twirl_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46360,7 +46208,7 @@ int lua_ax_base_ActionManager_addAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Action* arg0;
         ax::Node* arg1;
@@ -46416,7 +46264,7 @@ int lua_ax_base_ActionManager_removeAllActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46463,7 +46311,7 @@ int lua_ax_base_ActionManager_removeAllActionsFromTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -46513,7 +46361,7 @@ int lua_ax_base_ActionManager_removeAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Action* arg0;
 
@@ -46563,7 +46411,7 @@ int lua_ax_base_ActionManager_removeActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         ax::Node* arg1;
@@ -46616,7 +46464,7 @@ int lua_ax_base_ActionManager_removeAllActionsByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         ax::Node* arg1;
@@ -46669,7 +46517,7 @@ int lua_ax_base_ActionManager_removeActionsByFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::Node* arg1;
@@ -46722,7 +46570,7 @@ int lua_ax_base_ActionManager_getActionByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         const ax::Node* arg1;
@@ -46775,7 +46623,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActionsInTarget(lua_State* tolua
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const ax::Node* arg0;
 
@@ -46825,7 +46673,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -46872,7 +46720,7 @@ int lua_ax_base_ActionManager_getNumberOfRunningActionsInTargetByTag(lua_State* 
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const ax::Node* arg0;
         int arg1;
@@ -46925,7 +46773,7 @@ int lua_ax_base_ActionManager_pauseTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -46975,7 +46823,7 @@ int lua_ax_base_ActionManager_resumeTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -47025,7 +46873,7 @@ int lua_ax_base_ActionManager_pauseAllRunningActions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47072,7 +46920,7 @@ int lua_ax_base_ActionManager_resumeTargets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::Node *> arg0;
 
@@ -47122,7 +46970,7 @@ int lua_ax_base_ActionManager_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -47159,7 +47007,7 @@ int lua_ax_base_ActionManager_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47303,7 +47151,7 @@ int lua_ax_base_ProgressTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -47381,7 +47229,7 @@ int lua_ax_base_ProgressTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47453,7 +47301,7 @@ int lua_ax_base_ProgressFromTo_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         double arg1;
@@ -47536,7 +47384,7 @@ int lua_ax_base_ProgressFromTo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47608,7 +47456,7 @@ int lua_ax_base_ShakyTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47696,7 +47544,7 @@ int lua_ax_base_ShakyTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47768,7 +47616,7 @@ int lua_ax_base_ShatteredTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -47856,7 +47704,7 @@ int lua_ax_base_ShatteredTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -47928,7 +47776,7 @@ int lua_ax_base_ShuffleTiles_getDelta(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -47978,7 +47826,7 @@ int lua_ax_base_ShuffleTiles_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -48061,7 +47909,7 @@ int lua_ax_base_ShuffleTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48134,7 +47982,7 @@ int lua_ax_base_FadeOutTRTiles_testFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -48187,7 +48035,7 @@ int lua_ax_base_FadeOutTRTiles_turnOnTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48237,7 +48085,7 @@ int lua_ax_base_FadeOutTRTiles_turnOffTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48287,7 +48135,7 @@ int lua_ax_base_FadeOutTRTiles_transformTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -48365,7 +48213,7 @@ int lua_ax_base_FadeOutTRTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48465,7 +48313,7 @@ int lua_ax_base_FadeOutBLTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48561,7 +48409,7 @@ int lua_ax_base_FadeOutUpTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48657,7 +48505,7 @@ int lua_ax_base_FadeOutDownTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -48728,7 +48576,7 @@ int lua_ax_base_TurnOffTiles_turnOnTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48778,7 +48626,7 @@ int lua_ax_base_TurnOffTiles_turnOffTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -48828,7 +48676,7 @@ int lua_ax_base_TurnOffTiles_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -48872,7 +48720,7 @@ int lua_ax_base_TurnOffTiles_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -48891,7 +48739,7 @@ int lua_ax_base_TurnOffTiles_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -48928,7 +48776,7 @@ int lua_ax_base_TurnOffTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49002,7 +48850,7 @@ int lua_ax_base_WavesTiles3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49049,7 +48897,7 @@ int lua_ax_base_WavesTiles3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -49099,7 +48947,7 @@ int lua_ax_base_WavesTiles3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49146,7 +48994,7 @@ int lua_ax_base_WavesTiles3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -49196,7 +49044,7 @@ int lua_ax_base_WavesTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -49284,7 +49132,7 @@ int lua_ax_base_WavesTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49360,7 +49208,7 @@ int lua_ax_base_JumpTiles3D_getAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49407,7 +49255,7 @@ int lua_ax_base_JumpTiles3D_setAmplitude(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -49457,7 +49305,7 @@ int lua_ax_base_JumpTiles3D_getAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49504,7 +49352,7 @@ int lua_ax_base_JumpTiles3D_setAmplitudeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -49554,7 +49402,7 @@ int lua_ax_base_JumpTiles3D_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         ax::Vec2 arg1;
@@ -49642,7 +49490,7 @@ int lua_ax_base_JumpTiles3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49718,7 +49566,7 @@ int lua_ax_base_SplitRows_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         unsigned int arg1;
@@ -49796,7 +49644,7 @@ int lua_ax_base_SplitRows_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -49868,7 +49716,7 @@ int lua_ax_base_SplitCols_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         unsigned int arg1;
@@ -49946,7 +49794,7 @@ int lua_ax_base_SplitCols_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50018,7 +49866,7 @@ int lua_ax_base_ActionTween_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         std::string_view arg1;
@@ -50140,7 +49988,7 @@ int lua_ax_base_ActionCoroutine_initWithCoroutine(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<ax::Coroutine ()> arg0;
 
@@ -50221,7 +50069,7 @@ int lua_ax_base_ActionCoroutine_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50293,7 +50141,7 @@ int lua_ax_base_AtlasNode_updateAtlasValues(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50340,7 +50188,7 @@ int lua_ax_base_AtlasNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50387,7 +50235,7 @@ int lua_ax_base_AtlasNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -50437,7 +50285,7 @@ int lua_ax_base_AtlasNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -50487,7 +50335,7 @@ int lua_ax_base_AtlasNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50534,7 +50382,7 @@ int lua_ax_base_AtlasNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -50584,7 +50432,7 @@ int lua_ax_base_AtlasNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50631,7 +50479,7 @@ int lua_ax_base_AtlasNode_setQuadsToDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -50681,7 +50529,7 @@ int lua_ax_base_AtlasNode_getQuadsToDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50728,7 +50576,7 @@ int lua_ax_base_AtlasNode_initWithTileFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         int arg1;
@@ -50787,7 +50635,7 @@ int lua_ax_base_AtlasNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Texture2D* arg0;
         int arg1;
@@ -50875,7 +50723,7 @@ int lua_ax_base_AtlasNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -50957,7 +50805,7 @@ int lua_ax_base_ClippingNode_getStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51004,7 +50852,7 @@ int lua_ax_base_ClippingNode_setStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -51018,7 +50866,7 @@ int lua_ax_base_ClippingNode_setStencil(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -51071,7 +50919,7 @@ int lua_ax_base_ClippingNode_hasContent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51118,7 +50966,7 @@ int lua_ax_base_ClippingNode_getAlphaThreshold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51165,7 +51013,7 @@ int lua_ax_base_ClippingNode_setAlphaThreshold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -51215,7 +51063,7 @@ int lua_ax_base_ClippingNode_isInverted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51262,7 +51110,7 @@ int lua_ax_base_ClippingNode_setInverted(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -51312,7 +51160,7 @@ int lua_ax_base_ClippingNode_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -51350,7 +51198,7 @@ int lua_ax_base_ClippingNode_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -51363,7 +51211,7 @@ int lua_ax_base_ClippingNode_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -51435,7 +51283,7 @@ int lua_ax_base_ClippingRectangleNode_getClippingRegion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51482,7 +51330,7 @@ int lua_ax_base_ClippingRectangleNode_setClippingRegion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -51532,7 +51380,7 @@ int lua_ax_base_ClippingRectangleNode_isClippingEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -51579,7 +51427,7 @@ int lua_ax_base_ClippingRectangleNode_setClippingEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -51617,7 +51465,7 @@ int lua_ax_base_ClippingRectangleNode_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -51627,7 +51475,7 @@ int lua_ax_base_ClippingRectangleNode_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -51698,7 +51546,7 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -51718,7 +51566,7 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -51777,7 +51625,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51797,7 +51645,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51820,7 +51668,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -51846,7 +51694,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52229,7 +52077,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52255,7 +52103,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52320,7 +52168,7 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52349,7 +52197,7 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 7)
+    if (argc == 7) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52417,7 +52265,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52443,7 +52291,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52508,7 +52356,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52537,7 +52385,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 7)
+    if (argc == 7) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52605,7 +52453,7 @@ int lua_ax_base_DrawNode_drawDot(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         double arg1;
@@ -52661,7 +52509,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52681,7 +52529,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -52704,7 +52552,7 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53212,7 +53060,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53235,7 +53083,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53261,7 +53109,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 6)
+    if (argc == 6) 
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
@@ -53326,7 +53174,7 @@ int lua_ax_base_DrawNode_drawColoredTriangle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const ax::Vec2* arg0;
         const ax::Color* arg1;
@@ -53586,7 +53434,7 @@ int lua_ax_base_DrawNode_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53633,7 +53481,7 @@ int lua_ax_base_DrawNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53680,7 +53528,7 @@ int lua_ax_base_DrawNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -53730,7 +53578,7 @@ int lua_ax_base_DrawNode_setIsolated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -53780,7 +53628,7 @@ int lua_ax_base_DrawNode_isIsolated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53848,7 +53696,7 @@ int lua_ax_base_DrawNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -53940,7 +53788,7 @@ int lua_ax_base_Label_setTTFConfig(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::_ttfConfig arg0;
 
@@ -53990,7 +53838,7 @@ int lua_ax_base_Label_getTTFConfig(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54176,7 +54024,7 @@ int lua_ax_base_Label_getBMFontFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54314,7 +54162,7 @@ int lua_ax_base_Label_setSystemFontName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -54364,7 +54212,7 @@ int lua_ax_base_Label_getSystemFontName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54411,7 +54259,7 @@ int lua_ax_base_Label_setSystemFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -54461,7 +54309,7 @@ int lua_ax_base_Label_getSystemFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54508,7 +54356,7 @@ int lua_ax_base_Label_requestSystemFontRefresh(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54555,7 +54403,7 @@ int lua_ax_base_Label_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -54605,7 +54453,7 @@ int lua_ax_base_Label_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54652,7 +54500,7 @@ int lua_ax_base_Label_getStringNumLines(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54699,7 +54547,7 @@ int lua_ax_base_Label_getStringLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54746,7 +54594,7 @@ int lua_ax_base_Label_setTextColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54796,7 +54644,7 @@ int lua_ax_base_Label_getTextColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54843,7 +54691,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -54854,7 +54702,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54868,7 +54716,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -54885,7 +54733,7 @@ int lua_ax_base_Label_enableShadow(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -54941,7 +54789,7 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -54955,7 +54803,7 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Color32 arg0;
         int arg1;
@@ -55008,7 +54856,7 @@ int lua_ax_base_Label_enableGlow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -55058,7 +54906,7 @@ int lua_ax_base_Label_enableItalics(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55105,7 +54953,7 @@ int lua_ax_base_Label_enableBold(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55152,7 +55000,7 @@ int lua_ax_base_Label_enableUnderline(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55199,7 +55047,7 @@ int lua_ax_base_Label_enableStrikethrough(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55297,7 +55145,7 @@ int lua_ax_base_Label_isShadowEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55344,7 +55192,7 @@ int lua_ax_base_Label_getShadowOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55391,7 +55239,7 @@ int lua_ax_base_Label_getShadowBlurRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55438,7 +55286,7 @@ int lua_ax_base_Label_getShadowColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55485,7 +55333,7 @@ int lua_ax_base_Label_getOutlineSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55532,7 +55380,7 @@ int lua_ax_base_Label_getLabelEffectType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55579,7 +55427,7 @@ int lua_ax_base_Label_getEffectColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55685,7 +55533,7 @@ int lua_ax_base_Label_getTextAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55732,7 +55580,7 @@ int lua_ax_base_Label_setHorizontalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextHAlignment arg0;
 
@@ -55782,7 +55630,7 @@ int lua_ax_base_Label_getHorizontalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55829,7 +55677,7 @@ int lua_ax_base_Label_setVerticalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextVAlignment arg0;
 
@@ -55879,7 +55727,7 @@ int lua_ax_base_Label_getVerticalAlignment(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -55926,7 +55774,7 @@ int lua_ax_base_Label_setLineBreakWithoutSpace(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -55976,7 +55824,7 @@ int lua_ax_base_Label_setMaxLineWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56026,7 +55874,7 @@ int lua_ax_base_Label_getMaxLineWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56073,7 +55921,7 @@ int lua_ax_base_Label_setTTFFaceSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -56123,7 +55971,7 @@ int lua_ax_base_Label_getTTFFaceSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56170,7 +56018,7 @@ int lua_ax_base_Label_setBMFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56220,7 +56068,7 @@ int lua_ax_base_Label_getBMFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56267,7 +56115,7 @@ int lua_ax_base_Label_enableWrap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -56317,7 +56165,7 @@ int lua_ax_base_Label_isWrapEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56364,7 +56212,7 @@ int lua_ax_base_Label_setOverflow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Label::Overflow arg0;
 
@@ -56414,7 +56262,7 @@ int lua_ax_base_Label_getOverflow(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56461,7 +56309,7 @@ int lua_ax_base_Label_setWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56511,7 +56359,7 @@ int lua_ax_base_Label_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56558,7 +56406,7 @@ int lua_ax_base_Label_setHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56608,7 +56456,7 @@ int lua_ax_base_Label_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56655,7 +56503,7 @@ int lua_ax_base_Label_setDimensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -56708,7 +56556,7 @@ int lua_ax_base_Label_getDimensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56755,7 +56603,7 @@ int lua_ax_base_Label_updateContent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56802,7 +56650,7 @@ int lua_ax_base_Label_getLetter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -56852,7 +56700,7 @@ int lua_ax_base_Label_setClipMarginEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -56902,7 +56750,7 @@ int lua_ax_base_Label_isClipMarginEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -56949,7 +56797,7 @@ int lua_ax_base_Label_setLineHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -56999,7 +56847,7 @@ int lua_ax_base_Label_getLineHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57046,7 +56894,7 @@ int lua_ax_base_Label_setLineSpacing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -57096,7 +56944,7 @@ int lua_ax_base_Label_getLineSpacing(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57143,7 +56991,7 @@ int lua_ax_base_Label_getLabelType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57190,7 +57038,7 @@ int lua_ax_base_Label_getRenderingFontSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57237,7 +57085,7 @@ int lua_ax_base_Label_setAdditionalKerning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -57287,7 +57135,7 @@ int lua_ax_base_Label_getAdditionalKerning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57334,7 +57182,7 @@ int lua_ax_base_Label_getFontAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57381,7 +57229,7 @@ int lua_ax_base_Label_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -57428,7 +57276,7 @@ int lua_ax_base_Label_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -57478,7 +57326,7 @@ int lua_ax_base_Label_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -57848,7 +57696,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 6)
         {
@@ -57876,7 +57724,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -57892,7 +57740,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -57911,7 +57759,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -57933,7 +57781,7 @@ int lua_ax_base_Label_createWithBMFont(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -57980,7 +57828,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -58002,7 +57850,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -58024,7 +57872,7 @@ int lua_ax_base_Label_createWithCharMap(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -58268,7 +58116,7 @@ int lua_ax_base_LabelAtlas_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -58318,7 +58166,7 @@ int lua_ax_base_LabelAtlas_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58353,7 +58201,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -58369,7 +58217,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -58394,7 +58242,7 @@ int lua_ax_base_LabelAtlas_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -58440,7 +58288,7 @@ int lua_ax_base_LabelAtlas_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58514,7 +58362,7 @@ int lua_ax_base_Sprite_getBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58561,7 +58409,7 @@ int lua_ax_base_Sprite_setBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteBatchNode* arg0;
 
@@ -58666,7 +58514,7 @@ int lua_ax_base_Sprite_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58776,7 +58624,7 @@ int lua_ax_base_Sprite_setVertexRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -58826,7 +58674,7 @@ int lua_ax_base_Sprite_setCenterRectNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -58876,7 +58724,7 @@ int lua_ax_base_Sprite_getCenterRectNormalized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -58923,7 +58771,7 @@ int lua_ax_base_Sprite_setCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -58973,7 +58821,7 @@ int lua_ax_base_Sprite_getCenterRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59075,7 +58923,7 @@ int lua_ax_base_Sprite_isFrameDisplayed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -59125,7 +58973,7 @@ int lua_ax_base_Sprite_getSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59172,7 +59020,7 @@ int lua_ax_base_Sprite_setDisplayFrameWithAnimationName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         unsigned int arg1;
@@ -59225,7 +59073,7 @@ int lua_ax_base_Sprite_isDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59272,7 +59120,7 @@ int lua_ax_base_Sprite_setDirty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59322,7 +59170,7 @@ int lua_ax_base_Sprite_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59372,7 +59220,7 @@ int lua_ax_base_Sprite_isTextureRectRotated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59419,7 +59267,7 @@ int lua_ax_base_Sprite_getAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59466,7 +59314,7 @@ int lua_ax_base_Sprite_setAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -59516,7 +59364,7 @@ int lua_ax_base_Sprite_getTextureRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59563,7 +59411,7 @@ int lua_ax_base_Sprite_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59610,7 +59458,7 @@ int lua_ax_base_Sprite_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -59660,7 +59508,7 @@ int lua_ax_base_Sprite_getOffsetPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59707,7 +59555,7 @@ int lua_ax_base_Sprite_isFlippedX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59754,7 +59602,7 @@ int lua_ax_base_Sprite_setFlippedX(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59804,7 +59652,7 @@ int lua_ax_base_Sprite_isFlippedY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59851,7 +59699,7 @@ int lua_ax_base_Sprite_setFlippedY(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59901,7 +59749,7 @@ int lua_ax_base_Sprite_setStretchEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -59951,7 +59799,7 @@ int lua_ax_base_Sprite_isStretchEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -59998,7 +59846,7 @@ int lua_ax_base_Sprite_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -60048,7 +59896,7 @@ int lua_ax_base_Sprite_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60095,7 +59943,7 @@ int lua_ax_base_Sprite_getResourceType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60142,7 +59990,7 @@ int lua_ax_base_Sprite_getResourceName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60268,7 +60116,7 @@ int lua_ax_base_Sprite_initWithSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -60318,7 +60166,7 @@ int lua_ax_base_Sprite_initWithSpriteFrameName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -60443,7 +60291,7 @@ int lua_ax_base_Sprite_initWithImageData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Data arg0;
         std::string_view arg1;
@@ -60496,7 +60344,7 @@ int lua_ax_base_Sprite_setVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60543,7 +60391,7 @@ int lua_ax_base_Sprite_setAutoUpdatePS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -60593,7 +60441,7 @@ int lua_ax_base_Sprite_setAutoSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -60631,7 +60479,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -60647,7 +60495,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -60666,7 +60514,7 @@ int lua_ax_base_Sprite_createWithTexture(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -60772,7 +60620,7 @@ int lua_ax_base_Sprite_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -60941,7 +60789,7 @@ int lua_ax_base_LayerColor_changeWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -60991,7 +60839,7 @@ int lua_ax_base_LayerColor_changeHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -61041,7 +60889,7 @@ int lua_ax_base_LayerColor_changeWidthAndHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -61145,7 +60993,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -61164,7 +61012,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -61174,7 +61022,7 @@ int lua_ax_base_LayerColor_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -61208,7 +61056,7 @@ int lua_ax_base_LayerColor_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61283,7 +61131,7 @@ int lua_ax_base_LayerGradient_setCompressedInterpolation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -61333,7 +61181,7 @@ int lua_ax_base_LayerGradient_isCompressedInterpolation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61380,7 +61228,7 @@ int lua_ax_base_LayerGradient_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -61430,7 +61278,7 @@ int lua_ax_base_LayerGradient_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61477,7 +61325,7 @@ int lua_ax_base_LayerGradient_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -61527,7 +61375,7 @@ int lua_ax_base_LayerGradient_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61574,7 +61422,7 @@ int lua_ax_base_LayerGradient_setStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -61624,7 +61472,7 @@ int lua_ax_base_LayerGradient_getStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61671,7 +61519,7 @@ int lua_ax_base_LayerGradient_setEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -61721,7 +61569,7 @@ int lua_ax_base_LayerGradient_getEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61768,7 +61616,7 @@ int lua_ax_base_LayerGradient_setVector(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -61818,7 +61666,7 @@ int lua_ax_base_LayerGradient_getVector(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -61920,7 +61768,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -61936,7 +61784,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -61946,7 +61794,7 @@ int lua_ax_base_LayerGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -61986,7 +61834,7 @@ int lua_ax_base_LayerGradient_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62070,7 +61918,7 @@ int lua_ax_base_LayerRadialGradient_setStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -62120,7 +61968,7 @@ int lua_ax_base_LayerRadialGradient_getStartOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62167,7 +62015,7 @@ int lua_ax_base_LayerRadialGradient_setEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         uint16_t arg0;
 
@@ -62217,7 +62065,7 @@ int lua_ax_base_LayerRadialGradient_getEndOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62264,7 +62112,7 @@ int lua_ax_base_LayerRadialGradient_setRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -62314,7 +62162,7 @@ int lua_ax_base_LayerRadialGradient_getRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62361,7 +62209,7 @@ int lua_ax_base_LayerRadialGradient_setCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -62411,7 +62259,7 @@ int lua_ax_base_LayerRadialGradient_getCenter(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62458,7 +62306,7 @@ int lua_ax_base_LayerRadialGradient_setExpand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -62508,7 +62356,7 @@ int lua_ax_base_LayerRadialGradient_getExpand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62555,7 +62403,7 @@ int lua_ax_base_LayerRadialGradient_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -62605,7 +62453,7 @@ int lua_ax_base_LayerRadialGradient_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62652,7 +62500,7 @@ int lua_ax_base_LayerRadialGradient_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -62702,7 +62550,7 @@ int lua_ax_base_LayerRadialGradient_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62749,7 +62597,7 @@ int lua_ax_base_LayerRadialGradient_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -62799,7 +62647,7 @@ int lua_ax_base_LayerRadialGradient_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -62846,7 +62694,7 @@ int lua_ax_base_LayerRadialGradient_initWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::Color32 arg0;
         ax::Color32 arg1;
@@ -62896,7 +62744,7 @@ int lua_ax_base_LayerRadialGradient_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -62906,7 +62754,7 @@ int lua_ax_base_LayerRadialGradient_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -62952,7 +62800,7 @@ int lua_ax_base_LayerRadialGradient_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63040,7 +62888,7 @@ int lua_ax_base_LayerMultiplex_addLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -63149,7 +62997,7 @@ int lua_ax_base_LayerMultiplex_switchToAndReleaseMe(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -63199,7 +63047,7 @@ int lua_ax_base_LayerMultiplex_initWithArray(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::Node *> arg0;
 
@@ -63236,7 +63084,7 @@ int lua_ax_base_LayerMultiplex_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63310,7 +63158,7 @@ int lua_ax_base_MenuItem_rect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63357,7 +63205,7 @@ int lua_ax_base_MenuItem_activate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63404,7 +63252,7 @@ int lua_ax_base_MenuItem_selected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63451,7 +63299,7 @@ int lua_ax_base_MenuItem_unselected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63498,7 +63346,7 @@ int lua_ax_base_MenuItem_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63545,7 +63393,7 @@ int lua_ax_base_MenuItem_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -63595,7 +63443,7 @@ int lua_ax_base_MenuItem_isSelected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63629,7 +63477,7 @@ int lua_ax_base_MenuItem_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63706,7 +63554,7 @@ int lua_ax_base_MenuItemLabel_setString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -63756,7 +63604,7 @@ int lua_ax_base_MenuItemLabel_getString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63803,7 +63651,7 @@ int lua_ax_base_MenuItemLabel_getDisabledColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63850,7 +63698,7 @@ int lua_ax_base_MenuItemLabel_setDisabledColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -63900,7 +63748,7 @@ int lua_ax_base_MenuItemLabel_getLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -63947,7 +63795,7 @@ int lua_ax_base_MenuItemLabel_setLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -63997,7 +63845,7 @@ int lua_ax_base_MenuItemLabel_initWithLabel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         std::function<void (ax::Object *)> arg1;
@@ -64041,7 +63889,7 @@ int lua_ax_base_MenuItemLabel_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64118,7 +63966,7 @@ int lua_ax_base_MenuItemAtlasFont_initWithString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 6)
+    if (argc == 6) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -64174,7 +64022,7 @@ int lua_ax_base_MenuItemAtlasFont_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64245,7 +64093,7 @@ int lua_ax_base_MenuItemFont_setFontSizeObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -64295,7 +64143,7 @@ int lua_ax_base_MenuItemFont_getFontSizeObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64342,7 +64190,7 @@ int lua_ax_base_MenuItemFont_setFontNameObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -64392,7 +64240,7 @@ int lua_ax_base_MenuItemFont_getFontNameObj(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64439,7 +64287,7 @@ int lua_ax_base_MenuItemFont_initWithString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::function<void (ax::Object *)> arg1;
@@ -64623,7 +64471,7 @@ int lua_ax_base_MenuItemFont_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64702,7 +64550,7 @@ int lua_ax_base_MenuItemSprite_getNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64749,7 +64597,7 @@ int lua_ax_base_MenuItemSprite_setNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -64799,7 +64647,7 @@ int lua_ax_base_MenuItemSprite_getSelectedImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64846,7 +64694,7 @@ int lua_ax_base_MenuItemSprite_setSelectedImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -64896,7 +64744,7 @@ int lua_ax_base_MenuItemSprite_getDisabledImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -64943,7 +64791,7 @@ int lua_ax_base_MenuItemSprite_setDisabledImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -64993,7 +64841,7 @@ int lua_ax_base_MenuItemSprite_selected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65040,7 +64888,7 @@ int lua_ax_base_MenuItemSprite_unselected(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65087,7 +64935,7 @@ int lua_ax_base_MenuItemSprite_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -65137,7 +64985,7 @@ int lua_ax_base_MenuItemSprite_initWithNormalSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Node* arg0;
         ax::Node* arg1;
@@ -65187,7 +65035,7 @@ int lua_ax_base_MenuItemSprite_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65267,7 +65115,7 @@ int lua_ax_base_MenuItemImage_setNormalSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -65317,7 +65165,7 @@ int lua_ax_base_MenuItemImage_setSelectedSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -65367,7 +65215,7 @@ int lua_ax_base_MenuItemImage_setDisabledSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -65417,7 +65265,7 @@ int lua_ax_base_MenuItemImage_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65464,7 +65312,7 @@ int lua_ax_base_MenuItemImage_initWithNormalImage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -65514,7 +65362,7 @@ int lua_ax_base_MenuItemImage_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65589,7 +65437,7 @@ int lua_ax_base_MenuItemToggle_addSubItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MenuItem* arg0;
 
@@ -65639,7 +65487,7 @@ int lua_ax_base_MenuItemToggle_getSelectedItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65686,7 +65534,7 @@ int lua_ax_base_MenuItemToggle_getSelectedIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65733,7 +65581,7 @@ int lua_ax_base_MenuItemToggle_setSelectedIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -65783,7 +65631,7 @@ int lua_ax_base_MenuItemToggle_setSubItems(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::MenuItem *> arg0;
 
@@ -65833,7 +65681,7 @@ int lua_ax_base_MenuItemToggle_initWithItem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::MenuItem* arg0;
 
@@ -65870,7 +65718,7 @@ int lua_ax_base_MenuItemToggle_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65946,7 +65794,7 @@ int lua_ax_base_Menu_alignItemsVertically(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -65993,7 +65841,7 @@ int lua_ax_base_Menu_alignItemsVerticallyWithPadding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -66043,7 +65891,7 @@ int lua_ax_base_Menu_alignItemsHorizontally(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66090,7 +65938,7 @@ int lua_ax_base_Menu_alignItemsHorizontallyWithPadding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -66140,7 +65988,7 @@ int lua_ax_base_Menu_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66187,7 +66035,7 @@ int lua_ax_base_Menu_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -66237,7 +66085,7 @@ int lua_ax_base_Menu_initWithArray(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::MenuItem *> arg0;
 
@@ -66274,7 +66122,7 @@ int lua_ax_base_Menu_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66351,7 +66199,7 @@ int lua_ax_base_MotionStreak_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66398,7 +66246,7 @@ int lua_ax_base_MotionStreak_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -66448,7 +66296,7 @@ int lua_ax_base_MotionStreak_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -66498,7 +66346,7 @@ int lua_ax_base_MotionStreak_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66545,7 +66393,7 @@ int lua_ax_base_MotionStreak_tintWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -66595,7 +66443,7 @@ int lua_ax_base_MotionStreak_reset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66642,7 +66490,7 @@ int lua_ax_base_MotionStreak_isFastMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66689,7 +66537,7 @@ int lua_ax_base_MotionStreak_setFastMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -66739,7 +66587,7 @@ int lua_ax_base_MotionStreak_getStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66786,7 +66634,7 @@ int lua_ax_base_MotionStreak_setStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -66836,7 +66684,7 @@ int lua_ax_base_MotionStreak_isStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -66883,7 +66731,7 @@ int lua_ax_base_MotionStreak_setStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -67008,7 +66856,7 @@ int lua_ax_base_MotionStreak_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -67033,7 +66881,7 @@ int lua_ax_base_MotionStreak_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -67079,7 +66927,7 @@ int lua_ax_base_MotionStreak_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67210,7 +67058,7 @@ int lua_ax_base_NodeGrid_setGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::GridBase* arg0;
 
@@ -67260,7 +67108,7 @@ int lua_ax_base_NodeGrid_setTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -67310,7 +67158,7 @@ int lua_ax_base_NodeGrid_setGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -67360,7 +67208,7 @@ int lua_ax_base_NodeGrid_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67395,7 +67243,7 @@ int lua_ax_base_NodeGrid_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -67408,7 +67256,7 @@ int lua_ax_base_NodeGrid_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -67439,7 +67287,7 @@ int lua_ax_base_NodeGrid_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67515,7 +67363,7 @@ int lua_ax_base_ParticleBatchNode_insertChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ParticleSystem* arg0;
         int arg1;
@@ -67568,7 +67416,7 @@ int lua_ax_base_ParticleBatchNode_removeChildAtIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         bool arg1;
@@ -67621,7 +67469,7 @@ int lua_ax_base_ParticleBatchNode_removeAllChildrenWithCleanup(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -67671,7 +67519,7 @@ int lua_ax_base_ParticleBatchNode_disableParticle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -67721,7 +67569,7 @@ int lua_ax_base_ParticleBatchNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67768,7 +67616,7 @@ int lua_ax_base_ParticleBatchNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -67818,7 +67666,7 @@ int lua_ax_base_ParticleBatchNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -67865,7 +67713,7 @@ int lua_ax_base_ParticleBatchNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -67915,7 +67763,7 @@ int lua_ax_base_ParticleBatchNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -67965,7 +67813,7 @@ int lua_ax_base_ParticleBatchNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68012,7 +67860,7 @@ int lua_ax_base_ParticleBatchNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         int arg1;
@@ -68065,7 +67913,7 @@ int lua_ax_base_ParticleBatchNode_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         int arg1;
@@ -68207,7 +68055,7 @@ int lua_ax_base_ParticleBatchNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68310,7 +68158,7 @@ int lua_ax_base_SpriteFrameCache_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68488,7 +68336,7 @@ int lua_ax_base_SpriteFrameCache_addSpriteFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::SpriteFrame* arg0;
         std::string_view arg1;
@@ -68541,7 +68389,7 @@ int lua_ax_base_SpriteFrameCache_isSpriteFramesWithFileLoaded(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68591,7 +68439,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68638,7 +68486,7 @@ int lua_ax_base_SpriteFrameCache_removeUnusedSpriteFrames(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68685,7 +68533,7 @@ int lua_ax_base_SpriteFrameCache_removeUnusedSpriteSheets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -68732,7 +68580,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFrameByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68782,7 +68630,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68832,7 +68680,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromFileContent(lua_State* to
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68882,7 +68730,7 @@ int lua_ax_base_SpriteFrameCache_removeSpriteFramesFromTexture(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -68932,7 +68780,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteFrameByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -68982,7 +68830,7 @@ int lua_ax_base_SpriteFrameCache_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -69032,7 +68880,7 @@ int lua_ax_base_SpriteFrameCache_findFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -69082,7 +68930,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteFrameName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -69132,7 +68980,7 @@ int lua_ax_base_SpriteFrameCache_eraseFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -69182,7 +69030,7 @@ int lua_ax_base_SpriteFrameCache_addSpriteFrameCapInset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::SpriteFrame* arg0;
         ax::Rect arg1;
@@ -69238,7 +69086,7 @@ int lua_ax_base_SpriteFrameCache_deregisterSpriteSheetLoader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -69288,7 +69136,7 @@ int lua_ax_base_SpriteFrameCache_getSpriteSheetLoader(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -69446,7 +69294,7 @@ int lua_ax_base_ParticleData_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -69496,7 +69344,7 @@ int lua_ax_base_ParticleData_release(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69543,7 +69391,7 @@ int lua_ax_base_ParticleData_getMaxCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69590,7 +69438,7 @@ int lua_ax_base_ParticleData_copyParticle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         int arg1;
@@ -69630,7 +69478,7 @@ int lua_ax_base_ParticleData_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -69964,7 +69812,7 @@ int lua_ax_base_ParticleEmissionMaskCache_removeMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -70014,7 +69862,7 @@ int lua_ax_base_ParticleEmissionMaskCache_removeAllMasks(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70119,7 +69967,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -70133,7 +69981,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         int arg1;
@@ -70150,7 +69998,7 @@ int lua_ax_base_ParticleSystem_addParticles(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         int arg0;
         int arg1;
@@ -70206,7 +70054,7 @@ int lua_ax_base_ParticleSystem_stopSystem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70253,7 +70101,7 @@ int lua_ax_base_ParticleSystem_resetSystem(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70300,7 +70148,7 @@ int lua_ax_base_ParticleSystem_isFull(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70347,7 +70195,7 @@ int lua_ax_base_ParticleSystem_updateParticleQuads(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70394,7 +70242,7 @@ int lua_ax_base_ParticleSystem_postStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70441,7 +70289,7 @@ int lua_ax_base_ParticleSystem_updateWithNoTime(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70488,7 +70336,7 @@ int lua_ax_base_ParticleSystem_isAutoRemoveOnFinish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70535,7 +70383,7 @@ int lua_ax_base_ParticleSystem_setAutoRemoveOnFinish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -70585,7 +70433,7 @@ int lua_ax_base_ParticleSystem_getGravity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70632,7 +70480,7 @@ int lua_ax_base_ParticleSystem_setGravity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -70682,7 +70530,7 @@ int lua_ax_base_ParticleSystem_getSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70729,7 +70577,7 @@ int lua_ax_base_ParticleSystem_setSpeed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70779,7 +70627,7 @@ int lua_ax_base_ParticleSystem_getSpeedVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70826,7 +70674,7 @@ int lua_ax_base_ParticleSystem_setSpeedVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70876,7 +70724,7 @@ int lua_ax_base_ParticleSystem_getTangentialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -70923,7 +70771,7 @@ int lua_ax_base_ParticleSystem_setTangentialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -70973,7 +70821,7 @@ int lua_ax_base_ParticleSystem_getTangentialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71020,7 +70868,7 @@ int lua_ax_base_ParticleSystem_setTangentialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71070,7 +70918,7 @@ int lua_ax_base_ParticleSystem_getRadialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71117,7 +70965,7 @@ int lua_ax_base_ParticleSystem_setRadialAccel(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71167,7 +71015,7 @@ int lua_ax_base_ParticleSystem_getRadialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71214,7 +71062,7 @@ int lua_ax_base_ParticleSystem_setRadialAccelVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71264,7 +71112,7 @@ int lua_ax_base_ParticleSystem_getRotationIsDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71311,7 +71159,7 @@ int lua_ax_base_ParticleSystem_setRotationIsDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -71361,7 +71209,7 @@ int lua_ax_base_ParticleSystem_getStartRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71408,7 +71256,7 @@ int lua_ax_base_ParticleSystem_setStartRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71458,7 +71306,7 @@ int lua_ax_base_ParticleSystem_getStartRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71505,7 +71353,7 @@ int lua_ax_base_ParticleSystem_setStartRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71555,7 +71403,7 @@ int lua_ax_base_ParticleSystem_getEndRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71602,7 +71450,7 @@ int lua_ax_base_ParticleSystem_setEndRadius(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71652,7 +71500,7 @@ int lua_ax_base_ParticleSystem_getEndRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71699,7 +71547,7 @@ int lua_ax_base_ParticleSystem_setEndRadiusVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71749,7 +71597,7 @@ int lua_ax_base_ParticleSystem_getRotatePerSecond(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71796,7 +71644,7 @@ int lua_ax_base_ParticleSystem_setRotatePerSecond(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71846,7 +71694,7 @@ int lua_ax_base_ParticleSystem_getRotatePerSecondVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71893,7 +71741,7 @@ int lua_ax_base_ParticleSystem_setRotatePerSecondVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -71943,7 +71791,7 @@ int lua_ax_base_ParticleSystem_isActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -71990,7 +71838,7 @@ int lua_ax_base_ParticleSystem_isBlendAdditive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72037,7 +71885,7 @@ int lua_ax_base_ParticleSystem_setBlendAdditive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -72087,7 +71935,7 @@ int lua_ax_base_ParticleSystem_getBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72134,7 +71982,7 @@ int lua_ax_base_ParticleSystem_setBatchNode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ParticleBatchNode* arg0;
 
@@ -72184,7 +72032,7 @@ int lua_ax_base_ParticleSystem_getAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72231,7 +72079,7 @@ int lua_ax_base_ParticleSystem_setAtlasIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -72281,7 +72129,7 @@ int lua_ax_base_ParticleSystem_getParticleCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72328,7 +72176,7 @@ int lua_ax_base_ParticleSystem_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72375,7 +72223,7 @@ int lua_ax_base_ParticleSystem_setDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72425,7 +72273,7 @@ int lua_ax_base_ParticleSystem_getSourcePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72472,7 +72320,7 @@ int lua_ax_base_ParticleSystem_setSourcePosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -72522,7 +72370,7 @@ int lua_ax_base_ParticleSystem_getPosVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72569,7 +72417,7 @@ int lua_ax_base_ParticleSystem_setPosVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -72619,7 +72467,7 @@ int lua_ax_base_ParticleSystem_getLife(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72666,7 +72514,7 @@ int lua_ax_base_ParticleSystem_setLife(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72716,7 +72564,7 @@ int lua_ax_base_ParticleSystem_getLifeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72763,7 +72611,7 @@ int lua_ax_base_ParticleSystem_setLifeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72813,7 +72661,7 @@ int lua_ax_base_ParticleSystem_getAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72860,7 +72708,7 @@ int lua_ax_base_ParticleSystem_setAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -72910,7 +72758,7 @@ int lua_ax_base_ParticleSystem_getAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -72957,7 +72805,7 @@ int lua_ax_base_ParticleSystem_setAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73007,7 +72855,7 @@ int lua_ax_base_ParticleSystem_getEmitterMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73054,7 +72902,7 @@ int lua_ax_base_ParticleSystem_setEmitterMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ParticleSystem::Mode arg0;
 
@@ -73104,7 +72952,7 @@ int lua_ax_base_ParticleSystem_getStartSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73151,7 +72999,7 @@ int lua_ax_base_ParticleSystem_setStartSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73201,7 +73049,7 @@ int lua_ax_base_ParticleSystem_getStartSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73248,7 +73096,7 @@ int lua_ax_base_ParticleSystem_setStartSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73298,7 +73146,7 @@ int lua_ax_base_ParticleSystem_getEndSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73345,7 +73193,7 @@ int lua_ax_base_ParticleSystem_setEndSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73395,7 +73243,7 @@ int lua_ax_base_ParticleSystem_getEndSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73442,7 +73290,7 @@ int lua_ax_base_ParticleSystem_setEndSizeVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -73492,7 +73340,7 @@ int lua_ax_base_ParticleSystem_getStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73539,7 +73387,7 @@ int lua_ax_base_ParticleSystem_setStartColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73589,7 +73437,7 @@ int lua_ax_base_ParticleSystem_getStartColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73636,7 +73484,7 @@ int lua_ax_base_ParticleSystem_setStartColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73686,7 +73534,7 @@ int lua_ax_base_ParticleSystem_getEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73733,7 +73581,7 @@ int lua_ax_base_ParticleSystem_setEndColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73783,7 +73631,7 @@ int lua_ax_base_ParticleSystem_getEndColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73830,7 +73678,7 @@ int lua_ax_base_ParticleSystem_setEndColorVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -73880,7 +73728,7 @@ int lua_ax_base_ParticleSystem_useHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -73930,7 +73778,7 @@ int lua_ax_base_ParticleSystem_isHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -73977,7 +73825,7 @@ int lua_ax_base_ParticleSystem_getHue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74024,7 +73872,7 @@ int lua_ax_base_ParticleSystem_setHue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74074,7 +73922,7 @@ int lua_ax_base_ParticleSystem_getHueVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74121,7 +73969,7 @@ int lua_ax_base_ParticleSystem_setHueVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74171,7 +74019,7 @@ int lua_ax_base_ParticleSystem_getHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74218,7 +74066,7 @@ int lua_ax_base_ParticleSystem_setHSV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::HSV arg0;
 
@@ -74269,7 +74117,7 @@ int lua_ax_base_ParticleSystem_getHSVVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74316,7 +74164,7 @@ int lua_ax_base_ParticleSystem_setHSVVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::HSV arg0;
 
@@ -74367,7 +74215,7 @@ int lua_ax_base_ParticleSystem_getStartSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74414,7 +74262,7 @@ int lua_ax_base_ParticleSystem_setStartSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74464,7 +74312,7 @@ int lua_ax_base_ParticleSystem_getStartSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74511,7 +74359,7 @@ int lua_ax_base_ParticleSystem_setStartSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74561,7 +74409,7 @@ int lua_ax_base_ParticleSystem_getEndSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74608,7 +74456,7 @@ int lua_ax_base_ParticleSystem_setEndSpin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74658,7 +74506,7 @@ int lua_ax_base_ParticleSystem_getEndSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74705,7 +74553,7 @@ int lua_ax_base_ParticleSystem_setEndSpinVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74755,7 +74603,7 @@ int lua_ax_base_ParticleSystem_getSpawnAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74802,7 +74650,7 @@ int lua_ax_base_ParticleSystem_setSpawnAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74852,7 +74700,7 @@ int lua_ax_base_ParticleSystem_getSpawnAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74899,7 +74747,7 @@ int lua_ax_base_ParticleSystem_setSpawnAngleVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -74949,7 +74797,7 @@ int lua_ax_base_ParticleSystem_getSpawnFadeIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -74996,7 +74844,7 @@ int lua_ax_base_ParticleSystem_setSpawnFadeIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75046,7 +74894,7 @@ int lua_ax_base_ParticleSystem_getSpawnFadeInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75093,7 +74941,7 @@ int lua_ax_base_ParticleSystem_setSpawnFadeInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75143,7 +74991,7 @@ int lua_ax_base_ParticleSystem_getSpawnScaleIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75190,7 +75038,7 @@ int lua_ax_base_ParticleSystem_setSpawnScaleIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75240,7 +75088,7 @@ int lua_ax_base_ParticleSystem_getSpawnScaleInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75287,7 +75135,7 @@ int lua_ax_base_ParticleSystem_setSpawnScaleInVar(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75337,7 +75185,7 @@ int lua_ax_base_ParticleSystem_getEmissionRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75384,7 +75232,7 @@ int lua_ax_base_ParticleSystem_setEmissionRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -75434,7 +75282,7 @@ int lua_ax_base_ParticleSystem_getTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75481,7 +75329,7 @@ int lua_ax_base_ParticleSystem_setTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -75531,7 +75379,7 @@ int lua_ax_base_ParticleSystem_setLifeAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75581,7 +75429,7 @@ int lua_ax_base_ParticleSystem_setEmitterAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75631,7 +75479,7 @@ int lua_ax_base_ParticleSystem_setLoopAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75681,7 +75529,7 @@ int lua_ax_base_ParticleSystem_isLifeAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75728,7 +75576,7 @@ int lua_ax_base_ParticleSystem_isEmitterAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75775,7 +75623,7 @@ int lua_ax_base_ParticleSystem_isLoopAnimated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75822,7 +75670,7 @@ int lua_ax_base_ParticleSystem_getTotalAnimationIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75869,7 +75717,7 @@ int lua_ax_base_ParticleSystem_setAnimationReverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -75919,7 +75767,7 @@ int lua_ax_base_ParticleSystem_isAnimationReversed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -75966,7 +75814,7 @@ int lua_ax_base_ParticleSystem_resetAnimationIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76013,7 +75861,7 @@ int lua_ax_base_ParticleSystem_resetAnimationDescriptors(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76060,7 +75908,7 @@ int lua_ax_base_ParticleSystem_setMultiAnimationRandomSpecific(lua_State* tolua_
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::vector<unsigned short> arg0;
 
@@ -76110,7 +75958,7 @@ int lua_ax_base_ParticleSystem_setMultiAnimationRandom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76347,7 +76195,7 @@ int lua_ax_base_ParticleSystem_setRectForUndefinedIndices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -76508,7 +76356,7 @@ int lua_ax_base_ParticleSystem_setAnimationSpeedTimescaleIndependent(lua_State* 
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -76558,7 +76406,7 @@ int lua_ax_base_ParticleSystem_isAnimationSpeedTimescaleIndependent(lua_State* t
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76605,7 +76453,7 @@ int lua_ax_base_ParticleSystem_setEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -76655,7 +76503,7 @@ int lua_ax_base_ParticleSystem_isEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76702,7 +76550,7 @@ int lua_ax_base_ParticleSystem_resetEmissionShapes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76749,7 +76597,7 @@ int lua_ax_base_ParticleSystem_addEmissionShape(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EmissionShape arg0;
 
@@ -76800,7 +76648,7 @@ int lua_ax_base_ParticleSystem_setEmissionShape(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned short arg0;
         ax::EmissionShape arg1;
@@ -76854,7 +76702,7 @@ int lua_ax_base_ParticleSystem_getPositionType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76901,7 +76749,7 @@ int lua_ax_base_ParticleSystem_setPositionType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ParticleSystem::PositionType arg0;
 
@@ -76951,7 +76799,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -76962,7 +76810,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -76976,7 +76824,7 @@ int lua_ax_base_ParticleSystem_simulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -77029,7 +76877,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77040,7 +76888,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -77054,7 +76902,7 @@ int lua_ax_base_ParticleSystem_resimulate(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         double arg1;
@@ -77107,7 +76955,7 @@ int lua_ax_base_ParticleSystem_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77154,7 +77002,7 @@ int lua_ax_base_ParticleSystem_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -77204,7 +77052,7 @@ int lua_ax_base_ParticleSystem_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -77254,7 +77102,7 @@ int lua_ax_base_ParticleSystem_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77301,7 +77149,7 @@ int lua_ax_base_ParticleSystem_getResourceFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77348,7 +77196,7 @@ int lua_ax_base_ParticleSystem_start(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77395,7 +77243,7 @@ int lua_ax_base_ParticleSystem_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77442,7 +77290,7 @@ int lua_ax_base_ParticleSystem_setSourcePositionCompatible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -77492,7 +77340,7 @@ int lua_ax_base_ParticleSystem_isSourcePositionCompatible(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77539,7 +77387,7 @@ int lua_ax_base_ParticleSystem_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -77648,7 +77496,7 @@ int lua_ax_base_ParticleSystem_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -77698,7 +77546,7 @@ int lua_ax_base_ParticleSystem_isPaused(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77745,7 +77593,7 @@ int lua_ax_base_ParticleSystem_pauseEmissions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77792,7 +77640,7 @@ int lua_ax_base_ParticleSystem_resumeEmissions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77839,7 +77687,7 @@ int lua_ax_base_ParticleSystem_getFixedFPS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77886,7 +77734,7 @@ int lua_ax_base_ParticleSystem_setFixedFPS(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77897,7 +77745,7 @@ int lua_ax_base_ParticleSystem_setFixedFPS(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -77947,7 +77795,7 @@ int lua_ax_base_ParticleSystem_getTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -77994,7 +77842,7 @@ int lua_ax_base_ParticleSystem_setTimeScale(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -78005,7 +77853,7 @@ int lua_ax_base_ParticleSystem_setTimeScale(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -78614,7 +78462,7 @@ int lua_ax_base_ParticleSystem_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -78853,7 +78701,7 @@ int lua_ax_base_ParticleSystemQuad_setDisplayFrame(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::SpriteFrame* arg0;
 
@@ -78903,7 +78751,7 @@ int lua_ax_base_ParticleSystemQuad_setTextureWithRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         ax::Rect arg1;
@@ -78956,7 +78804,7 @@ int lua_ax_base_ParticleSystemQuad_listenRendererRecreated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::EventCustom* arg0;
 
@@ -78994,7 +78842,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -79007,7 +78855,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -79017,7 +78865,7 @@ int lua_ax_base_ParticleSystemQuad_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -79087,7 +78935,7 @@ int lua_ax_base_ParticleSystemQuad_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79219,7 +79067,7 @@ int lua_ax_base_ParticleFire_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79291,7 +79139,7 @@ int lua_ax_base_ParticleFireworks_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79338,7 +79186,7 @@ int lua_ax_base_ParticleFireworks_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79445,7 +79293,7 @@ int lua_ax_base_ParticleFireworks_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79519,7 +79367,7 @@ int lua_ax_base_ParticleSun_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79566,7 +79414,7 @@ int lua_ax_base_ParticleSun_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79673,7 +79521,7 @@ int lua_ax_base_ParticleSun_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79747,7 +79595,7 @@ int lua_ax_base_ParticleGalaxy_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79794,7 +79642,7 @@ int lua_ax_base_ParticleGalaxy_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -79901,7 +79749,7 @@ int lua_ax_base_ParticleGalaxy_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -79975,7 +79823,7 @@ int lua_ax_base_ParticleFlower_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80022,7 +79870,7 @@ int lua_ax_base_ParticleFlower_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80129,7 +79977,7 @@ int lua_ax_base_ParticleFlower_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80203,7 +80051,7 @@ int lua_ax_base_ParticleMeteor_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80250,7 +80098,7 @@ int lua_ax_base_ParticleMeteor_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80357,7 +80205,7 @@ int lua_ax_base_ParticleMeteor_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80431,7 +80279,7 @@ int lua_ax_base_ParticleSpiral_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80478,7 +80326,7 @@ int lua_ax_base_ParticleSpiral_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80585,7 +80433,7 @@ int lua_ax_base_ParticleSpiral_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80659,7 +80507,7 @@ int lua_ax_base_ParticleExplosion_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80706,7 +80554,7 @@ int lua_ax_base_ParticleExplosion_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -80813,7 +80661,7 @@ int lua_ax_base_ParticleExplosion_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80887,7 +80735,7 @@ int lua_ax_base_ParticleSmoke_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -80934,7 +80782,7 @@ int lua_ax_base_ParticleSmoke_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -81041,7 +80889,7 @@ int lua_ax_base_ParticleSmoke_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81115,7 +80963,7 @@ int lua_ax_base_ParticleSnow_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81162,7 +81010,7 @@ int lua_ax_base_ParticleSnow_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -81269,7 +81117,7 @@ int lua_ax_base_ParticleSnow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81343,7 +81191,7 @@ int lua_ax_base_ParticleRain_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81390,7 +81238,7 @@ int lua_ax_base_ParticleRain_initWithTotalParticles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -81497,7 +81345,7 @@ int lua_ax_base_ParticleRain_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81571,7 +81419,7 @@ int lua_ax_base_ProgressTimer_getType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81618,7 +81466,7 @@ int lua_ax_base_ProgressTimer_getPercentage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81665,7 +81513,7 @@ int lua_ax_base_ProgressTimer_getSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81712,7 +81560,7 @@ int lua_ax_base_ProgressTimer_setPercentage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -81762,7 +81610,7 @@ int lua_ax_base_ProgressTimer_setSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -81812,7 +81660,7 @@ int lua_ax_base_ProgressTimer_setType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ProgressTimer::Type arg0;
 
@@ -81862,7 +81710,7 @@ int lua_ax_base_ProgressTimer_isReverseDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -81909,7 +81757,7 @@ int lua_ax_base_ProgressTimer_setReverseDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -81959,7 +81807,7 @@ int lua_ax_base_ProgressTimer_setMidpoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -82009,7 +81857,7 @@ int lua_ax_base_ProgressTimer_getMidpoint(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82056,7 +81904,7 @@ int lua_ax_base_ProgressTimer_setBarChangeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -82106,7 +81954,7 @@ int lua_ax_base_ProgressTimer_getBarChangeRate(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82153,7 +82001,7 @@ int lua_ax_base_ProgressTimer_initWithSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -82226,7 +82074,7 @@ int lua_ax_base_ProgressTimer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82389,7 +82237,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -82439,7 +82287,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -82489,7 +82337,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -82503,7 +82351,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChild(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         bool arg1;
@@ -82556,7 +82404,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChildByTag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -82570,7 +82418,7 @@ int lua_ax_base_ProtectedNode_removeProtectedChildByTag(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         int arg0;
         bool arg1;
@@ -82623,7 +82471,7 @@ int lua_ax_base_ProtectedNode_removeAllProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82670,7 +82518,7 @@ int lua_ax_base_ProtectedNode_removeAllProtectedChildrenWithCleanup(lua_State* t
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -82720,7 +82568,7 @@ int lua_ax_base_ProtectedNode_reorderProtectedChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Node* arg0;
         int arg1;
@@ -82773,7 +82621,7 @@ int lua_ax_base_ProtectedNode_sortAllProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82820,7 +82668,7 @@ int lua_ax_base_ProtectedNode_getProtectedChildren(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82867,7 +82715,7 @@ int lua_ax_base_ProtectedNode_disableCascadeColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82914,7 +82762,7 @@ int lua_ax_base_ProtectedNode_disableCascadeOpacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -82982,7 +82830,7 @@ int lua_ax_base_ProtectedNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83065,7 +82913,7 @@ int lua_ax_base_RenderTexture_begin(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83227,7 +83075,7 @@ int lua_ax_base_RenderTexture_end(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83274,7 +83122,7 @@ int lua_ax_base_RenderTexture_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -83333,7 +83181,7 @@ int lua_ax_base_RenderTexture_clearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -83383,7 +83231,7 @@ int lua_ax_base_RenderTexture_clearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -83691,7 +83539,7 @@ int lua_ax_base_RenderTexture_getClearFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83738,7 +83586,7 @@ int lua_ax_base_RenderTexture_setClearFlags(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::TargetBufferFlags arg0;
 
@@ -83788,7 +83636,7 @@ int lua_ax_base_RenderTexture_getClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83835,7 +83683,7 @@ int lua_ax_base_RenderTexture_setClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -83885,7 +83733,7 @@ int lua_ax_base_RenderTexture_getClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -83932,7 +83780,7 @@ int lua_ax_base_RenderTexture_setClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -83982,7 +83830,7 @@ int lua_ax_base_RenderTexture_getClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84029,7 +83877,7 @@ int lua_ax_base_RenderTexture_setClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -84079,7 +83927,7 @@ int lua_ax_base_RenderTexture_isAutoDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84126,7 +83974,7 @@ int lua_ax_base_RenderTexture_setAutoDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -84176,7 +84024,7 @@ int lua_ax_base_RenderTexture_getSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84223,7 +84071,7 @@ int lua_ax_base_RenderTexture_getRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84270,7 +84118,7 @@ int lua_ax_base_RenderTexture_setKeepMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -84320,7 +84168,7 @@ int lua_ax_base_RenderTexture_setVirtualViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Vec2 arg0;
         ax::Rect arg1;
@@ -84376,7 +84224,7 @@ int lua_ax_base_RenderTexture_isSharedRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84538,7 +84386,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -84557,7 +84405,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -84579,7 +84427,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -84601,7 +84449,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -84626,7 +84474,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -84642,7 +84490,7 @@ int lua_ax_base_RenderTexture_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -84682,7 +84530,7 @@ int lua_ax_base_RenderTexture_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84777,7 +84625,7 @@ int lua_ax_base_TransitionEaseScene_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -84847,7 +84695,7 @@ int lua_ax_base_TransitionScene_finish(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84894,7 +84742,7 @@ int lua_ax_base_TransitionScene_hideOutShowIn(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84941,7 +84789,7 @@ int lua_ax_base_TransitionScene_getInScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -84988,7 +84836,7 @@ int lua_ax_base_TransitionScene_getDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85035,7 +84883,7 @@ int lua_ax_base_TransitionScene_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         double arg0;
         ax::Scene* arg1;
@@ -85113,7 +84961,7 @@ int lua_ax_base_TransitionScene_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85189,7 +85037,7 @@ int lua_ax_base_TransitionSceneOriented_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Scene* arg1;
@@ -85272,7 +85120,7 @@ int lua_ax_base_TransitionSceneOriented_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85369,7 +85217,7 @@ int lua_ax_base_TransitionRotoZoom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85465,7 +85313,7 @@ int lua_ax_base_TransitionJumpZoom_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85536,7 +85384,7 @@ int lua_ax_base_TransitionMoveInL_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85583,7 +85431,7 @@ int lua_ax_base_TransitionMoveInL_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -85658,7 +85506,7 @@ int lua_ax_base_TransitionMoveInL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85756,7 +85604,7 @@ int lua_ax_base_TransitionMoveInR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85852,7 +85700,7 @@ int lua_ax_base_TransitionMoveInT_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -85948,7 +85796,7 @@ int lua_ax_base_TransitionMoveInB_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86019,7 +85867,7 @@ int lua_ax_base_TransitionSlideInL_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -86069,7 +85917,7 @@ int lua_ax_base_TransitionSlideInL_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86141,7 +85989,7 @@ int lua_ax_base_TransitionSlideInL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86239,7 +86087,7 @@ int lua_ax_base_TransitionSlideInR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86335,7 +86183,7 @@ int lua_ax_base_TransitionSlideInB_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86431,7 +86279,7 @@ int lua_ax_base_TransitionSlideInT_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86502,7 +86350,7 @@ int lua_ax_base_TransitionShrinkGrow_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -86577,7 +86425,7 @@ int lua_ax_base_TransitionShrinkGrow_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86637,7 +86485,7 @@ int lua_ax_base_TransitionFlipX_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86653,7 +86501,7 @@ int lua_ax_base_TransitionFlipX_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86693,7 +86541,7 @@ int lua_ax_base_TransitionFlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86752,7 +86600,7 @@ int lua_ax_base_TransitionFlipY_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86768,7 +86616,7 @@ int lua_ax_base_TransitionFlipY_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86808,7 +86656,7 @@ int lua_ax_base_TransitionFlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86867,7 +86715,7 @@ int lua_ax_base_TransitionFlipAngular_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86883,7 +86731,7 @@ int lua_ax_base_TransitionFlipAngular_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -86923,7 +86771,7 @@ int lua_ax_base_TransitionFlipAngular_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -86982,7 +86830,7 @@ int lua_ax_base_TransitionZoomFlipX_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -86998,7 +86846,7 @@ int lua_ax_base_TransitionZoomFlipX_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -87038,7 +86886,7 @@ int lua_ax_base_TransitionZoomFlipX_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87097,7 +86945,7 @@ int lua_ax_base_TransitionZoomFlipY_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -87113,7 +86961,7 @@ int lua_ax_base_TransitionZoomFlipY_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -87153,7 +87001,7 @@ int lua_ax_base_TransitionZoomFlipY_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87212,7 +87060,7 @@ int lua_ax_base_TransitionZoomFlipAngular_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -87228,7 +87076,7 @@ int lua_ax_base_TransitionZoomFlipAngular_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -87268,7 +87116,7 @@ int lua_ax_base_TransitionZoomFlipAngular_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87394,7 +87242,7 @@ int lua_ax_base_TransitionFade_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -87410,7 +87258,7 @@ int lua_ax_base_TransitionFade_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -87450,7 +87298,7 @@ int lua_ax_base_TransitionFade_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87547,7 +87395,7 @@ int lua_ax_base_TransitionCrossFade_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87618,7 +87466,7 @@ int lua_ax_base_TransitionTurnOffTiles_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -87693,7 +87541,7 @@ int lua_ax_base_TransitionTurnOffTiles_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87765,7 +87613,7 @@ int lua_ax_base_TransitionSplitCols_action(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87812,7 +87660,7 @@ int lua_ax_base_TransitionSplitCols_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -87887,7 +87735,7 @@ int lua_ax_base_TransitionSplitCols_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -87985,7 +87833,7 @@ int lua_ax_base_TransitionSplitRows_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88056,7 +87904,7 @@ int lua_ax_base_TransitionFadeTR_actionWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -88106,7 +87954,7 @@ int lua_ax_base_TransitionFadeTR_easeActionWithAction(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ActionInterval* arg0;
 
@@ -88181,7 +88029,7 @@ int lua_ax_base_TransitionFadeTR_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88279,7 +88127,7 @@ int lua_ax_base_TransitionFadeBL_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88375,7 +88223,7 @@ int lua_ax_base_TransitionFadeUp_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88471,7 +88319,7 @@ int lua_ax_base_TransitionFadeDown_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88542,7 +88390,7 @@ int lua_ax_base_TransitionPageTurn_initWithDuration(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         double arg0;
         ax::Scene* arg1;
@@ -88598,7 +88446,7 @@ int lua_ax_base_TransitionPageTurn_actionWithSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -88675,7 +88523,7 @@ int lua_ax_base_TransitionPageTurn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88773,7 +88621,7 @@ int lua_ax_base_TransitionProgress_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88869,7 +88717,7 @@ int lua_ax_base_TransitionProgressRadialCCW_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -88965,7 +88813,7 @@ int lua_ax_base_TransitionProgressRadialCW_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89061,7 +88909,7 @@ int lua_ax_base_TransitionProgressHorizontal_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89157,7 +89005,7 @@ int lua_ax_base_TransitionProgressVertical_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89253,7 +89101,7 @@ int lua_ax_base_TransitionProgressInOut_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89349,7 +89197,7 @@ int lua_ax_base_TransitionProgressOutIn_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89420,7 +89268,7 @@ int lua_ax_base_Camera_getCameraFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89467,7 +89315,7 @@ int lua_ax_base_Camera_setCameraFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::CameraFlag arg0;
 
@@ -89517,7 +89365,7 @@ int lua_ax_base_Camera_lookAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -89531,7 +89379,7 @@ int lua_ax_base_Camera_lookAt(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Vec3 arg0;
         ax::Vec3 arg1;
@@ -89584,7 +89432,7 @@ int lua_ax_base_Camera_getProjectionMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89631,7 +89479,7 @@ int lua_ax_base_Camera_getViewMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89678,7 +89526,7 @@ int lua_ax_base_Camera_getViewProjectionMatrix(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -89725,7 +89573,7 @@ int lua_ax_base_Camera_project(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -89775,7 +89623,7 @@ int lua_ax_base_Camera_projectGL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -89825,7 +89673,7 @@ int lua_ax_base_Camera_isVisibleInFrustum(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         const ax::AABB* arg0;
 
@@ -89875,7 +89723,7 @@ int lua_ax_base_Camera_getDepthInView(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -89925,7 +89773,7 @@ int lua_ax_base_Camera_setDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int32_t arg0;
 
@@ -89975,7 +89823,7 @@ int lua_ax_base_Camera_getDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90022,7 +89870,7 @@ int lua_ax_base_Camera_getRenderOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90069,7 +89917,7 @@ int lua_ax_base_Camera_getFOV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90116,7 +89964,7 @@ int lua_ax_base_Camera_setFOV(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90166,7 +90014,7 @@ int lua_ax_base_Camera_getFarPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90213,7 +90061,7 @@ int lua_ax_base_Camera_setFarPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90263,7 +90111,7 @@ int lua_ax_base_Camera_getNearPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90310,7 +90158,7 @@ int lua_ax_base_Camera_setNearPlane(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90360,7 +90208,7 @@ int lua_ax_base_Camera_getZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90407,7 +90255,7 @@ int lua_ax_base_Camera_setZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -90457,7 +90305,7 @@ int lua_ax_base_Camera_applyZoom(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90504,7 +90352,7 @@ int lua_ax_base_Camera_clearBackground(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90551,7 +90399,7 @@ int lua_ax_base_Camera_apply(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90598,7 +90446,7 @@ int lua_ax_base_Camera_isViewProjectionUpdated(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90645,7 +90493,7 @@ int lua_ax_base_Camera_setBackgroundBrush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::CameraBackgroundBrush* arg0;
 
@@ -90695,7 +90543,7 @@ int lua_ax_base_Camera_getBackgroundBrush(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90742,7 +90590,7 @@ int lua_ax_base_Camera_isBrushValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90789,7 +90637,7 @@ int lua_ax_base_Camera_setScene(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Scene* arg0;
 
@@ -90839,7 +90687,7 @@ int lua_ax_base_Camera_setAdditionalProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -90889,7 +90737,7 @@ int lua_ax_base_Camera_initDefault(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -90936,7 +90784,7 @@ int lua_ax_base_Camera_initPerspective(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -90995,7 +90843,7 @@ int lua_ax_base_Camera_initOrthographic(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -91054,7 +90902,7 @@ int lua_ax_base_Camera_applyViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91345,7 +91193,7 @@ int lua_ax_base_Camera_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91456,7 +91304,7 @@ int lua_ax_base_CameraBackgroundBrush_getBrushType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91503,7 +91351,7 @@ int lua_ax_base_CameraBackgroundBrush_drawBackground(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Camera* arg0;
 
@@ -91553,7 +91401,7 @@ int lua_ax_base_CameraBackgroundBrush_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91600,7 +91448,7 @@ int lua_ax_base_CameraBackgroundBrush_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91799,7 +91647,7 @@ int lua_ax_base_CameraBackgroundBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -91877,7 +91725,7 @@ int lua_ax_base_CameraBackgroundDepthBrush_setDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -91950,7 +91798,7 @@ int lua_ax_base_CameraBackgroundDepthBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92022,7 +91870,7 @@ int lua_ax_base_CameraBackgroundColorBrush_setColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color arg0;
 
@@ -92097,7 +91945,7 @@ int lua_ax_base_CameraBackgroundColorBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92169,7 +92017,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureCube* arg0;
 
@@ -92219,7 +92067,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92266,7 +92114,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_isActived(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92313,7 +92161,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setActived(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -92363,7 +92211,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_setTextureValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -92401,7 +92249,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 0)
         {
@@ -92411,7 +92259,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 6)
         {
@@ -92460,7 +92308,7 @@ int lua_ax_base_CameraBackgroundSkyBoxBrush_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92536,7 +92384,7 @@ int lua_ax_base_GridBase_beforeBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92583,7 +92431,7 @@ int lua_ax_base_GridBase_afterBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92630,7 +92478,7 @@ int lua_ax_base_GridBase_blit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92677,7 +92525,7 @@ int lua_ax_base_GridBase_reuse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92724,7 +92572,7 @@ int lua_ax_base_GridBase_calculateVertexPoints(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92874,7 +92722,7 @@ int lua_ax_base_GridBase_isActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -92921,7 +92769,7 @@ int lua_ax_base_GridBase_setActive(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -92971,7 +92819,7 @@ int lua_ax_base_GridBase_getReuseGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93018,7 +92866,7 @@ int lua_ax_base_GridBase_setReuseGrid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -93068,7 +92916,7 @@ int lua_ax_base_GridBase_getGridSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93115,7 +92963,7 @@ int lua_ax_base_GridBase_setGridSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -93165,7 +93013,7 @@ int lua_ax_base_GridBase_getStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93212,7 +93060,7 @@ int lua_ax_base_GridBase_setStep(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -93262,7 +93110,7 @@ int lua_ax_base_GridBase_isTextureFlipped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93309,7 +93157,7 @@ int lua_ax_base_GridBase_setTextureFlipped(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -93359,7 +93207,7 @@ int lua_ax_base_GridBase_beforeDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93406,7 +93254,7 @@ int lua_ax_base_GridBase_afterDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Node* arg0;
 
@@ -93456,7 +93304,7 @@ int lua_ax_base_GridBase_set2DProjection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93503,7 +93351,7 @@ int lua_ax_base_GridBase_setGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Rect arg0;
 
@@ -93553,7 +93401,7 @@ int lua_ax_base_GridBase_getGridRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93640,7 +93488,7 @@ int lua_ax_base_Grid3D_setNeedDepthTestForBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -93690,7 +93538,7 @@ int lua_ax_base_Grid3D_getNeedDepthTestForBlit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93725,7 +93573,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -93741,7 +93589,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -93754,7 +93602,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -93773,7 +93621,7 @@ int lua_ax_base_Grid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -93816,7 +93664,7 @@ int lua_ax_base_Grid3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -93877,7 +93725,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 2)
         {
@@ -93893,7 +93741,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 1)
         {
@@ -93906,7 +93754,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 3)
         {
@@ -93925,7 +93773,7 @@ int lua_ax_base_TiledGrid3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 4)
         {
@@ -94001,7 +93849,7 @@ int lua_ax_base_BaseLight_getLightType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94048,7 +93896,7 @@ int lua_ax_base_BaseLight_getIntensity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94095,7 +93943,7 @@ int lua_ax_base_BaseLight_setIntensity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -94145,7 +93993,7 @@ int lua_ax_base_BaseLight_getLightFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94192,7 +94040,7 @@ int lua_ax_base_BaseLight_setLightFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::LightFlag arg0;
 
@@ -94242,7 +94090,7 @@ int lua_ax_base_BaseLight_setEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -94292,7 +94140,7 @@ int lua_ax_base_BaseLight_isEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94365,7 +94213,7 @@ int lua_ax_base_DirectionLight_setDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -94415,7 +94263,7 @@ int lua_ax_base_DirectionLight_getDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94462,7 +94310,7 @@ int lua_ax_base_DirectionLight_getDirectionInWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94534,7 +94382,7 @@ int lua_ax_base_DirectionLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94608,7 +94456,7 @@ int lua_ax_base_PointLight_getRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94655,7 +94503,7 @@ int lua_ax_base_PointLight_setRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -94732,7 +94580,7 @@ int lua_ax_base_PointLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94805,7 +94653,7 @@ int lua_ax_base_SpotLight_setDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -94855,7 +94703,7 @@ int lua_ax_base_SpotLight_getDirection(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94902,7 +94750,7 @@ int lua_ax_base_SpotLight_getDirectionInWorld(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -94949,7 +94797,7 @@ int lua_ax_base_SpotLight_setRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -94999,7 +94847,7 @@ int lua_ax_base_SpotLight_getRange(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95046,7 +94894,7 @@ int lua_ax_base_SpotLight_setInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -95096,7 +94944,7 @@ int lua_ax_base_SpotLight_getInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95143,7 +94991,7 @@ int lua_ax_base_SpotLight_getCosInnerAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95190,7 +95038,7 @@ int lua_ax_base_SpotLight_setOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -95240,7 +95088,7 @@ int lua_ax_base_SpotLight_getOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95287,7 +95135,7 @@ int lua_ax_base_SpotLight_getCosOuterAngle(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95367,7 +95215,7 @@ int lua_ax_base_SpotLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95472,7 +95320,7 @@ int lua_ax_base_AmbientLight_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95543,7 +95391,7 @@ int lua_ax_base_RenderState_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95590,7 +95438,7 @@ int lua_ax_base_RenderState_bindPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Pass* arg0;
         ax::MeshCommand* arg1;
@@ -95664,7 +95512,7 @@ int lua_ax_base_Technique_addPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Pass* arg0;
 
@@ -95714,7 +95562,7 @@ int lua_ax_base_Technique_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95761,7 +95609,7 @@ int lua_ax_base_Technique_getPassByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -95811,7 +95659,7 @@ int lua_ax_base_Technique_getPassCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95858,7 +95706,7 @@ int lua_ax_base_Technique_getPasses(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95905,7 +95753,7 @@ int lua_ax_base_Technique_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -95952,7 +95800,7 @@ int lua_ax_base_Technique_setMaterial(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Material* arg0;
 
@@ -96104,7 +95952,7 @@ int lua_ax_base_Material_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8)
+    if (argc == 8) 
     {
         ax::MeshCommand* arg0;
         double arg1;
@@ -96175,7 +96023,7 @@ int lua_ax_base_Material_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96222,7 +96070,7 @@ int lua_ax_base_Material_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -96272,7 +96120,7 @@ int lua_ax_base_Material_getTechniqueByName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -96322,7 +96170,7 @@ int lua_ax_base_Material_getTechniqueByIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -96372,7 +96220,7 @@ int lua_ax_base_Material_getTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96419,7 +96267,7 @@ int lua_ax_base_Material_getTechniques(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96466,7 +96314,7 @@ int lua_ax_base_Material_getTechniqueCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96513,7 +96361,7 @@ int lua_ax_base_Material_addTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Technique* arg0;
 
@@ -96563,7 +96411,7 @@ int lua_ax_base_Material_setTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -96613,7 +96461,7 @@ int lua_ax_base_Material_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96660,7 +96508,7 @@ int lua_ax_base_Material_getRenderState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96707,7 +96555,7 @@ int lua_ax_base_Material_setPrimitiveType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::PrimitiveType arg0;
 
@@ -96757,7 +96605,7 @@ int lua_ax_base_Material_getPrimitiveType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96804,7 +96652,7 @@ int lua_ax_base_Material_setTransparent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -96854,7 +96702,7 @@ int lua_ax_base_Material_isTransparent(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -96901,7 +96749,7 @@ int lua_ax_base_Material_setForce2DQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -96951,7 +96799,7 @@ int lua_ax_base_Material_isForce2DQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97146,7 +96994,7 @@ int lua_ax_base_Pass_getProgramState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97193,7 +97041,7 @@ int lua_ax_base_Pass_draw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 8)
+    if (argc == 8) 
     {
         ax::MeshCommand* arg0;
         double arg1;
@@ -97264,7 +97112,7 @@ int lua_ax_base_Pass_setVertexInputBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::VertexInputBinding* arg0;
 
@@ -97314,7 +97162,7 @@ int lua_ax_base_Pass_getVertexAttributeBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97361,7 +97209,7 @@ int lua_ax_base_Pass_setName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -97411,7 +97259,7 @@ int lua_ax_base_Pass_getName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97458,7 +97306,7 @@ int lua_ax_base_Pass_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -97505,7 +97353,7 @@ int lua_ax_base_Pass_setTechnique(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Technique* arg0;
 
@@ -97555,7 +97403,7 @@ int lua_ax_base_Pass_updateMVPUniform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Mat4 arg0;
 
@@ -97605,7 +97453,7 @@ int lua_ax_base_Pass_setUniformTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::rhi::Texture* arg1;
@@ -97658,7 +97506,7 @@ int lua_ax_base_Pass_setUniformNormTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         ax::rhi::Texture* arg1;
@@ -97711,7 +97559,7 @@ int lua_ax_base_Pass_setUniformColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97765,7 +97613,7 @@ int lua_ax_base_Pass_setUniformMatrixPalette(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97819,7 +97667,7 @@ int lua_ax_base_Pass_setUniformDirLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97873,7 +97721,7 @@ int lua_ax_base_Pass_setUniformDirLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97927,7 +97775,7 @@ int lua_ax_base_Pass_setUniformPointLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -97981,7 +97829,7 @@ int lua_ax_base_Pass_setUniformPointLightPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98035,7 +97883,7 @@ int lua_ax_base_Pass_setUniformPointLightRangeInverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98089,7 +97937,7 @@ int lua_ax_base_Pass_setUniformSpotLightColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98143,7 +97991,7 @@ int lua_ax_base_Pass_setUniformSpotLightPosition(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98197,7 +98045,7 @@ int lua_ax_base_Pass_setUniformSpotLightDir(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98251,7 +98099,7 @@ int lua_ax_base_Pass_setUniformSpotLightInnerAngleCos(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98305,7 +98153,7 @@ int lua_ax_base_Pass_setUniformSpotLightOuterAngleCos(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98359,7 +98207,7 @@ int lua_ax_base_Pass_setUniformSpotLightRangeInverse(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98413,7 +98261,7 @@ int lua_ax_base_Pass_setUniformAmbientLigthColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         const void* arg0;
         unsigned int arg1;
@@ -98587,7 +98435,7 @@ int lua_ax_base_ProgramManager_getBuiltinProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -98637,7 +98485,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98654,7 +98502,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98674,7 +98522,7 @@ int lua_ax_base_ProgramManager_registerCustomProgram(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -98812,7 +98660,7 @@ int lua_ax_base_ProgramManager_unloadProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::Program* arg0;
 
@@ -98862,7 +98710,7 @@ int lua_ax_base_ProgramManager_unloadUnusedPrograms(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -98909,7 +98757,7 @@ int lua_ax_base_ProgramManager_unloadAllPrograms(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99088,7 +98936,7 @@ int lua_ax_base_Renderer_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99135,7 +98983,7 @@ int lua_ax_base_Renderer_addCallbackCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::function<void ()> arg0;
 
@@ -99153,7 +99001,7 @@ int lua_ax_base_Renderer_addCallbackCommand(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::function<void ()> arg0;
         double arg1;
@@ -99269,7 +99117,7 @@ int lua_ax_base_Renderer_getNextGroupCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99316,7 +99164,7 @@ int lua_ax_base_Renderer_pushGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -99366,7 +99214,7 @@ int lua_ax_base_Renderer_popGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99413,7 +99261,7 @@ int lua_ax_base_Renderer_createRenderQueue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99460,7 +99308,7 @@ int lua_ax_base_Renderer_render(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99507,7 +99355,7 @@ int lua_ax_base_Renderer_clean(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99554,7 +99402,7 @@ int lua_ax_base_Renderer_getDrawnBatches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99601,7 +99449,7 @@ int lua_ax_base_Renderer_addDrawnBatches(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -99651,7 +99499,7 @@ int lua_ax_base_Renderer_getDrawnVertices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99698,7 +99546,7 @@ int lua_ax_base_Renderer_addDrawnVertices(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -99748,7 +99596,7 @@ int lua_ax_base_Renderer_clearDrawStats(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99795,7 +99643,7 @@ int lua_ax_base_Renderer_getRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99842,7 +99690,7 @@ int lua_ax_base_Renderer_setRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::RenderTarget* arg0;
 
@@ -99892,7 +99740,7 @@ int lua_ax_base_Renderer_getDefaultRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99939,7 +99787,7 @@ int lua_ax_base_Renderer_getOffscreenRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -99986,7 +99834,7 @@ int lua_ax_base_Renderer_clear(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         ax::rhi::TargetBufferFlags arg0;
         ax::Color arg1;
@@ -100048,7 +99896,7 @@ int lua_ax_base_Renderer_getClearColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100095,7 +99943,7 @@ int lua_ax_base_Renderer_getClearDepth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100142,7 +99990,7 @@ int lua_ax_base_Renderer_getClearStencil(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100189,7 +100037,7 @@ int lua_ax_base_Renderer_getClearFlag(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100236,7 +100084,7 @@ int lua_ax_base_Renderer_setDepthTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -100286,7 +100134,7 @@ int lua_ax_base_Renderer_setDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -100336,7 +100184,7 @@ int lua_ax_base_Renderer_setDepthCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::CompareFunc arg0;
 
@@ -100386,7 +100234,7 @@ int lua_ax_base_Renderer_getDepthTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100433,7 +100281,7 @@ int lua_ax_base_Renderer_getDepthWrite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100480,7 +100328,7 @@ int lua_ax_base_Renderer_getDepthCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100527,7 +100375,7 @@ int lua_ax_base_Renderer_setStencilTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -100577,7 +100425,7 @@ int lua_ax_base_Renderer_setStencilCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::rhi::CompareFunc arg0;
         unsigned int arg1;
@@ -100633,7 +100481,7 @@ int lua_ax_base_Renderer_setStencilOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::rhi::StencilOp arg0;
         ax::rhi::StencilOp arg1;
@@ -100689,7 +100537,7 @@ int lua_ax_base_Renderer_setStencilWriteMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -100739,7 +100587,7 @@ int lua_ax_base_Renderer_getStencilTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100786,7 +100634,7 @@ int lua_ax_base_Renderer_getStencilFailureOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100833,7 +100681,7 @@ int lua_ax_base_Renderer_getStencilPassDepthFailureOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100880,7 +100728,7 @@ int lua_ax_base_Renderer_getStencilDepthPassOp(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100927,7 +100775,7 @@ int lua_ax_base_Renderer_getStencilCompareFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -100974,7 +100822,7 @@ int lua_ax_base_Renderer_getStencilReadMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101021,7 +100869,7 @@ int lua_ax_base_Renderer_getStencilWriteMask(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101068,7 +100916,7 @@ int lua_ax_base_Renderer_getStencilReferenceValue(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101115,7 +100963,7 @@ int lua_ax_base_Renderer_setDepthStencilDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::DepthStencilDesc arg0;
 
@@ -101166,7 +101014,7 @@ int lua_ax_base_Renderer_getDepthStencilDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101213,7 +101061,7 @@ int lua_ax_base_Renderer_setCullMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::CullMode arg0;
 
@@ -101263,7 +101111,7 @@ int lua_ax_base_Renderer_getCullMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101310,7 +101158,7 @@ int lua_ax_base_Renderer_setWinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::Winding arg0;
 
@@ -101360,7 +101208,7 @@ int lua_ax_base_Renderer_getWinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101407,7 +101255,7 @@ int lua_ax_base_Renderer_setViewPort(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         int arg0;
         int arg1;
@@ -101466,7 +101314,7 @@ int lua_ax_base_Renderer_getViewport(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101513,7 +101361,7 @@ int lua_ax_base_Renderer_setScissorTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -101563,7 +101411,7 @@ int lua_ax_base_Renderer_setScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         double arg0;
         double arg1;
@@ -101622,7 +101470,7 @@ int lua_ax_base_Renderer_getScissorTest(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101669,7 +101517,7 @@ int lua_ax_base_Renderer_getScissorRect(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101716,7 +101564,7 @@ int lua_ax_base_Renderer_checkVisibility(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Mat4 arg0;
         ax::Vec2 arg1;
@@ -101769,7 +101617,7 @@ int lua_ax_base_Renderer_readPixels(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::rhi::RenderTarget* arg0;
         std::function<void (const ax::rhi::PixelBufferDesc &)> arg1;
@@ -101826,7 +101674,7 @@ int lua_ax_base_Renderer_beginRenderPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101873,7 +101721,7 @@ int lua_ax_base_Renderer_endRenderPass(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101920,7 +101768,7 @@ int lua_ax_base_Renderer_nextCallbackCommand(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -101967,7 +101815,7 @@ int lua_ax_base_Renderer_resizeSwapChain(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         unsigned int arg0;
         unsigned int arg1;
@@ -102007,7 +101855,7 @@ int lua_ax_base_Renderer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102134,7 +101982,7 @@ int lua_ax_base_TextureCache_getDescription(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102236,7 +102084,7 @@ int lua_ax_base_TextureCache_getDummyTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102394,7 +102242,7 @@ int lua_ax_base_TextureCache_unbindImageAsync(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102444,7 +102292,7 @@ int lua_ax_base_TextureCache_unbindAllImageAsync(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102491,7 +102339,7 @@ int lua_ax_base_TextureCache_getTextureForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102541,7 +102389,7 @@ int lua_ax_base_TextureCache_reloadTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102591,7 +102439,7 @@ int lua_ax_base_TextureCache_removeAllTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102638,7 +102486,7 @@ int lua_ax_base_TextureCache_removeUnusedTextures(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102685,7 +102533,7 @@ int lua_ax_base_TextureCache_removeTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -102735,7 +102583,7 @@ int lua_ax_base_TextureCache_removeTextureForKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -102785,7 +102633,7 @@ int lua_ax_base_TextureCache_getCachedTextureInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102832,7 +102680,7 @@ int lua_ax_base_TextureCache_waitForQuit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -102879,7 +102727,7 @@ int lua_ax_base_TextureCache_getTextureFilePath(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -102929,7 +102777,7 @@ int lua_ax_base_TextureCache_renameTextureWithKey(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -103039,7 +102887,7 @@ int lua_ax_base_TextureCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103580,7 +103428,7 @@ int lua_ax_base_Application_setAnimationInterval(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -103630,7 +103478,7 @@ int lua_ax_base_Application_getCurrentLanguage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103677,7 +103525,7 @@ int lua_ax_base_Application_getCurrentLanguageCode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103724,7 +103572,7 @@ int lua_ax_base_Application_getTargetPlatform(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103771,7 +103619,7 @@ int lua_ax_base_Application_getVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -103818,7 +103666,7 @@ int lua_ax_base_Application_openURL(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104096,7 +103944,7 @@ int lua_ax_base_AnimationCache_init(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104143,7 +103991,7 @@ int lua_ax_base_AnimationCache_addAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Animation* arg0;
         std::string_view arg1;
@@ -104196,7 +104044,7 @@ int lua_ax_base_AnimationCache_removeAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104246,7 +104094,7 @@ int lua_ax_base_AnimationCache_getAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104296,7 +104144,7 @@ int lua_ax_base_AnimationCache_addAnimationsWithDictionary(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::ValueMap arg0;
         std::string_view arg1;
@@ -104349,7 +104197,7 @@ int lua_ax_base_AnimationCache_addAnimationsWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -104454,7 +104302,7 @@ int lua_ax_base_AnimationCache_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104530,7 +104378,7 @@ int lua_ax_base_SpriteBatchNode_getTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104577,7 +104425,7 @@ int lua_ax_base_SpriteBatchNode_setTextureAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TextureAtlas* arg0;
 
@@ -104627,7 +104475,7 @@ int lua_ax_base_SpriteBatchNode_increaseAtlasCapacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -104674,7 +104522,7 @@ int lua_ax_base_SpriteBatchNode_removeChildAtIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ssize_t arg0;
         bool arg1;
@@ -104727,7 +104575,7 @@ int lua_ax_base_SpriteBatchNode_appendChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104777,7 +104625,7 @@ int lua_ax_base_SpriteBatchNode_removeSpriteFromAtlas(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104827,7 +104675,7 @@ int lua_ax_base_SpriteBatchNode_rebuildIndexInOrder(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Sprite* arg0;
         ssize_t arg1;
@@ -104880,7 +104728,7 @@ int lua_ax_base_SpriteBatchNode_highestAtlasIndexInChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104930,7 +104778,7 @@ int lua_ax_base_SpriteBatchNode_lowestAtlasIndexInChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Sprite* arg0;
 
@@ -104980,7 +104828,7 @@ int lua_ax_base_SpriteBatchNode_atlasIndexForChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Sprite* arg0;
         int arg1;
@@ -105033,7 +104881,7 @@ int lua_ax_base_SpriteBatchNode_reorderBatch(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -105083,7 +104931,7 @@ int lua_ax_base_SpriteBatchNode_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105130,7 +104978,7 @@ int lua_ax_base_SpriteBatchNode_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -105180,7 +105028,7 @@ int lua_ax_base_SpriteBatchNode_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -105230,7 +105078,7 @@ int lua_ax_base_SpriteBatchNode_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105277,7 +105125,7 @@ int lua_ax_base_SpriteBatchNode_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -105327,7 +105175,7 @@ int lua_ax_base_SpriteBatchNode_insertQuadFromSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Sprite* arg0;
         ssize_t arg1;
@@ -105380,7 +105228,7 @@ int lua_ax_base_SpriteBatchNode_addSpriteWithoutQuad(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Sprite* arg0;
         int arg1;
@@ -105436,7 +105284,7 @@ int lua_ax_base_SpriteBatchNode_reserveCapacity(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ssize_t arg0;
 
@@ -105486,7 +105334,7 @@ int lua_ax_base_SpriteBatchNode_initWithTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -105500,7 +105348,7 @@ int lua_ax_base_SpriteBatchNode_initWithTexture(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Texture2D* arg0;
         ssize_t arg1;
@@ -105553,7 +105401,7 @@ int lua_ax_base_SpriteBatchNode_initWithFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -105567,7 +105415,7 @@ int lua_ax_base_SpriteBatchNode_initWithFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         ssize_t arg1;
@@ -105709,7 +105557,7 @@ int lua_ax_base_SpriteBatchNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -105802,7 +105650,7 @@ int lua_ax_base_ParallaxNode_addChild(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::Node* arg0;
         int arg1;
@@ -105861,7 +105709,7 @@ int lua_ax_base_ParallaxNode_removeAllChildrenWithCleanup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -105932,7 +105780,7 @@ int lua_ax_base_ParallaxNode_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106005,7 +105853,7 @@ int lua_ax_base_TMXObjectGroup_getGroupName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106052,7 +105900,7 @@ int lua_ax_base_TMXObjectGroup_setGroupName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106102,7 +105950,7 @@ int lua_ax_base_TMXObjectGroup_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106152,7 +106000,7 @@ int lua_ax_base_TMXObjectGroup_getObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106202,7 +106050,7 @@ int lua_ax_base_TMXObjectGroup_getPositionOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106249,7 +106097,7 @@ int lua_ax_base_TMXObjectGroup_setPositionOffset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -106346,7 +106194,7 @@ int lua_ax_base_TMXObjectGroup_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -106443,7 +106291,7 @@ int lua_ax_base_TMXObjectGroup_setObjects(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueVector arg0;
 
@@ -106480,7 +106328,7 @@ int lua_ax_base_TMXObjectGroup_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106560,7 +106408,7 @@ int lua_ax_base_TMXLayerInfo_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -106610,7 +106458,7 @@ int lua_ax_base_TMXLayerInfo_getProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106644,7 +106492,7 @@ int lua_ax_base_TMXLayerInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106716,7 +106564,7 @@ int lua_ax_base_TMXTilesetInfo_getRectForGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         unsigned int arg0;
 
@@ -106753,7 +106601,7 @@ int lua_ax_base_TMXTilesetInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -106824,7 +106672,7 @@ int lua_ax_base_TMXMapInfo_initWithTMXFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106874,7 +106722,7 @@ int lua_ax_base_TMXMapInfo_initWithXML(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -106927,7 +106775,7 @@ int lua_ax_base_TMXMapInfo_parseXMLFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -106977,7 +106825,7 @@ int lua_ax_base_TMXMapInfo_parseXMLString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -107027,7 +106875,7 @@ int lua_ax_base_TMXMapInfo_getTileProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107074,7 +106922,7 @@ int lua_ax_base_TMXMapInfo_setTileProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMapIntKey arg0;
 
@@ -107124,7 +106972,7 @@ int lua_ax_base_TMXMapInfo_getOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107171,7 +107019,7 @@ int lua_ax_base_TMXMapInfo_setOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107221,7 +107069,7 @@ int lua_ax_base_TMXMapInfo_getStaggerAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107268,7 +107116,7 @@ int lua_ax_base_TMXMapInfo_setStaggerAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107318,7 +107166,7 @@ int lua_ax_base_TMXMapInfo_getStaggerIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107365,7 +107213,7 @@ int lua_ax_base_TMXMapInfo_setStaggerIndex(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107415,7 +107263,7 @@ int lua_ax_base_TMXMapInfo_getHexSideLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107462,7 +107310,7 @@ int lua_ax_base_TMXMapInfo_setHexSideLength(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -107512,7 +107360,7 @@ int lua_ax_base_TMXMapInfo_getMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107559,7 +107407,7 @@ int lua_ax_base_TMXMapInfo_setMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -107609,7 +107457,7 @@ int lua_ax_base_TMXMapInfo_getTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -107656,7 +107504,7 @@ int lua_ax_base_TMXMapInfo_setTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -107753,7 +107601,7 @@ int lua_ax_base_TMXMapInfo_setLayers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXLayerInfo *> arg0;
 
@@ -107850,7 +107698,7 @@ int lua_ax_base_TMXMapInfo_setTilesets(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXTilesetInfo *> arg0;
 
@@ -107947,7 +107795,7 @@ int lua_ax_base_TMXMapInfo_setObjectGroups(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXObjectGroup *> arg0;
 
@@ -107997,7 +107845,7 @@ int lua_ax_base_TMXMapInfo_getParentElement(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108044,7 +107892,7 @@ int lua_ax_base_TMXMapInfo_setParentElement(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -108094,7 +107942,7 @@ int lua_ax_base_TMXMapInfo_getParentGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108141,7 +107989,7 @@ int lua_ax_base_TMXMapInfo_setParentGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -108191,7 +108039,7 @@ int lua_ax_base_TMXMapInfo_getLayerAttribs(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108238,7 +108086,7 @@ int lua_ax_base_TMXMapInfo_setLayerAttribs(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -108288,7 +108136,7 @@ int lua_ax_base_TMXMapInfo_isStoringCharacters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108335,7 +108183,7 @@ int lua_ax_base_TMXMapInfo_setStoringCharacters(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -108432,7 +108280,7 @@ int lua_ax_base_TMXMapInfo_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -108482,7 +108330,7 @@ int lua_ax_base_TMXMapInfo_getCurrentString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108529,7 +108377,7 @@ int lua_ax_base_TMXMapInfo_setCurrentString(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -108579,7 +108427,7 @@ int lua_ax_base_TMXMapInfo_getTMXFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108626,7 +108474,7 @@ int lua_ax_base_TMXMapInfo_setTMXFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -108676,7 +108524,7 @@ int lua_ax_base_TMXMapInfo_getExternalTilesetFileName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108784,7 +108632,7 @@ int lua_ax_base_TMXMapInfo_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -108895,7 +108743,7 @@ int lua_ax_base_TileMapAtlas_initWithTileFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 4)
+    if (argc == 4) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -108954,7 +108802,7 @@ int lua_ax_base_TileMapAtlas_getTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109004,7 +108852,7 @@ int lua_ax_base_TileMapAtlas_setTile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::Color32 arg0;
         ax::Vec2 arg1;
@@ -109057,7 +108905,7 @@ int lua_ax_base_TileMapAtlas_releaseMap(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109133,7 +108981,7 @@ int lua_ax_base_TileMapAtlas_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109275,7 +109123,7 @@ int lua_ax_base_FastTMXLayer_removeTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109325,7 +109173,7 @@ int lua_ax_base_FastTMXLayer_getPositionAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109375,7 +109223,7 @@ int lua_ax_base_FastTMXLayer_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -109425,7 +109273,7 @@ int lua_ax_base_FastTMXLayer_setupTiles(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109472,7 +109320,7 @@ int lua_ax_base_FastTMXLayer_getLayerName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109519,7 +109367,7 @@ int lua_ax_base_FastTMXLayer_setLayerName(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -109569,7 +109417,7 @@ int lua_ax_base_FastTMXLayer_getLayerSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109616,7 +109464,7 @@ int lua_ax_base_FastTMXLayer_setLayerSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109666,7 +109514,7 @@ int lua_ax_base_FastTMXLayer_getMapTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109713,7 +109561,7 @@ int lua_ax_base_FastTMXLayer_setMapTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -109763,7 +109611,7 @@ int lua_ax_base_FastTMXLayer_getTileSet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109810,7 +109658,7 @@ int lua_ax_base_FastTMXLayer_setTileSet(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::TMXTilesetInfo* arg0;
 
@@ -109860,7 +109708,7 @@ int lua_ax_base_FastTMXLayer_getLayerOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -109907,7 +109755,7 @@ int lua_ax_base_FastTMXLayer_setLayerOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -110004,7 +109852,7 @@ int lua_ax_base_FastTMXLayer_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -110054,7 +109902,7 @@ int lua_ax_base_FastTMXLayer_getTileAt(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -110104,7 +109952,7 @@ int lua_ax_base_FastTMXLayer_setupTileSprite(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::Sprite* arg0;
         ax::Vec2 arg1;
@@ -110160,7 +110008,7 @@ int lua_ax_base_FastTMXLayer_getAnimTileCoord(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110207,7 +110055,7 @@ int lua_ax_base_FastTMXLayer_hasTileAnimation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110254,7 +110102,7 @@ int lua_ax_base_FastTMXLayer_getTileAnimManager(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110301,7 +110149,7 @@ int lua_ax_base_FastTMXLayer_initWithTilesetInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::TMXTilesetInfo* arg0;
         ax::TMXLayerInfo* arg1;
@@ -110384,7 +110232,7 @@ int lua_ax_base_FastTMXLayer_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110478,7 +110326,7 @@ int lua_ax_base_TMXTileAnimTask_start(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110525,7 +110373,7 @@ int lua_ax_base_TMXTileAnimTask_stop(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110572,7 +110420,7 @@ int lua_ax_base_TMXTileAnimTask_isRunning(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110667,7 +110515,7 @@ int lua_ax_base_TMXTileAnimTask_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 3)
+    if (argc == 3) 
     {
         ax::FastTMXLayer* arg0;
         ax::TMXTileAnimInfo* arg1;
@@ -110691,7 +110539,7 @@ int lua_ax_base_TMXTileAnimTask_constructor(lua_State* tolua_S)
         toluafix_pushusertype_object(tolua_S, ID, luaID, (void*)cobj,"ax.TMXTileAnimTask");
         return 1;
     }
-    if (argc == 4)
+    if (argc == 4) 
     {
         ax::FastTMXLayer* arg0;
         ax::TMXTileAnimInfo* arg1;
@@ -110778,7 +110626,7 @@ int lua_ax_base_TMXTileAnimManager_startAll(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110825,7 +110673,7 @@ int lua_ax_base_TMXTileAnimManager_stopAll(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110872,7 +110720,7 @@ int lua_ax_base_TMXTileAnimManager_getTasks(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -110942,7 +110790,7 @@ int lua_ax_base_TMXTileAnimManager_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::FastTMXLayer* arg0;
 
@@ -111019,7 +110867,7 @@ int lua_ax_base_FastTMXTiledMap_getLayer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -111069,7 +110917,7 @@ int lua_ax_base_FastTMXTiledMap_getObjectGroup(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -111119,7 +110967,7 @@ int lua_ax_base_FastTMXTiledMap_getProperty(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -111169,7 +111017,7 @@ int lua_ax_base_FastTMXTiledMap_getPropertiesForGID(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -111219,7 +111067,7 @@ int lua_ax_base_FastTMXTiledMap_getMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111266,7 +111114,7 @@ int lua_ax_base_FastTMXTiledMap_setMapSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -111316,7 +111164,7 @@ int lua_ax_base_FastTMXTiledMap_getTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111363,7 +111211,7 @@ int lua_ax_base_FastTMXTiledMap_setTileSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec2 arg0;
 
@@ -111413,7 +111261,7 @@ int lua_ax_base_FastTMXTiledMap_getMapOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111460,7 +111308,7 @@ int lua_ax_base_FastTMXTiledMap_setMapOrientation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -111557,7 +111405,7 @@ int lua_ax_base_FastTMXTiledMap_setObjectGroups(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vector<ax::TMXObjectGroup *> arg0;
 
@@ -111607,7 +111455,7 @@ int lua_ax_base_FastTMXTiledMap_getProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111654,7 +111502,7 @@ int lua_ax_base_FastTMXTiledMap_setProperties(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::ValueMap arg0;
 
@@ -111704,7 +111552,7 @@ int lua_ax_base_FastTMXTiledMap_setTileAnimEnabled(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -111754,7 +111602,7 @@ int lua_ax_base_FastTMXTiledMap_getLayerCount(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111801,7 +111649,7 @@ int lua_ax_base_FastTMXTiledMap_getResourceFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111848,7 +111696,7 @@ int lua_ax_base_FastTMXTiledMap_getMapInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111895,7 +111743,7 @@ int lua_ax_base_FastTMXTiledMap_getTilesetInfo(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -111945,7 +111793,7 @@ int lua_ax_base_FastTMXTiledMap_getLayers(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -111992,7 +111840,7 @@ int lua_ax_base_FastTMXTiledMap_initWithTMXFile(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -112006,7 +111854,7 @@ int lua_ax_base_FastTMXTiledMap_initWithTMXFile(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         bool arg1;
@@ -112059,7 +111907,7 @@ int lua_ax_base_FastTMXTiledMap_initWithXML(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -112076,7 +111924,7 @@ int lua_ax_base_FastTMXTiledMap_initWithXML(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 3)
+    if (argc == 3) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -112225,7 +112073,7 @@ int lua_ax_base_FastTMXTiledMap_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112319,7 +112167,7 @@ int lua_ax_base_MotionStreak3D_tintWithColor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Color32 arg0;
 
@@ -112369,7 +112217,7 @@ int lua_ax_base_MotionStreak3D_reset(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112416,7 +112264,7 @@ int lua_ax_base_MotionStreak3D_getStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112463,7 +112311,7 @@ int lua_ax_base_MotionStreak3D_setStroke(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -112513,7 +112361,7 @@ int lua_ax_base_MotionStreak3D_isStartingPositionInitialized(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112560,7 +112408,7 @@ int lua_ax_base_MotionStreak3D_setStartingPositionInitialized(lua_State* tolua_S
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         bool arg0;
 
@@ -112610,7 +112458,7 @@ int lua_ax_base_MotionStreak3D_getTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112657,7 +112505,7 @@ int lua_ax_base_MotionStreak3D_setTexture(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Texture2D* arg0;
 
@@ -112707,7 +112555,7 @@ int lua_ax_base_MotionStreak3D_setBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::BlendFunc arg0;
 
@@ -112757,7 +112605,7 @@ int lua_ax_base_MotionStreak3D_getBlendFunc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112804,7 +112652,7 @@ int lua_ax_base_MotionStreak3D_setSweepAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::Vec3 arg0;
 
@@ -112854,7 +112702,7 @@ int lua_ax_base_MotionStreak3D_getSweepAxis(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -112976,7 +112824,7 @@ int lua_ax_base_MotionStreak3D_create(lua_State* tolua_S)
 
     argc = lua_gettop(tolua_S)-1;
 
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -113001,7 +112849,7 @@ int lua_ax_base_MotionStreak3D_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    do
+    do 
     {
         if (argc == 5)
         {
@@ -113047,7 +112895,7 @@ int lua_ax_base_MotionStreak3D_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -113131,7 +112979,7 @@ int lua_ax_base_ComponentLua_getScriptObject(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -113178,7 +113026,7 @@ int lua_ax_base_ComponentLua_update(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         double arg0;
 
@@ -113251,7 +113099,7 @@ int lua_ax_base_ComponentLua_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -113303,7 +113151,7 @@ int lua_register_ax_base_ComponentLua(lua_State* tolua_S)
 TOLUA_API int register_all_ax_base(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-
+	
 	tolua_module(tolua_S,"ax",0);
 	tolua_beginmodule(tolua_S,"ax");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
@@ -122,7 +122,7 @@ int lua_register_ax_rhi_PixelFormat(lua_State* tolua_S)
         tolua_constant(tolua_S, "RGBA32F", 28);
         tolua_constant(tolua_S, "D24S8", 29);
         tolua_constant(tolua_S, "COUNT", 30);
-        tolua_constant(tolua_S, "NONE", 65535);
+        tolua_constant(tolua_S, "AUTO", -1);
     tolua_endmodule(tolua_S);
 
     auto typeName = typeid(ax::rhi::PixelFormat).name(); // rtti is literal storage
@@ -298,9 +298,10 @@ int lua_register_ax_rhi_SamplerAddressMode(lua_State* tolua_S)
     tolua_module(tolua_S, "SamplerAddressMode", 0);
     tolua_beginmodule(tolua_S,"SamplerAddressMode");
         tolua_constant(tolua_S, "REPEAT", 0);
-        tolua_constant(tolua_S, "MIRROR_REPEAT", 1);
+        tolua_constant(tolua_S, "MIRROR", 1);
+        tolua_constant(tolua_S, "CLAMP", 2);
+        tolua_constant(tolua_S, "BORDER", 3);
         tolua_constant(tolua_S, "CLAMP_TO_EDGE", 2);
-        tolua_constant(tolua_S, "DONT_CARE", 3);
     tolua_endmodule(tolua_S);
 
     auto typeName = typeid(ax::rhi::SamplerAddressMode).name(); // rtti is literal storage
@@ -314,13 +315,16 @@ int lua_register_ax_rhi_SamplerFilter(lua_State* tolua_S)
 {
     tolua_module(tolua_S, "SamplerFilter", 0);
     tolua_beginmodule(tolua_S,"SamplerFilter");
+        tolua_constant(tolua_S, "MIN_NEAREST", 0);
+        tolua_constant(tolua_S, "MIN_LINEAR", 1);
+        tolua_constant(tolua_S, "MIN_ANISOTROPIC", 2);
+        tolua_constant(tolua_S, "MAG_NEAREST", 0);
+        tolua_constant(tolua_S, "MAG_LINEAR", 1);
+        tolua_constant(tolua_S, "MIP_NONE", 0);
+        tolua_constant(tolua_S, "MIP_NEAREST", 1);
+        tolua_constant(tolua_S, "MIP_LINEAR", 2);
         tolua_constant(tolua_S, "NEAREST", 0);
-        tolua_constant(tolua_S, "NEAREST_MIPMAP_NEAREST", 1);
-        tolua_constant(tolua_S, "NEAREST_MIPMAP_LINEAR", 2);
-        tolua_constant(tolua_S, "LINEAR", 3);
-        tolua_constant(tolua_S, "LINEAR_MIPMAP_LINEAR", 4);
-        tolua_constant(tolua_S, "LINEAR_MIPMAP_NEAREST", 5);
-        tolua_constant(tolua_S, "DONT_CARE", 6);
+        tolua_constant(tolua_S, "LINEAR", 1);
     tolua_endmodule(tolua_S);
 
     auto typeName = typeid(ax::rhi::SamplerFilter).name(); // rtti is literal storage
@@ -1378,31 +1382,7 @@ int lua_ax_rhi_ProgramState_setTexture(lua_State* tolua_S)
         }
     }while(0);
     ok  = true;
-    do{
-        if (argc == 4) {
-            ax::rhi::UniformLocation arg0;
-            ok &= luaval_to_uniformLocation(tolua_S, 2, arg0, "axrhi.ProgramState:setTexture");
-
-            if (!ok) { break; }
-            int arg1;
-            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "axrhi.ProgramState:setTexture");
-
-            if (!ok) { break; }
-            int arg2;
-            ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "axrhi.ProgramState:setTexture");
-
-            if (!ok) { break; }
-            ax::rhi::Texture* arg3;
-            ok &= luaval_to_object<ax::rhi::Texture>(tolua_S, 5, "axrhi.Texture",&arg3, "axrhi.ProgramState:setTexture");
-
-            if (!ok) { break; }
-            cobj->setTexture(arg0, arg1, arg2, arg3);
-            lua_settop(tolua_S, 1);
-            return 1;
-        }
-    }while(0);
-    ok  = true;
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "axrhi.ProgramState:setTexture",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "axrhi.ProgramState:setTexture",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -1962,24 +1942,6 @@ int lua_ax_rhi_Texture_updateTextureDesc(lua_State* tolua_S)
         lua_settop(tolua_S, 1);
         return 1;
     }
-    if (argc == 2) 
-    {
-        ax::rhi::TextureDesc arg0;
-        int arg1;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR TextureDesc
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "axrhi.Texture:updateTextureDesc");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_updateTextureDesc'", nullptr);
-            return 0;
-        }
-        cobj->updateTextureDesc(arg0, arg1);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
     luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:updateTextureDesc",argc, 1);
     return 0;
 
@@ -1990,7 +1952,7 @@ int lua_ax_rhi_Texture_updateTextureDesc(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_rhi_Texture_getTextureFormat(lua_State* tolua_S)
+int lua_ax_rhi_Texture_getPixelFormat(lua_State* tolua_S)
 {
     int argc = 0;
     ax::rhi::Texture* cobj = nullptr;
@@ -2010,7 +1972,7 @@ int lua_ax_rhi_Texture_getTextureFormat(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!cobj)
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_getTextureFormat'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_getPixelFormat'", nullptr);
         return 0;
     }
 #endif
@@ -2020,19 +1982,19 @@ int lua_ax_rhi_Texture_getTextureFormat(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_getTextureFormat'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_getPixelFormat'", nullptr);
             return 0;
         }
-        int ret = (int)cobj->getTextureFormat();
+        int ret = (int)cobj->getPixelFormat();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:getTextureFormat",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:getPixelFormat",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_getTextureFormat'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_getPixelFormat'.",&tolua_err);
 #endif
 
     return 0;
@@ -2348,7 +2310,7 @@ int lua_ax_rhi_Texture_updateFaceData(lua_State* tolua_S)
     if (argc == 2) 
     {
         ax::rhi::TextureCubeFace arg0;
-        void* arg1;
+        const void* arg1;
 
         ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axrhi.Texture:updateFaceData");
 
@@ -2360,27 +2322,6 @@ int lua_ax_rhi_Texture_updateFaceData(lua_State* tolua_S)
             return 0;
         }
         cobj->updateFaceData(arg0, arg1);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    if (argc == 3) 
-    {
-        ax::rhi::TextureCubeFace arg0;
-        void* arg1;
-        int arg2;
-
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axrhi.Texture:updateFaceData");
-
-        #pragma warning NO CONVERSION TO NATIVE FOR void*
-		ok = false;
-
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "axrhi.Texture:updateFaceData");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_updateFaceData'", nullptr);
-            return 0;
-        }
-        cobj->updateFaceData(arg0, arg1, arg2);
         lua_settop(tolua_S, 1);
         return 1;
     }
@@ -2409,7 +2350,7 @@ int lua_register_ax_rhi_Texture(lua_State* tolua_S)
         tolua_function(tolua_S,"updateSamplerDesc",lua_ax_rhi_Texture_updateSamplerDesc);
         tolua_function(tolua_S,"generateMipmaps",lua_ax_rhi_Texture_generateMipmaps);
         tolua_function(tolua_S,"updateTextureDesc",lua_ax_rhi_Texture_updateTextureDesc);
-        tolua_function(tolua_S,"getTextureFormat",lua_ax_rhi_Texture_getTextureFormat);
+        tolua_function(tolua_S,"getPixelFormat",lua_ax_rhi_Texture_getPixelFormat);
         tolua_function(tolua_S,"getTextureUsage",lua_ax_rhi_Texture_getTextureUsage);
         tolua_function(tolua_S,"getTextureType",lua_ax_rhi_Texture_getTextureType);
         tolua_function(tolua_S,"hasMipmaps",lua_ax_rhi_Texture_hasMipmaps);

--- a/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
@@ -488,7 +488,7 @@ int lua_ax_rhi_Program_getMaxVertexLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -535,7 +535,7 @@ int lua_ax_rhi_Program_getMaxFragmentLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -582,7 +582,7 @@ int lua_ax_rhi_Program_getVertexShaderSource(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -629,7 +629,7 @@ int lua_ax_rhi_Program_getFragmentShaderSource(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -676,7 +676,7 @@ int lua_ax_rhi_Program_defineVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::VertexLayoutType arg0;
 
@@ -726,7 +726,7 @@ int lua_ax_rhi_Program_getProgramType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -773,7 +773,7 @@ int lua_ax_rhi_Program_getProgramId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -820,7 +820,7 @@ int lua_ax_rhi_Program_getUniformBufferSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::ShaderStage arg0;
 
@@ -870,7 +870,7 @@ int lua_ax_rhi_Program_getVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -947,7 +947,7 @@ int lua_ax_rhi_VertexLayout_getStride(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -994,7 +994,7 @@ int lua_ax_rhi_VertexLayout_getInstanceStride(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1041,7 +1041,7 @@ int lua_ax_rhi_VertexLayout_getVertexStepMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1088,7 +1088,7 @@ int lua_ax_rhi_VertexLayout_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1135,7 +1135,7 @@ int lua_ax_rhi_VertexLayout_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1206,7 +1206,7 @@ int lua_ax_rhi_ProgramState_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1253,7 +1253,7 @@ int lua_ax_rhi_ProgramState_getProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1418,7 +1418,7 @@ int lua_ax_rhi_ProgramState_setParameterAutoBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -1471,7 +1471,7 @@ int lua_ax_rhi_ProgramState_getMutableVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1518,7 +1518,7 @@ int lua_ax_rhi_ProgramState_setSharedVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::VertexLayout* arg0;
 
@@ -1568,7 +1568,7 @@ int lua_ax_rhi_ProgramState_getBatchId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1615,7 +1615,7 @@ int lua_ax_rhi_ProgramState_isBatchable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1662,7 +1662,7 @@ int lua_ax_rhi_ProgramState_updateBatchId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1709,7 +1709,7 @@ int lua_ax_rhi_ProgramState_validateSharedVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::VertexLayoutType arg0;
 
@@ -1746,7 +1746,7 @@ int lua_ax_rhi_ProgramState_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::Program* arg0;
 
@@ -1830,7 +1830,7 @@ int lua_ax_rhi_Texture_updateSamplerDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::SamplerDesc arg0;
 
@@ -1880,7 +1880,7 @@ int lua_ax_rhi_Texture_updateTextureDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::TextureDesc arg0;
 
@@ -1931,7 +1931,7 @@ int lua_ax_rhi_Texture_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -1978,7 +1978,7 @@ int lua_ax_rhi_Texture_getTextureUsage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2025,7 +2025,7 @@ int lua_ax_rhi_Texture_getTextureType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2072,7 +2072,7 @@ int lua_ax_rhi_Texture_hasMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2119,7 +2119,7 @@ int lua_ax_rhi_Texture_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2166,7 +2166,7 @@ int lua_ax_rhi_Texture_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2213,7 +2213,7 @@ int lua_ax_rhi_Texture_updateData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 5)
+    if (argc == 5) 
     {
         const void* arg0;
         int arg1;
@@ -2276,7 +2276,7 @@ int lua_ax_rhi_Texture_updateSubData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 7)
+    if (argc == 7) 
     {
         int arg0;
         int arg1;
@@ -2345,7 +2345,7 @@ int lua_ax_rhi_Texture_updateFaceData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::rhi::TextureCubeFace arg0;
         const void* arg1;
@@ -2399,7 +2399,7 @@ int lua_ax_rhi_Texture_shouldGenMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2410,7 +2410,7 @@ int lua_ax_rhi_Texture_shouldGenMipmaps(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         int arg0;
 
@@ -2430,6 +2430,53 @@ int lua_ax_rhi_Texture_shouldGenMipmaps(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_shouldGenMipmaps'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_rhi_Texture_zeroTexData(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::rhi::Texture* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"axrhi.Texture",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::rhi::Texture*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_zeroTexData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_zeroTexData'", nullptr);
+            return 0;
+        }
+        cobj->zeroTexData();
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:zeroTexData",argc, 0);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_zeroTexData'.",&tolua_err);
 #endif
 
     return 0;
@@ -2458,6 +2505,7 @@ int lua_register_ax_rhi_Texture(lua_State* tolua_S)
         tolua_function(tolua_S,"updateSubData",lua_ax_rhi_Texture_updateSubData);
         tolua_function(tolua_S,"updateFaceData",lua_ax_rhi_Texture_updateFaceData);
         tolua_function(tolua_S,"shouldGenMipmaps",lua_ax_rhi_Texture_shouldGenMipmaps);
+        tolua_function(tolua_S,"zeroTexData",lua_ax_rhi_Texture_zeroTexData);
     tolua_endmodule(tolua_S);
     auto typeName = typeid(ax::rhi::Texture).name(); // rtti is literal storage
     g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "axrhi.Texture";
@@ -2491,7 +2539,7 @@ int lua_ax_rhi_DriverBase_createDefaultRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2538,7 +2586,7 @@ int lua_ax_rhi_DriverBase_createRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2549,7 +2597,7 @@ int lua_ax_rhi_DriverBase_createRenderTarget(lua_State* tolua_S)
         object_to_luaval<ax::rhi::RenderTarget>(tolua_S, "axrhi.RenderTarget",(ax::rhi::RenderTarget*)ret);
         return 1;
     }
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::Texture* arg0;
 
@@ -2563,7 +2611,7 @@ int lua_ax_rhi_DriverBase_createRenderTarget(lua_State* tolua_S)
         object_to_luaval<ax::rhi::RenderTarget>(tolua_S, "axrhi.RenderTarget",(ax::rhi::RenderTarget*)ret);
         return 1;
     }
-    if (argc == 2)
+    if (argc == 2) 
     {
         ax::rhi::Texture* arg0;
         ax::rhi::Texture* arg1;
@@ -2616,7 +2664,7 @@ int lua_ax_rhi_DriverBase_createProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2)
+    if (argc == 2) 
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -2669,7 +2717,7 @@ int lua_ax_rhi_DriverBase_createVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2716,7 +2764,7 @@ int lua_ax_rhi_DriverBase_resetState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2763,7 +2811,7 @@ int lua_ax_rhi_DriverBase_getVendor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2810,7 +2858,7 @@ int lua_ax_rhi_DriverBase_getRenderer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2857,7 +2905,7 @@ int lua_ax_rhi_DriverBase_getVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2904,7 +2952,7 @@ int lua_ax_rhi_DriverBase_getShaderVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -2951,7 +2999,7 @@ int lua_ax_rhi_DriverBase_hasExtension(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         std::string_view arg0;
 
@@ -3001,7 +3049,7 @@ int lua_ax_rhi_DriverBase_dumpExtensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3048,7 +3096,7 @@ int lua_ax_rhi_DriverBase_checkForFeatureSupported(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 1) 
     {
         ax::rhi::FeatureType arg0;
 
@@ -3098,7 +3146,7 @@ int lua_ax_rhi_DriverBase_getMaxTextureSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3145,7 +3193,7 @@ int lua_ax_rhi_DriverBase_getMaxAttributes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3192,7 +3240,7 @@ int lua_ax_rhi_DriverBase_getMaxTextureUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3239,7 +3287,7 @@ int lua_ax_rhi_DriverBase_getMaxSamplesAllowed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 0) 
     {
         if(!ok)
         {
@@ -3367,7 +3415,7 @@ int lua_register_ax_rhi_DriverBase(lua_State* tolua_S)
 TOLUA_API int register_all_ax_rhi(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-
+	
 	tolua_module(tolua_S,"axrhi",0);
 	tolua_beginmodule(tolua_S,"axrhi");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
@@ -122,7 +122,7 @@ int lua_register_ax_rhi_PixelFormat(lua_State* tolua_S)
         tolua_constant(tolua_S, "RGBA32F", 28);
         tolua_constant(tolua_S, "D24S8", 29);
         tolua_constant(tolua_S, "COUNT", 30);
-        tolua_constant(tolua_S, "AUTO", -1);
+        tolua_constant(tolua_S, "NONE", -1);
     tolua_endmodule(tolua_S);
 
     auto typeName = typeid(ax::rhi::PixelFormat).name(); // rtti is literal storage
@@ -320,9 +320,9 @@ int lua_register_ax_rhi_SamplerFilter(lua_State* tolua_S)
         tolua_constant(tolua_S, "MIN_ANISOTROPIC", 2);
         tolua_constant(tolua_S, "MAG_NEAREST", 0);
         tolua_constant(tolua_S, "MAG_LINEAR", 1);
-        tolua_constant(tolua_S, "MIP_NONE", 0);
-        tolua_constant(tolua_S, "MIP_NEAREST", 1);
-        tolua_constant(tolua_S, "MIP_LINEAR", 2);
+        tolua_constant(tolua_S, "MIP_NEAREST", 0);
+        tolua_constant(tolua_S, "MIP_LINEAR", 1);
+        tolua_constant(tolua_S, "MIP_DEFAULT", 3);
         tolua_constant(tolua_S, "NEAREST", 0);
         tolua_constant(tolua_S, "LINEAR", 1);
     tolua_endmodule(tolua_S);
@@ -488,7 +488,7 @@ int lua_ax_rhi_Program_getMaxVertexLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -535,7 +535,7 @@ int lua_ax_rhi_Program_getMaxFragmentLocation(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -582,7 +582,7 @@ int lua_ax_rhi_Program_getVertexShaderSource(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -629,7 +629,7 @@ int lua_ax_rhi_Program_getFragmentShaderSource(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -676,7 +676,7 @@ int lua_ax_rhi_Program_defineVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::VertexLayoutType arg0;
 
@@ -726,7 +726,7 @@ int lua_ax_rhi_Program_getProgramType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -773,7 +773,7 @@ int lua_ax_rhi_Program_getProgramId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -820,7 +820,7 @@ int lua_ax_rhi_Program_getUniformBufferSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::ShaderStage arg0;
 
@@ -870,7 +870,7 @@ int lua_ax_rhi_Program_getVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -947,7 +947,7 @@ int lua_ax_rhi_VertexLayout_getStride(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -994,7 +994,7 @@ int lua_ax_rhi_VertexLayout_getInstanceStride(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1041,7 +1041,7 @@ int lua_ax_rhi_VertexLayout_getVertexStepMode(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1088,7 +1088,7 @@ int lua_ax_rhi_VertexLayout_isValid(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1135,7 +1135,7 @@ int lua_ax_rhi_VertexLayout_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1206,7 +1206,7 @@ int lua_ax_rhi_ProgramState_clone(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1253,7 +1253,7 @@ int lua_ax_rhi_ProgramState_getProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1418,7 +1418,7 @@ int lua_ax_rhi_ProgramState_setParameterAutoBinding(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -1471,7 +1471,7 @@ int lua_ax_rhi_ProgramState_getMutableVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1518,7 +1518,7 @@ int lua_ax_rhi_ProgramState_setSharedVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::VertexLayout* arg0;
 
@@ -1568,7 +1568,7 @@ int lua_ax_rhi_ProgramState_getBatchId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1615,7 +1615,7 @@ int lua_ax_rhi_ProgramState_isBatchable(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1662,7 +1662,7 @@ int lua_ax_rhi_ProgramState_updateBatchId(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -1709,7 +1709,7 @@ int lua_ax_rhi_ProgramState_validateSharedVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::VertexLayoutType arg0;
 
@@ -1746,7 +1746,7 @@ int lua_ax_rhi_ProgramState_constructor(lua_State* tolua_S)
 
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::Program* arg0;
 
@@ -1830,7 +1830,7 @@ int lua_ax_rhi_Texture_updateSamplerDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::SamplerDesc arg0;
 
@@ -1850,53 +1850,6 @@ int lua_ax_rhi_Texture_updateSamplerDesc(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_updateSamplerDesc'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_rhi_Texture_generateMipmaps(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::rhi::Texture* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"axrhi.Texture",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::rhi::Texture*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_generateMipmaps'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_generateMipmaps'", nullptr);
-            return 0;
-        }
-        cobj->generateMipmaps();
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:generateMipmaps",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_generateMipmaps'.",&tolua_err);
 #endif
 
     return 0;
@@ -1927,7 +1880,7 @@ int lua_ax_rhi_Texture_updateTextureDesc(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::TextureDesc arg0;
 
@@ -1978,7 +1931,7 @@ int lua_ax_rhi_Texture_getPixelFormat(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2025,7 +1978,7 @@ int lua_ax_rhi_Texture_getTextureUsage(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2072,7 +2025,7 @@ int lua_ax_rhi_Texture_getTextureType(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2119,7 +2072,7 @@ int lua_ax_rhi_Texture_hasMipmaps(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2136,53 +2089,6 @@ int lua_ax_rhi_Texture_hasMipmaps(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_hasMipmaps'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_rhi_Texture_getCount(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::rhi::Texture* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"axrhi.Texture",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::rhi::Texture*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_getCount'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_getCount'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->getCount();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:getCount",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_getCount'.",&tolua_err);
 #endif
 
     return 0;
@@ -2213,7 +2119,7 @@ int lua_ax_rhi_Texture_getWidth(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2260,7 +2166,7 @@ int lua_ax_rhi_Texture_getHeight(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2277,6 +2183,138 @@ int lua_ax_rhi_Texture_getHeight(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_getHeight'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_rhi_Texture_updateData(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::rhi::Texture* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"axrhi.Texture",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::rhi::Texture*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_updateData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 5)
+    {
+        const void* arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+        int arg4;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "axrhi.Texture:updateData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "axrhi.Texture:updateData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "axrhi.Texture:updateData");
+
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "axrhi.Texture:updateData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_updateData'", nullptr);
+            return 0;
+        }
+        cobj->updateData(arg0, arg1, arg2, arg3, arg4);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:updateData",argc, 5);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_updateData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_rhi_Texture_updateSubData(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::rhi::Texture* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"axrhi.Texture",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::rhi::Texture*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_updateSubData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 7)
+    {
+        int arg0;
+        int arg1;
+        int arg2;
+        int arg3;
+        int arg4;
+        const void* arg5;
+        int arg6;
+
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axrhi.Texture:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "axrhi.Texture:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "axrhi.Texture:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "axrhi.Texture:updateSubData");
+
+        ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "axrhi.Texture:updateSubData");
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+
+        ok &= luaval_to_int32(tolua_S, 8,(int *)&arg6, "axrhi.Texture:updateSubData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_updateSubData'", nullptr);
+            return 0;
+        }
+        cobj->updateSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:updateSubData",argc, 7);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_updateSubData'.",&tolua_err);
 #endif
 
     return 0;
@@ -2307,7 +2345,7 @@ int lua_ax_rhi_Texture_updateFaceData(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::rhi::TextureCubeFace arg0;
         const void* arg1;
@@ -2335,6 +2373,67 @@ int lua_ax_rhi_Texture_updateFaceData(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_rhi_Texture_shouldGenMipmaps(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::rhi::Texture* cobj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"axrhi.Texture",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (ax::rhi::Texture*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_rhi_Texture_shouldGenMipmaps'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_shouldGenMipmaps'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->shouldGenMipmaps();
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    if (argc == 1)
+    {
+        int arg0;
+
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "axrhi.Texture:shouldGenMipmaps");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_Texture_shouldGenMipmaps'", nullptr);
+            return 0;
+        }
+        auto&& ret = cobj->shouldGenMipmaps(arg0);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axrhi.Texture:shouldGenMipmaps",argc, 0);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_Texture_shouldGenMipmaps'.",&tolua_err);
+#endif
+
+    return 0;
+}
 static int lua_ax_rhi_Texture_finalize(lua_State* tolua_S)
 {
     AXLOGV("luabindings: finalizing LUA object (Texture)");
@@ -2348,16 +2447,17 @@ int lua_register_ax_rhi_Texture(lua_State* tolua_S)
 
     tolua_beginmodule(tolua_S,"Texture");
         tolua_function(tolua_S,"updateSamplerDesc",lua_ax_rhi_Texture_updateSamplerDesc);
-        tolua_function(tolua_S,"generateMipmaps",lua_ax_rhi_Texture_generateMipmaps);
         tolua_function(tolua_S,"updateTextureDesc",lua_ax_rhi_Texture_updateTextureDesc);
         tolua_function(tolua_S,"getPixelFormat",lua_ax_rhi_Texture_getPixelFormat);
         tolua_function(tolua_S,"getTextureUsage",lua_ax_rhi_Texture_getTextureUsage);
         tolua_function(tolua_S,"getTextureType",lua_ax_rhi_Texture_getTextureType);
         tolua_function(tolua_S,"hasMipmaps",lua_ax_rhi_Texture_hasMipmaps);
-        tolua_function(tolua_S,"getCount",lua_ax_rhi_Texture_getCount);
         tolua_function(tolua_S,"getWidth",lua_ax_rhi_Texture_getWidth);
         tolua_function(tolua_S,"getHeight",lua_ax_rhi_Texture_getHeight);
+        tolua_function(tolua_S,"updateData",lua_ax_rhi_Texture_updateData);
+        tolua_function(tolua_S,"updateSubData",lua_ax_rhi_Texture_updateSubData);
         tolua_function(tolua_S,"updateFaceData",lua_ax_rhi_Texture_updateFaceData);
+        tolua_function(tolua_S,"shouldGenMipmaps",lua_ax_rhi_Texture_shouldGenMipmaps);
     tolua_endmodule(tolua_S);
     auto typeName = typeid(ax::rhi::Texture).name(); // rtti is literal storage
     g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "axrhi.Texture";
@@ -2391,7 +2491,7 @@ int lua_ax_rhi_DriverBase_createDefaultRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2438,7 +2538,7 @@ int lua_ax_rhi_DriverBase_createRenderTarget(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2449,7 +2549,7 @@ int lua_ax_rhi_DriverBase_createRenderTarget(lua_State* tolua_S)
         object_to_luaval<ax::rhi::RenderTarget>(tolua_S, "axrhi.RenderTarget",(ax::rhi::RenderTarget*)ret);
         return 1;
     }
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::Texture* arg0;
 
@@ -2463,7 +2563,7 @@ int lua_ax_rhi_DriverBase_createRenderTarget(lua_State* tolua_S)
         object_to_luaval<ax::rhi::RenderTarget>(tolua_S, "axrhi.RenderTarget",(ax::rhi::RenderTarget*)ret);
         return 1;
     }
-    if (argc == 2) 
+    if (argc == 2)
     {
         ax::rhi::Texture* arg0;
         ax::rhi::Texture* arg1;
@@ -2516,7 +2616,7 @@ int lua_ax_rhi_DriverBase_createProgram(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 2) 
+    if (argc == 2)
     {
         std::string_view arg0;
         std::string_view arg1;
@@ -2569,7 +2669,7 @@ int lua_ax_rhi_DriverBase_createVertexLayout(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2616,7 +2716,7 @@ int lua_ax_rhi_DriverBase_resetState(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2663,7 +2763,7 @@ int lua_ax_rhi_DriverBase_getVendor(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2710,7 +2810,7 @@ int lua_ax_rhi_DriverBase_getRenderer(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2757,7 +2857,7 @@ int lua_ax_rhi_DriverBase_getVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2804,7 +2904,7 @@ int lua_ax_rhi_DriverBase_getShaderVersion(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2851,7 +2951,7 @@ int lua_ax_rhi_DriverBase_hasExtension(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         std::string_view arg0;
 
@@ -2901,7 +3001,7 @@ int lua_ax_rhi_DriverBase_dumpExtensions(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -2948,7 +3048,7 @@ int lua_ax_rhi_DriverBase_checkForFeatureSupported(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
+    if (argc == 1)
     {
         ax::rhi::FeatureType arg0;
 
@@ -2998,7 +3098,7 @@ int lua_ax_rhi_DriverBase_getMaxTextureSize(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3045,7 +3145,7 @@ int lua_ax_rhi_DriverBase_getMaxAttributes(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3092,7 +3192,7 @@ int lua_ax_rhi_DriverBase_getMaxTextureUnits(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3139,7 +3239,7 @@ int lua_ax_rhi_DriverBase_getMaxSamplesAllowed(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
+    if (argc == 0)
     {
         if(!ok)
         {
@@ -3267,7 +3367,7 @@ int lua_register_ax_rhi_DriverBase(lua_State* tolua_S)
 TOLUA_API int register_all_ax_rhi(lua_State* tolua_S)
 {
 	tolua_open(tolua_S);
-	
+
 	tolua_module(tolua_S,"axrhi",0);
 	tolua_beginmodule(tolua_S,"axrhi");
 

--- a/extensions/spine/src/spine/SkeletonBatch.cpp
+++ b/extensions/spine/src/spine/SkeletonBatch.cpp
@@ -165,7 +165,7 @@ namespace spine {
 		auto pipelinePS = updateCommandPipelinePS(command, programState);
 
 		pipelinePS->setUniform(command->_locMVP, projectionMat.m, sizeof(projectionMat.m));
-		pipelinePS->setTexture(command->_locTexture, 0, texture->getBackendTexture());
+		pipelinePS->setTexture(command->_locTexture, 0, texture->getRHITexture());
 
 		command->init(globalOrder, texture, blendType, triangles, mv, flags);
 		renderer->addCommand(command);

--- a/extensions/spine/src/spine/SkeletonTwoColorBatch.cpp
+++ b/extensions/spine/src/spine/SkeletonTwoColorBatch.cpp
@@ -101,7 +101,7 @@ namespace spine {
 		auto finalMatrix = projectionMat * mv;
 
 		_programState->setUniform(_locPMatrix, finalMatrix.m, sizeof(finalMatrix.m));
-		_programState->setTexture(_locTexture, 0, texture->getBackendTexture());
+		_programState->setTexture(_locTexture, 0, texture->getRHITexture());
 
 
 		RenderCommand::init(globalOrder, mv, flags);
@@ -116,8 +116,8 @@ namespace spine {
 		_mv = mv;
 
 		if (_blendType.src != blendType.src || _blendType.dst != blendType.dst ||
-			_texture != texture->getBackendTexture() || _pipelineDesc.programState != _programState) {
-			_texture = texture->getBackendTexture();
+			_texture != texture->getRHITexture() || _pipelineDesc.programState != _programState) {
+			_texture = texture->getRHITexture();
 			_blendType = blendType;
 
 			_prog = _programState->getProgram();

--- a/tests/cpp-tests/Source/MeshRendererTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Source/MeshRendererTest/DrawNode3D.cpp
@@ -94,7 +94,7 @@ bool DrawNode3D::init()
                                       CustomCommand::BufferUsage::DYNAMIC);
     _isDirty = true;
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // Need to listen the event only when not use batchnode, because it will use VBO
     auto listener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom* event) {
         /** listen the event that coming to foreground on Android */

--- a/tests/cpp-tests/Source/MeshRendererTest/MeshRendererTest.cpp
+++ b/tests/cpp-tests/Source/MeshRendererTest/MeshRendererTest.cpp
@@ -2244,7 +2244,7 @@ void MeshRendererCubeMapTest::addNewMeshWithCoords(Vec2 p)
 
     // pass the texture sampler to our custom shader
     auto cubeTexLoc = state->getUniformLocation("u_cubeTex");
-    state->setTexture(cubeTexLoc, 0, _textureCube->getBackendTexture());
+    state->setTexture(cubeTexLoc, 0, _textureCube->getRHITexture());
 
     _teapot->setPosition3D(Vec3(0.0f, -5.0f, 0.0f));
     _teapot->setRotation3D(Vec3(-90.0f, 180.0f, 0.0f));
@@ -2283,7 +2283,7 @@ void MeshRendererCubeMapTest::addNewMeshWithCoords(Vec2 p)
         _skyBox->setTexture(_textureCube);
         // pass the texture sampler to our custom shader
         auto cubeTexLoc = state->getUniformLocation("u_cubeTex");
-        state->setTexture(cubeTexLoc, 0, _textureCube->getBackendTexture());
+        state->setTexture(cubeTexLoc, 0, _textureCube->getRHITexture());
     });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, 1);
 #endif

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
@@ -417,7 +417,7 @@ bool SpriteBlur::initWithTexture(Texture2D* texture, const Rect& rect)
     _blurRadius = 0;
     if (Sprite::initWithTexture(texture, rect))
     {
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         auto listener =
             EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom* event) { initProgram(); });
 

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
@@ -749,7 +749,7 @@ bool ShaderMultiTexture::init()
         auto programState   = new rhi::ProgramState(program);
         _sprite->setProgramState(programState);
 
-        SET_TEXTURE(programState, "u_tex1", 1, right->getTexture()->getBackendTexture());
+        SET_TEXTURE(programState, "u_tex1", 1, right->getTexture()->getRHITexture());
         SET_UNIFORM(programState, "u_interpolate", 0.5f);
 
         // slider
@@ -779,5 +779,5 @@ void ShaderMultiTexture::changeTexture(Object*)
     Sprite* right = dynamic_cast<Sprite*>(getChildByTag(rightSpriteTag));
     right->setTexture(texture);
     auto programState = _sprite->getProgramState();
-    SET_TEXTURE(programState, "u_tex1", 1, right->getTexture()->getBackendTexture());
+    SET_TEXTURE(programState, "u_tex1", 1, right->getTexture()->getRHITexture());
 }

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest2.cpp
@@ -435,7 +435,7 @@ bool EffectNormalMapped::init()
 bool EffectNormalMapped::initNormalMap(std::string_view normalMapFileName)
 {
     auto normalMapTexture = Director::getInstance()->getTextureCache()->addImage(normalMapFileName);
-    SET_TEXTURE(_programState, "u_normalMap", 1, normalMapTexture->getBackendTexture());
+    SET_TEXTURE(_programState, "u_normalMap", 1, normalMapTexture->getRHITexture());
     return true;
 }
 void EffectNormalMapped::setTarget(EffectSprite* sprite)

--- a/tests/cpp-tests/Source/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Source/SpriteTest/SpriteTest.cpp
@@ -3386,8 +3386,6 @@ SpriteBatchNodeChildrenChildren::SpriteBatchNodeChildrenChildren()
     //
 
     aParent = SpriteBatchNode::create("animations/ghosts.png");
-    // TODO: minggo
-    //    aParent->getTexture()->generateMipmap();
     addChild(aParent);
 
     // parent
@@ -4515,7 +4513,6 @@ SpriteBatchNodeReorderOneChild::SpriteBatchNodeReorderOneChild()
     aParent = SpriteBatchNode::create("animations/ghosts.png");
 
     _batchNode = aParent;
-    //[[aParent texture] generateMipmap];
     addChild(aParent);
 
     // parent

--- a/tests/cpp-tests/Source/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Source/Texture2dTest/Texture2dTest.cpp
@@ -540,8 +540,7 @@ void TextureMipMap::onEnter()
     TextureDemo::onEnter();
     auto s = Director::getInstance()->getWinSize();
 
-    auto texture0 = Director::getInstance()->getTextureCache()->addImage("Images/grossini_dance_atlas.png");
-    texture0->generateMipmap();
+    auto texture0 = Director::getInstance()->getTextureCache()->addImage("Images/grossini_dance_atlas.png", true);
     Texture2D::TexParams texParams{};
     texture0->setTexParameters(texParams);
 

--- a/tests/live2d-tests/Source/LAppLive2DManager.cpp
+++ b/tests/live2d-tests/Source/LAppLive2DManager.cpp
@@ -244,7 +244,7 @@ void LAppLive2DManager::OnUpdate(Csm::Rendering::CubismCommandBuffer_Cocos2dx* c
             Csm::Rendering::CubismCommandBuffer_Cocos2dx* lastCommandBuffer = commandBuffer;
 
             _sprite->SetColor(1.0f, 1.0f, 1.0f, 0.25f + (float)i * 0.5f);
-            _sprite->RenderImmidiate(commandBuffer, _renderBuffer->GetColorBuffer()->getBackendTexture(), uvVertex);
+            _sprite->RenderImmidiate(commandBuffer, _renderBuffer->GetColorBuffer()->getRHITexture(), uvVertex);
 
             // 元に戻す
             commandBuffer = lastCommandBuffer;

--- a/tests/live2d-tests/Source/LAppModel.cpp
+++ b/tests/live2d-tests/Source/LAppModel.cpp
@@ -641,14 +641,13 @@ void LAppModel::SetupTextures()
 
         // Cocos2d-x
         // テクスチャをファイルからロードする. ロードできなければnullptrが返る
-        Texture2D* texture = Director::getInstance()->getTextureCache()->addImage(std::string(texturePath.GetRawString()));
+        Texture2D* texture = Director::getInstance()->getTextureCache()->addImage(std::string(texturePath.GetRawString()), true);
 
         // テクスチャが読めていなければバインド処理をスキップ
         if(!texture) continue;
 
         const SamplerDesc texParams = Texture2D::chooseSamplerDesc(true, true);
         texture->setTexParameters(texParams);
-        texture->generateMipmap();
         _loadedTextures.PushBack(texture);
 
         //Cocos2d

--- a/tests/lua-tests/Content/src/Sprite3DTest/Sprite3DTest.lua
+++ b/tests/lua-tests/Content/src/Sprite3DTest/Sprite3DTest.lua
@@ -1136,7 +1136,7 @@ function Sprite3DCubeMapTest:addNewSpriteWithCoords(pos)
 
     --pass the texture sampler to our custom shader
     local locCubeTex = programState:getUniformLocation("u_cubeTex")
-    local cubeTexture = self._textureCube:getBackendTexture()
+    local cubeTexture = self._textureCube:getRHITexture()
     programState:setTexture(locCubeTex, 0, cubeTexture)
 
     self._teapot:setProgramState(programState)

--- a/tests/lua-tests/Content/src/Texture2dTest/Texture2dTest.lua
+++ b/tests/lua-tests/Content/src/Texture2dTest/Texture2dTest.lua
@@ -74,8 +74,7 @@ local function TextureMipMap()
     local s = ax.Director:getInstance():getWinSize()
 
     local texture0 = ax.Director:getInstance():getTextureCache():addImage(
-        "Images/grossini_dance_atlas.png")
-    texture0:generateMipmap()
+        "Images/grossini_dance_atlas.png", true)
     texture0:setTexParameters(ccb.SamplerFilter.LINEAR_MIPMAP_LINEAR, ccb.SamplerFilter.LINEAR, ccb.SamplerAddressMode.CLAMP_TO_EDGE, ccb.SamplerAddressMode.CLAMP_TO_EDGE)
 
     local texture1 = ax.Director:getInstance():getTextureCache():addImage(

--- a/tests/lua-tests/Source/lua_test_bindings.cpp
+++ b/tests/lua-tests/Source/lua_test_bindings.cpp
@@ -181,7 +181,7 @@ bool DrawNode3D::init()
     _customCommand.setBeforeCallback(AX_CALLBACK_0(DrawNode3D::onBeforeDraw, this));
     _customCommand.setAfterCallback(AX_CALLBACK_0(DrawNode3D::onAfterDraw, this));
 
-#if AX_ENABLE_CACHE_TEXTURE_DATA
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     // Need to listen the event only when not use batchnode, because it will use VBO
     auto listener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom* event) {
         /** listen the event that coming to foreground on Android */

--- a/tools/tolua/ax_base.ini
+++ b/tools/tolua/ax_base.ini
@@ -45,7 +45,7 @@ skip = Node::[setGLServerState description _setLocalZOrder getUserObject .*UserD
         LabelTextFormatProtocol::[*],
         .*Delegate::[*],
         PoolManager::[*],
-        Texture2D::[setTexParameters initWithData getPixelFormatInfoMap updateWithData initWithMipmaps],
+        Texture2D::[setTexParameters initWithData getPixelFormatInfoMap updateWithData initWithMipmaps initWithSpec],
         Set::[begin end acceptVisitor],
         IMEDispatcher::[*],
         SAXParser::[*],

--- a/tools/tolua/ax_base.ini
+++ b/tools/tolua/ax_base.ini
@@ -45,7 +45,7 @@ skip = Node::[setGLServerState description _setLocalZOrder getUserObject .*UserD
         LabelTextFormatProtocol::[*],
         .*Delegate::[*],
         PoolManager::[*],
-        Texture2D::[setTexParameters initWithData getPixelFormatInfoMap updateWithData initWithMipmaps initWithSpec],
+        Texture2D::[setTexParameters initWithData getPixelFormatInfoMap updateWithData initWithMipmaps initWithSpec chooseSamplerDesc],
         Set::[begin end acceptVisitor],
         IMEDispatcher::[*],
         SAXParser::[*],

--- a/tools/tolua/ax_rhi.ini
+++ b/tools/tolua/ax_rhi.ini
@@ -28,7 +28,7 @@ classes = VertexLayout BufferUsage BufferType ShaderStage VertexFormat PixelForm
 # functions from all classes.
 
 skip =  VertexLayout::[getBindings getInstanceBindings],
-        ProgramState::[getCallbackUniforms getVertexTextureInfos getVertexUniformInfos getFragmentTextureInfos getFragmentUniformInfos setTextureArray setCallbackUniform setUniform getVertexUniformBuffer getFragmentUniformBuffer getVertexLayout getUniformLocation],
+        ProgramState::[getCallbackUniforms getTextureBindingInfos getVertexUniformInfos getFragmentUniformInfos setTextureArray setCallbackUniform setUniform getVertexUniformBuffer getFragmentUniformBuffer getVertexLayout getUniformLocation],
         Program::[getFragmentUniformInfos getVertexUniformInfos cloneUniformBuffer getActiveUniformInfo getActiveUniformInfos getActiveVertexInputs],
         DriverBase::[createCommandBuffer createBuffer createTexture createDepthStencilState createRenderPipeline setFrameBufferOnly]
 rename_functions =


### PR DESCRIPTION
## Describe your changes

- Add sampler2DArray in shader support
- Remove texture array implementation in CPU side
- Simplify texture binding infos in `ProgramState`
- Add new API `Texture2D::initWithSpec`, all other init stubs will invoke it finally
- MipLevel improvemnts, remove API generateMipmaps in renderer, auto process in rhi
- Remove API `Texture2D::setRenderTarget`
- Rename `Texture2D::getBackendTexture` => `Texture2D::getRHITexture()`
- Rename `VolatileTextureMgr::getOrAddVolatileTexture` => `VolatileTextureMgr::ensureVolatileTexture`
- Rename macro `AX_ENABLE_CACHE_TEXTURE_DATA` => `AX_ENABLE_CONTEXT_LOSS_RECOVERY`

## Issue ticket number and link


## Checklist before requesting a review

### adopt changes

- [x] FairyGUI etc1 image load
- [x] metal backend
- [x] mipmap logic
- [x] dual sampler shaders
- [x] ui::MediaPlayer
- [x]  AX_ENABLE_CACHE_TEXTURE_DATA
- [x] Terrain
- [x] RenderTexture

### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
