### PR TITLE
Re-add ProgramState setTextureArray feature and do improvement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
           templates/**/*.apk
           tests/**/*.apk
   ios:
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       matrix:
         target_os:

--- a/1k/build.profiles
+++ b/1k/build.profiles
@@ -6,7 +6,7 @@
 # --- region platfom:common
 
 # The axmol shader compiler, legacy name is 'glslcc' before axmol-2.3.0
-axslcc=1.12.0+
+axslcc=1.13.1
 
 # The cmake, @gradle @axmol-cmdline
 # as latest as possible

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -256,6 +256,7 @@ Terrain::Terrain()
     _director->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, 1);
 #endif
     _dummyTexture = _director->getTextureCache()->getWhiteTexture();
+    AX_SAFE_RETAIN(_dummyTexture);
 }
 
 void Terrain::setChunksLOD(const Vec3& cameraPos)

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -135,36 +135,39 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
     _programState->setUniform(_lightDirLocation, &_lightDir, sizeof(_lightDir));
     if (!_alphaMap)
     {
-        _programState->setTexture(_detailMapLocation[0], 0, _detailMapTextures[0]->getRHITexture());
+        _programState->setTexture(_detailMapLocation, _detailMapBindings[0].slot, _detailMapBindings[0].tex);
         int hasAlphaMap = 0;
         _programState->setUniform(_alphaIsHasAlphaMapLocation, &hasAlphaMap, sizeof(hasAlphaMap));
+#if AX_RENDER_API != AX_RENDER_API_GL
+        _programState->setTexture(_lightMapLocation, BINDING_SLOT_ALPHA_MAP, _dummyTexture->getRHITexture());
+#endif
     }
     else
     {
         float detailMapSize[4] = {0.0f, 0.0f, 0.0f, 0.0f};
         for (int i = 0; i < _maxDetailMapValue; ++i)
         {
-            _programState->setTexture(_detailMapLocation[i], i, _detailMapTextures[i]->getRHITexture());
             detailMapSize[i] = _terrainData._detailMaps[i]._detailMapSize;
         }
+        _programState->setTextureArray(_detailMapLocation, _detailMapBindings);
         _programState->setUniform(_detailMapSizeLocation, detailMapSize, sizeof(detailMapSize));
 
         int hasAlphaMap = 1;
         _programState->setUniform(_alphaIsHasAlphaMapLocation, &hasAlphaMap, sizeof(hasAlphaMap));
-        _programState->setTexture(_alphaMapLocation, 4, _alphaMap->getRHITexture());
+        _programState->setTexture(_alphaMapLocation, BINDING_SLOT_ALPHA_MAP, _alphaMap->getRHITexture());
     }
     if (_lightMap)
     {
         int hasLightMap = 1;
         _programState->setUniform(_lightMapCheckLocation, &hasLightMap, sizeof(hasLightMap));
-        _programState->setTexture(_lightMapLocation, 5, _lightMap->getRHITexture());
+        _programState->setTexture(_lightMapLocation, BINDING_SLOT_LIGHT_MAP, _lightMap->getRHITexture());
     }
     else
     {
         int hasLightMap = 0;
         _programState->setUniform(_lightMapCheckLocation, &hasLightMap, sizeof(hasLightMap));
-#if AX_RENDER_API == AX_RENDER_API_MTL || AX_RENDER_API == AX_RENDER_API_D3D
-        _programState->setTexture(_lightMapLocation, 5, _detailMapTextures[0]->getRHITexture());
+#if AX_RENDER_API != AX_RENDER_API_GL
+        _programState->setTexture(_lightMapLocation, BINDING_SLOT_LIGHT_MAP, _dummyTexture->getRHITexture());
 #endif
     }
     auto camera = Camera::getVisitingCamera();
@@ -477,6 +480,7 @@ Terrain::~Terrain()
         {
             _detailMapTextures[i]->release();
         }
+        _detailMapBindings[i].reset();
     }
     for (int i = 0; i < MAX_CHUNKES; ++i)
     {
@@ -689,7 +693,6 @@ void Terrain::setDetailMap(unsigned int index, DetailMap detailMap)
     _terrainData._detailMaps[index] = detailMap;
     if (_detailMapTextures[index])
     {
-
         _detailMapTextures[index]->release();
     }
     _detailMapTextures[index] = new Texture2D();
@@ -697,6 +700,9 @@ void Terrain::setDetailMap(unsigned int index, DetailMap detailMap)
     textImage->initWithImageFile(detailMap._detailMapSrc);
     _detailMapTextures[index]->initWithImage(textImage);
     delete textImage;
+
+    _detailMapBindings[index].slot = BINDING_SLOT_DETAIL_BASE + index;
+    _detailMapBindings[index].tex = _detailMapTextures[index]->getRHITexture();
 }
 
 Terrain::ChunkIndices Terrain::lookForIndicesLOD(int neighborLod[4], int selfLod, bool* result)
@@ -799,26 +805,18 @@ void Terrain::onEnter()
 void Terrain::cacheUniformAttribLocation()
 {
     _alphaMapLocation.reset();
-    for (int i = 0; i < 4; ++i)
-    {
-        _detailMapLocation[i].reset();
-    }
+    _detailMapLocation.reset();
     _detailMapSizeLocation.reset();
 
     _alphaIsHasAlphaMapLocation = _programState->getUniformLocation("u_has_alpha");
     _lightMapCheckLocation      = _programState->getUniformLocation("u_has_light_map");
     if (!_alphaMap)
     {
-        _detailMapLocation[0] = _programState->getUniformLocation("u_tex0");
+        _detailMapLocation = _programState->getUniformLocation("u_details");
     }
     else
     {
-        char str[20];
-        for (int i = 0; i < _maxDetailMapValue; ++i)
-        {
-            auto key = fmt::format_to_z(str, "u_tex{}", i);
-            _detailMapLocation[i] = _programState->getUniformLocation(key);
-        }
+        _detailMapLocation = _programState->getUniformLocation("u_details");
 
         _detailMapSizeLocation = _programState->getUniformLocation("u_detailSize");  // float[4]
 
@@ -834,6 +832,7 @@ bool Terrain::initTextures()
     for (int i = 0; i < 4; ++i)
     {
         _detailMapTextures[i] = nullptr;
+        _detailMapBindings[i].reset();
     }
 
     rhi::TextureDesc texDesc;
@@ -855,6 +854,9 @@ bool Terrain::initTextures()
         texture->initWithSpec(texDesc, subDatas);
         _detailMapTextures[0] = texture;
         image->release();
+
+        _detailMapBindings[0].slot = BINDING_SLOT_DETAIL_BASE;
+        _detailMapBindings[0].tex = texture->getRHITexture();
     }
     else
     {
@@ -886,6 +888,9 @@ bool Terrain::initTextures()
             auto texture = new Texture2D();
             texture->initWithSpec(texDesc, subDatas);
             _detailMapTextures[i] = texture;
+
+            _detailMapBindings[i].slot = BINDING_SLOT_DETAIL_BASE + i;
+            _detailMapBindings[i].tex = texture->getRHITexture();
 
             image->release();
         }

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -47,15 +47,6 @@ using namespace ax;
 
 namespace ax
 {
-
-namespace
-{
-// It's used for creating a default texture when lightMap is nullpter
-static unsigned char ax_2x2_white_image[] = {
-    // RGBA8888
-    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-}  // namespace
-
 Terrain* Terrain::create(TerrainData& parameter, CrackFixedType fixedType)
 {
     Terrain* terrain = new Terrain();
@@ -138,9 +129,7 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
         _programState->setTexture(_detailMapLocation, _detailMapBindings[0].slot, _detailMapBindings[0].tex);
         int hasAlphaMap = 0;
         _programState->setUniform(_alphaIsHasAlphaMapLocation, &hasAlphaMap, sizeof(hasAlphaMap));
-#if AX_RENDER_API != AX_RENDER_API_GL
         _programState->setTexture(_lightMapLocation, BINDING_SLOT_ALPHA_MAP, _dummyTexture->getRHITexture());
-#endif
     }
     else
     {
@@ -166,9 +155,7 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
     {
         int hasLightMap = 0;
         _programState->setUniform(_lightMapCheckLocation, &hasLightMap, sizeof(hasLightMap));
-#if AX_RENDER_API != AX_RENDER_API_GL
         _programState->setTexture(_lightMapLocation, BINDING_SLOT_LIGHT_MAP, _dummyTexture->getRHITexture());
-#endif
     }
     auto camera = Camera::getVisitingCamera();
 
@@ -268,14 +255,7 @@ Terrain::Terrain()
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { reload(); });
     _director->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, 1);
 #endif
-#if AX_RENDER_API == AX_RENDER_API_MTL || AX_RENDER_API == AX_RENDER_API_D3D
-    auto image          = new Image();
-    bool AX_UNUSED isOK = image->initWithRawData(ax_2x2_white_image, sizeof(ax_2x2_white_image), 2, 2, 8);
-    AXASSERT(isOK, "The 2x2 empty texture was created unsuccessfully.");
-    _dummyTexture = new Texture2D();
-    _dummyTexture->initWithImage(image);
-    AX_SAFE_RELEASE(image);
-#endif
+    _dummyTexture = _director->getTextureCache()->getWhiteTexture();
 }
 
 void Terrain::setChunksLOD(const Vec3& cameraPos)

--- a/axmol/3d/Terrain.h
+++ b/axmol/3d/Terrain.h
@@ -100,6 +100,17 @@ public:
         INCREASE_LOWER,
     };
 
+    /* must match in shader terrain.frag
+        layout(binding = 0) uniform sampler2D u_details[4]; // will take slot 0~3
+        layout(binding = 4) uniform sampler2D u_alphaMap;
+        layout(binding = 5) uniform sampler2D u_lightMap;
+    */
+    enum TextureBindingSlot {
+        BINDING_SLOT_DETAIL_BASE = 0,
+        BINDING_SLOT_ALPHA_MAP = 4,
+        BINDING_SLOT_LIGHT_MAP = 5
+    };
+
     /**
      *DetailMap
      *this struct maintain a detail map data ,including source file ,detail size.
@@ -524,6 +535,7 @@ protected:
     unsigned char* _data;
     float _lodDistance[3];
     Texture2D* _detailMapTextures[4];
+    rhi::TextureBinding _detailMapBindings[4]; // weak ref
     Texture2D* _alphaMap;
     Texture2D* _lightMap;
     Texture2D* _dummyTexture = nullptr;
@@ -561,7 +573,7 @@ protected:
 
 private:
     // uniform locations
-    rhi::UniformLocation _detailMapLocation[4];
+    rhi::UniformLocation _detailMapLocation;
     rhi::UniformLocation _alphaMapLocation;
     rhi::UniformLocation _alphaIsHasAlphaMapLocation;
     rhi::UniformLocation _lightMapCheckLocation;

--- a/axmol/3d/VertexInputBinding.cpp
+++ b/axmol/3d/VertexInputBinding.cpp
@@ -33,7 +33,7 @@ namespace ax
 {
 
 /**
-* axmol-3.0: we use meshIndexData+instancing as key to ensure cache hit
+* axmol-3.0: we use meshIndexData+program+instancing as key to ensure cache hit
 * older version: cache miss always due to programState always changes when switch
 * render objects
 */
@@ -67,12 +67,14 @@ VertexInputBinding* VertexInputBinding::spawn(MeshIndexData* meshIndexData,
     struct HashMe
     {
         MeshIndexData* meshData;
+        Program* shaderProg;
         bool instancing;
     };
 
     HashMe hashMe;
     memset(&hashMe, 0, sizeof(hashMe));
     hashMe.meshData   = meshIndexData;
+    hashMe.shaderProg = pass->getProgramState()->getProgram();
     hashMe.instancing = instancing;
 
     auto hash   = XXH32(&hashMe, sizeof(hashMe), 0);

--- a/axmol/3d/VertexInputBinding.cpp
+++ b/axmol/3d/VertexInputBinding.cpp
@@ -166,7 +166,7 @@ void VertexInputBinding::setVertexInputPointer(VertexLayoutDesc& desc,
     }
     else
     {
-        AXLOGD("VertexInputBinding: warning: attribute: '{}' not present in shader", name);
+        AXLOGI("VertexInputBinding: attribute: '{}' not present in shader", name);
     }
 }
 

--- a/axmol/renderer/shaders/terrain.frag
+++ b/axmol/renderer/shaders/terrain.frag
@@ -6,11 +6,8 @@ precision highp int;
 
 layout(location = TEXCOORD0) in vec2 v_texCoord;
 layout(location = NORMAL) in vec3 v_normal;
-layout(binding = 0) uniform sampler2D u_alphaMap;
-layout(binding = 1) uniform sampler2D u_tex0;
-layout(binding = 2) uniform sampler2D u_tex1;
-layout(binding = 3) uniform sampler2D u_tex2;
-layout(binding = 4) uniform sampler2D u_tex3;
+layout(binding = 0) uniform sampler2D u_details[4]; // will take slot 0~3
+layout(binding = 4) uniform sampler2D u_alphaMap;
 layout(binding = 5) uniform sampler2D u_lightMap;
 layout(std140) uniform fs_ub {
     int u_has_alpha;
@@ -35,15 +32,15 @@ void main()
     float lightFactor = dot(-u_lightDir,v_normal);
     if(u_has_alpha<=0)
     {
-        FragColor = texture(u_tex0, v_texCoord)*lightColor*lightFactor;
+        FragColor = texture(u_details[0], v_texCoord)*lightColor*lightFactor;
     }
     else
     {
         vec4 blendFactor =texture(u_alphaMap,v_texCoord);
         vec4 color = vec4(0.0,0.0,0.0,0.0);
-        color = texture(u_tex0, v_texCoord*vfloat_at(u_detailSize, 0))*blendFactor.r +
-        texture(u_tex1, v_texCoord*vfloat_at(u_detailSize, 1))*blendFactor.g + texture(u_tex2, v_texCoord*vfloat_at(u_detailSize, 2))*blendFactor.b
-            + texture(u_tex3, v_texCoord*vfloat_at(u_detailSize, 3))*(1.0 - blendFactor.a);
+        color = texture(u_details[0], v_texCoord*vfloat_at(u_detailSize, 0))*blendFactor.r +
+        texture(u_details[1], v_texCoord*vfloat_at(u_detailSize, 1))*blendFactor.g + texture(u_details[2], v_texCoord*vfloat_at(u_detailSize, 2))*blendFactor.b
+            + texture(u_details[3], v_texCoord*vfloat_at(u_detailSize, 3))*(1.0 - blendFactor.a);
         FragColor = vec4(color.rgb*lightColor.rgb*lightFactor, 1.0);
     }
 }

--- a/axmol/rhi/ProgramState.cpp
+++ b/axmol/rhi/ProgramState.cpp
@@ -37,49 +37,51 @@ namespace ax::rhi {
 // static field
 std::vector<ProgramState::AutoBindingResolver*> ProgramState::_customAutoBindingResolvers;
 
-TextureBindingInfo::TextureBindingInfo(const TextureBindingInfo& other)
+TextureBindingSet::TextureBindingSet(const TextureBindingSet& other)
 {
     this->assign(other);
 }
 
-TextureBindingInfo::TextureBindingInfo(TextureBindingInfo&& other) noexcept
+TextureBindingSet::TextureBindingSet(TextureBindingSet&& other) noexcept
 {
-    this->assign(std::move(other));
+    this->swap(other);
 }
 
-TextureBindingInfo& TextureBindingInfo::operator=(const TextureBindingInfo& other) noexcept
+TextureBindingSet& TextureBindingSet::operator=(const TextureBindingSet& other) noexcept
 {
     this->assign(other);
     return *this;
 }
 
-TextureBindingInfo& TextureBindingInfo::operator=(TextureBindingInfo&& other) noexcept
+TextureBindingSet& TextureBindingSet::operator=(TextureBindingSet&& other) noexcept
 {
-    this->assign(std::move(other));
+    this->swap(other);
     return *this;
 }
 
-void TextureBindingInfo::assign(const TextureBindingInfo& other)
+TextureBindingSet::~TextureBindingSet()
+{
+    releaseTextures();
+}
+
+void TextureBindingSet::assign(const TextureBindingSet& other)
 {
     if (this != &other)
     {
-        AX_SAFE_RELEASE(this->tex);
-        this->slot = other.slot;
-        this->tex  = other.tex;
-        AX_SAFE_RETAIN(this->tex);
-
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-        location = other.location;
+        setTextureArray(other.location, other.slots, other.texs);
+#else
+        setTextureArray(-1, other.slots, other.texs);
 #endif
     }
 }
 
-void TextureBindingInfo::assign(TextureBindingInfo&& other)
+void TextureBindingSet::swap(TextureBindingSet& other)
 {
     if (this != &other)
     {
-        std::swap(slot, other.slot);
-        std::swap(tex, other.tex);
+        std::swap(slots, other.slots);
+        std::swap(texs, other.texs);
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
         std::swap(location, other.location);
@@ -87,24 +89,70 @@ void TextureBindingInfo::assign(TextureBindingInfo&& other)
     }
 }
 
-void TextureBindingInfo::setTexture(int location_, int slot_, rhi::Texture* tex_)
+void TextureBindingSet::setTexture(int location, int slot, rhi::Texture* tex)
 {
-    AX_SAFE_RELEASE(this->tex);
+    if(tex && slot >= 0) {
+        tex->retain();
+        releaseTextures();
+        this->slots.push_back(location);
+        this->texs.push_back(tex);
+    }
+}
 
-    this->slot = slot_;
-    this->tex  = tex_;
+void TextureBindingSet::setTextureArray(int location, std::span<const TextureBinding> units)
+{
+    for(auto& unit : units)
+        AX_SAFE_RETAIN(unit.tex);
 
-    AX_SAFE_RETAIN(this->tex);
+    releaseTextures();
+
+    if(!units.empty()) {
+        const auto count = units.size();
+        this->texs.resize(count);
+        this->slots.resize(count);
+        for (int i = 0; i < count; ++i) {
+            this->texs[i] = units[i].tex;
+            this->slots[i] = units[i].slot;
+        }
+    }
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     this->location = location_;
 #endif
 }
 
-TextureBindingInfo::~TextureBindingInfo()
+void TextureBindingSet::setTextureArray(int location, std::span<const int> slots, std::span<rhi::Texture*> texs)
 {
-    AX_SAFE_RELEASE(this->tex);
+    bool retain = !slots.empty() && (slots.size() == texs.size());
+
+    if (retain) {
+        for(auto tex : texs)
+            AX_SAFE_RETAIN(tex);
+    }
+
+    releaseTextures();
+
+    if(retain) {
+        this->slots.resize(slots.size());
+        this->texs.resize(slots.size());
+        
+        memcpy(this->slots.data(), slots.data(), slots.size_bytes());
+        memcpy(this->texs.data(), texs.data(), texs.size_bytes());
+    }
+
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
+    this->location = location_;
+#endif
 }
+
+void TextureBindingSet::releaseTextures()
+{
+    for(auto& tex: this->texs)
+        AX_SAFE_RELEASE(tex);
+    this->texs.clear();
+    this->slots.clear();
+}
+
 
 /* CLASS ProgramState */
 ProgramState::ProgramState(Program* program)
@@ -183,7 +231,7 @@ ProgramState::~ProgramState()
 ProgramState* ProgramState::clone() const
 {
     ProgramState* cp          = new ProgramState(_program);
-    cp->_textureBindingInfos  = _textureBindingInfos;
+    cp->_textureBindingSets   = _textureBindingSets;
 
     cp->_uniformBuffer = _uniformBuffer;
 #if AX_RENDER_API != AX_RENDER_API_GL
@@ -239,8 +287,28 @@ void ProgramState::setTexture(const rhi::UniformLocation& uniformLocation, int s
     auto location = uniformLocation.stages[0].location;
     if (location >= 0)
     {
-        auto& textureBinding = _textureBindingInfos[location];
-        textureBinding.setTexture(location, slot, texture);
+        auto& bindingSet = _textureBindingSets[location];
+        bindingSet.setTexture(location, slot, texture);
+    }
+}
+
+void ProgramState::setTextureArray(const rhi::UniformLocation& uniformLocation, std::span<TextureBinding> units)
+{
+    auto location = uniformLocation.stages[0].location;
+    if (location >= 0)
+    {
+        auto& bindingSet = _textureBindingSets[location];
+        bindingSet.setTextureArray(location, units);
+    }
+}
+
+void ProgramState::setTextureArray(const rhi::UniformLocation& uniformLocation, std::span<int> slots, std::span<rhi::Texture*> textures)
+{
+    auto location = uniformLocation.stages[0].location;
+    if (location >= 0)
+    {
+        auto& bindingSet = _textureBindingSets[location];
+        bindingSet.setTextureArray(location, slots, textures);
     }
 }
 

--- a/axmol/rhi/ProgramState.cpp
+++ b/axmol/rhi/ProgramState.cpp
@@ -69,7 +69,7 @@ void TextureBindingSet::assign(const TextureBindingSet& other)
     if (this != &other)
     {
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-        setTextureArray(other.location, other.slots, other.texs);
+        setTextureArray(other.loc, other.slots, other.texs);
 #else
         setTextureArray(-1, other.slots, other.texs);
 #endif
@@ -84,7 +84,7 @@ void TextureBindingSet::swap(TextureBindingSet& other)
         std::swap(texs, other.texs);
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-        std::swap(location, other.location);
+        std::swap(loc, other.loc);
 #endif
     }
 }
@@ -94,7 +94,7 @@ void TextureBindingSet::setTexture(int location, int slot, rhi::Texture* tex)
     if(tex && slot >= 0) {
         tex->retain();
         releaseTextures();
-        this->slots.push_back(location);
+        this->slots.push_back(slot);
         this->texs.push_back(tex);
     }
 }
@@ -117,7 +117,7 @@ void TextureBindingSet::setTextureArray(int location, std::span<const TextureBin
     }
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-    this->location = location_;
+    this->loc = location;
 #endif
 }
 
@@ -141,7 +141,7 @@ void TextureBindingSet::setTextureArray(int location, std::span<const int> slots
     }
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-    this->location = location_;
+    this->loc = location;
 #endif
 }
 
@@ -211,10 +211,9 @@ void ProgramState::resetUniforms()
         auto mappedLocation = _program->getMappedLocation(location);
 
         // check if current location had been set before
-        if (_textureBindingInfos.find(location) != _textureBindingInfos.end())
-        {
-            _textureBindingInfos[location].location = mappedLocation;
-        }
+        auto it = _textureBindingSets.find(location);
+        if (it != _textureBindingSets.end())
+            it->second.loc = mappedLocation;
     }
 #endif
 }

--- a/axmol/rhi/ProgramState.h
+++ b/axmol/rhi/ProgramState.h
@@ -87,7 +87,7 @@ struct AX_DLL TextureBindingSet
     axstd::pod_vector<int> slots;
     mutable axstd::pod_vector<rhi::Texture*> texs;
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-    int location = -1;
+    int loc = -1;
 #endif
 };
 

--- a/axmol/rhi/ProgramState.h
+++ b/axmol/rhi/ProgramState.h
@@ -63,7 +63,7 @@ class VertexLayout;
 /**
  * Store texture binding information.
  * OpenGL can use 1 location (logic var location) to store multi texture units, in shader is 'uniform sampler2D texs[4]'
- * Metal/D3D11 dicard location
+ * Metal/D3D11: location is bindingIndex reflected from shader
  */
 struct AX_DLL TextureBindingSet
 {

--- a/axmol/rhi/ProgramState.h
+++ b/axmol/rhi/ProgramState.h
@@ -49,26 +49,43 @@ class VertexLayout;
  * @{
  */
 
+ struct TextureBinding {
+    int slot{-1};
+    rhi::Texture* tex{nullptr};
+
+    void reset() 
+    {
+        slot = -1;
+        tex = nullptr;
+    }
+ };
+
 /**
- * Store texture information.
+ * Store texture binding information.
+ * OpenGL can use 1 location (logic var location) to store multi texture units, in shader is 'uniform sampler2D texs[4]'
+ * Metal/D3D11 dicard location
  */
-struct AX_DLL TextureBindingInfo
+struct AX_DLL TextureBindingSet
 {
-    TextureBindingInfo() = default;
-    TextureBindingInfo(const TextureBindingInfo&);
-    TextureBindingInfo(TextureBindingInfo&& rhs) noexcept;
-    ~TextureBindingInfo();
+    TextureBindingSet() = default;
+    TextureBindingSet(const TextureBindingSet&);
+    TextureBindingSet(TextureBindingSet&& rhs) noexcept;
+    ~TextureBindingSet();
 
-    TextureBindingInfo& operator=(const TextureBindingInfo& other) noexcept;
-    TextureBindingInfo& operator=(TextureBindingInfo&& other) noexcept;
+    TextureBindingSet& operator=(const TextureBindingSet& other) noexcept;
+    TextureBindingSet& operator=(TextureBindingSet&& other) noexcept;
 
-    void assign(const TextureBindingInfo& other);
-    void assign(TextureBindingInfo&& other);
+    void assign(const TextureBindingSet& other);
+    void swap(TextureBindingSet& other);
 
     void setTexture(int location, int slot, rhi::Texture* tex);
+    void setTextureArray(int location, std::span<const TextureBinding> units);
+    void setTextureArray(int location, std::span<const int> slots, std::span<rhi::Texture*> texs);
 
-    int slot{0};
-    rhi::Texture* tex{nullptr};
+    void releaseTextures();
+
+    axstd::pod_vector<int> slots;
+    mutable axstd::pod_vector<rhi::Texture*> texs;
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     int location = -1;
 #endif
@@ -177,21 +194,20 @@ public:
      * @param texture Specifies a pointer to backend texture.
      */
     void setTexture(rhi::Texture* texture);
-
-    /**
-     * Set texture.
-     * @param uniformLocation Specifies texture location.
-     * @param slot Specifies texture slot selector.
-     * @param texture Specifies a pointer to backend texture.
-     */
     void setTexture(const rhi::UniformLocation& uniformLocation, int slot, rhi::Texture* texture);
 
+    /**
+     * Set texture array in shader 'uniform sampler2D xxx[4];' unlikely sampoler2DArray, the array will
+     * use multi texture units
+     */
+    void setTextureArray(const rhi::UniformLocation& uniformLocation, std::span<TextureBinding> units);
+    void setTextureArray(const rhi::UniformLocation& uniformLocation, std::span<int> slot, std::span<rhi::Texture*> texture);
 
     /**
      * Get vertex texture informations
      * @return Vertex texture informations. Key is the texture location, Value store the texture informations
      */
-    inline const std::unordered_map<int, TextureBindingInfo>& getTextureBindingInfos() const { return _textureBindingInfos; }
+    inline const std::unordered_map<int, TextureBindingSet>& getTextureBindingSets() const { return _textureBindingSets; }
 
 #if AX_RENDER_API == AX_RENDER_API_GL
     std::span<const char> getUniformBuffer() { return std::span{_uniformBuffer}; }
@@ -337,7 +353,7 @@ protected:
     std::size_t _vertexUniformBufferStart = 0;
 #endif
 
-    std::unordered_map<int, TextureBindingInfo> _textureBindingInfos;
+    std::unordered_map<int, TextureBindingSet> _textureBindingSets;
 
     std::unordered_map<std::string, std::string> _autoBindings;
 

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -576,7 +576,7 @@ void CommandBufferImpl::prepareDrawing()
     for (const auto& [bindingIndex, bindingSet] : _programState->getTextureBindingSets())
     {
         auto& texs     = bindingSet.texs;
-        auto arraySize = bindingSet.slots.size();
+        auto arraySize = texs.size();
         for (size_t k = 0; k < arraySize; ++k)
         {
             const auto slot  = bindingIndex + k;

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -573,7 +573,7 @@ void CommandBufferImpl::prepareDrawing()
 
     // bind texture
     _textureBounds = 0;
-    for (const auto& [_, bindingInfo] : _programState->getTextureBindingInfos())
+    for (const auto& [_, bindingInfo] : _programState->getTextureBindingSets())
     {
         auto textureImpl    = static_cast<TextureImpl*>(bindingInfo.tex);
         auto& textureHandle = textureImpl->internalHandle();

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -573,14 +573,19 @@ void CommandBufferImpl::prepareDrawing()
 
     // bind texture
     _textureBounds = 0;
-    for (const auto& [_, bindingInfo] : _programState->getTextureBindingSets())
+    for (const auto& [_, bindingSet] : _programState->getTextureBindingSets())
     {
-        auto textureImpl    = static_cast<TextureImpl*>(bindingInfo.tex);
-        auto& textureHandle = textureImpl->internalHandle();
-        context->PSSetShaderResources(bindingInfo.slot, 1, &textureHandle.srv);
-        auto samplerState = textureImpl->getSamplerState();
-        context->PSSetSamplers(bindingInfo.slot, 1, &samplerState);
-        ++_textureBounds;
+        auto& slots    = bindingSet.slots;
+        auto& texs     = bindingSet.texs;
+        auto arraySize = bindingSet.slots.size();
+        for (size_t k = 0; k < arraySize; ++k)
+        {
+            auto textureImpl    = static_cast<TextureImpl*>(texs[k]);
+            context->PSSetShaderResources(slots[k], 1, &textureImpl->internalHandle().srv);
+            auto samplerState = textureImpl->getSamplerState();
+            context->PSSetSamplers(slots[k], 1, &samplerState);
+            ++_textureBounds;
+        }
     }
 
     // depth stencil

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -573,17 +573,17 @@ void CommandBufferImpl::prepareDrawing()
 
     // bind texture
     _textureBounds = 0;
-    for (const auto& [_, bindingSet] : _programState->getTextureBindingSets())
+    for (const auto& [bindingIndex, bindingSet] : _programState->getTextureBindingSets())
     {
-        auto& slots    = bindingSet.slots;
         auto& texs     = bindingSet.texs;
         auto arraySize = bindingSet.slots.size();
         for (size_t k = 0; k < arraySize; ++k)
         {
+            const auto slot  = bindingIndex + k;
             auto textureImpl    = static_cast<TextureImpl*>(texs[k]);
-            context->PSSetShaderResources(slots[k], 1, &textureImpl->internalHandle().srv);
+            context->PSSetShaderResources(slot, 1, &textureImpl->internalHandle().srv);
             auto samplerState = textureImpl->getSamplerState();
-            context->PSSetSamplers(slots[k], 1, &samplerState);
+            context->PSSetSamplers(slot, 1, &samplerState);
             ++_textureBounds;
         }
     }

--- a/axmol/rhi/metal/CommandBufferMTL.mm
+++ b/axmol/rhi/metal/CommandBufferMTL.mm
@@ -411,7 +411,7 @@ void CommandBufferImpl::afterDraw()
         [_mtlIndexBuffer release];
         _mtlIndexBuffer = nullptr;
     }
-    
+
     _programState = nullptr;
     _vertexLayout = nullptr;
 }
@@ -432,16 +432,16 @@ void CommandBufferImpl::prepareDrawing() const
 
 void CommandBufferImpl::setTextures() const
 {
-    for (const auto& [location, bindingSet] : _programState->getTextureBindingSets())
+    for (const auto& [bindingIndex, bindingSet] : _programState->getTextureBindingSets())
     {
         auto& texs = bindingSet.texs;
         auto arraySize = texs.size();
         for(auto k = 0; k < arraySize; ++k)
         {
-            const auto bindingIndex = location + k;
+            const auto slot = bindingIndex + k;
             auto textureImpl = static_cast<TextureImpl*>(texs[k]);
-            [_mtlRenderEncoder setFragmentTexture:textureImpl->internalHandle() atIndex:bindingIndex];
-            [_mtlRenderEncoder setFragmentSamplerState:textureImpl->internalSampler() atIndex:bindingIndex];
+            [_mtlRenderEncoder setFragmentTexture:textureImpl->internalHandle() atIndex:slot];
+            [_mtlRenderEncoder setFragmentSamplerState:textureImpl->internalSampler() atIndex:slot];
         }
     }
 }

--- a/axmol/rhi/metal/CommandBufferMTL.mm
+++ b/axmol/rhi/metal/CommandBufferMTL.mm
@@ -432,11 +432,17 @@ void CommandBufferImpl::prepareDrawing() const
 
 void CommandBufferImpl::setTextures() const
 {
-    for (auto& [location, bindingInfo] : _programState->getTextureBindingSets())
+    for (const auto& [location, bindingSet] : _programState->getTextureBindingSets())
     {
-        auto textureImpl = static_cast<TextureImpl*>(bindingInfo.tex);
-        [_mtlRenderEncoder setFragmentTexture:textureImpl->internalHandle() atIndex:location];
-        [_mtlRenderEncoder setFragmentSamplerState:textureImpl->internalSampler() atIndex:location];
+        auto& texs = bindingSet.texs;
+        auto arraySize = texs.size();
+        for(auto k = 0; k < arraySize; ++k)
+        {
+            const auto bindingIndex = location + k;
+            auto textureImpl = static_cast<TextureImpl*>(texs[k]);
+            [_mtlRenderEncoder setFragmentTexture:textureImpl->internalHandle() atIndex:bindingIndex];
+            [_mtlRenderEncoder setFragmentSamplerState:textureImpl->internalSampler() atIndex:bindingIndex];
+        }
     }
 }
 
@@ -448,7 +454,7 @@ void CommandBufferImpl::setUniformBuffer() const
         for (auto& cb : callbackUniforms)
             cb.second(_programState, cb.first);
 
-        // Uniform buffer: glsl-optimizer is bound to index 1, axslcc: bound to 0
+        // axslcc spec, bound to 0
         constexpr int bindingIndex = DriverImpl::VBO_BINDING_INDEX_START;
 
         auto vertexUB     = _programState->getVertexUniformBuffer();

--- a/axmol/rhi/metal/CommandBufferMTL.mm
+++ b/axmol/rhi/metal/CommandBufferMTL.mm
@@ -432,7 +432,7 @@ void CommandBufferImpl::prepareDrawing() const
 
 void CommandBufferImpl::setTextures() const
 {
-    for (auto& [location, bindingInfo] : _programState->getTextureBindingInfos())
+    for (auto& [location, bindingInfo] : _programState->getTextureBindingSets())
     {
         auto textureImpl = static_cast<TextureImpl*>(bindingInfo.tex);
         [_mtlRenderEncoder setFragmentTexture:textureImpl->internalHandle() atIndex:location];

--- a/axmol/rhi/opengl/CommandBufferGL.cpp
+++ b/axmol/rhi/opengl/CommandBufferGL.cpp
@@ -355,6 +355,11 @@ void CommandBufferImpl::bindUniforms(ProgramImpl* program) const
             const auto arraySize = slots.size();
             if (!arraySize) [[unlikely]]
                 continue;
+
+#if AX_ENABLE_CONTEXT_LOSS_RECOVERY
+            location = bindingSet.loc;
+#endif
+
             if (arraySize == 1) 
             { // perform bind for 'uniform sampler2D u_tex;' or 'uniform sampler2DArray u_texs;'
                 static_cast<TextureImpl*>(texs[0])->apply(slots[0]);

--- a/axmol/rhi/opengl/CommandBufferGL.cpp
+++ b/axmol/rhi/opengl/CommandBufferGL.cpp
@@ -348,10 +348,24 @@ void CommandBufferImpl::bindUniforms(ProgramImpl* program) const
         auto&& buffer            = _programState->getUniformBuffer();
         program->bindUniformBuffers(buffer.data(), buffer.size());
 
-        for (auto& [location, bindingInfo] : _programState->getTextureBindingInfos())
+        for (auto& [location, bindingSet] : _programState->getTextureBindingSets())
         {
-            static_cast<TextureImpl*>(bindingInfo.tex)->apply(bindingInfo.slot);
-            glUniform1i(location, bindingInfo.slot);
+            auto& slots = bindingSet.slots;
+            auto& texs = bindingSet.texs;
+            const auto arraySize = slots.size();
+            if (!arraySize) [[unlikely]]
+                continue;
+            if (arraySize == 1) 
+            { // perform bind for 'uniform sampler2D u_tex;' or 'uniform sampler2DArray u_texs;'
+                static_cast<TextureImpl*>(texs[0])->apply(slots[0]);
+                glUniform1i(location, slots[0]);
+            }
+            else 
+            { // perform bind for 'uniform sampler2D u_details[4];' in shader
+                for(size_t i = 0; i < arraySize; ++i)
+                    static_cast<TextureImpl*>(texs[i])->apply(slots[i]);
+                glUniform1iv(location, static_cast<GLsizei>(arraySize), static_cast<const GLint*>(slots.data()));
+            }
         }
     }
 }

--- a/axmol/rhi/opengl/CommandBufferGL.cpp
+++ b/axmol/rhi/opengl/CommandBufferGL.cpp
@@ -348,7 +348,7 @@ void CommandBufferImpl::bindUniforms(ProgramImpl* program) const
         auto&& buffer            = _programState->getUniformBuffer();
         program->bindUniformBuffers(buffer.data(), buffer.size());
 
-        for (auto& [location, bindingSet] : _programState->getTextureBindingSets())
+        for (const auto& [location, bindingSet] : _programState->getTextureBindingSets())
         {
             auto& slots = bindingSet.slots;
             auto& texs = bindingSet.texs;
@@ -357,19 +357,20 @@ void CommandBufferImpl::bindUniforms(ProgramImpl* program) const
                 continue;
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
-            location = bindingSet.loc;
+            auto loc = bindingSet.loc;
+#else
+            auto loc = location;
 #endif
-
-            if (arraySize == 1) 
+            if (arraySize == 1)
             { // perform bind for 'uniform sampler2D u_tex;' or 'uniform sampler2DArray u_texs;'
                 static_cast<TextureImpl*>(texs[0])->apply(slots[0]);
-                glUniform1i(location, slots[0]);
+                glUniform1i(loc, slots[0]);
             }
-            else 
+            else
             { // perform bind for 'uniform sampler2D u_details[4];' in shader
                 for(size_t i = 0; i < arraySize; ++i)
                     static_cast<TextureImpl*>(texs[i])->apply(slots[i]);
-                glUniform1iv(location, static_cast<GLsizei>(arraySize), static_cast<const GLint*>(slots.data()));
+                glUniform1iv(loc, static_cast<GLsizei>(arraySize), static_cast<const GLint*>(slots.data()));
             }
         }
     }

--- a/cmake/Modules/AXSLCC.cmake
+++ b/cmake/Modules/AXSLCC.cmake
@@ -135,8 +135,14 @@ function(ax_target_compile_shaders target_name)
       list(APPEND SC_FLAGS "--lang=msl")
     endif()
 
-    # automap, no-suffix since 1.18.1 released by axmolengine
-    list(APPEND SC_FLAGS "--automap" "--no-suffix")
+    # no-suffix since 1.18.1 released by axmolengine
+    list(APPEND SC_FLAGS "--no-suffix")
+
+    # since axslcc-1.13.1, but many exists shaders not specify it binding index for uniform blocks,
+    # so add auto map bindings suppress errors for exists shaders. in future if we migrate all
+    # shaders, this flag can be removed
+    # Note: axmol only use binding_index=0 for uniform blocks because axmol limit support per-uniform-block/per-stage
+    list(APPEND SC_FLAGS "--auto-map-bindings")
 
     # defines
     get_source_file_property(SOURCE_SC_DEFINES ${SC_FILE} AXSLCC_DEFINES)

--- a/cmake/Modules/AXSLCC.cmake
+++ b/cmake/Modules/AXSLCC.cmake
@@ -138,11 +138,12 @@ function(ax_target_compile_shaders target_name)
     # no-suffix since 1.18.1 released by axmolengine
     list(APPEND SC_FLAGS "--no-suffix")
 
-    # since axslcc-1.13.1, but many exists shaders not specify it binding index for uniform blocks,
+    # The follow flags was separated from --automap since axslcc-1.13.1, many exists shaders not specify it binding index for uniform blocks,
     # so add auto map bindings suppress errors for exists shaders. in future if we migrate all
-    # shaders, this flag can be removed
+    # shaders, these flags can be removed
     # Note: axmol only use binding_index=0 for uniform blocks because axmol limit support per-uniform-block/per-stage
     list(APPEND SC_FLAGS "--auto-map-bindings")
+    list(APPEND SC_FLAGS "--auto-map-locations")
 
     # defines
     get_source_file_property(SOURCE_SC_DEFINES ${SC_FILE} AXSLCC_DEFINES)

--- a/extensions/spine/src/spine/SkeletonBatch.cpp
+++ b/extensions/spine/src/spine/SkeletonBatch.cpp
@@ -94,12 +94,10 @@ namespace spine {
 		if(currentState == nullptr || currentState->getProgram() != programState->getProgram()) {
 	#endif
 			AX_SAFE_RELEASE(currentState);
-			//currentState = programState->clone();
-            programState->clone();
-            command->setWeakPSVL(programState, nullptr);
-
-			command->_locMVP     = currentState->getUniformLocation(rhi::UNIFORM_NAME_MVP_MATRIX);
-	        command->_locTexture = currentState->getUniformLocation(rhi::UNIFORM_NAME_TEXTURE);
+            currentState  = programState->clone();
+            command->_locMVP     = currentState->getUniformLocation(rhi::UNIFORM_NAME_MVP_MATRIX);
+            command->_locTexture = currentState->getUniformLocation(rhi::UNIFORM_NAME_TEXTURE);
+            command->setWeakPSVL(currentState, currentState->getVertexLayout());
 	}
 		return currentState;
 	}

--- a/extensions/spine/src/spine/SkeletonTwoColorBatch.cpp
+++ b/extensions/spine/src/spine/SkeletonTwoColorBatch.cpp
@@ -148,7 +148,6 @@ namespace spine {
 		}
 
 		bool needsUpdateStateLayout = false;
-		auto &pipelinePS = _pipelineDesc.programState;
 		if (programState != nullptr) {
 			if (_programState != programState) {
 				AX_SAFE_RELEASE(_programState);
@@ -163,15 +162,20 @@ namespace spine {
 		}
 
 		AXASSERT(_programState, "programState should not be null");
-		pipelinePS = _programState;
 
 		if (needsUpdateStateLayout) {
             AX_SAFE_RELEASE_NULL(_vertexLayout);
 			updateProgramStateLayout(_programState, _vertexLayout);
         }
-
+        else
+        {
+            Object::assign(_vertexLayout, __twoColorVertexLayout.get());
+        }
+        
 		_locPMatrix = __locPMatrix;
-		_locTexture = __locTexture;
+        _locTexture = __locTexture;
+
+        setWeakPSVL(_programState, _vertexLayout);
 	}
 
 	TwoColorTrianglesCommand::~TwoColorTrianglesCommand() {


### PR DESCRIPTION
## Describe your changes

- Restore `ProgramState::setTextureArray`
- Improve Terrain rendering, use `uniform sampler2D u_details[4]` to store detailMap textures
- Improve  Terrain rendering,  set alphaMap, lightMap dummy texture RHI independent when they are not used
- Fix Terrain rendering doesn't work when use d3d11
- Fix vertex attribute binding cache incorrect
- Use macos-14 for ios ci due to unexpected compile error
- Upgrade MSL version: 1.2 => 2.0 (requires macos13 and ios 11+) for supporting texture array `sampler2D u_details[4]`

## Issue ticket number and link

#2648 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.


## Use case

Store detailMap textures when rendering terrain