### PR TITLE
Fix wasm Downloader wrong rights

### DIFF
--- a/core/network/Downloader-wasm.cpp
+++ b/core/network/Downloader-wasm.cpp
@@ -183,7 +183,7 @@ namespace ax { namespace network {
                 }
 
                 // open file
-                auto _fs = util->openFileStream(storagePath, IFileStream::Mode::READ);
+                auto _fs = util->openFileStream(storagePath, IFileStream::Mode::WRITE);
                 if (!_fs)
                 {
                     errCode = DownloadTask::ERROR_OPEN_FILE_FAILED;


### PR DESCRIPTION
## Describe your changes

The wasm download can't write the file as the file is opened with READ instead of WRITE.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
