### PR TITLE
Refactor D3D11 device initialization with debug->release->WARP fallback

### DIFF
--- a/axmol/base/Director.h
+++ b/axmol/base/Director.h
@@ -187,6 +187,29 @@ public:
      */
     PowerPreference getPowerPreference() const { return _powerPreference; }
 
+    /**
+     * @brief Enable or disable the graphics API debug layer.
+     *
+     * When enabled, the underlying RHI (e.g. Direct3D, Metal, Vulkan) will
+     * activate its validation/debug layer if supported. This can provide
+     * detailed diagnostic messages, GPU state validation, and error reporting
+     * useful during development.
+     *
+     * @note Must be set before the graphics device is created to take effect.
+     *       Enabling the debug layer may impact performance and should be
+     *       disabled in production builds.
+     *
+     * @param value true to enable the debug layer, false to disable it.
+     */
+    void setDebugLayerEnabled(bool value) { _debugLayerEnabled = value; }
+
+    /**
+     * @brief Check whether the graphics API debug layer is enabled.
+     *
+     * @return true if the debug layer is enabled, false otherwise.
+     */
+    bool isDebugLayerEnabled() const { return _debugLayerEnabled; }
+
     /*
      * Gets singleton of TextureCache.
      */
@@ -665,6 +688,7 @@ protected:
 
     bool _childrenIndexerEnabled = false;
 
+    bool _debugLayerEnabled          = false;
     PowerPreference _powerPreference = PowerPreference::Auto;
 
     /* axmol thread id */

--- a/axmol/media/MFUtils.h
+++ b/axmol/media/MFUtils.h
@@ -32,15 +32,6 @@ inline TComPtr<_Ty> MakeComPtr(_Types&&... args)
     return obj;
 }
 
-template <typename _Ty>
-inline TComPtr<_Ty> ReferencedPtrToComPtr(_Ty* ptr)
-{
-    TComPtr<_Ty> obj;
-    _Ty** ppv = &obj;
-    *ppv      = ptr;
-    return obj;
-}
-
 template <typename T>
 inline HRESULT CreateInstance(REFCLSID clsid, Microsoft::WRL::ComPtr<T>& ptr)
 {

--- a/axmol/media/WmfMediaEngine.cpp
+++ b/axmol/media/WmfMediaEngine.cpp
@@ -586,17 +586,12 @@ HRESULT WmfMediaEngine::HandleEvent(IMFMediaEvent* pEvent)
     ::MediaEventType meType  = MEUnknown;              // Event type
     MF_TOPOSTATUS TopoStatus = MF_TOPOSTATUS_INVALID;  // Used with MESessionTopologyStatus event.
 
-    // auto pUnk = MFUtils::ReferencedPtrToComPtr((IUnknown*)pUnkPtr);
-    // TComPtr<IMFMediaEvent> pEvent;
-
     PROPVARIANT var;
 
     if (!pEvent)
     {
         return E_POINTER;
     }
-
-    // CHECK_HR(hr = pUnk->QueryInterface(__uuidof(IMFMediaEvent), (void**)&pEvent));
 
     // Get the event type.
     CHECK_HR(hr = pEvent->GetType(&meType));

--- a/axmol/platform/Common.h
+++ b/axmol/platform/Common.h
@@ -83,11 +83,6 @@ enum class AlertResult
  */
 AlertResult AX_DLL showAlert(std::string_view msg, std::string_view title, AlertStyle style = AlertStyle::Ok);
 
-AX_DEPRECATED(3.0) inline void messageBox(const char* msg, const char* title)
-{
-    showAlert(msg, title);
-}
-
 /**
 @brief Enum the language type supported now
 */

--- a/axmol/platform/Common.h
+++ b/axmol/platform/Common.h
@@ -68,7 +68,6 @@ enum class AlertResult
     No
 };
 
-
 /** @brief Display a modal alert dialog with configurable icon and buttons.
  *
  * @param msg         The message text to display, in UTF-8 encoding.

--- a/axmol/platform/Common.h
+++ b/axmol/platform/Common.h
@@ -29,8 +29,8 @@ THE SOFTWARE.
 /// @cond DO_NOT_SHOW
 
 #include "axmol/platform/PlatformMacros.h"
-
 #include "axmol/tlx/bitmask.hpp"
+#include <string_view>
 
 namespace ax
 {

--- a/axmol/platform/Common.h
+++ b/axmol/platform/Common.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 
@@ -29,6 +30,8 @@ THE SOFTWARE.
 
 #include "axmol/platform/PlatformMacros.h"
 
+#include "axmol/tlx/bitmask.hpp"
+
 namespace ax
 {
 
@@ -37,10 +40,54 @@ namespace ax
  * @{
  */
 
-/**
-@brief Pop out a message box
-*/
-void AX_DLL messageBox(const char* msg, const char* title);
+enum AlertStyle : unsigned int
+{
+    // Icon types (low bits)
+    IconInfo    = 0x0001,
+    IconWarning = 0x0002,
+    IconError   = 0x0004,
+    IconDebug   = 0x0008,
+
+    // Button sets (middle bits)
+    Ok          = 0x0100,
+    OkCancel    = 0x0200,
+    YesNo       = 0x0400,
+    YesNoCancel = 0x0800,
+
+    // Behavior flags (high bits)
+    RequireSync = 0x10000  ///< Enforce synchronous (blocking) behavior
+};
+AX_ENABLE_BITMASK_OPS(AlertStyle)
+
+enum class AlertResult
+{
+    None,
+    Ok,
+    Cancel,
+    Yes,
+    No
+};
+
+
+/** @brief Display a modal alert dialog with configurable icon and buttons.
+ *
+ * @param msg         The message text to display, in UTF-8 encoding.
+ * @param title       The dialog title text, in UTF-8 encoding.
+ * @param style       Bitwise OR combination of icon type and button set. See ::AlertStyle.
+ * @param requireSync When true, enforces synchronous (blocking) behavior for this call.
+ *                    On platforms where the default is non-blocking (e.g., UWP), this will
+ *                    block the calling thread until the dialog is closed.
+ *                    On platforms where the default is already blocking (e.g., Win32),
+ *                    this flag has no effect on execution but serves as an explicit
+ *                    indication that the caller expects synchronous behavior.
+ * @return            The button pressed by the user. See ::AlertResult.
+ */
+AlertResult AX_DLL showAlert(std::string_view msg, std::string_view title, AlertStyle style = AlertStyle::Ok);
+
+AX_DEPRECATED(3.0) inline void messageBox(const char* msg, const char* title)
+{
+    showAlert(msg, title);
+}
 
 /**
 @brief Enum the language type supported now

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -98,7 +98,7 @@ namespace ax
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WINRT
 struct PresentTarget
 {
-    IUnknown* swapChainPanel{nullptr};
+    void* surface{nullptr};
     float width{1};
     float height{1};
 };

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -552,7 +552,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
             message.append(_glfwError);
         }
 
-        messageBox(message.c_str(), "Error launch application");
+        showAlert(message, "Error launch application");
         utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
         return false;
     }

--- a/axmol/platform/android/Common-android.cpp
+++ b/axmol/platform/android/Common-android.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 
@@ -34,9 +35,10 @@ namespace ax
 
 #define MAX_LEN (ax::kMaxLogLen + 1)
 
-void messageBox(const char* pszMsg, const char* pszTitle)
+AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
 {
-    JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", pszTitle, pszMsg);
+    JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", msg, title，AlertStyle);
+    return AlertResult::None;
 }
 
 }  // namespace ax

--- a/axmol/platform/android/Common-android.cpp
+++ b/axmol/platform/android/Common-android.cpp
@@ -33,8 +33,6 @@ THE SOFTWARE.
 namespace ax
 {
 
-#define MAX_LEN (ax::kMaxLogLen + 1)
-
 AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
     JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", msg, title);

--- a/axmol/platform/android/Common-android.cpp
+++ b/axmol/platform/android/Common-android.cpp
@@ -35,9 +35,9 @@ namespace ax
 
 #define MAX_LEN (ax::kMaxLogLen + 1)
 
-AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
-    JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", msg, title，AlertStyle);
+    JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", msg, title);
     return AlertResult::None;
 }
 

--- a/axmol/platform/apple/FoundationBridge.h
+++ b/axmol/platform/apple/FoundationBridge.h
@@ -1,7 +1,5 @@
 /****************************************************************************
-Copyright (c) 2011      Laschweinski
-Copyright (c) 2013-2016 Chukong Technologies Inc.
-Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
@@ -25,25 +23,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "axmol/platform/PlatformConfig.h"
-#if AX_TARGET_PLATFORM == AX_PLATFORM_WASM
+#pragma once
 
-#    include "axmol/platform/Common.h"
-#    include "axmol/platform/wasm/StdC-wasm.h"
-#    include "axmol/base/Logging.h"
-#    include <emscripten/emscripten.h>
+#import <Foundation/NSString.h>
 
 namespace ax
 {
-
-AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
+static NSString* svtons(std::string_view str)
 {
-    auto pszMsg = msg.data();
-    auto pszTitle = title.data();
-    EM_ASM_ARGS({ window.alert(UTF8ToString($0) + ": " + UTF8ToString($1)); }, pszTitle, pszTitle);
-    return AlertResult::None;
+    return !str.empty() ? [[NSString alloc] initWithBytes:str.data() length:str.length() encoding:NSUTF8StringEncoding]
+                        : nil;
 }
-
 }  // namespace ax
-
-#endif  //  AX_TARGET_PLATFORM == AX_PLATFORM_WASM

--- a/axmol/platform/ios/Common-ios.mm
+++ b/axmol/platform/ios/Common-ios.mm
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -32,18 +33,18 @@
 #import <UIKit/UIWindow.h>
 #include "axmol/base/Director.h"
 #include "axmol/base/Logging.h"
+#include "axmol/platform/apple/FoundationBridge.h"
 
 namespace ax
 {
 
-// ios no MessageBox, use log instead
-void messageBox(const char* msg, const char* title)
+AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
 {
     // only enable it on iOS.
     // FIXME: Implement it for tvOS
 #if !defined(AX_TARGET_OS_TVOS)
-    NSString* tmpTitle = (title) ? [NSString stringWithUTF8String:title] : nil;
-    NSString* tmpMsg   = (msg) ? [NSString stringWithUTF8String:msg] : nil;
+    NSString* tmpTitle = svtons(title);
+    NSString* tmpMsg   = svtons(msg);
 
     UIAlertController* alertController = [UIAlertController alertControllerWithTitle:tmpTitle
                                                                              message:tmpMsg
@@ -57,7 +58,10 @@ void messageBox(const char* msg, const char* title)
     [alertController addAction:defaultAction];
     auto rootViewController = [UIApplication sharedApplication].windows[0].rootViewController;
     [rootViewController presentViewController:alertController animated:YES completion:nil];
+#else
+    AXLOGI("{}: {}", title, msg);
 #endif
+    return AlertResult::None;
 }
 
 }  // namespace ax

--- a/axmol/platform/ios/Common-ios.mm
+++ b/axmol/platform/ios/Common-ios.mm
@@ -38,7 +38,7 @@
 namespace ax
 {
 
-AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
     // only enable it on iOS.
     // FIXME: Implement it for tvOS

--- a/axmol/platform/linux/Common-linux.cpp
+++ b/axmol/platform/linux/Common-linux.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 namespace ax
 {
 
-AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
     AXLOGI("{}: {}", title, msg);
     return AlertResult::None;

--- a/axmol/platform/linux/Common-linux.cpp
+++ b/axmol/platform/linux/Common-linux.cpp
@@ -31,9 +31,10 @@ THE SOFTWARE.
 namespace ax
 {
 
-void messageBox(const char* msg, const char* title)
+AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
 {
-    AXLOGE("{}: {}", title, msg);
+    AXLOGI("{}: {}", title, msg);
+    return AlertResult::None;
 }
 
 }  // namespace ax

--- a/axmol/platform/mac/Common-mac.mm
+++ b/axmol/platform/mac/Common-mac.mm
@@ -36,7 +36,7 @@ THE SOFTWARE.
 namespace ax
 {
 
-AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
 
     NSString* tmpTitle = sv2ns(title);

--- a/axmol/platform/mac/Common-mac.mm
+++ b/axmol/platform/mac/Common-mac.mm
@@ -39,8 +39,8 @@ namespace ax
 AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
 
-    NSString* tmpTitle = sv2ns(title);
-    NSString* tmpMsg   = sv2ns(msg);
+    NSString* tmpTitle = svtons(title);
+    NSString* tmpMsg   = svtons(msg);
 
     NSAlert* alert = [[[NSAlert alloc] init] autorelease];
     [alert addButtonWithTitle:@"OK"];

--- a/axmol/platform/mac/Common-mac.mm
+++ b/axmol/platform/mac/Common-mac.mm
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 
@@ -24,6 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 #include "axmol/platform/Common.h"
+#include "axmol/platform/apple/FoundationBridge.h"
 
 #include "axmol/base/Director.h"
 
@@ -34,11 +36,11 @@ THE SOFTWARE.
 namespace ax
 {
 
-// ios no MessageBox, use log instead
-void messageBox(const char* msg, const char* title)
+AlertResult showAlert(std::string_view msg, std::string_view title，AlertStyle)
 {
-    NSString* tmpTitle = (title) ? [NSString stringWithUTF8String:title] : nil;
-    NSString* tmpMsg   = (msg) ? [NSString stringWithUTF8String:msg] : nil;
+
+    NSString* tmpTitle = sv2ns(title);
+    NSString* tmpMsg   = sv2ns(msg);
 
     NSAlert* alert = [[[NSAlert alloc] init] autorelease];
     [alert addButtonWithTitle:@"OK"];
@@ -49,6 +51,8 @@ void messageBox(const char* msg, const char* title)
     auto renderView = Director::getInstance()->getRenderView();
     id window       = (id)renderView->getCocoaWindow();
     [alert beginSheetModalForWindow:window completionHandler:nil];
+
+    return AlertResult::None;
 }
 
 }  // namespace ax

--- a/axmol/platform/wasm/Common-wasm.cpp
+++ b/axmol/platform/wasm/Common-wasm.cpp
@@ -38,7 +38,7 @@ namespace ax
 
 AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
-    auto pszMsg = msg.data();
+    auto pszMsg   = msg.data();
     auto pszTitle = title.data();
     EM_ASM_ARGS({ window.alert(UTF8ToString($0) + ": " + UTF8ToString($1)); }, pszTitle, pszTitle);
     return AlertResult::None;

--- a/axmol/platform/win32/ComPtr.h
+++ b/axmol/platform/win32/ComPtr.h
@@ -48,4 +48,4 @@ inline void SafeRelease(T& resource)
         resource = nullptr;
     }
 }
-}
+}  // namespace ax

--- a/axmol/platform/win32/ComPtr.h
+++ b/axmol/platform/win32/ComPtr.h
@@ -21,37 +21,31 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
+
 #pragma once
 
-#include "axmol/rhi/RenderPipeline.h"
-#include "axmol/platform/win32/ComPtr.h"
+#include <wrl/client.h>
 
-#include <d3d11.h>
-
-namespace ax::rhi::d3d
+namespace ax
 {
-/**
- * @addtogroup _d3d
- * @{
- */
+using Microsoft::WRL::ComPtr;
 
-/**
- * @brief A D3D11-based Shader RenderPipeline implementation
- *
- */
-class RenderPipelineImpl : public RenderPipeline
+template <typename T, unsigned int N>
+inline void SafeRelease(T (&resourceBlock)[N])
 {
-public:
-    RenderPipelineImpl(ID3D11Device* device, ID3D11DeviceContext* context) : _device(device), _context(context) {}
-    void update(const RenderTarget*, const PipelineDesc& desc) override;
+    for (unsigned int i = 0; i < N; i++)
+    {
+        SafeRelease(resourceBlock[i]);
+    }
+}
 
-private:
-    ID3D11Device* _device         = nullptr;
-    ID3D11DeviceContext* _context = nullptr;
-
-    axstd::hash_map<uint32_t, ComPtr<ID3D11BlendState>> _blendCache;
-};
-
-/** @} */
-
-}  // namespace ax::rhi::d3d
+template <typename T>
+inline void SafeRelease(T& resource)
+{
+    if (resource)
+    {
+        resource->Release();
+        resource = nullptr;
+    }
+}
+}

--- a/axmol/platform/win32/Common-win32.cpp
+++ b/axmol/platform/win32/Common-win32.cpp
@@ -33,11 +33,33 @@ namespace ax
 
 #define MAX_LEN (ax::kMaxLogLen + 1)
 
-void messageBox(const char* pszMsg, const char* pszTitle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle style)
 {
-    std::wstring wsMsg   = ntcvt::from_chars(pszMsg);
-    std::wstring wsTitle = ntcvt::from_chars(pszTitle);
-    MessageBoxW(nullptr, wsMsg.c_str(), wsTitle.c_str(), MB_OK | MB_TOPMOST);
+    std::wstring wsMsg       = ntcvt::from_chars(msg);
+    std::wstring wsTitle     = ntcvt::from_chars(title);
+    UINT flags               = MB_TOPMOST;
+
+    // level
+    if (bitmask::any(style, AlertStyle::IconError))
+        flags |= MB_ICONERROR;
+    else if (bitmask::any(style, AlertStyle::IconWarning))
+        flags |= MB_ICONWARNING;
+    else if (bitmask::any(style, AlertStyle::IconInfo))
+        flags |= MB_ICONINFORMATION;
+
+    // buttons
+    if (bitmask::any(style, AlertStyle::OkCancel))
+        flags |= MB_OKCANCEL;
+    else if (bitmask::any(style, AlertStyle::YesNo))
+        flags |= MB_YESNO;
+    else if (bitmask::any(style, AlertStyle::YesNoCancel))
+        flags |= MB_YESNOCANCEL;
+    else if (bitmask::any(style, AlertStyle::Ok))
+        flags |= MB_OK;
+
+    ::MessageBoxW(nullptr, wsMsg.c_str(), wsTitle.c_str(), flags);
+
+    return AlertResult::Ok;
 }
 
 }  // namespace ax

--- a/axmol/platform/win32/Common-win32.cpp
+++ b/axmol/platform/win32/Common-win32.cpp
@@ -31,8 +31,6 @@ THE SOFTWARE.
 namespace ax
 {
 
-#define MAX_LEN (ax::kMaxLogLen + 1)
-
 AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle style)
 {
     std::wstring wsMsg   = ntcvt::from_chars(msg);

--- a/axmol/platform/win32/Common-win32.cpp
+++ b/axmol/platform/win32/Common-win32.cpp
@@ -35,9 +35,9 @@ namespace ax
 
 AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle style)
 {
-    std::wstring wsMsg       = ntcvt::from_chars(msg);
-    std::wstring wsTitle     = ntcvt::from_chars(title);
-    UINT flags               = MB_TOPMOST;
+    std::wstring wsMsg   = ntcvt::from_chars(msg);
+    std::wstring wsTitle = ntcvt::from_chars(title);
+    UINT flags           = MB_TOPMOST;
 
     // level
     if (bitmask::any(style, AlertStyle::IconError))

--- a/axmol/platform/winrt/Common-winrt.cpp
+++ b/axmol/platform/winrt/Common-winrt.cpp
@@ -36,12 +36,12 @@ THE SOFTWARE.
 namespace ax
 {
 
-void messageBox(const char* pszMsg, const char* pszTitle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle style)
 {
     // Create the message dialog and set its content
-    auto message = PlatformStringFromString(pszMsg);
-    auto title   = PlatformStringFromString(pszTitle);
-    RenderViewImpl::sharedRenderView()->ShowMessageBox(title, message);
+    auto hmsg   = PlatformStringFromString(msg);
+    auto htitle = PlatformStringFromString(title);
+    return RenderViewImpl::sharedRenderView()->ShowAlertDialog(hmsg, htitle, style);
 }
 
 }  // namespace ax

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -187,15 +187,15 @@ AlertResult RenderViewImpl::ShowAlertDialog(const winrt::hstring& title,
         return AlertResult::No;
 
     bool isOnMainUIThread = m_dispatcher.get().HasThreadAccess();
-    bool needPromise      = !isOnMainUIThread && bitmask::any(style, AlertStyle::RequireSync);
+    bool canPromise      = !isOnMainUIThread && bitmask::any(style, AlertStyle::RequireSync);
 
     auto promisePtr = std::make_shared<std::promise<AlertResult>>();
     auto future     = promisePtr->get_future();
 
-    auto addCommand = [needPromise](MessageDialog& dlg, std::wstring_view btnTitle, AlertResult ret,
+    auto addCommand = [canPromise](MessageDialog& dlg, std::wstring_view btnTitle, AlertResult ret,
                                     std::shared_ptr<std::promise<AlertResult>> promisePtr) {
-        dlg.Commands().Append(UICommand(btnTitle, [promisePtr, ret, needPromise](auto&&) {
-            if (needPromise)
+        dlg.Commands().Append(UICommand(btnTitle, [promisePtr, ret, canPromise](auto&&) {
+            if (canPromise)
             {
                 try
                 {
@@ -244,7 +244,7 @@ AlertResult RenderViewImpl::ShowAlertDialog(const winrt::hstring& title,
         showDialogAsync();
     }
 
-    return needPromise ? future.get() : AlertResult::None;
+    return canPromise ? future.get() : AlertResult::None;
 }
 
 void RenderViewImpl::setIMEKeyboardState(bool bOpen, std::string_view str)

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -35,11 +35,14 @@ THE SOFTWARE.
 #include "axmol/platform/winrt/WinRTUtils.h"
 #include "axmol/base/EventDispatcher.h"
 #include "axmol/base/EventMouse.h"
-#include <map>
+#include <future>
 
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Popups.h>
 #include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Core.h>
 
 namespace ax
 {
@@ -165,7 +168,7 @@ void RenderViewImpl::setPanel(winrt::agile_ref<Windows::UI::Xaml::Controls::Pane
 {
     m_panel = panel;
 
-    m_presentTarget.swapChainPanel = winrt::get_unknown(m_panel.get());
+    m_presentTarget.surface = winrt::get_unknown(m_panel.get());
 }
 
 void RenderViewImpl::setIMEKeyboardState(bool bOpen)
@@ -173,22 +176,75 @@ void RenderViewImpl::setIMEKeyboardState(bool bOpen)
     setIMEKeyboardState(bOpen, "");
 }
 
-bool RenderViewImpl::ShowMessageBox(const winrt::hstring& title, const winrt::hstring& message)
+AlertResult RenderViewImpl::ShowAlertDialog(const winrt::hstring& title,
+                                            const winrt::hstring& message,
+                                            AlertStyle style)
 {
-    if (m_dispatcher)
-    {
-        m_dispatcher.get().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal,
-                                    Windows::UI::Core::DispatchedHandler([title, message]() {
-            // Show the message dialog
-            auto msg = Windows::UI::Popups::MessageDialog(message, title);
-            // Set the command to be invoked when a user presses 'ESC'
-            msg.CancelCommandIndex(1);
-            msg.ShowAsync();
-        }));
+    using namespace winrt::Windows::UI::Core;
+    using namespace winrt::Windows::UI::Popups;
 
-        return true;
+    if (!m_dispatcher)
+        return AlertResult::No;
+
+    bool isOnMainUIThread = m_dispatcher.get().HasThreadAccess();
+    bool needPromise      = !isOnMainUIThread && bitmask::any(style, AlertStyle::RequireSync);
+
+    auto promisePtr = std::make_shared<std::promise<AlertResult>>();
+    auto future     = promisePtr->get_future();
+
+    auto addCommand = [needPromise](MessageDialog& dlg, std::wstring_view btnTitle, AlertResult ret,
+                                    std::shared_ptr<std::promise<AlertResult>> promisePtr) {
+        dlg.Commands().Append(UICommand(btnTitle, [promisePtr, ret, needPromise](auto&&) {
+            if (needPromise)
+            {
+                try
+                {
+                    promisePtr->set_value(ret);
+                }
+                catch (...)
+                {}
+            }
+        }));
+    };
+
+    auto showDialogAsync = [title, message, style, addCommand, promisePtr]() mutable {
+        MessageDialog dlg(message, title);
+        dlg.CancelCommandIndex(1);
+
+        if (bitmask::any(style, AlertStyle::OkCancel))
+        {
+            addCommand(dlg, L"OK", AlertResult::Ok, promisePtr);
+            addCommand(dlg, L"Cancel", AlertResult::Cancel, promisePtr);
+        }
+        else if (bitmask::any(style, AlertStyle::YesNo))
+        {
+            addCommand(dlg, L"Yes", AlertResult::Yes, promisePtr);
+            addCommand(dlg, L"No", AlertResult::No, promisePtr);
+        }
+        else if (bitmask::any(style, AlertStyle::YesNoCancel))
+        {
+            addCommand(dlg, L"Yes", AlertResult::Yes, promisePtr);
+            addCommand(dlg, L"No", AlertResult::No, promisePtr);
+            addCommand(dlg, L"Cancel", AlertResult::Cancel, promisePtr);
+        }
+        else
+        {
+            addCommand(dlg, L"OK", AlertResult::Ok, promisePtr);
+        }
+
+        dlg.ShowAsync();
+    };
+
+    if (!isOnMainUIThread)
+    {
+        m_dispatcher.get().RunAsync(CoreDispatcherPriority::Normal, showDialogAsync);
     }
-    return false;
+    else
+    {
+        showDialogAsync();
+    }
+
+    return needPromise ? future.get() : AlertResult::None;
 }
 
 void RenderViewImpl::setIMEKeyboardState(bool bOpen, std::string_view str)
@@ -499,7 +555,8 @@ void RenderViewImpl::UpdateForWindowSizeChange(float width, float height)
         UpdateWindowSize();
 
 #if AX_RENDER_API == AX_RENDER_API_D3D
-        Director::getInstance()->getRenderer()->resizeSwapChain(m_width, m_height);
+        auto renderer = Director::getInstance()->getRenderer();
+        renderer->resizeSwapChain(static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height));
 #endif
     }
 }

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -187,13 +187,13 @@ AlertResult RenderViewImpl::ShowAlertDialog(const winrt::hstring& title,
         return AlertResult::No;
 
     bool isOnMainUIThread = m_dispatcher.get().HasThreadAccess();
-    bool canPromise      = !isOnMainUIThread && bitmask::any(style, AlertStyle::RequireSync);
+    bool canPromise       = !isOnMainUIThread && bitmask::any(style, AlertStyle::RequireSync);
 
     auto promisePtr = std::make_shared<std::promise<AlertResult>>();
     auto future     = promisePtr->get_future();
 
     auto addCommand = [canPromise](MessageDialog& dlg, std::wstring_view btnTitle, AlertResult ret,
-                                    std::shared_ptr<std::promise<AlertResult>> promisePtr) {
+                                   std::shared_ptr<std::promise<AlertResult>> promisePtr) {
         dlg.Commands().Append(UICommand(btnTitle, [promisePtr, ret, canPromise](auto&&) {
             if (canPromise)
             {

--- a/axmol/platform/winrt/RenderViewImpl-winrt.h
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.h
@@ -120,7 +120,7 @@ public:
     void QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
     void QueueEvent(std::shared_ptr<InputEvent>& event);
 
-    bool ShowMessageBox(const winrt::hstring& title, const winrt::hstring& message);
+    AlertResult ShowAlertDialog(const winrt::hstring& title, const winrt::hstring& message, AlertStyle style);
 
     int Run();
     void Render();

--- a/axmol/platform/winrt/WICImageLoader-winrt.cpp
+++ b/axmol/platform/winrt/WICImageLoader-winrt.cpp
@@ -30,6 +30,7 @@ obtained from https://directxtk.codeplex.com
 ****************************************************************************/
 #include "axmol/platform/winrt/WICImageLoader-winrt.h"
 #include "axmol/platform/winrt/WinRTUtils.h"
+#include "axmol/platform/win32/ComPtr.h"
 #include "ntcvt/ntcvt.hpp"
 
 namespace ax
@@ -254,8 +255,8 @@ bool WICImageLoader::decodeImageData(const uint8_t* blob, size_t size)
 
     bRet = processImage(pDecoder);
 
-    SafeRelease(&pWicStream);
-    SafeRelease(&pDecoder);
+    SafeRelease(pWicStream);
+    SafeRelease(pDecoder);
 
     return bRet;
 }
@@ -315,8 +316,8 @@ bool WICImageLoader::processImage(IWICBitmapDecoder* pDecoder)
         }
     }
 
-    SafeRelease(&pFrame);
-    SafeRelease(&pConv);
+    SafeRelease(pFrame);
+    SafeRelease(pConv);
     return SUCCEEDED(hr);
 }
 
@@ -408,8 +409,8 @@ size_t WICImageLoader::getBitsPerPixel(WICPixelFormatGUID format)
         hr = pPInfo->GetBitsPerPixel(&bpp);
     }
 
-    SafeRelease(&pCInfo);
-    SafeRelease(&pPInfo);
+    SafeRelease(pCInfo);
+    SafeRelease(pPInfo);
     return bpp;
 }
 
@@ -530,11 +531,11 @@ bool WICImageLoader::encodeImageData(std::string_view path,
         hr = pEnc->Commit();
     }
 
-    SafeRelease(&outStream);
-    SafeRelease(&pStream);
-    SafeRelease(&pEnc);
-    SafeRelease(&pFrame);
-    SafeRelease(&pProp);
+    SafeRelease(outStream);
+    SafeRelease(pStream);
+    SafeRelease(pEnc);
+    SafeRelease(pFrame);
+    SafeRelease(pProp);
     return SUCCEEDED(hr);
 }
 
@@ -557,7 +558,7 @@ IWICImagingFactory* WICImageLoader::getWICFactory()
 
         if (FAILED(hr))
         {
-            SafeRelease(&_wicFactory);
+            SafeRelease(_wicFactory);
         }
     }
 

--- a/axmol/platform/winrt/WICImageLoader-winrt.h
+++ b/axmol/platform/winrt/WICImageLoader-winrt.h
@@ -88,16 +88,6 @@ private:
     static IWICImagingFactory* _wicFactory;
 };
 
-template <typename T>
-void SafeRelease(T** ppObj)
-{
-    if (*ppObj != NULL)
-    {
-        (*ppObj)->Release();
-        *ppObj = NULL;
-    }
-}
-
 }  // namespace ax
 
 #endif

--- a/axmol/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/axmol/platform/winrt/xaml/AxmolRenderer.cpp
@@ -52,11 +52,11 @@ AxmolRenderer::AxmolRenderer(int width,
 
 AxmolRenderer::~AxmolRenderer() {}
 
-void AxmolRenderer::CreateRenderView()
+void AxmolRenderer::Resume()
 {
-    auto director   = ax::Director::getInstance();
-    auto renderView = static_cast<RenderViewImpl*>(director->getRenderView());
+    auto director = ax::Director::getInstance();
 
+    auto renderView = static_cast<RenderViewImpl*>(director->getRenderView());
     if (!renderView)
     {
         renderView = RenderViewImpl::createWithRect(
@@ -66,17 +66,8 @@ void AxmolRenderer::CreateRenderView()
         renderView->SetDPI(m_dpi);
         renderView->setDispatcher(m_dispatcher);
         director->setRenderView(renderView);
+        Application::getInstance()->run();
     }
-}
-
-void AxmolRenderer::Start()
-{
-    Application::getInstance()->run();
-}
-
-void AxmolRenderer::Resume()
-{
-    auto director = ax::Director::getInstance();
 
     Application::getInstance()->applicationWillEnterForeground();
     ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);

--- a/axmol/platform/winrt/xaml/AxmolRenderer.h
+++ b/axmol/platform/winrt/xaml/AxmolRenderer.h
@@ -47,12 +47,6 @@ public:
     void QueueKeyboardEvent(ax::WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
     void QueueBackButtonEvent();
 
-    /**  Create render view
-     * @remark: this API must call at main ui thread, others API should call at render thread
-     */
-    void CreateRenderView();
-
-    void Start();
     void Pause();
     void Resume();
     void DeviceLost();

--- a/axmol/platform/winrt/xaml/SwapChainPage.h
+++ b/axmol/platform/winrt/xaml/SwapChainPage.h
@@ -116,13 +116,6 @@ private:
     // must call at UI thread
     void UpdateCanvasSize();
 
-    // !!! Ensure Renderer available
-    // - opengl : must call at the render thread, otherwise rhi::gl::DriverImpl init will fail due to
-    //            eglContext makeCurrent not called
-    // - d3d    : must call the main UI thread; otherwise SetSwapChain will fail with RPC_E_WRONG_THREAD
-    //            and the renderer will display only a black frame.
-    void EnsureRenderer(const winrt::Windows::UI::Core::CoreDispatcher& dispatcher);
-
     std::condition_variable m_sleepCondition;
 
     Concurrency::concurrent_queue<std::function<void()>> m_operations;

--- a/axmol/rhi/DriverBase.h
+++ b/axmol/rhi/DriverBase.h
@@ -33,8 +33,6 @@
 
 #include "axmol/base/Object.h"
 
-#include <string>
-
 namespace ax::rhi
 {
 

--- a/axmol/rhi/RHITypes.h
+++ b/axmol/rhi/RHITypes.h
@@ -543,7 +543,6 @@ struct ProgramType
         VIDEO_TEXTURE_YUY2,
         VIDEO_TEXTURE_NV12,
         VIDEO_TEXTURE_I420, // For some android 11 and older devices
-        VIDEO_TEXTURE_BGR32,
 
         POS_UV_COLOR_2D,
 

--- a/axmol/rhi/d3d/BufferD3D.h
+++ b/axmol/rhi/d3d/BufferD3D.h
@@ -26,9 +26,9 @@
 #include <vector>
 #include <cassert>
 #include <d3d11.h>
-#include <wrl/client.h>
 
 #include "axmol/rhi/Buffer.h"
+#include "axmol/platform/win32/ComPtr.h"
 
 namespace ax::rhi::d3d
 {
@@ -77,7 +77,7 @@ private:
 
     ID3D11Device* _device;          // weak ref
     ID3D11DeviceContext* _context;  // weak ref
-    Microsoft::WRL::ComPtr<ID3D11Buffer> _buffer;
+    ComPtr<ID3D11Buffer> _buffer;
 
     D3D11_USAGE _nativeUsage  = D3D11_USAGE_DYNAMIC;
     UINT _cpuAccess           = D3D11_CPU_ACCESS_WRITE;

--- a/axmol/rhi/d3d/CommandBufferD3D.h
+++ b/axmol/rhi/d3d/CommandBufferD3D.h
@@ -25,12 +25,10 @@
 
 #include "axmol/rhi/CommandBuffer.h"
 #include "axmol/rhi/d3d/DriverD3D.h"
-#include <wrl/client.h>
+#include "axmol/platform/win32/ComPtr.h"
 
 namespace ax::rhi::d3d
 {
-using namespace Microsoft::WRL;
-
 /**
  * @addtogroup _d3d
  * @{

--- a/axmol/rhi/d3d/DepthStencilStateD3D.cpp
+++ b/axmol/rhi/d3d/DepthStencilStateD3D.cpp
@@ -137,7 +137,7 @@ void DepthStencilStateImpl::update(const DepthStencilDesc& desc)
     d.FrontFace        = make_op_desc(desc.frontFaceStencil);
     d.BackFace         = make_op_desc(desc.backFaceStencil);
 
-    Microsoft::WRL::ComPtr<ID3D11DepthStencilState> newState;
+    ComPtr<ID3D11DepthStencilState> newState;
     HRESULT hr = _device->CreateDepthStencilState(&d, newState.GetAddressOf());
     if (FAILED(hr))
     {

--- a/axmol/rhi/d3d/DepthStencilStateD3D.h
+++ b/axmol/rhi/d3d/DepthStencilStateD3D.h
@@ -23,7 +23,7 @@
  ****************************************************************************/
 #pragma once
 #include <d3d11.h>
-#include <wrl/client.h>
+#include "axmol/platform/win32/ComPtr.h"
 #include "axmol/rhi/DepthStencilState.h"
 
 namespace ax::rhi::d3d

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -31,10 +31,9 @@
 #include "axmol/rhi/d3d/RenderPipelineD3D.h"
 #include "axmol/rhi/d3d/DepthStencilStateD3D.h"
 #include "axmol/rhi/d3d/VertexLayoutD3D.h"
+#include "axmol/rhi/d3d/UtilsD3D.h"
 #include "axmol/base/Logging.h"
 #include "ntcvt/ntcvt.hpp"
-
-#include <wrl/client.h>
 
 #pragma comment(lib, "D3D11.lib")
 #pragma comment(lib, "DXGI.lib")
@@ -110,7 +109,10 @@ std::string_view GetVendorString(uint32_t vendorId)
 DriverBase* DriverBase::getInstance()
 {
     if (!_instance)
+    {
         _instance = new d3d::DriverImpl();
+        static_cast<d3d::DriverImpl*>(_instance)->init();
+    }
 
     return _instance;
 }
@@ -159,74 +161,12 @@ static uint32_t FindMaxMsaaSamples(ID3D11Device* device, DXGI_FORMAT format)
     }
     return best;
 }
-
-static Microsoft::WRL::ComPtr<IDXGIAdapter> ChooseAdapter(PowerPreference pref)
-{
-    if (pref == PowerPreference::Auto)
-        return {};
-
-    Microsoft::WRL::ComPtr<IDXGIFactory1> factory;
-    if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&factory)))
-        return nullptr;
-
-    Microsoft::WRL::ComPtr<IDXGIAdapter> bestAdapter;
-    int bestScore = std::numeric_limits<int>::min();
-
-    UINT i = 0;
-    Microsoft::WRL::ComPtr<IDXGIAdapter> adapter;
-    while (factory->EnumAdapters(i, adapter.ReleaseAndGetAddressOf()) != DXGI_ERROR_NOT_FOUND)
-    {
-        DXGI_ADAPTER_DESC desc;
-        adapter->GetDesc(&desc);
-
-        // Skip Microsoft Basic Render Driver (software adapter)
-        if (desc.VendorId == 0x1414 && desc.DeviceId == 0x8c)
-        {
-            ++i;
-            continue;
-        }
-
-        int score = 0;
-
-        // 1. Base score by GPU type
-        bool isDiscrete = desc.DedicatedVideoMemory > 0;
-        if (isDiscrete)
-            score += 1000;  // Higher base score for discrete GPU
-        else
-            score += 500;  // Lower base score for integrated GPU
-
-        // 2. Adjust score based on PowerPreference
-        if (pref == PowerPreference::HighPerformance && isDiscrete)
-            score += 500;
-        else if (pref == PowerPreference::LowPower && !isDiscrete)
-            score += 500;
-
-        // 3. Adjust score based on VRAM size
-        if (pref == PowerPreference::HighPerformance)
-            score += static_cast<int>(desc.DedicatedVideoMemory / (1024 * 1024));  // More VRAM = higher score
-        else if (pref == PowerPreference::LowPower)
-            score -= static_cast<int>(desc.DedicatedVideoMemory / (1024 * 1024));  // Less VRAM = higher score
-
-        // Keep the adapter with the highest score
-        if (score > bestScore)
-        {
-            bestScore   = score;
-            bestAdapter = adapter;
-        }
-
-        ++i;
-    }
-
-    return bestAdapter;
-}
 }  // namespace
 
-DriverImpl::DriverImpl()
-{
-    // Choose Adapter
-    const auto powerPreferrence = Director::getInstance()->getPowerPreference();
-    auto requestAdapter         = ChooseAdapter(powerPreferrence);
+DriverImpl::DriverImpl() {}
 
+void DriverImpl::init()
+{
     UINT createDeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 
 #if defined(_DEBUG)
@@ -238,8 +178,10 @@ DriverImpl::DriverImpl()
         D3D_FEATURE_LEVEL_11_0,
     };
 
-    auto requestDriverType = requestAdapter ? D3D_DRIVER_TYPE_UNKNOWN : D3D_DRIVER_TYPE_HARDWARE;
-    HRESULT hr             = D3D11CreateDevice(requestAdapter.Get(),      // Adapter
+    initializeAdapter();
+
+    auto requestDriverType = _dxgiAdapter ? D3D_DRIVER_TYPE_UNKNOWN : D3D_DRIVER_TYPE_HARDWARE;
+    HRESULT hr             = D3D11CreateDevice(_dxgiAdapter.Get(),        // Adapter
                                                requestDriverType,         // Driver Type
                                                nullptr,                   // Software
                                                createDeviceFlags,         // Flags
@@ -266,28 +208,32 @@ DriverImpl::DriverImpl()
                                &_featureLevel,            // Feature Level
                                &_context);
     }
+
     if (FAILED(hr))
+        fatalError("D3D11CreateDevice"sv, hr);
+
+    if (!_dxgiAdapter)
     {
-        auto msg = fmt::format("D3D11 required, please upgrade the driver of your video card.");
-        AXLOGE("{}", msg);
-        messageBox(msg.c_str(), "Failed to create D3D11 device.");
-        utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
+        ComPtr<IDXGIDevice> dxgiDevice;
+        AX_D3D_FAST_FAIL(
+            hr = _device->QueryInterface(__uuidof(IDXGIDevice), reinterpret_cast<void**>(dxgiDevice.GetAddressOf())));
+
+        AX_D3D_FAST_FAIL(hr = dxgiDevice->GetAdapter(&_dxgiAdapter));
     }
 
-    Microsoft::WRL::ComPtr<IDXGIDevice> dxgiDevice;
-    _device->QueryInterface(__uuidof(IDXGIDevice), reinterpret_cast<void**>(dxgiDevice.GetAddressOf()));
+    if (!_dxgiFactory)
+    {
+        AX_D3D_FAST_FAIL(hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.GetAddressOf()));
+    }
 
-    Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;
-    dxgiDevice->GetAdapter(&dxgiAdapter);
-
-    dxgiAdapter->GetDesc(&_adapterDesc);
+    _dxgiAdapter->GetDesc(&_adapterDesc);
 
     LARGE_INTEGER version;
-    hr = dxgiAdapter->CheckInterfaceSupport(__uuidof(IDXGIDevice), &version);
+    hr = _dxgiAdapter->CheckInterfaceSupport(__uuidof(IDXGIDevice), &version);
     if (FAILED(hr))
     {
         _driverVersion.reset();
-        AXLOGE("Error querying driver version from DXGI Adapter.");
+        AXLOGW("Error querying driver version from DXGI Adapter.");
     }
     else
     {
@@ -309,8 +255,71 @@ DriverImpl::DriverImpl()
 
 DriverImpl::~DriverImpl()
 {
+    _dxgiFactory.Reset();
+    _dxgiAdapter.Reset();
     SafeRelease(_context);
     SafeRelease(_device);
+}
+
+void DriverImpl::initializeAdapter()
+{
+    const auto powerPreferrence = Director::getInstance()->getPowerPreference();
+
+    if (powerPreferrence == PowerPreference::Auto)
+        return;
+
+    if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&_dxgiFactory)))
+        return;
+
+    ComPtr<IDXGIAdapter> bestAdapter;
+    int bestScore = std::numeric_limits<int>::min();
+
+    UINT i = 0;
+    ComPtr<IDXGIAdapter> adapter;
+    while (_dxgiFactory->EnumAdapters(i, adapter.ReleaseAndGetAddressOf()) != DXGI_ERROR_NOT_FOUND)
+    {
+        DXGI_ADAPTER_DESC desc;
+        adapter->GetDesc(&desc);
+
+        // Skip Microsoft Basic Render Driver (software adapter)
+        if (desc.VendorId == 0x1414 && desc.DeviceId == 0x8c)
+        {
+            ++i;
+            continue;
+        }
+
+        int score = 0;
+
+        // 1. Base score by GPU type
+        bool isDiscrete = desc.DedicatedVideoMemory > 0;
+        if (isDiscrete)
+            score += 1000;  // Higher base score for discrete GPU
+        else
+            score += 500;  // Lower base score for integrated GPU
+
+        // 2. Adjust score based on PowerPreference
+        if (powerPreferrence == PowerPreference::HighPerformance && isDiscrete)
+            score += 500;
+        else if (powerPreferrence == PowerPreference::LowPower && !isDiscrete)
+            score += 500;
+
+        // 3. Adjust score based on VRAM size
+        if (powerPreferrence == PowerPreference::HighPerformance)
+            score += static_cast<int>(desc.DedicatedVideoMemory / (1024 * 1024));  // More VRAM = higher score
+        else if (powerPreferrence == PowerPreference::LowPower)
+            score -= static_cast<int>(desc.DedicatedVideoMemory / (1024 * 1024));  // Less VRAM = higher score
+
+        // Keep the adapter with the highest score
+        if (score > bestScore)
+        {
+            bestScore   = score;
+            bestAdapter = adapter;
+        }
+
+        ++i;
+    }
+
+    _dxgiAdapter = std::move(bestAdapter);
 }
 
 CommandBuffer* DriverImpl::createCommandBuffer(void* presentTarget)
@@ -444,7 +453,6 @@ SamplerHandle DriverImpl::createSampler(const SamplerDesc& desc)
 
 void DriverImpl::destroySampler(SamplerHandle& h)
 {
-
     SafeRelease(reinterpret_cast<ID3D11SamplerState*&>(h));
 }
 

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -167,52 +167,10 @@ DriverImpl::DriverImpl() {}
 
 void DriverImpl::init()
 {
-    UINT createDeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-
-#if defined(_DEBUG)
-    createDeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
-#endif
-
-    D3D_FEATURE_LEVEL featureLevels[] = {
-        D3D_FEATURE_LEVEL_11_1,
-        D3D_FEATURE_LEVEL_11_0,
-    };
-
     initializeAdapter();
+    initializeDevice();
 
-    auto requestDriverType = _dxgiAdapter ? D3D_DRIVER_TYPE_UNKNOWN : D3D_DRIVER_TYPE_HARDWARE;
-    HRESULT hr             = D3D11CreateDevice(_dxgiAdapter.Get(),        // Adapter
-                                               requestDriverType,         // Driver Type
-                                               nullptr,                   // Software
-                                               createDeviceFlags,         // Flags
-                                               featureLevels,             // Feature Levels
-                                               ARRAYSIZE(featureLevels),  // Num Feature Levels
-                                               D3D11_SDK_VERSION,         // SDK Version
-                                               &_device,                  // Device
-                                               &_featureLevel,            // Feature Level
-                                               &_context);
-    if (hr == DXGI_ERROR_UNSUPPORTED)
-    {
-        _dxgiAdapter.Reset();
-        // Try again with software driver type
-        requestDriverType = D3D_DRIVER_TYPE_WARP;
-        // windows 7: D3D11 software adapter not support create debug device
-        createDeviceFlags &= ~D3D11_CREATE_DEVICE_DEBUG;
-        hr = D3D11CreateDevice(nullptr,                   // Adapter
-                               requestDriverType,         // Driver Type
-                               nullptr,                   // Software
-                               createDeviceFlags,         // Flags
-                               featureLevels,             // Feature Levels
-                               ARRAYSIZE(featureLevels),  // Num Feature Levels
-                               D3D11_SDK_VERSION,         // SDK Version
-                               &_device,                  // Device
-                               &_featureLevel,            // Feature Level
-                               &_context);
-    }
-
-    if (FAILED(hr))
-        fatalError("D3D11CreateDevice"sv, hr);
-
+    HRESULT hr{E_FAIL};
     if (!_dxgiAdapter)
     {
         ComPtr<IDXGIDevice> dxgiDevice;
@@ -225,8 +183,6 @@ void DriverImpl::init()
             hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.ReleaseAndGetAddressOf()));
     }
 
-    _dxgiAdapter->GetDesc(&_adapterDesc);
-
     LARGE_INTEGER version;
     hr = _dxgiAdapter->CheckInterfaceSupport(__uuidof(IDXGIDevice), &version);
     if (FAILED(hr))
@@ -238,6 +194,8 @@ void DriverImpl::init()
     {
         _driverVersion = version;
     }
+    _dxgiAdapter->GetDesc(&_adapterDesc);
+
     // _maxAttributes = D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT;
     // _maxTextureSize    = 16384;
     // _maxTextureUnits = D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT;
@@ -258,6 +216,48 @@ DriverImpl::~DriverImpl()
     _dxgiAdapter.Reset();
     SafeRelease(_context);
     SafeRelease(_device);
+}
+
+void DriverImpl::initializeDevice()
+{
+    constexpr UINT releaseFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+    constexpr UINT debugFlags   = releaseFlags | D3D11_CREATE_DEVICE_DEBUG;
+
+    HRESULT hr              = E_FAIL;
+    const bool isDebugLayer = Director::getInstance()->isDebugLayerEnabled();
+
+    if (isDebugLayer) [[unlikely]]
+    {
+        hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, debugFlags);
+        if (SUCCEEDED(hr))
+            return;
+
+        if (hr != DXGI_ERROR_UNSUPPORTED)
+        {
+            AXLOGI("Failed creating Debug D3D11 device - falling back to release runtime.");
+            goto L_ReleaseRuntime;
+        }
+        else
+        {
+            goto L_WarpRuntime;
+        }
+    }
+
+L_ReleaseRuntime:
+    hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, releaseFlags);
+    if (hr == DXGI_ERROR_UNSUPPORTED) [[unlikely]]
+    {
+    L_WarpRuntime:
+        AXLOGI("Failed creating hardware D3D11 device - falling back to software runtime.");
+        // Reset adapter to null before using D3D_DRIVER_TYPE_WARP,
+        // otherwise D3D11CreateDevice will return E_INVALIDARG when both
+        // a non-null adapter and a non-matching driver type are specified.
+        _dxgiAdapter.Reset();
+        hr = createD3DDevice(D3D_DRIVER_TYPE_WARP, releaseFlags);
+    }
+
+    if (FAILED(hr)) [[unlikely]]
+        fatalError("initializeDevice"sv, hr);
 }
 
 void DriverImpl::initializeAdapter()
@@ -319,6 +319,22 @@ void DriverImpl::initializeAdapter()
     }
 
     _dxgiAdapter = std::move(bestAdapter);
+}
+
+HRESULT DriverImpl::createD3DDevice(int requestDriverType, int createFlags)
+{
+    if (_dxgiAdapter)
+        requestDriverType = D3D_DRIVER_TYPE_UNKNOWN;
+    return ::D3D11CreateDevice(_dxgiAdapter.Get(),                  // Adapter
+                               (D3D_DRIVER_TYPE)requestDriverType,  // Driver Type
+                               nullptr,                             // Software
+                               createFlags,                         // Flags
+                               DEFAULT_REATURE_LEVELS,              // Feature Levels
+                               ARRAYSIZE(DEFAULT_REATURE_LEVELS),   // Num Feature Levels
+                               D3D11_SDK_VERSION,                   // SDK Version
+                               &_device,                            // Device
+                               &_featureLevel,                      // Feature Level
+                               &_context);
 }
 
 CommandBuffer* DriverImpl::createCommandBuffer(void* presentTarget)

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -221,7 +221,8 @@ void DriverImpl::init()
 
         AX_D3D_FAST_FAIL(hr = dxgiDevice->GetAdapter(&_dxgiAdapter));
 
-        AX_D3D_FAST_FAIL(hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.ReleaseAndGetAddressOf()));
+        AX_D3D_FAST_FAIL(
+            hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.ReleaseAndGetAddressOf()));
     }
 
     _dxgiAdapter->GetDesc(&_adapterDesc);

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -193,6 +193,7 @@ void DriverImpl::init()
                                                &_context);
     if (hr == DXGI_ERROR_UNSUPPORTED)
     {
+        _dxgiAdapter.Reset();
         // Try again with software driver type
         requestDriverType = D3D_DRIVER_TYPE_WARP;
         // windows 7: D3D11 software adapter not support create debug device
@@ -219,11 +220,8 @@ void DriverImpl::init()
             hr = _device->QueryInterface(__uuidof(IDXGIDevice), reinterpret_cast<void**>(dxgiDevice.GetAddressOf())));
 
         AX_D3D_FAST_FAIL(hr = dxgiDevice->GetAdapter(&_dxgiAdapter));
-    }
 
-    if (!_dxgiFactory)
-    {
-        AX_D3D_FAST_FAIL(hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.GetAddressOf()));
+        AX_D3D_FAST_FAIL(hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.ReleaseAndGetAddressOf()));
     }
 
     _dxgiAdapter->GetDesc(&_adapterDesc);

--- a/axmol/rhi/d3d/DriverD3D.h
+++ b/axmol/rhi/d3d/DriverD3D.h
@@ -60,6 +60,11 @@ public:
     /* The default attribs binding index */
     static constexpr uint32_t DEFAULT_ATTRIBS_BINDING_INDEX = VBO_BINDING_INDEX_START + MAX_VERTEX_ATTRIBS;
 
+    static constexpr D3D_FEATURE_LEVEL DEFAULT_REATURE_LEVELS[2] = {
+        D3D_FEATURE_LEVEL_11_1,
+        D3D_FEATURE_LEVEL_11_0,
+    };
+
     /// @name Constructor, Destructor and Initializers
     DriverImpl();
     ~DriverImpl();
@@ -165,8 +170,6 @@ public:
     const ComPtr<IDXGIFactory>& getDXGIFactory() const { return _dxgiFactory; }
     const ComPtr<IDXGIAdapter> getDXGIAdapter() const { return _dxgiAdapter; }
 
-    static bool supportD24S8() { return _isDepth24Stencil8PixelFormatSupported; }
-
 protected:
     /**
      * Create a shaderModule.
@@ -180,6 +183,8 @@ protected:
 
 private:
     void initializeAdapter();
+    void initializeDevice();
+    HRESULT createD3DDevice(int requestDriverType, int createFlags);
 
     ID3D11Device* _device         = nullptr;
     ID3D11DeviceContext* _context = nullptr;
@@ -189,12 +194,11 @@ private:
 
     DXGI_ADAPTER_DESC _adapterDesc{};
 
+    D3D_FEATURE_LEVEL _featureLevel{};
+
     // FeatureSet _featureSet = FeatureSet::Unknown;
-    static bool _isDepth24Stencil8PixelFormatSupported;
 
     std::optional<LARGE_INTEGER> _driverVersion;
-
-    D3D_FEATURE_LEVEL _featureLevel{};
 };
 
 /** @} */

--- a/axmol/rhi/d3d/DriverD3D.h
+++ b/axmol/rhi/d3d/DriverD3D.h
@@ -24,8 +24,12 @@
 #pragma once
 
 #include "axmol/rhi/DriverBase.h"
-#include <optional>
+#include "axmol/platform/win32/ComPtr.h"
+
 #include <d3d11.h>
+#include <dxgi.h>
+
+#include <optional>
 
 namespace ax::rhi::d3d
 {
@@ -59,6 +63,8 @@ public:
     /// @name Constructor, Destructor and Initializers
     DriverImpl();
     ~DriverImpl();
+
+    void init();
 
     /// @name Setters & Getters
     /**
@@ -154,8 +160,10 @@ public:
     bool checkForFeatureSupported(FeatureType feature) override;
 
     inline ID3D11Device* getDevice() const { return _device; }
-
     inline ID3D11DeviceContext* getContext() const { return _context; }
+
+    const ComPtr<IDXGIFactory>& getDXGIFactory() const { return _dxgiFactory; }
+    const ComPtr<IDXGIAdapter> getDXGIAdapter() const { return _dxgiAdapter; }
 
     static bool supportD24S8() { return _isDepth24Stencil8PixelFormatSupported; }
 
@@ -171,10 +179,15 @@ protected:
     void destroySampler(SamplerHandle& h) override;
 
 private:
+    void initializeAdapter();
+
     ID3D11Device* _device         = nullptr;
     ID3D11DeviceContext* _context = nullptr;
 
-    DXGI_ADAPTER_DESC _adapterDesc;
+    ComPtr<IDXGIFactory> _dxgiFactory;
+    ComPtr<IDXGIAdapter> _dxgiAdapter;
+
+    DXGI_ADAPTER_DESC _adapterDesc{};
 
     // FeatureSet _featureSet = FeatureSet::Unknown;
     static bool _isDepth24Stencil8PixelFormatSupported;

--- a/axmol/rhi/d3d/ShaderModuleD3D.cpp
+++ b/axmol/rhi/d3d/ShaderModuleD3D.cpp
@@ -23,7 +23,7 @@
  ****************************************************************************/
 // refer: https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics
 #include "axmol/rhi/d3d/ShaderModuleD3D.h"
-#include <wrl/client.h>
+#include "axmol/platform/win32/ComPtr.h"
 #include "axmol/base/Logging.h"
 #include "yasio/ibstream.hpp"
 #include "axmol/rhi/axslc-spec.h"
@@ -199,7 +199,7 @@ void ShaderModuleImpl::compileShader(ID3D11Device* device, ShaderStage stage, st
         assert(ibs.eof());
     } while (false);  // iterator stages, current only 1 stage
 
-    Microsoft::WRL::ComPtr<ID3DBlob> errorBlob;
+    ComPtr<ID3DBlob> errorBlob;
     UINT flags = D3DCOMPILE_OPTIMIZATION_LEVEL2 | D3DCOMPILE_ENABLE_STRICTNESS;
 #if defined(_DEBUG)
     flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;

--- a/axmol/rhi/d3d/TextureD3D.h
+++ b/axmol/rhi/d3d/TextureD3D.h
@@ -23,19 +23,14 @@
  ****************************************************************************/
 #pragma once
 
-#include <array>
 #include "axmol/rhi/Texture.h"
 #include "axmol/base/EventListenerCustom.h"
-
+#include "axmol/platform/win32/ComPtr.h"
 #include <d3d11.h>
 #include <dxgi.h>
-#include <wrl/client.h>
-#include <array>  // std::array
 
 namespace ax::rhi::d3d
 {
-using namespace Microsoft::WRL;
-
 /**
  * @addtogroup _d3d
  * @{

--- a/axmol/rhi/d3d/UtilsD3D.cpp
+++ b/axmol/rhi/d3d/UtilsD3D.cpp
@@ -210,10 +210,9 @@ TextureImpl* UtilsD3D::getDefaultDepthStencilAttachment()
     return s_defaultDepthStencilAttachment;
 }
 
-
 void UtilsD3D::fatalError(std::string_view op, HRESULT hr)
 {
-    auto msg  = fmt::format("{}: 0x{:08X}", op, static_cast<unsigned>(hr));
+    auto msg = fmt::format("{}: 0x{:08X}", op, static_cast<unsigned>(hr));
     showAlert(msg, "D3D: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);
     utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
 }

--- a/axmol/rhi/d3d/UtilsD3D.cpp
+++ b/axmol/rhi/d3d/UtilsD3D.cpp
@@ -210,7 +210,8 @@ TextureImpl* UtilsD3D::getDefaultDepthStencilAttachment()
     return s_defaultDepthStencilAttachment;
 }
 
-void UtilsD3D::fatalError(std::string_view op, HRESULT hr) {
+void UtilsD3D::fatalError(std::string_view op, HRESULT hr)
+{
     _com_error err(hr, nullptr);
     auto msg = fmt::format("{}:{}", op, ntcvt::from_chars(err.ErrorMessage()));
     showAlert(msg, "Axmol: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);

--- a/axmol/rhi/d3d/UtilsD3D.cpp
+++ b/axmol/rhi/d3d/UtilsD3D.cpp
@@ -36,14 +36,14 @@
 
 #include "axmol/rhi/d3d/UtilsD3D.h"
 #include "axmol/rhi/d3d/DriverD3D.h"
-#include <dxgiformat.h>
-#include <wrl/client.h>
+#include "axmol/rhi/RHIUtils.h"
 
 #include "axmol/base/Logging.h"
 
-#include "axmol/rhi/RHIUtils.h"
+#include "ntcvt/ntcvt.hpp"
 
-using namespace Microsoft::WRL;
+#include <dxgiformat.h>
+#include <comdef.h>
 
 namespace ax::rhi::d3d
 {
@@ -204,9 +204,17 @@ TextureImpl* UtilsD3D::getDefaultColorAttachment()
 {
     return s_defaultColorAttachment;
 }
+
 TextureImpl* UtilsD3D::getDefaultDepthStencilAttachment()
 {
     return s_defaultDepthStencilAttachment;
+}
+
+void UtilsD3D::fatalError(std::string_view op, HRESULT hr) {
+    _com_error err(hr, nullptr);
+    auto msg = fmt::format("{}:{}", op, ntcvt::from_chars(err.ErrorMessage()));
+    showAlert(msg, "Axmol: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);
+    utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
 }
 
 }  // namespace ax::rhi::d3d

--- a/axmol/rhi/d3d/UtilsD3D.cpp
+++ b/axmol/rhi/d3d/UtilsD3D.cpp
@@ -210,46 +210,10 @@ TextureImpl* UtilsD3D::getDefaultDepthStencilAttachment()
     return s_defaultDepthStencilAttachment;
 }
 
-static std::string hresultToString(HRESULT hr)
-{
-    LPWSTR buf = nullptr;
-    DWORD len =
-        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                       nullptr, hr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&buf, 0, nullptr);
-
-    std::string result;
-    if (buf)
-    {
-        result = ntcvt::from_chars(std::wstring_view(buf, len));
-        LocalFree(buf);
-    }
-
-    if (result.empty())
-    {
-        switch (hr)
-        {
-        case DXGI_ERROR_UNSUPPORTED:
-            result = "The specified device interface or feature level is not supported on this system.";
-            break;
-        case DXGI_ERROR_DEVICE_REMOVED:
-            result = "The video card has been physically removed or a driver upgrade for the video card has occurred.";
-            break;
-        case DXGI_ERROR_DEVICE_HUNG:
-            result = "The application's device failed due to badly formed commands sent by the application.";
-            break;
-        default:
-            result = "Unknown error.";
-            break;
-        }
-    }
-
-    return result;
-}
 
 void UtilsD3D::fatalError(std::string_view op, HRESULT hr)
 {
-    auto desc = hresultToString(hr);
-    auto msg  = fmt::format("{}: 0x{:08X} ({})", op, static_cast<unsigned>(hr), desc);
+    auto msg  = fmt::format("{}: 0x{:08X}", op, static_cast<unsigned>(hr));
     showAlert(msg, "D3D: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);
     utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
 }

--- a/axmol/rhi/d3d/UtilsD3D.cpp
+++ b/axmol/rhi/d3d/UtilsD3D.cpp
@@ -210,11 +210,47 @@ TextureImpl* UtilsD3D::getDefaultDepthStencilAttachment()
     return s_defaultDepthStencilAttachment;
 }
 
+static std::string hresultToString(HRESULT hr)
+{
+    LPWSTR buf = nullptr;
+    DWORD len =
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                       nullptr, hr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&buf, 0, nullptr);
+
+    std::string result;
+    if (buf)
+    {
+        result = ntcvt::from_chars(std::wstring_view(buf, len));
+        LocalFree(buf);
+    }
+
+    if (result.empty())
+    {
+        switch (hr)
+        {
+        case DXGI_ERROR_UNSUPPORTED:
+            result = "The specified device interface or feature level is not supported on this system.";
+            break;
+        case DXGI_ERROR_DEVICE_REMOVED:
+            result = "The video card has been physically removed or a driver upgrade for the video card has occurred.";
+            break;
+        case DXGI_ERROR_DEVICE_HUNG:
+            result = "The application's device failed due to badly formed commands sent by the application.";
+            break;
+        default:
+            result = "Unknown error.";
+            break;
+        }
+    }
+
+    return result;
+}
+
 void UtilsD3D::fatalError(std::string_view op, HRESULT hr)
 {
-    _com_error err(hr, nullptr);
-    auto msg = fmt::format("{}:{}", op, ntcvt::from_chars(err.ErrorMessage()));
-    showAlert(msg, "Axmol: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);
+    auto desc = hresultToString(hr);
+    auto msg  = fmt::format("{}: 0x{:08X} ({})", op, static_cast<unsigned>(hr), desc);
+    showAlert(msg, "D3D: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);
     utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
 }
 

--- a/axmol/rhi/metal/TextureMTL.h
+++ b/axmol/rhi/metal/TextureMTL.h
@@ -28,7 +28,6 @@
 #include "axmol/rhi/Texture.h"
 #include "axmol/rhi/metal/DriverMTL.h"
 #import <Metal/Metal.h>
-#include <array>
 
 namespace ax::rhi::mtl
 {

--- a/axmol/rhi/opengl/DriverGL.cpp
+++ b/axmol/rhi/opengl/DriverGL.cpp
@@ -125,7 +125,7 @@ DriverImpl::DriverImpl()
             REQUIRED_GLES_MAJOR, AX_GLES_PROFILE % AX_GLES_PROFILE, _version);
 #endif
         AXLOGE("{}", msg);
-        messageBox(msg.c_str(), "OpenGL version too old");
+        showAlert(msg, "OpenGL version too old");
         utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
         return;
     }

--- a/axmol/rhi/opengl/TextureGL.h
+++ b/axmol/rhi/opengl/TextureGL.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <array>
 #include "axmol/rhi/Texture.h"
 #include "axmol/platform/GL.h"
 #include "axmol/base/EventListenerCustom.h"

--- a/axmol/ui/UIMediaPlayer.cpp
+++ b/axmol/ui/UIMediaPlayer.cpp
@@ -243,7 +243,7 @@ struct PrivateVideoContext
                     .pixelFormat = PixelFormat::BGRA8,
                 },
                 Texture2D::DEFAULT_SLICE_DATA);
-            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_BGR32);
+            _vrender->setProgramState(rhi::ProgramType::VIDEO_TEXTURE_RGB32);
             _renderFrameFunc = [this](const MEVideoFrame& frame) {
                 if (_vtexture)
                 {


### PR DESCRIPTION
## Describe your changes

```txt
- Refactor D3D11 device creation with multi-step fallback:
  1. Attempt hardware device with debug layer if enabled.
  2. If debug layer creation fails (but hardware is supported), retry with release runtime.
  3. If hardware is unsupported (DXGI_ERROR_UNSUPPORTED), reset DXGI adapter and fall back to WARP runtime.
- Add explicit DXGI adapter reset before WARP creation to avoid E_INVALIDARG when
  specifying a non-null adapter with a non-matching driver type.
- Improve logging for each fallback step to aid troubleshooting.

- Rename `ax::messageBox` to `ax::showAlert` and add `AlertStyle` parameter.
- Mark `ax::messageBox` as deprecated starting from axmol-2.9.0.

- Fix MediaPlayer crash on UWP platform.
- Ensure thread-safe SwapChain creation in CommandBufferD3D for UWP platform.
```

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
