### PR TITLE
deprecate some APIs

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,7 +32,7 @@
 # include_guard (GLOBAL)
 
 # The version number
-set(_AX_VERSION 2.8)
+set(_AX_VERSION 2.9)
 
 if(NOT DEFINED _AX_CORE_LIB)
   set(_AX_CORE_LIB axmol CACHE INTERNAL "The axmol core lib name")

--- a/core/axmolver.h.in
+++ b/core/axmolver.h.in
@@ -4,7 +4,7 @@
 // 0x00 HI ME LO
 // 00   03 08 00
 #define AX_VERSION_MAJOR 2
-#define AX_VERSION_MINOR 8
+#define AX_VERSION_MINOR 9
 #define AX_VERSION_PATCH 0
 
 /* Define axmol version helper macros */

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -261,10 +261,10 @@ void Director::setDefaultValues()
     Image::setCompressedImagesHavePMA(Image::CompressedImagePMAFlag::ETC2, etc2_alpha_premultiplied);
 }
 
-void Director::setGLDefaultValues()
+void Director::setRenderDefaults()
 {
     // This method SHOULD be called only after _renderView was initialized
-    AXASSERT(_renderView, "opengl view should not be null");
+    AXASSERT(_renderView, "render view should not be null");
 
     _renderer->setDepthTest(false);
     _renderer->setDepthCompareFunction(backend::CompareFunction::LESS_EQUAL);

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -365,12 +365,15 @@ public:
     /** Sets the default values based on the Configuration info. */
     void setDefaultValues();
 
-    // OpenGL Helper
+    // Render Helper
 
-    /** Sets the OpenGL default values.
+    /** Sets the Render default values.
      * It will enable alpha blending, disable depth test.
      */
-    void setGLDefaultValues();
+    void setRenderDefaults();
+#ifndef AX_CORE_PROFILE
+    AX_DEPRECATED(2.9) void setGLDefaultValues() { setRenderDefaults(); }
+#endif
 
     /** Sets clear values for the color buffers,
      * value range of each element is [0.0, 1.0].

--- a/core/platform/Common.h
+++ b/core/platform/Common.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 
@@ -28,6 +29,8 @@ THE SOFTWARE.
 /// @cond DO_NOT_SHOW
 
 #include "platform/PlatformMacros.h"
+#include "base/bitmask.hpp"
+#include <string_view>
 
 namespace ax
 {
@@ -37,10 +40,52 @@ namespace ax
  * @{
  */
 
-/**
-@brief Pop out a message box
-*/
-void AX_DLL messageBox(const char* msg, const char* title);
+enum AlertStyle : unsigned int
+{
+    // Icon types (low bits)
+    IconInfo    = 0x0001,
+    IconWarning = 0x0002,
+    IconError   = 0x0004,
+    IconDebug   = 0x0008,
+
+    // Button sets (middle bits)
+    Ok          = 0x0100,
+    OkCancel    = 0x0200,
+    YesNo       = 0x0400,
+    YesNoCancel = 0x0800,
+
+    // Behavior flags (high bits)
+    RequireSync = 0x10000  ///< Enforce synchronous (blocking) behavior
+};
+AX_ENABLE_BITMASK_OPS(AlertStyle)
+
+enum class AlertResult
+{
+    None,
+    Ok,
+    Cancel,
+    Yes,
+    No
+};
+
+/** @brief Display a modal alert dialog with configurable icon and buttons.
+ *
+ * @param msg         The message text to display, in UTF-8 encoding.
+ * @param title       The dialog title text, in UTF-8 encoding.
+ * @param style       Bitwise OR combination of icon type and button set. See ::AlertStyle.
+ * @param requireSync When true, enforces synchronous (blocking) behavior for this call.
+ *                    On platforms where the default is non-blocking (e.g., UWP), this will
+ *                    block the calling thread until the dialog is closed.
+ *                    On platforms where the default is already blocking (e.g., Win32),
+ *                    this flag has no effect on execution but serves as an explicit
+ *                    indication that the caller expects synchronous behavior.
+ * @return            The button pressed by the user. See ::AlertResult.
+ */
+AlertResult AX_DLL showAlert(std::string_view msg, std::string_view title, AlertStyle style = AlertStyle::Ok);
+
+#ifndef AX_CORE_PROFILE
+AX_DEPRECATED(2.9) inline void messageBox(const char* msg, const char* title) { showAlert(msg, title); }
+#endif
 
 /**
 @brief Enum the language type supported now
@@ -73,6 +118,6 @@ enum class LanguageType
 // END of platform group
 /// @}
 
-}
+}  // namespace ax
 
 /// @endcond

--- a/core/platform/Common.h
+++ b/core/platform/Common.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 /// @cond DO_NOT_SHOW
 
 #include "platform/PlatformMacros.h"
-#include "base/bitmask.hpp"
+#include "base/bitmask.h"
 #include <string_view>
 
 namespace ax

--- a/core/platform/RenderViewImpl.cpp
+++ b/core/platform/RenderViewImpl.cpp
@@ -544,7 +544,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rec
             message.append(_glfwError);
         }
 
-        messageBox(message.c_str(), "Error launch application");
+        showAlert(message, "Error launch application");
         utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
         return false;
     }
@@ -597,7 +597,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName, const ax::Rect& rec
     glfwMakeContextCurrent(_mainWindow);
     glfwSetWindowUserPointer(_mainWindow, backend::__gl);
 #endif
-    
+
 #if !defined(__APPLE__)
     handleWindowSize(static_cast<int>(windowSize.width), static_cast<int>(windowSize.height));
 #else

--- a/core/platform/android/Common-android.cpp
+++ b/core/platform/android/Common-android.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 
@@ -32,11 +33,10 @@ THE SOFTWARE.
 namespace ax
 {
 
-#define MAX_LEN (ax::kMaxLogLen + 1)
-
-void messageBox(const char* pszMsg, const char* pszTitle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
-    JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", pszTitle, pszMsg);
+    JniHelper::callStaticVoidMethod("dev.axmol.lib.AxmolEngine", "showDialog", msg, title);
+    return AlertResult::None;
 }
 
-}
+}  // namespace ax

--- a/core/platform/apple/FoundationBridge.h
+++ b/core/platform/apple/FoundationBridge.h
@@ -1,7 +1,5 @@
 /****************************************************************************
-Copyright (c) 2010-2012 cocos2d-x.org
-Copyright (c) 2013-2016 Chukong Technologies Inc.
-Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
@@ -24,40 +22,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
-#include "platform/Common.h"
-#include "platform/StdC.h"
-#include "ntcvt/ntcvt.hpp"
+
+#pragma once
+
+#import <Foundation/NSString.h>
 
 namespace ax
 {
-
-AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle style)
+static NSString* svtons(std::string_view str)
 {
-    std::wstring wsMsg   = ntcvt::from_chars(msg);
-    std::wstring wsTitle = ntcvt::from_chars(title);
-    UINT flags           = MB_TOPMOST;
-
-    // level
-    if (bitmask::any(style, AlertStyle::IconError))
-        flags |= MB_ICONERROR;
-    else if (bitmask::any(style, AlertStyle::IconWarning))
-        flags |= MB_ICONWARNING;
-    else if (bitmask::any(style, AlertStyle::IconInfo))
-        flags |= MB_ICONINFORMATION;
-
-    // buttons
-    if (bitmask::any(style, AlertStyle::OkCancel))
-        flags |= MB_OKCANCEL;
-    else if (bitmask::any(style, AlertStyle::YesNo))
-        flags |= MB_YESNO;
-    else if (bitmask::any(style, AlertStyle::YesNoCancel))
-        flags |= MB_YESNOCANCEL;
-    else if (bitmask::any(style, AlertStyle::Ok))
-        flags |= MB_OK;
-
-    ::MessageBoxW(nullptr, wsMsg.c_str(), wsTitle.c_str(), flags);
-
-    return AlertResult::Ok;
+    return !str.empty() ? [[NSString alloc] initWithBytes:str.data() length:str.length() encoding:NSUTF8StringEncoding]
+                        : nil;
 }
-
 }  // namespace ax

--- a/core/platform/ios/Common-ios.mm
+++ b/core/platform/ios/Common-ios.mm
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -32,18 +33,18 @@
 #import <UIKit/UIWindow.h>
 #include "base/Director.h"
 #include "base/Logging.h"
+#include "platform/apple/FoundationBridge.h"
 
 namespace ax
 {
 
-// ios no MessageBox, use log instead
-void messageBox(const char* msg, const char* title)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
     // only enable it on iOS.
     // FIXME: Implement it for tvOS
 #if !defined(AX_TARGET_OS_TVOS)
-    NSString* tmpTitle = (title) ? [NSString stringWithUTF8String:title] : nil;
-    NSString* tmpMsg   = (msg) ? [NSString stringWithUTF8String:msg] : nil;
+    NSString* tmpTitle = svtons(title);
+    NSString* tmpMsg   = svtons(msg);
 
     UIAlertController* alertController = [UIAlertController alertControllerWithTitle:tmpTitle
                                                                              message:tmpMsg
@@ -57,7 +58,10 @@ void messageBox(const char* msg, const char* title)
     [alertController addAction:defaultAction];
     auto rootViewController = [UIApplication sharedApplication].windows[0].rootViewController;
     [rootViewController presentViewController:alertController animated:YES completion:nil];
+#else
+    AXLOGI("{}: {}", title, msg);
 #endif
+    return AlertResult::None;
 }
 
-}
+}  // namespace ax

--- a/core/platform/linux/Common-linux.cpp
+++ b/core/platform/linux/Common-linux.cpp
@@ -31,9 +31,10 @@ THE SOFTWARE.
 namespace ax
 {
 
-void messageBox(const char* msg, const char* title)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
-    AXLOGE("{}: {}", title, msg);
+    AXLOGI("{}: {}", title, msg);
+    return AlertResult::None;
 }
 
-}
+}  // namespace ax

--- a/core/platform/mac/Common-mac.mm
+++ b/core/platform/mac/Common-mac.mm
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 #include "platform/Common.h"
+#include "platform/apple/FoundationBridge.h"
 
 #include "base/Director.h"
 
@@ -34,11 +35,11 @@ THE SOFTWARE.
 namespace ax
 {
 
-// ios no MessageBox, use log instead
-void messageBox(const char* msg, const char* title)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
-    NSString* tmpTitle = (title) ? [NSString stringWithUTF8String:title] : nil;
-    NSString* tmpMsg   = (msg) ? [NSString stringWithUTF8String:msg] : nil;
+
+    NSString* tmpTitle = svtons(title);
+    NSString* tmpMsg   = svtons(msg);
 
     NSAlert* alert = [[[NSAlert alloc] init] autorelease];
     [alert addButtonWithTitle:@"OK"];
@@ -47,8 +48,10 @@ void messageBox(const char* msg, const char* title)
     [alert setAlertStyle:NSAlertStyleWarning];
 
     auto renderView = Director::getInstance()->getRenderView();
-    id window   = (id)renderView->getCocoaWindow();
+    id window       = (id)renderView->getCocoaWindow();
     [alert beginSheetModalForWindow:window completionHandler:nil];
+
+    return AlertResult::None;
 }
 
-}
+}  // namespace ax

--- a/core/platform/wasm/Common-wasm.cpp
+++ b/core/platform/wasm/Common-wasm.cpp
@@ -36,13 +36,14 @@ THE SOFTWARE.
 namespace ax
 {
 
-void messageBox(const char * msg, const char * title)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
 {
-    EM_ASM_ARGS({
-        window.alert(UTF8ToString($0) + ": " + UTF8ToString($1));
-    }, title, msg);
+    auto pszMsg   = msg.data();
+    auto pszTitle = title.data();
+    EM_ASM_ARGS({ window.alert(UTF8ToString($0) + ": " + UTF8ToString($1)); }, pszTitle, pszTitle);
+    return AlertResult::None;
 }
 
-}
+}  // namespace ax
 
-#endif //  AX_TARGET_PLATFORM == AX_PLATFORM_WASM
+#endif  //  AX_TARGET_PLATFORM == AX_PLATFORM_WASM

--- a/core/platform/winrt/Common-winrt.cpp
+++ b/core/platform/winrt/Common-winrt.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010 cocos2d-x.org
 Copyright (c) Microsoft Open Technologies, Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 
@@ -35,12 +36,12 @@ THE SOFTWARE.
 namespace ax
 {
 
-void messageBox(const char * pszMsg, const char * pszTitle)
+AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle style)
 {
     // Create the message dialog and set its content
-    auto message = PlatformStringFromString(pszMsg);
-    auto title = PlatformStringFromString(pszTitle);
-    RenderViewImpl::sharedRenderView()->ShowMessageBox(title, message);
+    auto hmsg   = PlatformStringFromString(msg);
+    auto htitle = PlatformStringFromString(title);
+    return RenderViewImpl::sharedRenderView()->ShowAlertDialog(hmsg, htitle, style);
 }
 
-}
+}  // namespace ax

--- a/core/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/core/platform/winrt/RenderViewImpl-winrt.cpp
@@ -35,11 +35,14 @@ THE SOFTWARE.
 #include "platform/winrt/WinRTUtils.h"
 #include "base/EventDispatcher.h"
 #include "base/EventMouse.h"
-#include <map>
+#include <future>
 
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Popups.h>
 #include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Core.h>
 
 namespace ax
 {
@@ -165,22 +168,75 @@ void RenderViewImpl::setIMEKeyboardState(bool bOpen)
     setIMEKeyboardState(bOpen, "");
 }
 
-bool RenderViewImpl::ShowMessageBox(const winrt::hstring& title, const winrt::hstring& message)
+AlertResult RenderViewImpl::ShowAlertDialog(const winrt::hstring& title,
+                                            const winrt::hstring& message,
+                                            AlertStyle style)
 {
-    if (m_dispatcher)
-    {
-        m_dispatcher.get().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal,
-                                     Windows::UI::Core::DispatchedHandler([title, message]() {
-                                         // Show the message dialog
-                                         auto msg = Windows::UI::Popups::MessageDialog(message, title);
-                                         // Set the command to be invoked when a user presses 'ESC'
-                                         msg.CancelCommandIndex(1);
-                                         msg.ShowAsync();
-                                     }));
+    using namespace winrt::Windows::UI::Core;
+    using namespace winrt::Windows::UI::Popups;
 
-        return true;
+    if (!m_dispatcher)
+        return AlertResult::No;
+
+    bool isOnMainUIThread = m_dispatcher.get().HasThreadAccess();
+    bool canPromise       = !isOnMainUIThread && bitmask::any(style, AlertStyle::RequireSync);
+
+    auto promisePtr = std::make_shared<std::promise<AlertResult>>();
+    auto future     = promisePtr->get_future();
+
+    auto addCommand = [canPromise](MessageDialog& dlg, std::wstring_view btnTitle, AlertResult ret,
+                                   std::shared_ptr<std::promise<AlertResult>> promisePtr) {
+        dlg.Commands().Append(UICommand(btnTitle, [promisePtr, ret, canPromise](auto&&) {
+            if (canPromise)
+            {
+                try
+                {
+                    promisePtr->set_value(ret);
+                }
+                catch (...)
+                {}
+            }
+        }));
+    };
+
+    auto showDialogAsync = [title, message, style, addCommand, promisePtr]() mutable {
+        MessageDialog dlg(message, title);
+        dlg.CancelCommandIndex(1);
+
+        if (bitmask::any(style, AlertStyle::OkCancel))
+        {
+            addCommand(dlg, L"OK", AlertResult::Ok, promisePtr);
+            addCommand(dlg, L"Cancel", AlertResult::Cancel, promisePtr);
+        }
+        else if (bitmask::any(style, AlertStyle::YesNo))
+        {
+            addCommand(dlg, L"Yes", AlertResult::Yes, promisePtr);
+            addCommand(dlg, L"No", AlertResult::No, promisePtr);
+        }
+        else if (bitmask::any(style, AlertStyle::YesNoCancel))
+        {
+            addCommand(dlg, L"Yes", AlertResult::Yes, promisePtr);
+            addCommand(dlg, L"No", AlertResult::No, promisePtr);
+            addCommand(dlg, L"Cancel", AlertResult::Cancel, promisePtr);
+        }
+        else
+        {
+            addCommand(dlg, L"OK", AlertResult::Ok, promisePtr);
+        }
+
+        dlg.ShowAsync();
+    };
+
+    if (!isOnMainUIThread)
+    {
+        m_dispatcher.get().RunAsync(CoreDispatcherPriority::Normal, showDialogAsync);
     }
-    return false;
+    else
+    {
+        showDialogAsync();
+    }
+
+    return canPromise ? future.get() : AlertResult::None;
 }
 
 void RenderViewImpl::setIMEKeyboardState(bool bOpen, std::string_view str)

--- a/core/platform/winrt/RenderViewImpl-winrt.h
+++ b/core/platform/winrt/RenderViewImpl-winrt.h
@@ -113,7 +113,7 @@ public:
     void QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
     void QueueEvent(std::shared_ptr<InputEvent>& event);
 
-    bool ShowMessageBox(const winrt::hstring& title, const winrt::hstring& message);
+    AlertResult ShowAlertDialog(const winrt::hstring& title, const winrt::hstring& message, AlertStyle style);
 
     int Run();
     void Render();

--- a/core/renderer/backend/opengl/DriverGL.cpp
+++ b/core/renderer/backend/opengl/DriverGL.cpp
@@ -119,6 +119,10 @@ DriverGL::DriverGL()
             _verInfo.minor = (_version[2] - '0');
         }
     }
+    else
+    {
+        _version = "null";
+    }
 
     // check OpenGL version at first
     constexpr int REQUIRED_GLES_MAJOR = (AX_GLES_PROFILE / AX_GLES_PROFILE_DEN);
@@ -134,7 +138,7 @@ DriverGL::DriverGL()
             "OpeGL ES {}.{}+ is required (your version is {}). Please upgrade the driver of your video card.",
             REQUIRED_GLES_MAJOR, AX_GLES_PROFILE % AX_GLES_PROFILE, _version);
 #endif
-        messageBox(msg.c_str(), "OpenGL version too old");
+        showAlert(msg, "OpenGL version too old");
         utils::killCurrentProcess();  // kill current process, don't cause crash when driver issue.
         return;
     }


### PR DESCRIPTION
- Mark Director::setGLDefaultValues as deprecated; use setRenderDefaults instead.
- Mark messageBox as deprecated; use showAlert instead.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
