### PR TITLE
Revert DrawNode color param to Color4F to fix Lua test issues

### DIFF
--- a/core/2d/DrawNode.cpp
+++ b/core/2d/DrawNode.cpp
@@ -273,7 +273,7 @@ void DrawNode::updateBuffers()
 
 void DrawNode::drawPoint(const Vec2& position,
                          const float pointSize,
-                         const Color4B& color,
+                         const Color4F& color,
                          const DrawNode::PointType pointType)
 {
     if (pointSize <= 0.0f)
@@ -284,7 +284,7 @@ void DrawNode::drawPoint(const Vec2& position,
 
 void DrawNode::drawPoints(const Vec2* position,
                           unsigned int numberOfPoints,
-                          const Color4B& color,
+                          const Color4F& color,
                           const DrawNode::PointType pointType)
 {
     _drawPoints(position, numberOfPoints, 1.0f, color, pointType);
@@ -293,7 +293,7 @@ void DrawNode::drawPoints(const Vec2* position,
 void DrawNode::drawPoints(const Vec2* position,
                           unsigned int numberOfPoints,
                           const float pointSize,
-                          const Color4B& color,
+                          const Color4F& color,
                           const DrawNode::PointType pointType)
 {
     if (pointSize <= 0.0f)
@@ -303,7 +303,7 @@ void DrawNode::drawPoints(const Vec2* position,
 
 void DrawNode::drawLine(const Vec2& origin,
                         const Vec2& destination,
-                        const Color4B& color,
+                        const Color4F& color,
                         float thickness,
                         DrawNode::EndType etStart,
                         DrawNode::EndType etEnd)
@@ -320,7 +320,7 @@ void DrawNode::drawLine(const Vec2& origin,
 void DrawNode::drawPoly(const Vec2* poli,
                         unsigned int numberOfPoints,
                         bool closedPolygon,
-                        const Color4B& color,
+                        const Color4F& color,
                         float thickness)
 {
     if (thickness <= 0.0f)
@@ -338,7 +338,7 @@ void DrawNode::drawCircle(const Vec2& center,
                           bool drawLineToCenter,
                           float scaleX,
                           float scaleY,
-                          const Color4B& color,
+                          const Color4F& color,
                           float thickness)
 {
     if (thickness <= 0.0f)
@@ -352,7 +352,7 @@ void DrawNode::drawCircle(const Vec2& center,
         return;
     }
 
-    _drawCircle(center, radius, angle, segments, drawLineToCenter, scaleX, scaleY, color, Color4B(), false, thickness);
+    _drawCircle(center, radius, angle, segments, drawLineToCenter, scaleX, scaleY, color, Color4F(), false, thickness);
 }
 
 void DrawNode::drawCircle(const Vec2& center,
@@ -360,7 +360,7 @@ void DrawNode::drawCircle(const Vec2& center,
                           float angle,
                           unsigned int segments,
                           bool drawLineToCenter,
-                          const Color4B& color,
+                          const Color4F& color,
                           float thickness)
 {
     if (thickness <= 0.0f)
@@ -381,7 +381,7 @@ void DrawNode::drawStar(const Vec2& center,
                         float radiusI,
                         float radiusO,
                         unsigned int segments,
-                        const Color4B& color,
+                        const Color4F& color,
                         float thickness)
 {
     if (thickness <= 0.0f)
@@ -396,8 +396,8 @@ void DrawNode::drawSolidStar(const Vec2& center,
                              float radiusI,  // inner
                              float radiusO,  // outer
                              unsigned int segments,
-                             const Color4B& color,
-                             const Color4B& filledColor,
+                             const Color4F& color,
+                             const Color4F& filledColor,
                              float thickness)
 {
     if (thickness < 0.0f)
@@ -412,7 +412,7 @@ void DrawNode::drawQuadBezier(const Vec2& origin,
                               const Vec2& control,
                               const Vec2& destination,
                               unsigned int segments,
-                              const Color4B& color,
+                              const Color4F& color,
                               float thickness)
 {
     if (thickness <= 0.0f)
@@ -442,7 +442,7 @@ void DrawNode::drawCubicBezier(const Vec2& origin,
                                const Vec2& control2,
                                const Vec2& destination,
                                unsigned int segments,
-                               const Color4B& color,
+                               const Color4F& color,
                                float thickness)
 {
     if (thickness <= 0.0f)
@@ -471,7 +471,7 @@ void DrawNode::drawCubicBezier(const Vec2& origin,
 void DrawNode::drawCardinalSpline(const PointArray* configIn,
                                   float tension,
                                   unsigned int segments,
-                                  const Color4B& color,
+                                  const Color4F& color,
                                   float thickness,
                                   bool closed)
 {
@@ -533,7 +533,7 @@ void DrawNode::drawCardinalSpline(const PointArray* configIn,
     _drawPoly(_vertices.data(), segments, false, color, thickness, true);
 }
 
-void DrawNode::drawCatmullRom(const PointArray* pointsIn, unsigned int segments, const Color4B& color, float thickness, bool closed)
+void DrawNode::drawCatmullRom(const PointArray* pointsIn, unsigned int segments, const Color4F& color, float thickness, bool closed)
 {
     if (thickness <= 0.0f)
     {
@@ -543,7 +543,7 @@ void DrawNode::drawCatmullRom(const PointArray* pointsIn, unsigned int segments,
     drawCardinalSpline(pointsIn, 0.5f, segments, color, thickness, closed);
 }
 
-void DrawNode::drawDot(const Vec2& pos, float radius, const Color4B& color)
+void DrawNode::drawDot(const Vec2& pos, float radius, const Color4F& color)
 {
     if (radius <= 0.0f)
     {
@@ -557,7 +557,7 @@ void DrawNode::drawRect(const Vec2& p1,
                         const Vec2& p2,
                         const Vec2& p3,
                         const Vec2& p4,
-                        const Color4B& color,
+                        const Color4F& color,
                         float thickness)
 {
     if (thickness <= 0.0f)
@@ -570,7 +570,7 @@ void DrawNode::drawRect(const Vec2& p1,
     _drawPoly(line, 5, false, color, thickness, true);
 }
 
-void DrawNode::drawRect(const Vec2& origin, const Vec2& destination, const Color4B& color, float thickness)
+void DrawNode::drawRect(const Vec2& origin, const Vec2& destination, const Color4F& color, float thickness)
 {
     if (thickness <= 0.0f)
     {
@@ -585,7 +585,7 @@ void DrawNode::drawRect(const Vec2& origin, const Vec2& destination, const Color
 void DrawNode::drawSegment(const Vec2& from,
                            const Vec2& to,
                            float thickness,
-                           const Color4B& color,
+                           const Color4F& color,
                            DrawNode::EndType etStart,
                            DrawNode::EndType etEnd)
 {
@@ -599,9 +599,9 @@ void DrawNode::drawSegment(const Vec2& from,
 
 void DrawNode::drawPolygon(const Vec2* verts,
                            int count,
-                           const Color4B& fillColor,
+                           const Color4F& fillColor,
                            float thickness,
-                           const Color4B& borderColor,
+                           const Color4F& borderColor,
                            bool isconvex)
 {
     if (thickness < 0.0f)
@@ -612,21 +612,21 @@ void DrawNode::drawPolygon(const Vec2* verts,
     _drawPolygon(verts, count, fillColor, borderColor, true, thickness, isconvex);
 }
 
-void DrawNode::drawPolygon(const Vec2* verts, int count, float thickness, const Color4B& borderColor, bool isconvex)
+void DrawNode::drawPolygon(const Vec2* verts, int count, float thickness, const Color4F& borderColor, bool isconvex)
 {
     if (thickness < 0.0f)
     {
         AXLOGW("{}: thickness < 0, changed to 0", __FUNCTION__);
         thickness = 0.0f;
     }
-    _drawPolygon(verts, count, Color4B::TRANSPARENT, borderColor, true, thickness, isconvex);
+    _drawPolygon(verts, count, Color4F::TRANSPARENT, borderColor, true, thickness, isconvex);
 }
 
 void DrawNode::drawSolidPolygon(const Vec2* verts,
                                 int count,
-                                const Color4B& fillColor,
+                                const Color4F& fillColor,
                                 float thickness,
-                                const Color4B& borderColor,
+                                const Color4F& borderColor,
                                 bool isconvex)
 {
     if (thickness < 0.0f)
@@ -639,9 +639,9 @@ void DrawNode::drawSolidPolygon(const Vec2* verts,
 
 void DrawNode::drawSolidRect(const Vec2& origin,
                              const Vec2& destination,
-                             const Color4B& fillColor,
+                             const Color4F& fillColor,
                              float thickness,
-                             const Color4B& borderColor)
+                             const Color4F& borderColor)
 {
     if (thickness < 0.0f)
     {
@@ -654,9 +654,9 @@ void DrawNode::drawSolidRect(const Vec2& origin,
 
 void DrawNode::drawSolidPoly(const Vec2* poli,
                              unsigned int numberOfPoints,
-                             const Color4B& color,
+                             const Color4F& color,
                              float thickness,
-                             const Color4B& borderColor,
+                             const Color4F& borderColor,
                              bool isconvex)
 {
     if (thickness < 0.0f)
@@ -674,8 +674,8 @@ void DrawNode::drawPie(const Vec2& center,
                        int endAngle,
                        float scaleX,
                        float scaleY,
-                       const Color4B& fillColor,
-                       const Color4B& borderColor,
+                       const Color4F& fillColor,
+                       const Color4F& borderColor,
                        DrawMode drawMode,
                        float thickness)
 {
@@ -695,10 +695,10 @@ void DrawNode::drawPie(const Vec2& center,
                        int endAngle,
                        float scaleX,
                        float scaleY,
-                       const Color4B& color,
+                       const Color4F& color,
                        DrawMode drawMode)
 {
-    _drawPie(center, radius, angle, startAngle, endAngle, scaleX, scaleY, Color4B::TRANSPARENT, color, drawMode, 1.0f);
+    _drawPie(center, radius, angle, startAngle, endAngle, scaleX, scaleY, Color4F::TRANSPARENT, color, drawMode, 1.0f);
 }
 
 void DrawNode::drawSolidCircle(const Vec2& center,
@@ -707,9 +707,9 @@ void DrawNode::drawSolidCircle(const Vec2& center,
                                unsigned int segments,
                                float scaleX,
                                float scaleY,
-                               const Color4B& fillColor,
+                               const Color4F& fillColor,
                                float thickness,
-                               const Color4B& borderColor,
+                               const Color4F& borderColor,
                                bool drawLineToCenter)
 {
     if (thickness < 0.0f)
@@ -727,51 +727,51 @@ void DrawNode::drawSolidCircle(const Vec2& center,
                                unsigned int segments,
                                float scaleX,
                                float scaleY,
-                               const Color4B& color)
+                               const Color4F& color)
 {
     if (radius < 0.0f)
     {
         AXLOGW("{}: radius < 0, changed to 0", __FUNCTION__);
         radius = 0.0f;
     }
-    _drawCircle(center, radius, angle, segments, false, scaleX, scaleY, Color4B(), color, true);
+    _drawCircle(center, radius, angle, segments, false, scaleX, scaleY, Color4F(), color, true);
 }
 
 void DrawNode::drawSolidCircle(const Vec2& center,
                                float radius,
                                float angle,
                                unsigned int segments,
-                               const Color4B& color)
+                               const Color4F& color)
 {
     if (radius < 0.0f)
     {
         AXLOGW("{}: radius < 0, changed to 0", __FUNCTION__);
         radius = 0.0f;
     }
-    _drawCircle(center, radius, angle, segments, false, 1.0f, 1.0f, Color4B(), color, true);
+    _drawCircle(center, radius, angle, segments, false, 1.0f, 1.0f, Color4F(), color, true);
 }
 
-void DrawNode::drawColoredTriangle(const Vec2* vertices3, const Color4B* color3)
+void DrawNode::drawColoredTriangle(const Vec2* vertices3, const Color4F* color3)
 {
     Vec2 vertices[3] = {vertices3[0], vertices3[1], vertices3[2]};
     _drawColoredTriangle(vertices, color3);
 }
 
-void DrawNode::drawTriangle(const Vec2* vertices3, const Color4B& color)
+void DrawNode::drawTriangle(const Vec2* vertices3, const Color4F& color)
 {
     Vec2 vertices[3] = {vertices3[0], vertices3[1], vertices3[2]};
-    _drawTriangle(vertices, Color4B::TRANSPARENT, color, false, 0.0f);
+    _drawTriangle(vertices, Color4F::TRANSPARENT, color, false, 0.0f);
 }
 
-void DrawNode::drawTriangle(const Vec2& p1, const Vec2& p2, const Vec2& p3, const Color4B& color)
+void DrawNode::drawTriangle(const Vec2& p1, const Vec2& p2, const Vec2& p3, const Color4F& color)
 {
     Vec2 vertices[3] = {p1, p2, p3};
-    _drawTriangle(vertices, Color4B::TRANSPARENT, color, false, 0.0f);
+    _drawTriangle(vertices, Color4F::TRANSPARENT, color, false, 0.0f);
 }
 
 void DrawNode::drawSolidTriangle(const Vec2* vertices3,
-                                 const Color4B& fillColor,
-                                 const Color4B& borderColor,
+                                 const Color4F& fillColor,
+                                 const Color4F& borderColor,
                                  float thickness)
 {
     if (thickness < 0.0f)
@@ -786,8 +786,8 @@ void DrawNode::drawSolidTriangle(const Vec2* vertices3,
 void DrawNode::drawSolidTriangle(const Vec2& p1,
                                  const Vec2& p2,
                                  const Vec2& p3,
-                                 const Color4B& fillColor,
-                                 const Color4B& borderColor,
+                                 const Color4F& fillColor,
+                                 const Color4F& borderColor,
                                  float thickness)
 {
     if (thickness < 0.0f)
@@ -837,8 +837,8 @@ void DrawNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t p
 
 void DrawNode::_drawPolygon(const Vec2* verts,
                             unsigned int count,
-                            const Color4B& fillColor,
-                            const Color4B& borderColor,
+                            const Color4F& fillColor,
+                            const Color4F& borderColor,
                             bool closedPolygon,
                             float thickness,
                             bool isconvex)
@@ -1036,7 +1036,7 @@ void DrawNode::_drawPolygon(const Vec2* verts,
 void DrawNode::_drawPoly(const Vec2* verts,
                          unsigned int count,
                          bool closedPolygon,
-                         const Color4B& color,
+                         const Color4F& color,
                          float thickness,
                          bool isconvex)
 {
@@ -1063,13 +1063,13 @@ void DrawNode::_drawPoly(const Vec2* verts,
     }
     else
     {
-        _drawPolygon(verts, count, Color4B::TRANSPARENT, color, closedPolygon, thickness, isconvex);
+        _drawPolygon(verts, count, Color4F::TRANSPARENT, color, closedPolygon, thickness, isconvex);
     }
 }
 
 void DrawNode::_drawSegment(const Vec2& from,
                             const Vec2& to,
-                            const Color4B& color,
+                            const Color4F& color,
                             float thickness,
                             DrawNode::EndType etStart,
                             DrawNode::EndType etEnd)
@@ -1198,7 +1198,7 @@ void DrawNode::_drawSegment(const Vec2& from,
     }
 }
 // Internal function _drawLine => thickness is always 1 (fastes way to draw a line)
-void DrawNode::_drawLine(const Vec2& from, const Vec2& to, const Color4B& color)
+void DrawNode::_drawLine(const Vec2& from, const Vec2& to, const Color4F& color)
 {
     Vec2 vertices[2] = {from, to};
     applyTransform(vertices, vertices, 2);
@@ -1211,7 +1211,7 @@ void DrawNode::_drawLine(const Vec2& from, const Vec2& to, const Color4B& color)
     line[1] = {vertices[1], color, Vec2::ZERO};
 }
 
-void DrawNode::_drawDot(const Vec2& pos, float radius, const Color4B& color)
+void DrawNode::_drawDot(const Vec2& pos, float radius, const Color4F& color)
 {
     unsigned int vertex_count = 2 * 3;
     auto triangles = reinterpret_cast<V2F_C4B_T2F_Triangle*>(expandBufferAndGetPointer(_triangles, vertex_count));
@@ -1233,8 +1233,8 @@ void DrawNode::_drawCircle(const Vec2& center,
                            bool drawLineToCenter,
                            float scaleX,
                            float scaleY,
-                           const Color4B& borderColor,
-                           const Color4B& fillColor,
+                           const Color4F& borderColor,
+                           const Color4F& fillColor,
                            bool solid,
                            float thickness)
 {
@@ -1265,7 +1265,7 @@ void DrawNode::_drawCircle(const Vec2& center,
 }
 
 void DrawNode::_drawColoredTriangle(Vec2* vertices3,
-                             const Color4B* color3)
+                             const Color4F* color3)
 {
     unsigned int vertex_count = 3;
 
@@ -1281,8 +1281,8 @@ void DrawNode::_drawColoredTriangle(Vec2* vertices3,
 
 
 void DrawNode::_drawTriangle(Vec2* vertices3,
-                             const Color4B& borderColor,
-                             const Color4B& fillColor,
+                             const Color4F& borderColor,
+                             const Color4F& fillColor,
                              bool solid,
                              float thickness)
 {
@@ -1309,8 +1309,8 @@ void DrawNode::_drawAStar(const Vec2& center,
                           float radiusI,  // inner
                           float radiusO,  // outer
                           unsigned int segments,
-                          const Color4B& color,
-                          const Color4B& filledColor,
+                          const Color4F& color,
+                          const Color4F& filledColor,
                           float thickness,
                           bool solid)
 {
@@ -1341,7 +1341,7 @@ void DrawNode::_drawAStar(const Vec2& center,
 void DrawNode::_drawPoints(const Vec2* position,
                            unsigned int numberOfPoints,
                            const float pointSize,
-                           const Color4B& color,
+                           const Color4F& color,
                            const DrawNode::PointType pointType)
 {
     if (properties.drawOrder == true)
@@ -1354,7 +1354,7 @@ void DrawNode::_drawPoints(const Vec2* position,
             {
             case PointType::Circle:
             {
-                _drawCircle(position[i], pointSize4, 90, 32, false, 1.0f, 1.0f, Color4B(), color, true);
+                _drawCircle(position[i], pointSize4, 90, 32, false, 1.0f, 1.0f, Color4F(), color, true);
                 break;
             }
             case PointType::Rect:
@@ -1384,7 +1384,7 @@ void DrawNode::_drawPoints(const Vec2* position,
 
 void DrawNode::_drawPoint(const Vec2& position,
                           const float pointSize,
-                          const Color4B& color,
+                          const Color4F& color,
                           const DrawNode::PointType pointType)
 {
     if (properties.drawOrder == true)
@@ -1396,7 +1396,7 @@ void DrawNode::_drawPoint(const Vec2& position,
         {
         case PointType::Circle:
         {
-            _drawCircle(position, pointSize4, 90, 32, false, 1.0f, 1.0f, Color4B(), color, true);
+            _drawCircle(position, pointSize4, 90, 32, false, 1.0f, 1.0f, Color4F(), color, true);
             break;
         }
         case PointType::Rect:
@@ -1439,8 +1439,8 @@ void DrawNode::_drawPie(const Vec2& center,
                         int endAngle,
                         float scaleX,
                         float scaleY,
-                        const Color4B& fillColor,
-                        const Color4B& borderColor,
+                        const Color4F& fillColor,
+                        const Color4F& borderColor,
                         DrawMode drawMode,
                         float thickness)
 {
@@ -1459,11 +1459,11 @@ void DrawNode::_drawPie(const Vec2& center,
             _drawCircle(center, radius, 0.0f, 360, false, scaleX, scaleY, borderColor, fillColor, true, thickness);
             break;
         case DrawMode::Outline:
-            _drawCircle(center, radius, 0.0f, 360, false, scaleX, scaleY, borderColor, Color4B::TRANSPARENT, true,
+            _drawCircle(center, radius, 0.0f, 360, false, scaleX, scaleY, borderColor, Color4F::TRANSPARENT, true,
                         thickness);
             break;
         case DrawMode::Line:
-            _drawCircle(center, radius, 0.0f, 360, false, scaleX, scaleY, borderColor, Color4B::TRANSPARENT, true,
+            _drawCircle(center, radius, 0.0f, 360, false, scaleX, scaleY, borderColor, Color4F::TRANSPARENT, true,
                         thickness);
             break;
         case DrawMode::Semi:
@@ -1508,7 +1508,7 @@ void DrawNode::_drawPie(const Vec2& center,
         case DrawMode::Fill:
             _vertices[n++] = center;
             _vertices[n++] = _vertices[0];
-            _drawPolygon(_vertices.data(), n, fillColor, Color4B::TRANSPARENT, true, 0, false);
+            _drawPolygon(_vertices.data(), n, fillColor, Color4F::TRANSPARENT, true, 0, false);
             _drawPoly(_vertices.data(), n, false, borderColor, thickness, true);
             break;
         case DrawMode::Outline:
@@ -1520,7 +1520,7 @@ void DrawNode::_drawPie(const Vec2& center,
             _drawPoly(_vertices.data(), n,  false, borderColor, thickness, true);
             break;
         case DrawMode::Semi:
-            if (fillColor != Color4B::TRANSPARENT)
+            if (fillColor != Color4F::TRANSPARENT)
                 _drawPolygon(_vertices.data(), n, fillColor, borderColor, true, 0, false);
             _drawPoly(_vertices.data(), n, true, borderColor, thickness, true);
             break;

--- a/core/2d/DrawNode.h
+++ b/core/2d/DrawNode.h
@@ -99,7 +99,7 @@ public:
      */
     void drawPoint(const Vec2& point,
                    const float pointSize,
-                   const Color4B& color,
+                   const Color4F& color,
                    DrawNode::PointType pointType = DrawNode::PointType::Rect);
 
     /** Draw a group point.
@@ -110,7 +110,7 @@ public:
      */
     void drawPoints(const Vec2* position,
                     unsigned int numberOfPoints,
-                    const Color4B& color,
+                    const Color4F& color,
                     DrawNode::PointType pointType = DrawNode::PointType::Rect);
 
     /** Draw a group point.
@@ -123,7 +123,7 @@ public:
     void drawPoints(const Vec2* position,
                     unsigned int numberOfPoints,
                     const float pointSize,
-                    const Color4B& color,
+                    const Color4F& color,
                     DrawNode::PointType pointType = DrawNode::PointType::Rect);
 
     /** Draw an line from origin to destination with color.
@@ -134,7 +134,7 @@ public:
      */
     void drawLine(const Vec2& origin,
                   const Vec2& destination,
-                  const Color4B& color,
+                  const Color4F& color,
                   float thickness           = 1.0f,
                   DrawNode::EndType etStart = DrawNode::EndType::Round,
                   DrawNode::EndType etEnd   = DrawNode::EndType::Round);
@@ -146,7 +146,7 @@ public:
      * @param destination The rectangle destination.
      * @param color The rectangle color.
      */
-    void drawRect(const Vec2& origin, const Vec2& destination, const Color4B& color, float thickness = 1.0f);
+    void drawRect(const Vec2& origin, const Vec2& destination, const Color4F& color, float thickness = 1.0f);
 
     /** Draws a polygon given a pointer to point coordinates and the number of vertices measured in points.
      * The polygon can be closed or open.
@@ -159,7 +159,7 @@ public:
     void drawPoly(const Vec2* poli,
                   unsigned int numberOfPoints,
                   bool closedPolygon,
-                  const Color4B& color,
+                  const Color4F& color,
                   float thickness = 1.0f);
 
     /** Draws a circle given the center, radius and number of segments.
@@ -181,7 +181,7 @@ public:
                     bool drawLineToCenter,
                     float scaleX,
                     float scaleY,
-                    const Color4B& color,
+                    const Color4F& color,
                     float thickness = 1.0f);
 
     /** Draws a circle given the center, radius and number of segments.
@@ -199,7 +199,7 @@ public:
                     float angle,
                     unsigned int segments,
                     bool drawLineToCenter,
-                    const Color4B& color,
+                    const Color4F& color,
                     float thickness = 1.0f);
 
     /** Draws a star given the center, radiusI, radiusO and number of segments.
@@ -215,7 +215,7 @@ public:
                   float radiusI,
                   float radiusO,
                   unsigned int segments,
-                  const Color4B& color,
+                  const Color4F& color,
                   float thickness = 1.0f);
 
     /** Draws a solid star given the center, radiusI, radiusO and number of segments.
@@ -231,8 +231,8 @@ public:
                        float radiusI,
                        float radiusO,
                        unsigned int segments,
-                       const Color4B& color,
-                       const Color4B& filledColor,
+                       const Color4F& color,
+                       const Color4F& filledColor,
                        float thickness = 1.0f);
 
     /** Draws a quad bezier path.
@@ -247,7 +247,7 @@ public:
                         const Vec2& control,
                         const Vec2& destination,
                         unsigned int segments,
-                        const Color4B& color,
+                        const Color4F& color,
                         float thickness = 1.0f);
 
     /** Draw a cubic bezier curve with color and number of segments
@@ -264,7 +264,7 @@ public:
                          const Vec2& control2,
                          const Vec2& destination,
                          unsigned int segments,
-                         const Color4B& color,
+                         const Color4F& color,
                          float thickness = 1.0f);
 
     /** Draws a Cardinal Spline path.
@@ -277,7 +277,7 @@ public:
     void drawCardinalSpline(const PointArray* configIn,
                             float tension,
                             unsigned int segments,
-                            const Color4B& color,
+                            const Color4F& color,
                             float thickness = 1.0f,
                             bool closed = false);
 
@@ -289,7 +289,7 @@ public:
      */
     void drawCatmullRom(const PointArray* pointsIn,
                         unsigned int segments,
-                        const Color4B& color,
+                        const Color4F& color,
                         float thickness = 1.0f,
                         bool closed = false);
 
@@ -299,7 +299,7 @@ public:
      * @param radius The dot radius.
      * @param color The dot color.
      */
-    void drawDot(const Vec2& pos, float radius, const Color4B& color);
+    void drawDot(const Vec2& pos, float radius, const Color4F& color);
 
     /** Draws a rectangle with 4 points.
      *
@@ -313,7 +313,7 @@ public:
                   const Vec2& p2,
                   const Vec2& p3,
                   const Vec2& p4,
-                  const Color4B& color,
+                  const Color4F& color,
                   float thickness = 1.0f);
 
     /** Draws a solid rectangle given the origin and destination point measured in points.
@@ -325,9 +325,9 @@ public:
      */
     void drawSolidRect(const Vec2& origin,
                        const Vec2& destination,
-                       const Color4B& color,
+                       const Color4F& color,
                        float thickness            = 0,
-                       const Color4B& borderColor = Color4B(0, 0, 0, 0));
+                       const Color4F& borderColor = Color4F(0, 0, 0, 0));
 
     /** Draws a solid polygon given a pointer to CGPoint coordinates, the number of vertices measured in points, and a
      * color.
@@ -338,9 +338,9 @@ public:
      */
     void drawSolidPoly(const Vec2* poli,
                        unsigned int numberOfPoints,
-                       const Color4B& color,
+                       const Color4F& color,
                        float thickness            = 0,
-                       const Color4B& borderColor = Color4B(0, 0, 0, 0),
+                       const Color4F& borderColor = Color4F(0, 0, 0, 0),
                        bool isconvex              = false);
 
     /** Draws a solid circle given the center, radius and number of segments.
@@ -361,9 +361,9 @@ public:
                          unsigned int segments,
                          float scaleX,
                          float scaleY,
-                         const Color4B& fillColor,
+                         const Color4F& fillColor,
                          float thickness,
-                         const Color4B& borderColor,
+                         const Color4F& borderColor,
                          bool drawLineToCenter = false);
 
     /** Draws a solid circle given the center, radius and number of segments.
@@ -381,7 +381,7 @@ public:
                          unsigned int segments,
                          float scaleX,
                          float scaleY,
-                         const Color4B& color);
+                         const Color4F& color);
 
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
@@ -390,7 +390,7 @@ public:
      * @param segments The number of segments.
      * @param color The solid circle color.
      */
-    void drawSolidCircle(const Vec2& center, float radius, float angle, unsigned int segments, const Color4B& color);
+    void drawSolidCircle(const Vec2& center, float radius, float angle, unsigned int segments, const Color4F& color);
 
     /** Draws a pie given the center, radius, angle, start angle, end angle  and number of segments.
      * @param center The circle center point.
@@ -411,8 +411,8 @@ public:
                  int endAngle,
                  float scaleX,
                  float scaleY,
-                 const Color4B& fillColor,
-                 const Color4B& borderColor,
+                 const Color4F& fillColor,
+                 const Color4F& borderColor,
                  DrawMode drawMode = DrawMode::Outline,
                  float thickness = 1.0f);
 
@@ -435,7 +435,7 @@ public:
                  int endAngle,
                  float scaleX,
                  float scaleY,
-                 const Color4B& color,
+                 const Color4F& color,
                  DrawMode drawMode = DrawMode::Outline);
 
     void setIsConvex(bool isConvex)
@@ -454,7 +454,7 @@ public:
     void drawSegment(const Vec2& from,
                      const Vec2& to,
                      float radius,
-                     const Color4B& color,
+                     const Color4F& color,
                      DrawNode::EndType etStart = DrawNode::EndType::Round,
                      DrawNode::EndType etEnd   = DrawNode::EndType::Round);
 
@@ -472,18 +472,18 @@ public:
      */
     void drawPolygon(const Vec2* verts,
                      int count,
-                     const Color4B& fillColor,
+                     const Color4F& fillColor,
                      float thickness,
-                     const Color4B& borderColor,
+                     const Color4F& borderColor,
                      bool isconvex = false);
 
-    void drawPolygon(const Vec2* verts, int count, float thickness, const Color4B& borderColor, bool isconvex = false);
+    void drawPolygon(const Vec2* verts, int count, float thickness, const Color4F& borderColor, bool isconvex = false);
 
     void drawSolidPolygon(const Vec2* verts,
                           int count,
-                          const Color4B& fillColor,
+                          const Color4F& fillColor,
                           float thickness,
-                          const Color4B& borderColor,
+                          const Color4F& borderColor,
                           bool isconvex = false);
 
     /** draw a triangle with color.
@@ -494,21 +494,21 @@ public:
      * @param color The triangle color.
      */
 
-    void drawColoredTriangle(const Vec2* vertices3, const Color4B* color3);
-    void drawTriangle(const Vec2* vertices3, const Color4B& color);
+    void drawColoredTriangle(const Vec2* vertices3, const Color4F* color3);
+    void drawTriangle(const Vec2* vertices3, const Color4F& color);
 
-    void drawTriangle(const Vec2& p1, const Vec2& p2, const Vec2& p3, const Color4B& color);
+    void drawTriangle(const Vec2& p1, const Vec2& p2, const Vec2& p3, const Color4F& color);
 
     void drawSolidTriangle(const Vec2* vertices3,
-                           const Color4B& fillColor,
-                           const Color4B& borderColor,
+                           const Color4F& fillColor,
+                           const Color4F& borderColor,
                            float thickness = 1.0f);
 
     void drawSolidTriangle(const Vec2& p1,
                            const Vec2& p2,
                            const Vec2& p3,
-                           const Color4B& fillColor,
-                           const Color4B& borderColor,
+                           const Color4F& fillColor,
+                           const Color4F& borderColor,
                            float thickness = 1.0f);
 
     /** Clear the geometry in the node's buffer. */
@@ -578,37 +578,37 @@ private:
     // Internal function _drawPoint
     void _drawPoint(const Vec2& position,
                     const float pointSize,
-                    const Color4B& color,
+                    const Color4F& color,
                     const DrawNode::PointType pointType);
 
     // Internal function _drawPoints
     void _drawPoints(const Vec2* position,
                      unsigned int numberOfPoints,
                      const float pointSize,
-                     const Color4B& color,
+                     const Color4F& color,
                      const DrawNode::PointType pointType);
 
     // Internal function _drawDot
-    void _drawDot(const Vec2& pos, float radius, const Color4B& color);
+    void _drawDot(const Vec2& pos, float radius, const Color4F& color);
 
     // Internal function _drawTriangle
     // Note: modifies supplied vertex array
     void _drawTriangle(Vec2* vertices3,
-                       const Color4B& borderColor,
-                       const Color4B& fillColor,
+                       const Color4F& borderColor,
+                       const Color4F& fillColor,
                        bool solid      = true,
                        float thickness = 0.0f);
 
     void _drawColoredTriangle(Vec2* vertices3,
-                       const Color4B* color3);
+                       const Color4F* color3);
 
     // Internal function _drawAStar
     void _drawAStar(const Vec2& center,
                     float radiusI,
                     float radiusO,
                     unsigned int segments,
-                    const Color4B& color,
-                    const Color4B& filledColor,
+                    const Color4F& color,
+                    const Color4F& filledColor,
                     float thickness = 1.0f,
                     bool solid      = false);
 
@@ -616,26 +616,26 @@ private:
     void _drawPoly(const Vec2* poli,
                    unsigned int numberOfPoints,
                    bool closedPolygon,
-                   const Color4B& color,
+                   const Color4F& color,
                    float thickness = 1.0f,
                    bool isconvex   = true);
 
     // Internal function _drawPolygon
     void _drawPolygon(const Vec2* verts,
                       unsigned int count,
-                      const Color4B& fillColor,
-                      const Color4B& borderColor,
+                      const Color4F& fillColor,
+                      const Color4F& borderColor,
                       bool closedPolygon = true,
                       float thickness    = 1.0f,
                       bool isconvex      = true);
 
     // Internal function _drawLine
-    void _drawLine(const Vec2& from, const Vec2& to, const Color4B& color);
+    void _drawLine(const Vec2& from, const Vec2& to, const Color4F& color);
 
     // Internal function _drawSegment
     void _drawSegment(const Vec2& origin,
                       const Vec2& destination,
-                      const Color4B& color,
+                      const Color4F& color,
                       float thickness           = 1.0f,
                       DrawNode::EndType etStart = DrawNode::EndType::Square,
                       DrawNode::EndType etEnd   = DrawNode::EndType::Square);
@@ -648,8 +648,8 @@ private:
                      bool drawLineToCenter,
                      float scaleX,
                      float scaleY,
-                     const Color4B& borderColor,
-                     const Color4B& fillColor,
+                     const Color4F& borderColor,
+                     const Color4F& fillColor,
                      bool solid,
                      float thickness = 1.0f);
 
@@ -661,8 +661,8 @@ private:
                   int endAngle,
                   float scaleX,
                   float scaleY,
-                  const Color4B& fillColor,
-                  const Color4B& borderColor,
+                  const Color4F& fillColor,
+                  const Color4F& borderColor,
                   DrawMode drawMode,
                   float thickness = 1.0f);
 

--- a/core/ui/UILayout.cpp
+++ b/core/ui/UILayout.cpp
@@ -449,7 +449,7 @@ void Layout::setStencilClippingSize(const Vec2& /*size*/)
     if (_clippingEnabled && _clippingType == ClippingType::STENCIL)
     {
         _clippingStencil->clear();
-        _clippingStencil->drawSolidRect(Vec2::ZERO, _contentSize, Color4B::GREEN);  // Fix issue #1546
+        _clippingStencil->drawSolidRect(Vec2::ZERO, _contentSize, Color4F::GREEN);  // Fix issue #1546
     }
 }
 

--- a/core/ui/UIMediaPlayer.cpp
+++ b/core/ui/UIMediaPlayer.cpp
@@ -220,7 +220,7 @@ void createMediaControlTexture()
 
     auto DrawStop = [&](const Vec2& middle) -> void {
         auto s = Vec2(middle.x - iconW / 2.f, middle.y + iconH / 2.f);
-        drawNode->drawSolidRect(s, s + Vec2(iconW, -iconH), Color4B::WHITE);
+        drawNode->drawSolidRect(s, s + Vec2(iconW, -iconH), Color4F::WHITE);
     };
 
     auto DrawPlay = [&](const Vec2& middle) -> void {
@@ -228,15 +228,15 @@ void createMediaControlTexture()
         auto p2 = Vec2(middle.x + iconW / 2.f, middle.y);
         auto p3 = Vec2(middle.x - iconW / 2.f, middle.y - iconH / 2.f);
 
-        drawNode->drawTriangle(p1, p2, p3, Color4B::WHITE);
+        drawNode->drawTriangle(p1, p2, p3, Color4F::WHITE);
     };
 
     auto DrawPause = [&](const Vec2& middle) -> void {
         auto start = Vec2(middle.x - 3, middle.y + iconH / 2.f);
-        drawNode->drawSolidRect(start, start + Vec2(-6, -iconH), Color4B::WHITE);
+        drawNode->drawSolidRect(start, start + Vec2(-6, -iconH), Color4F::WHITE);
 
         start = Vec2(middle.x + 3, middle.y + iconH / 2.f);
-        drawNode->drawSolidRect(start, start + Vec2(6, -iconH), Color4B::WHITE);
+        drawNode->drawSolidRect(start, start + Vec2(6, -iconH), Color4F::WHITE);
     };
 
     auto DrawEnterFullscreen = [&](const Vec2& middle) -> void {
@@ -246,20 +246,20 @@ void createMediaControlTexture()
         auto bottomRight = Vec2(middle.x + panelW / 2.f - 6, middle.y - panelH / 2.f + 6);
 
         // Top left
-        drawNode->drawSolidRect(topLeft, topLeft + Vec2(20, -6), Color4B::WHITE);
-        drawNode->drawSolidRect(topLeft, topLeft + Vec2(6, -20), Color4B::WHITE);
+        drawNode->drawSolidRect(topLeft, topLeft + Vec2(20, -6), Color4F::WHITE);
+        drawNode->drawSolidRect(topLeft, topLeft + Vec2(6, -20), Color4F::WHITE);
 
         // Top right
-        drawNode->drawSolidRect(topRight, topRight + Vec2(-20, -6), Color4B::WHITE);
-        drawNode->drawSolidRect(topRight, topRight + Vec2(-6, -20), Color4B::WHITE);
+        drawNode->drawSolidRect(topRight, topRight + Vec2(-20, -6), Color4F::WHITE);
+        drawNode->drawSolidRect(topRight, topRight + Vec2(-6, -20), Color4F::WHITE);
 
         // Bottom left
-        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(20, 6), Color4B::WHITE);
-        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(6, 20), Color4B::WHITE);
+        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(20, 6), Color4F::WHITE);
+        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(6, 20), Color4F::WHITE);
 
         // Bottom right
-        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(-20, 6), Color4B::WHITE);
-        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(-6, 20), Color4B::WHITE);
+        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(-20, 6), Color4F::WHITE);
+        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(-6, 20), Color4F::WHITE);
     };
 
     auto DrawExitFullScreen = [&](const Vec2& middle) -> void {
@@ -269,24 +269,24 @@ void createMediaControlTexture()
         auto bottomRight = Vec2(middle.x + 4, middle.y - 4);
 
         // Top left
-        drawNode->drawSolidRect(topLeft, topLeft + Vec2(-20, 6), Color4B::WHITE);
-        drawNode->drawSolidRect(topLeft, topLeft + Vec2(-6, 20), Color4B::WHITE);
+        drawNode->drawSolidRect(topLeft, topLeft + Vec2(-20, 6), Color4F::WHITE);
+        drawNode->drawSolidRect(topLeft, topLeft + Vec2(-6, 20), Color4F::WHITE);
 
         // Top right
-        drawNode->drawSolidRect(topRight, topRight + Vec2(20, 6), Color4B::WHITE);
-        drawNode->drawSolidRect(topRight, topRight + Vec2(6, 20), Color4B::WHITE);
+        drawNode->drawSolidRect(topRight, topRight + Vec2(20, 6), Color4F::WHITE);
+        drawNode->drawSolidRect(topRight, topRight + Vec2(6, 20), Color4F::WHITE);
 
         // Bottom left
-        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(-20, -6), Color4B::WHITE);
-        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(-6, -20), Color4B::WHITE);
+        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(-20, -6), Color4F::WHITE);
+        drawNode->drawSolidRect(bottomLeft, bottomLeft + Vec2(-6, -20), Color4F::WHITE);
 
         // Bottom right
-        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(20, -6), Color4B::WHITE);
-        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(6, -20), Color4B::WHITE);
+        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(20, -6), Color4F::WHITE);
+        drawNode->drawSolidRect(bottomRight, bottomRight + Vec2(6, -20), Color4F::WHITE);
     };
 
     auto DrawSliderControlButton = [&](const Vec2& middle) -> void {
-        drawNode->drawSolidCircle(middle, panelW / 2, 0, 180, Color4B::WHITE);
+        drawNode->drawSolidCircle(middle, panelW / 2, 0, 180, Color4F::WHITE);
     };
 
     std::map<MediaControlButtonId, std::function<void(const Vec2&)>> items = {
@@ -1148,7 +1148,7 @@ void MediaPlayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags
     _debugDrawNode->clear();
     auto size         = getContentSize();
     Point vertices[4] = {Point::ZERO, Point(size.width, 0), Point(size.width, size.height), Point(0, size.height)};
-    _debugDrawNode->drawPoly(vertices, 4, true, Color4B::WHITE);
+    _debugDrawNode->drawPoly(vertices, 4, true, Color4F::WHITE);
 #    endif
 }
 

--- a/extensions/fairygui/src/fairygui/GGraph.cpp
+++ b/extensions/fairygui/src/fairygui/GGraph.cpp
@@ -5,7 +5,7 @@
 NS_FGUI_BEGIN
 using namespace ax;
 
-static void drawVertRect(ax::DrawNode* shape, float x, float y, float width, float height, const ax::Color4B& color)
+static void drawVertRect(ax::DrawNode* shape, float x, float y, float width, float height, const ax::Color4F& color)
 {
     float mx = x + width;
     float my = y + height;
@@ -16,8 +16,8 @@ static void drawVertRect(ax::DrawNode* shape, float x, float y, float width, flo
 GGraph::GGraph() : _shape(nullptr),
                    _type(0),
                    _lineSize(1),
-                   _lineColor(Color4B::BLACK),
-                   _fillColor(Color4B::WHITE),
+                   _lineColor(Color4F::BLACK),
+                   _fillColor(Color4F::WHITE),
                    _cornerRadius(nullptr),
                    _polygonPoints(nullptr),
                    _distances(nullptr)
@@ -40,7 +40,7 @@ void GGraph::handleInit()
     _displayObject = _shape;
 }
 
-void GGraph::drawRect(float aWidth, float aHeight, int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor)
+void GGraph::drawRect(float aWidth, float aHeight, int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor)
 {
     _type = 0; //avoid updateshape call in handleSizeChange
     setSize(aWidth, aHeight);
@@ -51,7 +51,7 @@ void GGraph::drawRect(float aWidth, float aHeight, int lineSize, const ax::Color
     updateShape();
 }
 
-void GGraph::drawEllipse(float aWidth, float aHeight, int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor)
+void GGraph::drawEllipse(float aWidth, float aHeight, int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor)
 {
     _type = 0; //avoid updateshape call in handleSizeChange
     setSize(aWidth, aHeight);
@@ -62,7 +62,7 @@ void GGraph::drawEllipse(float aWidth, float aHeight, int lineSize, const ax::Co
     updateShape();
 }
 
-void GGraph::drawPolygon(int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor, const ax::Vec2* points, int count)
+void GGraph::drawPolygon(int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor, const ax::Vec2* points, int count)
 {
     _type = 3;
     _lineSize = lineSize;
@@ -83,7 +83,7 @@ void GGraph::drawPolygon(int lineSize, const ax::Color4B& lineColor, const ax::C
     updateShape();
 }
 
-void GGraph::drawRegularPolygon(int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor,
+void GGraph::drawRegularPolygon(int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor,
                                 int sides, float startAngle, const float* distances, int count)
 {
     _type = 4;
@@ -189,7 +189,7 @@ ax::Color3B GGraph::getColor() const
 
 void GGraph::setColor(const ax::Color3B& value)
 {
-    _fillColor = Color4B(value, _fillColor.a);
+    _fillColor = Color4F(value, _fillColor.a);
     updateShape();
 }
 
@@ -247,8 +247,8 @@ void GGraph::setup_beforeAdd(ByteBuffer* buffer, int beginPos)
     if (_type != 0)
     {
         _lineSize = buffer->readInt();
-        _lineColor = (Color4B)buffer->readColor();
-        _fillColor = (Color4B)buffer->readColor();
+        _lineColor = (Color4F)buffer->readColor();
+        _fillColor = (Color4F)buffer->readColor();
         if (buffer->readBool())
         {
             _cornerRadius = new float[4];

--- a/extensions/fairygui/src/fairygui/GGraph.h
+++ b/extensions/fairygui/src/fairygui/GGraph.h
@@ -15,10 +15,10 @@ public:
 
     CREATE_FUNC(GGraph);
 
-    void drawRect(float aWidth, float aHeight, int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor);
-    void drawEllipse(float aWidth, float aHeight, int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor);
-    void drawPolygon(int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor, const ax::Vec2* points, int count);
-    void drawRegularPolygon(int lineSize, const ax::Color4B& lineColor, const ax::Color4B& fillColor, int sides, float startAngle = 0, const float* distances = nullptr, int distanceCount = 0);
+    void drawRect(float aWidth, float aHeight, int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor);
+    void drawEllipse(float aWidth, float aHeight, int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor);
+    void drawPolygon(int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor, const ax::Vec2* points, int count);
+    void drawRegularPolygon(int lineSize, const ax::Color4F& lineColor, const ax::Color4F& fillColor, int sides, float startAngle = 0, const float* distances = nullptr, int distanceCount = 0);
     bool isEmpty() const { return _type == 0; }
 
     ax::Color3B getColor() const;
@@ -36,8 +36,8 @@ private:
     void updateShape();
 
     int _type;
-    ax::Color4B _lineColor;
-    ax::Color4B _fillColor;
+    ax::Color4F _lineColor;
+    ax::Color4F _fillColor;
     int _lineSize;
     float* _cornerRadius;
     std::vector<ax::Vec2>* _polygonPoints;

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNodeChipmunk2D.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNodeChipmunk2D.cpp
@@ -78,7 +78,7 @@ static Vec2 cpVert2Point(const cpVect& vert)
 static void DrawShape(cpShape* shape, DrawNode* renderer)
 {
     cpBody* body  = cpShapeGetBody(shape);
-    Color4B color = ColorForBody(body);
+    Color4F color{ColorForBody(body)};
 
     switch (shape->klass->type)
     {
@@ -101,7 +101,7 @@ static void DrawShape(cpShape* shape, DrawNode* renderer)
     case CP_POLY_SHAPE:
     {
         cpPolyShape* poly = (cpPolyShape*)shape;
-        Color4B line      = color;
+        Color4F line      = color;
         line.a            = cpflerp(color.a, 1.0, 0.5);
         int num           = poly->count;
         Vec2* pPoints     = new Vec2[num];
@@ -109,7 +109,7 @@ static void DrawShape(cpShape* shape, DrawNode* renderer)
             pPoints[i] = cpVert2Point(poly->planes[i].v0);
         if (cpfmax(poly->r, 1.0) > 1.0)
         {
-            renderer->drawPolygon(pPoints, num, Color4B(127, 127, 127,0), poly->r, color);
+            renderer->drawPolygon(pPoints, num, Color4F{}, poly->r, color);
         }
         else
         {
@@ -124,7 +124,7 @@ static void DrawShape(cpShape* shape, DrawNode* renderer)
     }
 }
 
-static Color4B CONSTRAINT_COLOR(0, 255, 0, 127);
+static Color4F CONSTRAINT_COLOR(0, 1, 0, 0.5f);
 
 static void DrawConstraint(cpConstraint* constraint, DrawNode* renderer)
 {

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -51733,13 +51733,13 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         double arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawPoint");
 
         ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.DrawNode:drawPoint");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawPoint");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawPoint");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawPoint'", nullptr);
@@ -51753,14 +51753,14 @@ int lua_ax_base_DrawNode_drawPoint(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         double arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
         ax::DrawNode::PointType arg3;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawPoint");
 
         ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.DrawNode:drawPoint");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawPoint");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawPoint");
 
         ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ax.DrawNode:drawPoint");
         if(!ok)
@@ -51812,13 +51812,13 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawLine");
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawLine");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawLine'", nullptr);
@@ -51832,14 +51832,14 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
         double arg3;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawLine");
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawLine");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
 
         ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.DrawNode:drawLine");
         if(!ok)
@@ -51855,7 +51855,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
         double arg3;
         ax::DrawNode::EndType arg4;
 
@@ -51863,7 +51863,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawLine");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
 
         ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.DrawNode:drawLine");
 
@@ -51881,7 +51881,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
         double arg3;
         ax::DrawNode::EndType arg4;
         ax::DrawNode::EndType arg5;
@@ -51890,7 +51890,7 @@ int lua_ax_base_DrawNode_drawLine(lua_State* tolua_S)
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawLine");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawLine");
 
         ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.DrawNode:drawLine");
 
@@ -51955,8 +51955,8 @@ int lua_ax_base_DrawNode_drawRect(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 5, &arg3, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
-            ax::Color4B arg4;
-            ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawRect");
+            ax::Color4F arg4;
+            ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
             cobj->drawRect(arg0, arg1, arg2, arg3, arg4);
@@ -51983,8 +51983,8 @@ int lua_ax_base_DrawNode_drawRect(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 5, &arg3, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
-            ax::Color4B arg4;
-            ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawRect");
+            ax::Color4F arg4;
+            ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
             double arg5;
@@ -52007,8 +52007,8 @@ int lua_ax_base_DrawNode_drawRect(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
-            ax::Color4B arg2;
-            ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawRect");
+            ax::Color4F arg2;
+            ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
             cobj->drawRect(arg0, arg1, arg2);
@@ -52027,8 +52027,8 @@ int lua_ax_base_DrawNode_drawRect(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
-            ax::Color4B arg2;
-            ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawRect");
+            ax::Color4F arg2;
+            ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawRect");
 
             if (!ok) { break; }
             double arg3;
@@ -52094,8 +52094,8 @@ int lua_ax_base_DrawNode_drawCircle(lua_State* tolua_S)
             ok &= luaval_to_boolean(tolua_S, 6,&arg4, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg5;
-            ok &=luaval_to_color4b(tolua_S, 7, &arg5, "ax.DrawNode:drawCircle");
+            ax::Color4F arg5;
+            ok &=luaval_to_color4f(tolua_S, 7, &arg5, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
             cobj->drawCircle(arg0, arg1, arg2, arg3, arg4, arg5);
@@ -52126,8 +52126,8 @@ int lua_ax_base_DrawNode_drawCircle(lua_State* tolua_S)
             ok &= luaval_to_boolean(tolua_S, 6,&arg4, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg5;
-            ok &=luaval_to_color4b(tolua_S, 7, &arg5, "ax.DrawNode:drawCircle");
+            ax::Color4F arg5;
+            ok &=luaval_to_color4f(tolua_S, 7, &arg5, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
             double arg6;
@@ -52170,8 +52170,8 @@ int lua_ax_base_DrawNode_drawCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawCircle");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
             cobj->drawCircle(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
@@ -52210,8 +52210,8 @@ int lua_ax_base_DrawNode_drawCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawCircle");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawCircle");
 
             if (!ok) { break; }
             double arg8;
@@ -52266,7 +52266,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
         double arg1;
         double arg2;
         unsigned int arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg4;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawStar");
 
@@ -52276,7 +52276,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawStar");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawStar");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawStar");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawStar'", nullptr);
@@ -52292,7 +52292,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
         double arg1;
         double arg2;
         unsigned int arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg4;
         double arg5;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawStar");
@@ -52303,7 +52303,7 @@ int lua_ax_base_DrawNode_drawStar(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawStar");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawStar");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawStar");
 
         ok &= luaval_to_number(tolua_S, 7,&arg5, "ax.DrawNode:drawStar");
         if(!ok)
@@ -52357,8 +52357,8 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
         double arg1;
         double arg2;
         unsigned int arg3;
-        ax::Color4B arg4;
-        ax::Color4B arg5;
+        ax::Color4F arg4;
+        ax::Color4F arg5;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidStar");
 
@@ -52368,9 +52368,9 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawSolidStar");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidStar");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidStar");
 
-        ok &=luaval_to_color4b(tolua_S, 7, &arg5, "ax.DrawNode:drawSolidStar");
+        ok &=luaval_to_color4f(tolua_S, 7, &arg5, "ax.DrawNode:drawSolidStar");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawSolidStar'", nullptr);
@@ -52386,8 +52386,8 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
         double arg1;
         double arg2;
         unsigned int arg3;
-        ax::Color4B arg4;
-        ax::Color4B arg5;
+        ax::Color4F arg4;
+        ax::Color4F arg5;
         double arg6;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidStar");
@@ -52398,9 +52398,9 @@ int lua_ax_base_DrawNode_drawSolidStar(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawSolidStar");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidStar");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidStar");
 
-        ok &=luaval_to_color4b(tolua_S, 7, &arg5, "ax.DrawNode:drawSolidStar");
+        ok &=luaval_to_color4f(tolua_S, 7, &arg5, "ax.DrawNode:drawSolidStar");
 
         ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawSolidStar");
         if(!ok)
@@ -52454,7 +52454,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
         ax::Vec2 arg1;
         ax::Vec2 arg2;
         unsigned int arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg4;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawQuadBezier");
 
@@ -52464,7 +52464,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawQuadBezier");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawQuadBezier");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawQuadBezier");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawQuadBezier'", nullptr);
@@ -52480,7 +52480,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
         ax::Vec2 arg1;
         ax::Vec2 arg2;
         unsigned int arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg4;
         double arg5;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawQuadBezier");
@@ -52491,7 +52491,7 @@ int lua_ax_base_DrawNode_drawQuadBezier(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawQuadBezier");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawQuadBezier");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawQuadBezier");
 
         ok &= luaval_to_number(tolua_S, 7,&arg5, "ax.DrawNode:drawQuadBezier");
         if(!ok)
@@ -52546,7 +52546,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
         ax::Vec2 arg2;
         ax::Vec2 arg3;
         unsigned int arg4;
-        ax::Color4B arg5;
+        ax::Color4F arg5;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawCubicBezier");
 
@@ -52558,7 +52558,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ax.DrawNode:drawCubicBezier");
 
-        ok &=luaval_to_color4b(tolua_S, 7, &arg5, "ax.DrawNode:drawCubicBezier");
+        ok &=luaval_to_color4f(tolua_S, 7, &arg5, "ax.DrawNode:drawCubicBezier");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawCubicBezier'", nullptr);
@@ -52575,7 +52575,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
         ax::Vec2 arg2;
         ax::Vec2 arg3;
         unsigned int arg4;
-        ax::Color4B arg5;
+        ax::Color4F arg5;
         double arg6;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawCubicBezier");
@@ -52588,7 +52588,7 @@ int lua_ax_base_DrawNode_drawCubicBezier(lua_State* tolua_S)
 
         ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ax.DrawNode:drawCubicBezier");
 
-        ok &=luaval_to_color4b(tolua_S, 7, &arg5, "ax.DrawNode:drawCubicBezier");
+        ok &=luaval_to_color4f(tolua_S, 7, &arg5, "ax.DrawNode:drawCubicBezier");
 
         ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawCubicBezier");
         if(!ok)
@@ -52640,13 +52640,13 @@ int lua_ax_base_DrawNode_drawDot(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         double arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawDot");
 
         ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.DrawNode:drawDot");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawDot");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawDot");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawDot'", nullptr);
@@ -52696,13 +52696,13 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidRect");
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidRect");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidRect");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidRect");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawSolidRect'", nullptr);
@@ -52716,14 +52716,14 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
         double arg3;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidRect");
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidRect");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidRect");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidRect");
 
         ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.DrawNode:drawSolidRect");
         if(!ok)
@@ -52739,19 +52739,19 @@ int lua_ax_base_DrawNode_drawSolidRect(lua_State* tolua_S)
     {
         ax::Vec2 arg0;
         ax::Vec2 arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
         double arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg4;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidRect");
 
         ok &= luaval_to_vec2(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidRect");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidRect");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidRect");
 
         ok &= luaval_to_number(tolua_S, 5,&arg3, "ax.DrawNode:drawSolidRect");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidRect");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidRect");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawSolidRect'", nullptr);
@@ -52818,8 +52818,8 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 7,&arg5, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg6;
-            ok &=luaval_to_color4b(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
+            ax::Color4F arg6;
+            ok &=luaval_to_color4f(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             cobj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
@@ -52854,16 +52854,16 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 7,&arg5, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg6;
-            ok &=luaval_to_color4b(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
+            ax::Color4F arg6;
+            ok &=luaval_to_color4f(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             double arg7;
             ok &= luaval_to_number(tolua_S, 9,&arg7, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg8;
-            ok &=luaval_to_color4b(tolua_S, 10, &arg8, "ax.DrawNode:drawSolidCircle");
+            ax::Color4F arg8;
+            ok &=luaval_to_color4f(tolua_S, 10, &arg8, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             cobj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
@@ -52898,16 +52898,16 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 7,&arg5, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg6;
-            ok &=luaval_to_color4b(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
+            ax::Color4F arg6;
+            ok &=luaval_to_color4f(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             double arg7;
             ok &= luaval_to_number(tolua_S, 9,&arg7, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg8;
-            ok &=luaval_to_color4b(tolua_S, 10, &arg8, "ax.DrawNode:drawSolidCircle");
+            ax::Color4F arg8;
+            ok &=luaval_to_color4f(tolua_S, 10, &arg8, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             bool arg9;
@@ -52938,8 +52938,8 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
             ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            ax::Color4B arg4;
-            ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidCircle");
+            ax::Color4F arg4;
+            ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             cobj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4);
@@ -53009,8 +53009,8 @@ int lua_ax_base_DrawNode_drawPie(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
             cobj->drawPie(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
@@ -53049,8 +53049,8 @@ int lua_ax_base_DrawNode_drawPie(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
             ax::DrawNode::DrawMode arg8;
@@ -53093,12 +53093,12 @@ int lua_ax_base_DrawNode_drawPie(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg8;
-            ok &=luaval_to_color4b(tolua_S, 10, &arg8, "ax.DrawNode:drawPie");
+            ax::Color4F arg8;
+            ok &=luaval_to_color4f(tolua_S, 10, &arg8, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
             cobj->drawPie(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
@@ -53137,12 +53137,12 @@ int lua_ax_base_DrawNode_drawPie(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg8;
-            ok &=luaval_to_color4b(tolua_S, 10, &arg8, "ax.DrawNode:drawPie");
+            ax::Color4F arg8;
+            ok &=luaval_to_color4f(tolua_S, 10, &arg8, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
             ax::DrawNode::DrawMode arg9;
@@ -53185,12 +53185,12 @@ int lua_ax_base_DrawNode_drawPie(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 8,&arg6, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg7;
-            ok &=luaval_to_color4b(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
+            ax::Color4F arg7;
+            ok &=luaval_to_color4f(tolua_S, 9, &arg7, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
-            ax::Color4B arg8;
-            ok &=luaval_to_color4b(tolua_S, 10, &arg8, "ax.DrawNode:drawPie");
+            ax::Color4F arg8;
+            ok &=luaval_to_color4f(tolua_S, 10, &arg8, "ax.DrawNode:drawPie");
 
             if (!ok) { break; }
             ax::DrawNode::DrawMode arg9;
@@ -53298,7 +53298,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         ax::Vec2 arg0;
         ax::Vec2 arg1;
         double arg2;
-        ax::Color4B arg3;
+        ax::Color4F arg3;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSegment");
 
@@ -53306,7 +53306,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
 
         ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.DrawNode:drawSegment");
 
-        ok &=luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawSegment");
+        ok &=luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawSegment");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_DrawNode_drawSegment'", nullptr);
@@ -53321,7 +53321,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         ax::Vec2 arg0;
         ax::Vec2 arg1;
         double arg2;
-        ax::Color4B arg3;
+        ax::Color4F arg3;
         ax::DrawNode::EndType arg4;
 
         ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSegment");
@@ -53330,7 +53330,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
 
         ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.DrawNode:drawSegment");
 
-        ok &=luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawSegment");
+        ok &=luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawSegment");
 
         ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.DrawNode:drawSegment");
         if(!ok)
@@ -53347,7 +53347,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
         ax::Vec2 arg0;
         ax::Vec2 arg1;
         double arg2;
-        ax::Color4B arg3;
+        ax::Color4F arg3;
         ax::DrawNode::EndType arg4;
         ax::DrawNode::EndType arg5;
 
@@ -53357,7 +53357,7 @@ int lua_ax_base_DrawNode_drawSegment(lua_State* tolua_S)
 
         ok &= luaval_to_number(tolua_S, 4,&arg2, "ax.DrawNode:drawSegment");
 
-        ok &=luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawSegment");
+        ok &=luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawSegment");
 
         ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "ax.DrawNode:drawSegment");
 
@@ -53410,11 +53410,11 @@ int lua_ax_base_DrawNode_drawColoredTriangle(lua_State* tolua_S)
     if (argc == 2) 
     {
         const ax::Vec2* arg0;
-        const ax::Color4B* arg1;
+        const ax::Color4F* arg1;
 
         ok &= luaval_to_object<const ax::Vec2>(tolua_S, 2, "ax.Vec2",&arg0, "ax.DrawNode:drawColoredTriangle");
 
-        #pragma warning NO CONVERSION TO NATIVE FOR Color4B*
+        #pragma warning NO CONVERSION TO NATIVE FOR Color4F*
 		ok = false;
         if(!ok)
         {
@@ -53470,8 +53470,8 @@ int lua_ax_base_DrawNode_drawTriangle(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 4, &arg2, "ax.DrawNode:drawTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg3;
-            ok &=luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawTriangle");
+            ax::Color4F arg3;
+            ok &=luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawTriangle");
 
             if (!ok) { break; }
             cobj->drawTriangle(arg0, arg1, arg2, arg3);
@@ -53486,8 +53486,8 @@ int lua_ax_base_DrawNode_drawTriangle(lua_State* tolua_S)
             ok &= luaval_to_object<const ax::Vec2>(tolua_S, 2, "ax.Vec2",&arg0, "ax.DrawNode:drawTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg1;
-            ok &=luaval_to_color4b(tolua_S, 3, &arg1, "ax.DrawNode:drawTriangle");
+            ax::Color4F arg1;
+            ok &=luaval_to_color4f(tolua_S, 3, &arg1, "ax.DrawNode:drawTriangle");
 
             if (!ok) { break; }
             cobj->drawTriangle(arg0, arg1);
@@ -53541,12 +53541,12 @@ int lua_ax_base_DrawNode_drawSolidTriangle(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg3;
-            ok &=luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg3;
+            ok &=luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg4;
-            ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg4;
+            ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
             cobj->drawSolidTriangle(arg0, arg1, arg2, arg3, arg4);
@@ -53569,12 +53569,12 @@ int lua_ax_base_DrawNode_drawSolidTriangle(lua_State* tolua_S)
             ok &= luaval_to_vec2(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg3;
-            ok &=luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg3;
+            ok &=luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg4;
-            ok &=luaval_to_color4b(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg4;
+            ok &=luaval_to_color4f(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
             double arg5;
@@ -53593,12 +53593,12 @@ int lua_ax_base_DrawNode_drawSolidTriangle(lua_State* tolua_S)
             ok &= luaval_to_object<const ax::Vec2>(tolua_S, 2, "ax.Vec2",&arg0, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg1;
-            ok &=luaval_to_color4b(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg1;
+            ok &=luaval_to_color4f(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg2;
-            ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg2;
+            ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
             cobj->drawSolidTriangle(arg0, arg1, arg2);
@@ -53613,12 +53613,12 @@ int lua_ax_base_DrawNode_drawSolidTriangle(lua_State* tolua_S)
             ok &= luaval_to_object<const ax::Vec2>(tolua_S, 2, "ax.Vec2",&arg0, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg1;
-            ok &=luaval_to_color4b(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg1;
+            ok &=luaval_to_color4f(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
-            ax::Color4B arg2;
-            ok &=luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidTriangle");
+            ax::Color4F arg2;
+            ok &=luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidTriangle");
 
             if (!ok) { break; }
             double arg3;

--- a/extensions/scripting/lua-bindings/auto/axlua_fairygui_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_fairygui_auto.cpp
@@ -10767,8 +10767,8 @@ int lua_ax_fairygui_GGraph_drawRect(lua_State* tolua_S)
         double arg0;
         double arg1;
         int arg2;
-        ax::Color4B arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg3;
+        ax::Color4F arg4;
 
         ok &= luaval_to_number(tolua_S, 2,&arg0, "fgui.GGraph:drawRect");
 
@@ -10776,9 +10776,9 @@ int lua_ax_fairygui_GGraph_drawRect(lua_State* tolua_S)
 
         ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "fgui.GGraph:drawRect");
 
-        ok &=luaval_to_color4b(tolua_S, 5, &arg3, "fgui.GGraph:drawRect");
+        ok &=luaval_to_color4f(tolua_S, 5, &arg3, "fgui.GGraph:drawRect");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "fgui.GGraph:drawRect");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "fgui.GGraph:drawRect");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_fairygui_GGraph_drawRect'", nullptr);
@@ -10829,8 +10829,8 @@ int lua_ax_fairygui_GGraph_drawEllipse(lua_State* tolua_S)
         double arg0;
         double arg1;
         int arg2;
-        ax::Color4B arg3;
-        ax::Color4B arg4;
+        ax::Color4F arg3;
+        ax::Color4F arg4;
 
         ok &= luaval_to_number(tolua_S, 2,&arg0, "fgui.GGraph:drawEllipse");
 
@@ -10838,9 +10838,9 @@ int lua_ax_fairygui_GGraph_drawEllipse(lua_State* tolua_S)
 
         ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "fgui.GGraph:drawEllipse");
 
-        ok &=luaval_to_color4b(tolua_S, 5, &arg3, "fgui.GGraph:drawEllipse");
+        ok &=luaval_to_color4f(tolua_S, 5, &arg3, "fgui.GGraph:drawEllipse");
 
-        ok &=luaval_to_color4b(tolua_S, 6, &arg4, "fgui.GGraph:drawEllipse");
+        ok &=luaval_to_color4f(tolua_S, 6, &arg4, "fgui.GGraph:drawEllipse");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_fairygui_GGraph_drawEllipse'", nullptr);
@@ -10889,16 +10889,16 @@ int lua_ax_fairygui_GGraph_drawPolygon(lua_State* tolua_S)
     if (argc == 5) 
     {
         int arg0;
-        ax::Color4B arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg1;
+        ax::Color4F arg2;
         const ax::Vec2* arg3;
         int arg4;
 
         ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "fgui.GGraph:drawPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 3, &arg1, "fgui.GGraph:drawPolygon");
+        ok &=luaval_to_color4f(tolua_S, 3, &arg1, "fgui.GGraph:drawPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "fgui.GGraph:drawPolygon");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "fgui.GGraph:drawPolygon");
 
         ok &= luaval_to_object<const ax::Vec2>(tolua_S, 5, "ax.Vec2",&arg3, "fgui.GGraph:drawPolygon");
 
@@ -10951,15 +10951,15 @@ int lua_ax_fairygui_GGraph_drawRegularPolygon(lua_State* tolua_S)
     if (argc == 4) 
     {
         int arg0;
-        ax::Color4B arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg1;
+        ax::Color4F arg2;
         int arg3;
 
         ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
 
         ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "fgui.GGraph:drawRegularPolygon");
         if(!ok)
@@ -10974,16 +10974,16 @@ int lua_ax_fairygui_GGraph_drawRegularPolygon(lua_State* tolua_S)
     if (argc == 5) 
     {
         int arg0;
-        ax::Color4B arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg1;
+        ax::Color4F arg2;
         int arg3;
         double arg4;
 
         ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
 
         ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "fgui.GGraph:drawRegularPolygon");
 
@@ -11000,17 +11000,17 @@ int lua_ax_fairygui_GGraph_drawRegularPolygon(lua_State* tolua_S)
     if (argc == 6) 
     {
         int arg0;
-        ax::Color4B arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg1;
+        ax::Color4F arg2;
         int arg3;
         double arg4;
         const float* arg5;
 
         ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
 
         ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "fgui.GGraph:drawRegularPolygon");
 
@@ -11030,8 +11030,8 @@ int lua_ax_fairygui_GGraph_drawRegularPolygon(lua_State* tolua_S)
     if (argc == 7) 
     {
         int arg0;
-        ax::Color4B arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg1;
+        ax::Color4F arg2;
         int arg3;
         double arg4;
         const float* arg5;
@@ -11039,9 +11039,9 @@ int lua_ax_fairygui_GGraph_drawRegularPolygon(lua_State* tolua_S)
 
         ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 3, &arg1, "fgui.GGraph:drawRegularPolygon");
 
-        ok &=luaval_to_color4b(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
+        ok &=luaval_to_color4f(tolua_S, 4, &arg2, "fgui.GGraph:drawRegularPolygon");
 
         ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "fgui.GGraph:drawRegularPolygon");
 

--- a/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
+++ b/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
@@ -2189,8 +2189,8 @@ static int toaxlua_DrawNode_drawPolygon(lua_State* tolua_S)
                 lua_pop(tolua_S, 1);
             }
 
-            Color4B fillColor;
-            if (!luaval_to_color4b(tolua_S, 4, &fillColor, "ax.DrawNode:drawPolygon"))
+            Color4F fillColor;
+            if (!luaval_to_color4f(tolua_S, 4, &fillColor, "ax.DrawNode:drawPolygon"))
             {
                 AX_SAFE_DELETE_ARRAY(points);
                 return 0;
@@ -2198,8 +2198,8 @@ static int toaxlua_DrawNode_drawPolygon(lua_State* tolua_S)
 
             float borderWidth = (float)tolua_tonumber(tolua_S, 5, 0);
 
-            Color4B borderColor;
-            if (!luaval_to_color4b(tolua_S, 6, &borderColor, "ax.DrawNode:drawPolygon"))
+            Color4F borderColor;
+            if (!luaval_to_color4f(tolua_S, 6, &borderColor, "ax.DrawNode:drawPolygon"))
             {
                 AX_SAFE_DELETE_ARRAY(points);
                 return 0;
@@ -2273,9 +2273,9 @@ int toaxlua_DrawNode_drawSolidPoly(lua_State* tolua_S)
                 lua_pop(tolua_S, 1);
             }
 
-            ax::Color4B arg2;
+            ax::Color4F arg2;
 
-            ok &= luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidPoly");
+            ok &= luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidPoly");
             if (!ok)
                 return 0;
             self->drawSolidPoly(points, size, arg2);
@@ -2352,11 +2352,11 @@ int toaxlua_DrawNode_drawPoly(lua_State* tolua_S)
             }
 
             bool arg2;
-            ax::Color4B arg3;
+            ax::Color4F arg3;
 
             ok &= luaval_to_boolean(tolua_S, 4, &arg2, "ax.DrawNode:drawPoly");
 
-            ok &= luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawPoly");
+            ok &= luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawPoly");
             if (!ok)
                 return 0;
 
@@ -2421,13 +2421,13 @@ int toaxlua_DrawNode_drawCardinalSpline(lua_State* tolua_S)
 
         double arg1;
         unsigned int arg2;
-        ax::Color4B arg3;
+        ax::Color4F arg3;
 
         ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.DrawNode:drawCardinalSpline");
 
         ok &= luaval_to_uint32(tolua_S, 4, &arg2, "ax.DrawNode:drawCardinalSpline");
 
-        ok &= luaval_to_color4b(tolua_S, 5, &arg3, "ax.DrawNode:drawCardinalSpline");
+        ok &= luaval_to_color4f(tolua_S, 5, &arg3, "ax.DrawNode:drawCardinalSpline");
         if (!ok)
             return 0;
         self->drawCardinalSpline(config, (float)arg1, arg2, arg3);
@@ -2488,11 +2488,11 @@ int toaxlua_DrawNode_drawCatmullRom(lua_State* tolua_S)
         AX_SAFE_DELETE_ARRAY(arr);
 
         unsigned int arg1;
-        ax::Color4B arg2;
+        ax::Color4F arg2;
 
         ok &= luaval_to_uint32(tolua_S, 3, &arg1, "ax.DrawNode:drawCatmullRom");
 
-        ok &= luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawCatmullRom");
+        ok &= luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawCatmullRom");
         if (!ok)
             return 0;
         self->drawCatmullRom(config, arg1, arg2);
@@ -2563,9 +2563,9 @@ int toaxlua_DrawNode_drawPoints(lua_State* tolua_S)
                 lua_pop(tolua_S, 1);
             }
 
-            ax::Color4B arg2;
+            ax::Color4F arg2;
 
-            ok &= luaval_to_color4b(tolua_S, 4, &arg2, "ax.DrawNode:drawPoints");
+            ok &= luaval_to_color4f(tolua_S, 4, &arg2, "ax.DrawNode:drawPoints");
             if (!ok)
                 return 0;
             self->drawPoints(points, size, arg2);
@@ -2601,8 +2601,8 @@ int toaxlua_DrawNode_drawPoints(lua_State* tolua_S)
             }
 
             float pointSize = (float)tolua_tonumber(tolua_S, 4, 0);
-            ax::Color4B color;
-            ok &= luaval_to_color4b(tolua_S, 5, &color, "ax.DrawNode:drawPoints");
+            ax::Color4F color;
+            ok &= luaval_to_color4f(tolua_S, 5, &color, "ax.DrawNode:drawPoints");
             if (!ok)
                 return 0;
             self->drawPoints(points, size, pointSize, color);

--- a/extensions/spine/src/spine/SkeletonRenderer.cpp
+++ b/extensions/spine/src/spine/SkeletonRenderer.cpp
@@ -535,7 +535,7 @@ namespace spine {
 							{brect.origin.x + brect.size.width, brect.origin.y},
 							{brect.origin.x + brect.size.width, brect.origin.y + brect.size.height},
 							{brect.origin.x, brect.origin.y + brect.size.height}};
-			drawNode->drawPoly(points, 4, true, Color4B::GREEN, 2.0f);
+			drawNode->drawPoly(points, 4, true, Color4F::GREEN, 2.0f);
 		}
 
 		if (_debugSlots) {
@@ -561,7 +561,7 @@ namespace spine {
 								{worldVertices[2], worldVertices[3]},
 								{worldVertices[4], worldVertices[5]},
 								{worldVertices[6], worldVertices[7]}};
-				drawNode->drawPoly(points, 4, true, Color4B::BLUE, 2.0f);
+				drawNode->drawPoly(points, 4, true, Color4F::BLUE, 2.0f);
 			}
 		}
 
@@ -572,15 +572,15 @@ namespace spine {
 				if (!bone->isActive()) continue;
 				float x = bone->getData().getLength() * bone->getA() + bone->getWorldX();
 				float y = bone->getData().getLength() * bone->getC() + bone->getWorldY();
-				drawNode->drawLine(Vec2(bone->getWorldX(), bone->getWorldY()), Vec2(x, y), Color4B::RED, 2.0f);
+				drawNode->drawLine(Vec2(bone->getWorldX(), bone->getWorldY()), Vec2(x, y), Color4F::RED, 2.0f);
 			}
 			// Bone origins.
-			auto color = Color4B::BLUE;// Root bone is blue.
+			auto color = Color4F::BLUE;// Root bone is blue.
 			for (int i = 0, n = (int)_skeleton->getBones().size(); i < n; i++) {
 				Bone *bone = _skeleton->getBones()[i];
 				if (!bone->isActive()) continue;
 				drawNode->drawPoint(Vec2(bone->getWorldX(), bone->getWorldY()), 4, color);
-				if (i == 0) color = Color4B::GREEN;
+				if (i == 0) color = Color4F::GREEN;
 			}
 		}
 
@@ -603,7 +603,7 @@ namespace spine {
 									worldCoord + (idx0 * 2),
 									worldCoord + (idx1 * 2),
 									worldCoord + (idx2 * 2)};
-					drawNode->drawPoly(v, 3, true, Color4B::YELLOW, 2.0f);
+					drawNode->drawPoly(v, 3, true, Color4F::YELLOW, 2.0f);
 				}
 				VLA_FREE(worldCoord);
 			}

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
@@ -1084,14 +1084,14 @@ void UniqueChildStencilTest::addChildStencils()
     // Child stencil 1
     constexpr auto radius = 30.f;
     auto* drawNode        = DrawNode::create();
-    drawNode->drawSolidCircle(Vec2(50, 50), radius, 360, 180, 1, 1, Color4B::MAGENTA);
+    drawNode->drawSolidCircle(Vec2(50, 50), radius, 360, 180, 1, 1, Color4F::MAGENTA);
 
     _parentStencil->addChild(drawNode);
 
     // Child stencil 2
     drawNode = DrawNode::create();
     drawNode->drawSolidRect(Vec2(contentSize.width - 75, contentSize.height - 75),
-                            Vec2(contentSize.width - 25, contentSize.height - 25), Color4B::MAGENTA);
+                            Vec2(contentSize.width - 25, contentSize.height - 25), Color4F::MAGENTA);
     _parentStencil->addChild(drawNode);
 
     // Child stencil 3

--- a/tests/cpp-tests/Source/DrawNodeTest/DrawNodeTest.cpp
+++ b/tests/cpp-tests/Source/DrawNodeTest/DrawNodeTest.cpp
@@ -1675,7 +1675,7 @@ void DrawNodeMorphTest_SolidPolygon::update(float dt)
 
         drawNodeArray[n]->properties.setScale(Vec2(0.5f, 0.5f));
         drawNodeArray[n]->drawSolidPolygon(verticesObjMorph[n], segments, color[n], sliderValue[sliderType::Thickness],
-            Color4B::YELLOW);
+            Color4F::YELLOW);
     }
 }
 
@@ -1957,9 +1957,9 @@ void DrawNodeJellyFishTest::DrawFrame()
         CalculatePoint(ii, ii / 235.0, t, px, py);
         dots[i] = Vec2(px + 150, py + 50);
     }
-    drawNode->drawPoints(dots, NUM_POINTS - 1, Color4B::GREEN);
+    drawNode->drawPoints(dots, NUM_POINTS - 1, Color4F::GREEN);
     UpdateJellyPoints();
-    drawNode->drawPoints(dots, NUM_POINTS - 1, Color4B::WHITE);
+    drawNode->drawPoints(dots, NUM_POINTS - 1, Color4F::WHITE);
 }
 
 
@@ -2086,7 +2086,7 @@ void DrawNodeThicknessTest::update(float dt)
         {135.250000f, 108.625000f}, {151.000000f, 124.125000f}, {90.500000f, 131.875000f},  {113.250000f, 120.875000f},
         {88.000000f, 116.875000f},  {106.000000f, 103.875000f}, {88.000000f, 97.875000f},
     };
-    drawNode->drawPolygon(vertices24, sizeof(vertices24) / sizeof(vertices24[0]), Color4B::TRANSPARENT,
+    drawNode->drawPolygon(vertices24, sizeof(vertices24) / sizeof(vertices24[0]), Color4F::TRANSPARENT,
         sliderValue[sliderType::Thickness] / 2, Color4F::RED);
 
     // open random color poly
@@ -2350,7 +2350,7 @@ void DrawNodeThicknessStressTest::update(float dt)
         {135.250000f, 108.625000f}, {151.000000f, 124.125000f}, {90.500000f, 131.875000f},  {113.250000f, 120.875000f},
         {88.000000f, 116.875000f},  {106.000000f, 103.875000f}, {88.000000f, 97.875000f},
     };
-    drawNode->drawPolygon(vertices24, sizeof(vertices24) / sizeof(vertices24[0]), Color4B::TRANSPARENT,
+    drawNode->drawPolygon(vertices24, sizeof(vertices24) / sizeof(vertices24[0]), Color4F::TRANSPARENT,
         negativThickness, Color4F::RED);
 
     // open random color poly
@@ -2708,7 +2708,7 @@ void DrawNodeMethodsTest::drawAll()
             Vec2 p3 = pts->getControlPointAtIndex(i);
 
             drawNode->properties.setPosition(Vec2(-100, -100));
-            drawNode->drawQuadBezier(p1, p2, p3, 30, Color4B::RED, sliderValue[sliderType::Thickness]);
+            drawNode->drawQuadBezier(p1, p2, p3, 30, Color4F::RED, sliderValue[sliderType::Thickness]);
         }
 
         for (int i = 0; i < 360;)
@@ -2718,7 +2718,7 @@ void DrawNodeMethodsTest::drawAll()
             Vec2 p3 = pts2->getControlPointAtIndex(i);
 
             drawNode->properties.setPosition(Vec2(-100, -100));
-            drawNode->drawQuadBezier(p1, p2, p3, 30, Color4B::GREEN, sliderValue[sliderType::Thickness]);
+            drawNode->drawQuadBezier(p1, p2, p3, 30, Color4F::GREEN, sliderValue[sliderType::Thickness]);
         }
 
         break;
@@ -2812,13 +2812,13 @@ void DrawNodeMethodsTest::drawAll()
     {
         Vec2 vertices[5] = { {0.0f, 0.0f}, {50.0f, 50.0f}, {100.0f, 50.0f}, {100.0f, 100.0f}, {50.0f, 100.0f} };
         drawNode->properties.setPosition(Vec2(-200, -300));
-        drawNode->drawPoly(vertices, 5, false, Color4B::BLUE, sliderValue[sliderType::Thickness]);
+        drawNode->drawPoly(vertices, 5, false, Color4F::BLUE, sliderValue[sliderType::Thickness]);
 
         Vec2 vertices2[3] = { {30.0f, 130.0f}, {30.0f, 230.0f}, {50.0f, 200.0f} };
-        drawNode->drawPoly(vertices2, 3, true, Color4B::GREEN, sliderValue[sliderType::Thickness]);
+        drawNode->drawPoly(vertices2, 3, true, Color4F::GREEN, sliderValue[sliderType::Thickness]);
 
         drawNode->properties.setDefaultValues();
-        drawNode->drawPoly(vertices1, sizeof(vertices1) / sizeof(vertices1[0]), true, Color4B::RED,
+        drawNode->drawPoly(vertices1, sizeof(vertices1) / sizeof(vertices1[0]), true, Color4F::RED,
             sliderValue[sliderType::Thickness]);
 
         drawNode->properties.setPosition(Vec2(0, -300));
@@ -2928,14 +2928,14 @@ void DrawNodeMethodsTest::drawAll()
     }
     case drawMethodes::Triangle:
     {
-        static Color4B color3[] = { Color4B::GREEN, Color4B::BLUE, Color4B::RED };
+        static Color4F color3[] = { Color4F::GREEN, Color4F::BLUE, Color4F::RED };
         drawNode->properties.setPosition(center);
         drawNode->properties.setScale(Vec2(10, 10));
 
         {
             drawNode->drawTriangle(Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20,
                 Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20,
-                Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20, Color4B::RED);
+                                   Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20, Color4F::RED);
         }
         {
             Vec2 triangle[] = { Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20,
@@ -2958,11 +2958,11 @@ void DrawNodeMethodsTest::drawAll()
 
             drawNode->drawSolidTriangle(Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20,
                 Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20,
-                Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20, Color4B::RED,
-                Color4B::BLUE, sliderValue[sliderType::Thickness]);
+                                        Vec2(AXRANDOM_MINUS1_1(), AXRANDOM_MINUS1_1()) * 20, Color4F::RED,
+                                        Color4F::BLUE, sliderValue[sliderType::Thickness]);
 
             drawNode->properties.setPosition(center - Vec2(200, 200));
-            drawNode->drawSolidTriangle(triangle, Color4B::GREEN, Color4B::BLUE, sliderValue[sliderType::Thickness]);
+            drawNode->drawSolidTriangle(triangle, Color4F::GREEN, Color4F::BLUE, sliderValue[sliderType::Thickness]);
         }
         break;
     }
@@ -3178,7 +3178,7 @@ void DrawNodeDrawInWrongOrder_Issue1888::update(float dt)
 
     drawNode->clear();
 
-    drawNode->drawLine(Vec2(20, 140), Vec2(450, 110), Color4B::RED, 20.0f);
+    drawNode->drawLine(Vec2(20, 140), Vec2(450, 110), Color4F::RED, 20.0f);
 
     for (int i = 0; i < 200; i++)
     {
@@ -3190,7 +3190,7 @@ void DrawNodeDrawInWrongOrder_Issue1888::update(float dt)
         drawNode->drawPoints(position1, 4, 10, Color4F(AXRANDOM_0_1(), AXRANDOM_0_1(), AXRANDOM_0_1(), 1));
     }
 
-    drawNode->drawSolidRect(Vec2(150, 80), Vec2(400, 220), Color4B::YELLOW);
+    drawNode->drawSolidRect(Vec2(150, 80), Vec2(400, 220), Color4F::YELLOW);
 
     for (int i = 0; i < 50; i++)
     {
@@ -3198,9 +3198,9 @@ void DrawNodeDrawInWrongOrder_Issue1888::update(float dt)
             Color4F(AXRANDOM_0_1(), AXRANDOM_0_1(), AXRANDOM_0_1(), 1.0f));
     }
 
-    drawNode->drawLine(Vec2(20, 100), Vec2(450, 220), Color4B::GREEN, 8.0f);
+    drawNode->drawLine(Vec2(20, 100), Vec2(450, 220), Color4F::GREEN, 8.0f);
 
-    drawNode->drawLine(Vec2(200, 100), Vec2(450, 250), Color4B::BLUE, 6.0f);
+    drawNode->drawLine(Vec2(200, 100), Vec2(450, 250), Color4F::BLUE, 6.0f);
 }
 
 DrawNodeAxmolTest2::DrawNodeAxmolTest2()
@@ -3488,7 +3488,7 @@ DrawNodeIssueTester::DrawNodeIssueTester()
         drawNode->drawLine(Vec2(140, y), Vec2(180, y), Color4F(AXRANDOM_0_1(), AXRANDOM_0_1(), AXRANDOM_0_1(), 1.0f),
             thick);
     }
-    drawNode->drawPie(Vec2(-220, 150), 20, 0, 100, 300, 1, 1, Color4B::TRANSPARENT, Color4B::BLUE,
+    drawNode->drawPie(Vec2(-220, 150), 20, 0, 100, 300, 1, 1, Color4F::TRANSPARENT, Color4F::BLUE,
         DrawNode::DrawMode::Line, 10);
 
     drawNode->properties.setPosition(Vec2(50, -100));


### PR DESCRIPTION
## Describe your changes

In axmol-2.2.0, the DrawNode color parameter was changed to Color4B, which caused some Lua binding test cases to be unable to detect the change and thus failed to achieve the expected results. Since DrawNode internally already uses Color4F to pass color data to the GPU, keeping Color4F should have no noticeable performance impact.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
