### PR TITLE
Add support for audio panning

### DIFF
--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -551,4 +551,14 @@ bool AudioEngine::isEnabled()
 {
     return _isEnabled;
 }
+
+void AudioEngine::setPan(int audioId, float value)
+{
+    if (!_audioEngineImpl)
+    {
+        return;
+    }
+
+    _audioEngineImpl->setPan(audioId, value);
+}
 }

--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -552,14 +552,14 @@ bool AudioEngine::isEnabled()
     return _isEnabled;
 }
 
-void AudioEngine::setPan(int audioId, float value)
+void AudioEngine::setPan(int audioId, float value, float distance)
 {
     if (!_audioEngineImpl)
     {
         return;
     }
 
-    _audioEngineImpl->setPan(audioId, value);
+    _audioEngineImpl->setPan(audioId, value, distance);
 }
 
 float AudioEngine::getPan(int audioId)
@@ -570,5 +570,25 @@ float AudioEngine::getPan(int audioId)
     }
 
     return _audioEngineImpl->getPan(audioId);
+}
+
+ax::Vec3 AudioEngine::getSourcePosition(int audioId)
+{
+    if (!_audioEngineImpl)
+    {
+        return {};
+    }
+
+    return _audioEngineImpl->getSourcePosition(audioId);
+}
+
+void AudioEngine::setSourcePosition(int audioId, const ax::Vec3& position)
+{
+    if (!_audioEngineImpl)
+    {
+        return;
+    }
+
+    _audioEngineImpl->setSourcePosition(audioId, position);
 }
 }

--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -561,4 +561,14 @@ void AudioEngine::setPan(int audioId, float value)
 
     _audioEngineImpl->setPan(audioId, value);
 }
+
+float AudioEngine::getPan(int audioId)
+{
+    if (!_audioEngineImpl)
+    {
+        return 0.f;
+    }
+
+    return _audioEngineImpl->getPan(audioId);
+}
 }

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -347,13 +347,21 @@ public:
     static bool isEnabled();
 
     /**
-     * Sets the current playback position of an audio instance.
+     * Sets the pan of an audio instance.
      *
      * @param audioId   An audioID returned by the play2d function.
      * @param value     Panning value, from -1.f to +1.f, representing -60 degrees to +60 degrees
      * @return
      */
     static void setPan(AUDIO_ID audioId, float value);
+
+    /**
+     * Gets the pan of an audio instance.
+     *
+     * @param audioId   An audioID returned by the play2d function.
+     * @return pan value as a float between -1.0f to +1.0f
+     */
+    static float getPan(AUDIO_ID audioId);
 
 protected:
     static void addTask(const std::function<void()>& task);

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -346,6 +346,15 @@ public:
      */
     static bool isEnabled();
 
+    /**
+     * Sets the current playback position of an audio instance.
+     *
+     * @param audioId   An audioID returned by the play2d function.
+     * @param value     Panning value, from -1.f to +1.f, representing -60 degrees to +60 degrees
+     * @return
+     */
+    static void setPan(AUDIO_ID audioId, float value);
+
 protected:
     static void addTask(const std::function<void()>& task);
     static void remove(AUDIO_ID audioID);

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "core/math/Vec3.h"
 #include "platform/PlatformConfig.h"
 #include "platform/PlatformMacros.h"
 #include "audio/AudioMacros.h"
@@ -351,9 +352,10 @@ public:
      *
      * @param audioId   An audioID returned by the play2d function.
      * @param value     Panning value, from -1.f to +1.f, representing -60 degrees to +60 degrees
+     * @param distance  Distance from source, with -0.5f being the default
      * @return
      */
-    static void setPan(AUDIO_ID audioId, float value);
+    static void setPan(AUDIO_ID audioId, float value, float distance = -0.5f);
 
     /**
      * Gets the pan of an audio instance.
@@ -362,6 +364,22 @@ public:
      * @return pan value as a float between -1.0f to +1.0f
      */
     static float getPan(AUDIO_ID audioId);
+
+    /**
+     * Gets the position of the audio source.
+     *
+     * @param audioId   An audioID returned by the play2d function.
+     * @return Vec3 position of source
+     */
+    static ax::Vec3 getSourcePosition(AUDIO_ID audioId);
+
+    /**
+     * Sets the position of the audio source.
+     *
+     * @param audioId   An audioID returned by the play2d function.
+     * @param position position of source
+     */
+    static void setSourcePosition(AUDIO_ID audioId, const ax::Vec3& position);
 
 protected:
     static void addTask(const std::function<void()>& task);

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "core/math/Vec3.h"
+#include "math/Vec3.h"
 #include "platform/PlatformConfig.h"
 #include "platform/PlatformMacros.h"
 #include "audio/AudioMacros.h"

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -936,14 +936,22 @@ void AudioEngineImpl::setPan(AUDIO_ID audioId, float value)
     }
 }
 
+float AudioEngineImpl::getPan(int audioId)
+{
+    std::unique_lock<std::recursive_mutex> lck(_threadMutex);
+    auto iter = _audioPlayers.find(audioId);
+    if (iter == _audioPlayers.end())
+        return 0.f;
+
+    auto player = iter->second;
+    lck.unlock();
+
+    return player->_pan;
+}
+
 bool AudioEngineImpl::isExtensionPresent(const char* extensionId)
 {
-    if (alIsExtensionPresent(extensionId))
-    {
-        return true;
-    }
-
-    return false;
+    return alIsExtensionPresent(extensionId);
 }
 
 void AudioEngineImpl::checkExtensions()

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -931,7 +931,7 @@ void AudioEngineImpl::setPan(AUDIO_ID audioId, float value)
         panAngles[0] = (1.0f - player->_pan) * angle;
         panAngles[1] = (1.0f + player->_pan) * -angle;
 
-        alSourcei(player->_alSource, AL_SOURCE_RELATIVE, TRUE); // relative to listener
+        alSourcei(player->_alSource, AL_SOURCE_RELATIVE, AL_TRUE); // relative to listener
         alSourcefv(player->_alSource, AL_STEREO_ANGLES, panAngles);
     }
 }

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -932,7 +932,7 @@ void AudioEngineImpl::setPan(AUDIO_ID audioId, float value)
         panAngles[1] = (1.0f + player->_pan) * -angle;
 
         alSourcei(player->_alSource, AL_SOURCE_RELATIVE, AL_TRUE); // relative to listener
-        alSourcefv(player->_alSource, AL_STEREO_ANGLES, panAngles);
+        alSourcefv(player->_alSource, 0x1030, panAngles); // AL_STEREO_ANGLES = 0x1030
     }
 }
 

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -490,6 +490,8 @@ bool AudioEngineImpl::init()
             alDisable(AL_STOP_SOURCES_ON_DISCONNECT_SOFT);
 #endif
 
+            checkExtensions();
+
             AXLOGI("OpenAL was initialized successfully, vender:{}, version:{}", vender, version);
         }
     } while (false);
@@ -905,6 +907,48 @@ void AudioEngineImpl::update(float /*dt*/)
 {
     std::unique_lock<std::recursive_mutex> lck(_threadMutex);
     _updatePlayers(false);
+}
+
+void AudioEngineImpl::setPan(AUDIO_ID audioId, float value)
+{
+    std::unique_lock<std::recursive_mutex> lck(_threadMutex);
+    auto iter = _audioPlayers.find(audioId);
+    if (iter == _audioPlayers.end())
+        return;
+
+    auto player = iter->second;
+    lck.unlock();
+
+    player->_pan = value;
+
+    alSource3f(player->_alSource, AL_POSITION, player->_pan, 0.0f, -1.f);
+    if (_stereoExtension)
+    {
+        // pan between -60 degrees when fully left (-1) and 60 degrees when fully right (1)
+        auto angle = static_cast<float>(M_PI) / 6.f;
+
+        float panAngles[2];
+        panAngles[0] = (1.0f - player->_pan) * angle;
+        panAngles[1] = (1.0f + player->_pan) * -angle;
+
+        alSourcei(player->_alSource, AL_SOURCE_RELATIVE, TRUE); // relative to listener
+        alSourcefv(player->_alSource, AL_STEREO_ANGLES, panAngles);
+    }
+}
+
+bool AudioEngineImpl::isExtensionPresent(const char* extensionId)
+{
+    if (alIsExtensionPresent(extensionId))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+void AudioEngineImpl::checkExtensions()
+{
+    _stereoExtension = isExtensionPresent("AL_EXT_STEREO_ANGLES");
 }
 
 void AudioEngineImpl::_updatePlayers(bool forStop)

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -909,7 +909,7 @@ void AudioEngineImpl::update(float /*dt*/)
     _updatePlayers(false);
 }
 
-void AudioEngineImpl::setPan(AUDIO_ID audioId, float value)
+void AudioEngineImpl::setPan(AUDIO_ID audioId, float value, float distance)
 {
     std::unique_lock<std::recursive_mutex> lck(_threadMutex);
     auto iter = _audioPlayers.find(audioId);
@@ -919,19 +919,20 @@ void AudioEngineImpl::setPan(AUDIO_ID audioId, float value)
     auto player = iter->second;
     lck.unlock();
 
+    player->_sourcePosition.set(value, 0.0f, distance);
     player->_pan = value;
 
-    alSource3f(player->_alSource, AL_POSITION, player->_pan, 0.0f, -1.f);
+    alSourcei(player->_alSource, AL_SOURCE_RELATIVE, AL_TRUE);  // relative to listener
+    alSource3f(player->_alSource, AL_POSITION, value, 0.0f, distance);
     if (_stereoExtension)
     {
         // pan between -60 degrees when fully left (-1) and 60 degrees when fully right (1)
         auto angle = static_cast<float>(M_PI) / 6.f;
 
         float panAngles[2];
-        panAngles[0] = (1.0f - player->_pan) * angle;
-        panAngles[1] = (1.0f + player->_pan) * -angle;
+        panAngles[0] = (1.0f - value) * angle;
+        panAngles[1] = (1.0f + value) * -angle;
 
-        alSourcei(player->_alSource, AL_SOURCE_RELATIVE, AL_TRUE); // relative to listener
         alSourcefv(player->_alSource, 0x1030, panAngles); // AL_STEREO_ANGLES = 0x1030
     }
 }
@@ -947,6 +948,34 @@ float AudioEngineImpl::getPan(int audioId)
     lck.unlock();
 
     return player->_pan;
+}
+
+ax::Vec3 AudioEngineImpl::getSourcePosition(int audioId)
+{
+    std::unique_lock<std::recursive_mutex> lck(_threadMutex);
+    auto iter = _audioPlayers.find(audioId);
+    if (iter == _audioPlayers.end())
+        return {};
+
+    auto player = iter->second;
+    lck.unlock();
+
+    return player->_sourcePosition;
+}
+
+void AudioEngineImpl::setSourcePosition(int audioId, const ax::Vec3& position)
+{
+    std::unique_lock<std::recursive_mutex> lck(_threadMutex);
+    auto iter = _audioPlayers.find(audioId);
+    if (iter == _audioPlayers.end())
+        return;
+
+    auto player = iter->second;
+    lck.unlock();
+
+    player->_sourcePosition.set(position);
+
+    alSource3f(player->_alSource, AL_POSITION, position.x, position.y, position.z);
 }
 
 bool AudioEngineImpl::isExtensionPresent(const char* extensionId)

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -36,7 +36,7 @@
 #    include "audio/AudioMacros.h"
 #    include "audio/AudioCache.h"
 #    include "audio/AudioPlayer.h"
-#    include "core/math/Vec3.h"
+#    include "math/Vec3.h"
 
 namespace ax
 {

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -62,6 +62,7 @@ public:
     bool setCurrentTime(AUDIO_ID audioID, float time);
     void setFinishCallback(AUDIO_ID audioID, const std::function<void(AUDIO_ID, std::string_view)>& callback);
     void setPan(AUDIO_ID audioId, float value);
+    float getPan(AUDIO_ID audioId);
 
     void uncache(std::string_view filePath);
     void uncacheAll();

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -61,8 +61,10 @@ public:
     float getCurrentTime(AUDIO_ID audioID);
     bool setCurrentTime(AUDIO_ID audioID, float time);
     void setFinishCallback(AUDIO_ID audioID, const std::function<void(AUDIO_ID, std::string_view)>& callback);
-    void setPan(AUDIO_ID audioId, float value);
+    void setPan(AUDIO_ID audioId, float value, float distance);
     float getPan(AUDIO_ID audioId);
+    ax::Vec3 getSourcePosition(AUDIO_ID audioId);
+    void setSourcePosition(AUDIO_ID audioId, const ax::Vec3& position);
 
     void uncache(std::string_view filePath);
     void uncacheAll();

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -61,6 +61,7 @@ public:
     float getCurrentTime(AUDIO_ID audioID);
     bool setCurrentTime(AUDIO_ID audioID, float time);
     void setFinishCallback(AUDIO_ID audioID, const std::function<void(AUDIO_ID, std::string_view)>& callback);
+    void setPan(AUDIO_ID audioId, float value);
 
     void uncache(std::string_view filePath);
     void uncacheAll();
@@ -68,6 +69,9 @@ public:
     void update(float dt);
 
 private:
+    bool isExtensionPresent(const char* extensionId);
+    void checkExtensions();
+
     // query players state per frame and dispatch finish callback if possible
     void _updatePlayers(bool forStop);
     void _play2d(AudioCache* cache, AUDIO_ID audioID);
@@ -95,6 +99,8 @@ private:
 
     AUDIO_ID _currentAudioID;
     Scheduler* _scheduler;
+
+    bool _stereoExtension{};
 };
 
 }

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -36,6 +36,7 @@
 #    include "audio/AudioMacros.h"
 #    include "audio/AudioCache.h"
 #    include "audio/AudioPlayer.h"
+#    include "core/math/Vec3.h"
 
 namespace ax
 {

--- a/core/audio/AudioPlayer.h
+++ b/core/audio/AudioPlayer.h
@@ -74,6 +74,8 @@ protected:
     float _volume;
     float _pitch;
     bool _loop;
+    float _pan{};
+
     std::function<void(AUDIO_ID, std::string_view)> _finishCallbak;
 
     bool _isDestroyed;

--- a/core/audio/AudioPlayer.h
+++ b/core/audio/AudioPlayer.h
@@ -37,6 +37,7 @@
 #include "audio/AudioMacros.h"
 #include "platform/PlatformMacros.h"
 #include "audio/alconfig.h"
+#include "math/Vec3.h"
 
 namespace ax
 {

--- a/core/audio/AudioPlayer.h
+++ b/core/audio/AudioPlayer.h
@@ -75,6 +75,7 @@ protected:
     float _pitch;
     bool _loop;
     float _pan{};
+    Vec3 _sourcePosition;
 
     std::function<void(AUDIO_ID, std::string_view)> _finishCallbak;
 

--- a/tests/cpp-tests/Source/AudioEngineTest/AudioEngineTest.cpp
+++ b/tests/cpp-tests/Source/AudioEngineTest/AudioEngineTest.cpp
@@ -56,6 +56,7 @@ AudioEngineTests::AudioEngineTests()
 
     ADD_TEST_CASE(AudioIssue18597Test);
     ADD_TEST_CASE(AudioIssue11143Test);
+    ADD_TEST_CASE(AudioPanningTest);
 
     // FIXME: Please keep AudioSwitchStateTest to the last position since this test case doesn't work well on each
     // platforms.
@@ -1279,4 +1280,211 @@ std::string AudioUncacheInFinishedCB::title() const
 std::string AudioUncacheInFinishedCB::subtitle() const
 {
     return "Should not crash";
+}
+
+// AudioPanningTest
+bool AudioPanningTest::init()
+{
+    auto ret          = AudioEngineTestDemo::init();
+    _audioID          = AudioEngine::INVALID_AUDIO_ID;
+    _loopEnabled      = false;
+    _volume           = 1.0f;
+    _duration         = AudioEngine::TIME_UNKNOWN;
+    _timeRatio        = 0.0f;
+    _updateTimeSlider = true;
+    _isStopped        = false;
+    _pan              = 0.0f;
+
+    std::string fontFilePath = "fonts/arial.ttf";
+
+    auto& layerSize = this->getContentSize();
+
+    _playOverLabel = Label::createWithSystemFont("Play Over", "", 30);
+    _playOverLabel->setPosition(Vec2(layerSize / 2) + Vec2(0, 30));
+    _playOverLabel->setVisible(false);
+    addChild(_playOverLabel, 99999);
+
+    auto playItem = TextButton::create("play", [&](TextButton* button) {
+        if (_audioID == AudioEngine::INVALID_AUDIO_ID)
+        {
+            _audioID = AudioEngine::play2d("background.mp3", _loopEnabled, _volume);
+
+            if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+            {
+                _isStopped = false;
+
+                button->setEnabled(false);
+                AudioEngine::setFinishCallback(_audioID, [&](int id, std::string_view filePath) {
+                    AXLOGD("_audioID({}), _isStopped:({}), played over!!!", _audioID, _isStopped);
+
+                    _playOverLabel->setVisible(true);
+
+                    scheduleOnce([&](float dt) { _playOverLabel->setVisible(false); }, 2.0f, "hide_play_over_label");
+
+                    assert(!_isStopped);  // Stop audio should not trigger finished callback
+                    _audioID = AudioEngine::INVALID_AUDIO_ID;
+                    ((TextButton*)_playItem)->setEnabled(true);
+
+                    _timeRatio = 0.0f;
+                    ((SliderEx*)_timeSlider)->setRatio(_timeRatio);
+                });
+            }
+        }
+    });
+    _playItem     = playItem;
+    playItem->setPosition(layerSize.width * 0.3f, layerSize.height * 0.8f);
+    addChild(playItem);
+
+    auto stopItem = TextButton::create("stop", [&](TextButton* button) {
+        if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+        {
+            _isStopped = true;
+            AudioEngine::stop(_audioID);
+
+            _audioID = AudioEngine::INVALID_AUDIO_ID;
+            ((TextButton*)_playItem)->setEnabled(true);
+        }
+    });
+    stopItem->setPosition(layerSize.width * 0.7f, layerSize.height * 0.8f);
+    addChild(stopItem);
+
+    auto pauseItem = TextButton::create("pause", [&](TextButton* button) {
+        if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+        {
+            AudioEngine::pause(_audioID);
+        }
+    });
+    pauseItem->setPosition(layerSize.width * 0.3f, layerSize.height * 0.7f);
+    addChild(pauseItem);
+
+    auto resumeItem = TextButton::create("resume", [&](TextButton* button) {
+        if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+        {
+            AudioEngine::resume(_audioID);
+        }
+    });
+    resumeItem->setPosition(layerSize.width * 0.7f, layerSize.height * 0.7f);
+    addChild(resumeItem);
+
+    auto loopItem = TextButton::create("enable-loop", [&](TextButton* button) {
+        _loopEnabled = !_loopEnabled;
+
+        if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+        {
+            AudioEngine::setLoop(_audioID, _loopEnabled);
+        }
+        if (_loopEnabled)
+        {
+            button->setString("disable-loop");
+        }
+        else
+        {
+            button->setString("enable-loop");
+        }
+    });
+    loopItem->setPosition(layerSize.width * 0.5f, layerSize.height * 0.5f);
+    addChild(loopItem);
+
+    auto volumeSlider = SliderEx::create();
+    volumeSlider->setPercent(100);
+    volumeSlider->addEventListener([&](Object* sender, Slider::EventType event) {
+        SliderEx* slider = dynamic_cast<SliderEx*>(sender);
+        _volume          = slider->getRatio();
+        if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+        {
+            AudioEngine::setVolume(_audioID, _volume);
+        }
+    });
+    volumeSlider->setPosition(Vec2(layerSize.width * 0.5f, layerSize.height * 0.40f));
+    addChild(volumeSlider);
+
+    auto timeSlider = SliderEx::create();
+    timeSlider->addEventListener([&](Object* sender, Slider::EventType event) {
+        SliderEx* slider = dynamic_cast<SliderEx*>(sender);
+        switch (event)
+        {
+        case Slider::EventType::ON_SLIDEBALL_DOWN:
+            _updateTimeSlider = false;
+            break;
+        case Slider::EventType::ON_SLIDEBALL_UP:
+            if (_audioID != AudioEngine::INVALID_AUDIO_ID && _duration != AudioEngine::TIME_UNKNOWN)
+            {
+                float ratio = (float)slider->getPercent() / 100;
+                ratio       = clampf(ratio, 0.0f, 1.0f);
+                AudioEngine::setCurrentTime(_audioID, _duration * ratio);
+            }
+        case Slider::EventType::ON_SLIDEBALL_CANCEL:
+            _updateTimeSlider = true;
+        case Slider::EventType::ON_PERCENTAGE_CHANGED:
+        default:
+            // ignore
+            break;
+        }
+    });
+    timeSlider->setPosition(Vec2(layerSize.width * 0.5f, layerSize.height * 0.30f));
+    addChild(timeSlider);
+    _timeSlider = timeSlider;
+
+    auto panningSlider = SliderEx::create();
+    panningSlider->setPercent(50);
+    panningSlider->addEventListener([&](Object* sender, Slider::EventType event) {
+        SliderEx* slider = dynamic_cast<SliderEx*>(sender);
+        _pan             = (slider->getRatio() * 2.f) - 1.f;
+        if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+        {
+            AudioEngine::setPan(_audioID, _pan);
+        }
+    });
+    panningSlider->setPosition(Vec2(layerSize.width * 0.5f, layerSize.height * 0.20f));
+    addChild(panningSlider);
+
+    auto& volumeSliderPos = volumeSlider->getPosition();
+    auto& sliderSize      = volumeSlider->getContentSize();
+    auto volumeLabel      = Label::createWithTTF("volume:  ", fontFilePath, 20);
+    volumeLabel->setAnchorPoint(Vec2::ANCHOR_MIDDLE_RIGHT);
+    volumeLabel->setPosition(volumeSliderPos.x - sliderSize.width / 2, volumeSliderPos.y);
+    addChild(volumeLabel);
+
+    auto& timeSliderPos = timeSlider->getPosition();
+    auto timeLabel      = Label::createWithTTF("time:  ", fontFilePath, 20);
+    timeLabel->setAnchorPoint(Vec2::ANCHOR_MIDDLE_RIGHT);
+    timeLabel->setPosition(timeSliderPos.x - sliderSize.width / 2, timeSliderPos.y);
+    addChild(timeLabel);
+
+    auto& panningPos = panningSlider->getPosition();
+    auto panLabel    = Label::createWithTTF("pan:  ", fontFilePath, 20);
+    panLabel->setAnchorPoint(Vec2::ANCHOR_MIDDLE_RIGHT);
+    panLabel->setPosition(panningPos.x - sliderSize.width / 2, panningPos.y);
+    addChild(panLabel);
+
+    this->schedule(AX_CALLBACK_1(AudioPanningTest::update, this), 0.1f, "update_key");
+
+    return ret;
+}
+
+void AudioPanningTest::update(float dt)
+{
+    if (_audioID != AudioEngine::INVALID_AUDIO_ID)
+    {
+        if (_duration == AudioEngine::TIME_UNKNOWN)
+        {
+            _duration = AudioEngine::getDuration(_audioID);
+        }
+        if (_duration != AudioEngine::TIME_UNKNOWN)
+        {
+            auto time  = AudioEngine::getCurrentTime(_audioID);
+            _timeRatio = time / _duration;
+            if (_updateTimeSlider)
+            {
+                ((SliderEx*)_timeSlider)->setRatio(_timeRatio);
+            }
+        }
+    }
+}
+
+AudioPanningTest::~AudioPanningTest() {}
+
+std::string AudioPanningTest::title() const
+{
+    return "Audio panning test";
 }

--- a/tests/cpp-tests/Source/AudioEngineTest/AudioEngineTest.h
+++ b/tests/cpp-tests/Source/AudioEngineTest/AudioEngineTest.h
@@ -358,4 +358,30 @@ public:
 private:
 };
 
+class AudioPanningTest : public AudioEngineTestDemo
+{
+public:
+    CREATE_FUNC(AudioPanningTest);
+
+    ~AudioPanningTest() override;
+
+    bool init() override;
+    void update(float dt) override;
+    std::string title() const override;
+
+private:
+    int _audioID;
+    bool _loopEnabled;
+    float _volume;
+    float _pan;
+    float _duration;
+    float _timeRatio;
+
+    void* _playItem;
+    void* _timeSlider;
+    bool _updateTimeSlider;
+    bool _isStopped;
+    ax::Label* _playOverLabel;
+};
+
 #endif /* defined(__NEWAUDIOENGINE_TEST_H_) */


### PR DESCRIPTION
## Describe your changes

 Add support for audio panning relative to the listener, from left to right, -60° to +60°.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
