### PR TITLE
Refactor: unify platform window/display access interfaces

### DIFF
--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -114,6 +114,20 @@ class Director;
  * @addtogroup platform
  * @{
  */
+
+enum class WindowPlatform
+{
+    Unknown,     // Unknown or unsupported platform
+    Win32,       // Windows desktop applications using HWND
+    CoreWindow,  // UWP or Xbox applications using CoreWindow/AppWindow
+    Cocoa,       // macOS applications using NSWindow
+    X11,         // Linux applications using the X11 window system
+    Wayland,     // Linux applications using the Wayland protocol
+    UIKit,       // iOS/tvOS applications using UIView/UIWindow
+    Android,     // Android applications using SurfaceView or native window
+    Web          // WebAssembly applications using HTML canvas or DOM
+};
+
 /**
  * @brief By RenderView you can operate the frame information of EGL view through some function.
  */
@@ -452,6 +466,13 @@ public:
      *   iOS/tvOS: EARenderView*
      */
     virtual void* getNativeDisplay() const { return nullptr; }
+
+    /**
+     * @brief Get the Window Platform object
+     *
+     * @return WindowPlatform
+     */
+    virtual WindowPlatform getWindowPlatform() const { return WindowPlatform::Unknown; };
 
     /**
      * Renders a Scene with a Renderer

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -431,24 +431,27 @@ public:
      */
     ResolutionPolicy getResolutionPolicy() const { return _resolutionPolicy; }
 
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
-    virtual HWND getWin32Window() = 0;
-#elif (AX_TARGET_PLATFORM == AX_PLATFORM_WINRT)
-    virtual PresentTarget* getPresentTarget() const = 0;
-#elif (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-    virtual void* getCocoaWindow() = 0;
-    virtual void* getNSGLContext() = 0;  // stevetranby: added
-#elif (AX_TARGET_PLATFORM == AX_PLATFORM_IOS)
-    virtual void* getEAWindow() const     = 0;  // @since axmol-2.8.0
-    virtual void* getEARenderView() const = 0;  // @since axmol-2.8.0
-#elif (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
-    virtual void* getX11Window()  = 0;
-    virtual void* getX11Display() = 0;
-#    ifdef AX_ENABLE_WAYLAND
-    virtual void* getWaylandWindow()  = 0;
-    virtual void* getWaylandDisplay() = 0;
-#    endif
-#endif  // #if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
+    /**
+     * @brief Get the Native Window object
+     *
+     * @return void*
+     *    win32: HWND
+     *    winrt: PresentTarget*
+     *    linux: x11 or wayland window
+     *    macOS: NSWindow*
+     *    iOS: UIWindow*
+     */
+    virtual void* getNativeWindow() const { return nullptr; }
+
+    /**
+     * @brief Get the Native Display object
+     *
+     * @return void*
+     *   linux: x11 or wayland display
+     *   macOS: NSGLContext*
+     *   iOS/tvOS: EARenderView*
+     */
+    virtual void* getNativeDisplay() const { return nullptr; }
 
     /**
      * Renders a Scene with a Renderer

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -415,10 +415,25 @@ void* RenderViewImpl::getNativeDisplay() const
     return (void*)glfwGetNSGLContext(_mainWindow);
 #elif AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
     int platform = glfwGetPlatform();
-    return platform == GLFW_PLATFORM_WAYLAND ? (void*)glfwGetWaylandDisplay(_mainWindow)
-                                             : (void*)glfwGetX11Display(_mainWindow);
+    return platform == GLFW_PLATFORM_WAYLAND ? (void*)glfwGetWaylandDisplay() : (void*)glfwGetX11Display();
 #else
     return nullptr;
+#endif
+}
+
+WindowPlatform RenderViewImpl::getWindowPlatform() const
+{
+#if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
+    return WindowPlatform::Win32;
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_MAC
+    return WindowPlatform::Cocoa;
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
+    int platform = glfwGetPlatform();
+    return platform == GLFW_PLATFORM_WAYLAND ? WindowPlatform::Wayland : WindowPlatform::X11;
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_WASM
+    return WindowPlatform::Web;
+#else
+    return WindowPlatform::Unknown;
 #endif
 }
 

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -394,40 +394,33 @@ RenderViewImpl::~RenderViewImpl()
     glfwTerminate();
 }
 
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
-HWND RenderViewImpl::getWin32Window()
+void* RenderViewImpl::getNativeWindow() const
 {
+#if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
     return glfwGetWin32Window(_mainWindow);
-}
-#elif (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-void* RenderViewImpl::getCocoaWindow()
-{
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_MAC
     return (void*)glfwGetCocoaWindow(_mainWindow);
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
+    int platform = glfwGetPlatform();
+    return platform == GLFW_PLATFORM_WAYLAND ? (void*)glfwGetWaylandWindow(_mainWindow)
+                                             : (void*)glfwGetX11Window(_mainWindow);
+#else
+    return nullptr;
+#endif
 }
-void* RenderViewImpl::getNSGLContext()
+
+void* RenderViewImpl::getNativeDisplay() const
 {
+#if AX_TARGET_PLATFORM == AX_PLATFORM_MAC
     return (void*)glfwGetNSGLContext(_mainWindow);
-}  // stevetranby: added
-#elif (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
-void* RenderViewImpl::getX11Window()
-{
-    return (void*)glfwGetX11Window(_mainWindow);
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
+    int platform = glfwGetPlatform();
+    return platform == GLFW_PLATFORM_WAYLAND ? (void*)glfwGetWaylandDisplay(_mainWindow)
+                                             : (void*)glfwGetX11Display(_mainWindow);
+#else
+    return nullptr;
+#endif
 }
-void* RenderViewImpl::getX11Display()
-{
-    return (void*)glfwGetX11Display();
-}
-#    ifdef AX_ENABLE_WAYLAND
-void* RenderViewImpl::getWaylandWindow()
-{
-    return (void*)glfwGetWaylandWindow(_mainWindow);
-}
-void* RenderViewImpl::getWaylandDisplay()
-{
-    return (void*)glfwGetWaylandDisplay();
-}
-#    endif
-#endif  // #if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
 
 RenderViewImpl* RenderViewImpl::create(std::string_view viewName)
 {
@@ -583,7 +576,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
         return false;
     }
 
-    NSView* contentView = [(id)getCocoaWindow() contentView];
+    NSView* contentView = [(id)getNativeWindow() contentView];
     [contentView setWantsLayer:YES];
     CAMetalLayer* layer = [CAMetalLayer layer];
     [layer setDevice:device];

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -131,6 +131,7 @@ public:
 
     void* getNativeWindow() const override;
     void* getNativeDisplay() const override;
+    WindowPlatform getWindowPlatform() const override;
 
 protected:
     RenderViewImpl(bool initglfw = true);

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -129,23 +129,8 @@ public:
 
     bool isHighDPI() const override { return _isHighDPI; }
 
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
-    HWND getWin32Window() override;
-#endif /* (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32) */
-
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-    void* getCocoaWindow() override;
-    void* getNSGLContext() override;  // stevetranby: added
-#endif                                // #if (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
-
-#if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
-    void* getX11Window() override;
-    void* getX11Display() override;
-#    ifdef AX_ENABLE_WAYLAND
-    void* getWaylandWindow() override;
-    void* getWaylandDisplay() override;
-#    endif
-#endif  // #if (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX)
+    void* getNativeWindow() const override;
+    void* getNativeDisplay() const override;
 
 protected:
     RenderViewImpl(bool initglfw = true);

--- a/axmol/platform/android/RenderViewImpl-android.h
+++ b/axmol/platform/android/RenderViewImpl-android.h
@@ -53,6 +53,8 @@ public:
 
     void queueOperation(void (*op)(void*), void* param) override;
 
+    WindowPlatform getWindowPlatform() const override { return WindowPlatform::Android; }
+
 protected:
     RenderViewImpl();
     virtual ~RenderViewImpl();

--- a/axmol/platform/ios/DirectorCaller-ios.mm
+++ b/axmol/platform/ios/DirectorCaller-ios.mm
@@ -139,7 +139,7 @@ static id s_sharedDirectorCaller;
     {
         ax::Director* director = ax::Director::getInstance();
 #if AX_GLES_PROFILE
-        EAGLContext* context = [(__bridge EARenderView*)director->getRenderView()->getEARenderView() context];
+        EAGLContext* context = [(__bridge EARenderView*)director->getRenderView()->getNativeDisplay() context];
         if (context != [EAGLContext currentContext])
             glFlush();
 

--- a/axmol/platform/ios/RenderViewImpl-ios.h
+++ b/axmol/platform/ios/RenderViewImpl-ios.h
@@ -68,11 +68,11 @@ public:
     /** returns whether or not the view is in high DPI mode */
     bool isHighDPI() const override { return getContentScaleFactor() == 2.0; }
 
-    /** @since axmol-2.8.0, returns the objective-c UIWindow instance */
-    void* getEAWindow() const override { return _eaWindowHandle; }
+    /** @since axmol-3.0, returns the objective-c UIWindow instance */
+    void* getNativeWindow() const override { return _eaWindowHandle; }
 
-    /** @since axmol-2.8.0, returns the objective-c EARenderView instance */
-    void* getEARenderView() const override { return _eaViewHandle; }
+    /** @since axmol-3.0, returns the objective-c EARenderView instance */
+    void* getNativeDisplay() const override { return _eaViewHandle; }
 
     // overrides
     bool isGfxContextReady() override;

--- a/axmol/platform/ios/RenderViewImpl-ios.h
+++ b/axmol/platform/ios/RenderViewImpl-ios.h
@@ -74,6 +74,8 @@ public:
     /** @since axmol-3.0, returns the objective-c EARenderView instance */
     void* getNativeDisplay() const override { return _eaViewHandle; }
 
+    WindowPlatform getWindowPlatform() const override { return WindowPlatform::UIKit; }
+
     // overrides
     bool isGfxContextReady() override;
     void end() override;

--- a/axmol/platform/mac/Common-mac.mm
+++ b/axmol/platform/mac/Common-mac.mm
@@ -49,7 +49,7 @@ AlertResult showAlert(std::string_view msg, std::string_view title, AlertStyle)
     [alert setAlertStyle:NSAlertStyleWarning];
 
     auto renderView = Director::getInstance()->getRenderView();
-    id window       = (id)renderView->getCocoaWindow();
+    id window       = (id)renderView->getNativeWindow();
     [alert beginSheetModalForWindow:window completionHandler:nil];
 
     return AlertResult::None;

--- a/axmol/platform/winrt/RenderViewImpl-winrt.h
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.h
@@ -144,7 +144,7 @@ public:
 
     void SetQueueOperationCb(std::function<void(AsyncOperation, void*)> cb);
 
-    PresentTarget* getPresentTarget() const override { return &m_presentTarget; }
+    void* getNativeWindow() const override { return &m_presentTarget; }
 
 protected:
     RenderViewImpl();

--- a/axmol/platform/winrt/RenderViewImpl-winrt.h
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.h
@@ -145,6 +145,7 @@ public:
     void SetQueueOperationCb(std::function<void(AsyncOperation, void*)> cb);
 
     void* getNativeWindow() const override { return &m_presentTarget; }
+    WindowPlatform getWindowPlatform() const override { return WindowPlatform::CoreWindow; }
 
 protected:
     RenderViewImpl();

--- a/axmol/renderer/Renderer.cpp
+++ b/axmol/renderer/Renderer.cpp
@@ -206,7 +206,7 @@ void Renderer::init()
     auto driver = axdrv;
 #if AX_RENDER_API == AX_RENDER_API_D3D
     auto nativeWindow = Director::getInstance()->getRenderView()->getNativeWindow();
-    _commandBuffer = driver->createCommandBuffer(nativeWindow);
+    _commandBuffer    = driver->createCommandBuffer(nativeWindow);
 #else
     _commandBuffer = driver->createCommandBuffer(nullptr);
 #endif

--- a/axmol/renderer/Renderer.cpp
+++ b/axmol/renderer/Renderer.cpp
@@ -205,12 +205,8 @@ void Renderer::init()
 
     auto driver = axdrv;
 #if AX_RENDER_API == AX_RENDER_API_D3D
-#    if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
-    auto presentTarget = Director::getInstance()->getRenderView()->getWin32Window();
-#    else
-    auto presentTarget = Director::getInstance()->getRenderView()->getPresentTarget();
-#    endif
-    _commandBuffer = driver->createCommandBuffer(presentTarget);
+    auto nativeWindow = Director::getInstance()->getRenderView()->getNativeWindow();
+    _commandBuffer = driver->createCommandBuffer(nativeWindow);
 #else
     _commandBuffer = driver->createCommandBuffer(nullptr);
 #endif

--- a/axmol/ui/UIEditBox/Mac/UIEditBoxMac.mm
+++ b/axmol/ui/UIEditBox/Mac/UIEditBoxMac.mm
@@ -132,7 +132,7 @@
 - (NSWindow*)window
 {
     auto renderView = ax::Director::getInstance()->getRenderView();
-    return (NSWindow*)renderView->getCocoaWindow();
+    return (NSWindow*)renderView->getNativeWindow();
 }
 
 - (void)openKeyboard

--- a/axmol/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/axmol/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -182,7 +182,7 @@ void EditBoxImplIOS::setNativeVisible(bool visible)
 void EditBoxImplIOS::updateNativeFrame(const Rect& rect)
 {
     auto renderView      = ax::Director::getInstance()->getRenderView();
-    EARenderView* eaView = (__bridge EARenderView*)renderView->getEARenderView();
+    EARenderView* eaView = (__bridge EARenderView*)renderView->getNativeDisplay();
 
     float factor = eaView.contentScaleFactor;
 
@@ -210,7 +210,7 @@ void EditBoxImplIOS::nativeCloseKeyboard()
 UIFont* EditBoxImplIOS::constructFont(const char* fontName, int fontSize)
 {
     AXASSERT(fontName != nullptr, "fontName can't be nullptr");
-    auto eaView        = static_cast<EARenderView*>(ax::Director::getInstance()->getRenderView()->getEARenderView());
+    auto eaView        = static_cast<EARenderView*>(ax::Director::getInstance()->getRenderView()->getNativeDisplay());
     float retinaFactor = eaView.contentScaleFactor;
     NSString* fntName  = [NSString stringWithUTF8String:fontName];
 

--- a/axmol/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/axmol/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -55,7 +55,7 @@ HWND EditBoxImplWin::s_hwndCocos           = 0;
 
 void EditBoxImplWin::lazyInit()
 {
-    s_hwndCocos = ax::Director::getInstance()->getRenderView()->getWin32Window();
+    s_hwndCocos = (HWND)ax::Director::getInstance()->getRenderView()->getNativeWindow();
     LONG style  = ::GetWindowLongW(s_hwndCocos, GWL_STYLE);
     ::SetWindowLongW(s_hwndCocos, GWL_STYLE, style | WS_CLIPCHILDREN);
     s_isInitialized    = true;

--- a/axmol/ui/UIEditBox/iOS/UIEditBoxIOS.mm
+++ b/axmol/ui/UIEditBox/iOS/UIEditBoxIOS.mm
@@ -320,7 +320,7 @@
 - (void)doAnimationWhenKeyboardMoveWithDuration:(float)duration distance:(float)distance
 {
     auto view            = ax::Director::getInstance()->getRenderView();
-    EARenderView* eaView = (__bridge EARenderView*)view->getEARenderView();
+    EARenderView* eaView = (__bridge EARenderView*)view->getNativeDisplay();
 
     [eaView doAnimationWhenKeyboardMoveWithDuration:duration distance:distance];
 }
@@ -337,7 +337,7 @@
 - (void)openKeyboard
 {
     auto view            = ax::Director::getInstance()->getRenderView();
-    EARenderView* eaView = (__bridge EARenderView*)view->getEARenderView();
+    EARenderView* eaView = (__bridge EARenderView*)view->getNativeDisplay();
 
     [eaView addSubview:self.textInput];
     [self.textInput becomeFirstResponder];
@@ -362,7 +362,7 @@
 - (void)animationSelector
 {
     auto view            = ax::Director::getInstance()->getRenderView();
-    EARenderView* eaView = (__bridge EARenderView*)view->getEARenderView();
+    EARenderView* eaView = (__bridge EARenderView*)view->getNativeDisplay();
 
     [eaView doAnimationWhenAnotherEditBeClicked];
 }
@@ -376,7 +376,7 @@
     _returnPressed = NO;
 
     auto view            = ax::Director::getInstance()->getRenderView();
-    EARenderView* eaView = (__bridge EARenderView*)view->getEARenderView();
+    EARenderView* eaView = (__bridge EARenderView*)view->getNativeDisplay();
 
     if ([eaView isKeyboardShown])
     {
@@ -469,7 +469,7 @@
     _returnPressed = NO;
 
     auto view            = ax::Director::getInstance()->getRenderView();
-    EARenderView* eaView = (__bridge EARenderView*)view->getEARenderView();
+    EARenderView* eaView = (__bridge EARenderView*)view->getNativeDisplay();
 
     if ([eaView isKeyboardShown])
     {

--- a/axmol/ui/UIWebView/UIWebViewImpl-ios.mm
+++ b/axmol/ui/UIWebView/UIWebViewImpl-ios.mm
@@ -133,7 +133,7 @@
     if (!self.wkWebView.superview)
     {
         auto view   = ax::Director::getInstance()->getRenderView();
-        auto eaView = (__bridge EARenderView*)view->getEARenderView();
+        auto eaView = (__bridge EARenderView*)view->getNativeDisplay();
         [eaView addSubview:self.wkWebView];
     }
 }
@@ -503,7 +503,7 @@ void WebViewImpl::draw(ax::Renderer* renderer, ax::Mat4 const& transform, uint32
         auto renderView = director->getRenderView();
         auto windowSize = renderView->getWindowSize();
 
-        auto scaleFactor = [static_cast<EARenderView*>(renderView->getEARenderView()) contentScaleFactor];
+        auto scaleFactor = [static_cast<EARenderView*>(renderView->getNativeDisplay()) contentScaleFactor];
 
         auto logicalSize = director->getLogicalSize();
 

--- a/axmol/ui/UIWebView/UIWebViewImpl-linux.cpp
+++ b/axmol/ui/UIWebView/UIWebViewImpl-linux.cpp
@@ -278,8 +278,8 @@ class GTKWebKit
 public:
     GTKWebKit() : isXwayland(webkit_dmabuf::is_wayland_display())
     {
-        m_X11Display      = static_cast<Display*>(ax::Director::getInstance()->getRenderView()->getX11Display());
-        m_ParentX11Window = reinterpret_cast<Window>(ax::Director::getInstance()->getRenderView()->getX11Window());
+        m_X11Display      = static_cast<Display*>(ax::Director::getInstance()->getRenderView()->getNativeDisplay());
+        m_ParentX11Window = reinterpret_cast<Window>(ax::Director::getInstance()->getRenderView()->getNativeWindow());
 
         init_gtk_platform_with_display(m_X11Display);
 

--- a/axmol/ui/UIWebView/UIWebViewImpl-win32.cpp
+++ b/axmol/ui/UIWebView/UIWebViewImpl-win32.cpp
@@ -667,7 +667,7 @@ void Win32WebControl::lazyInit()
 {
 #    if AX_TARGET_PLATFORM != AX_PLATFORM_WINRT
     // reset the main windows style so that its drawing does not cover the webview sub window
-    auto hwnd        = ax::Director::getInstance()->getRenderView()->getWin32Window();
+    auto hwnd        = (HWND)ax::Director::getInstance()->getRenderView()->getNativeWindow();
     const auto style = GetWindowLong(hwnd, GWL_STYLE);
     SetWindowLong(hwnd, GWL_STYLE, style | WS_CLIPCHILDREN);
 
@@ -692,7 +692,7 @@ bool Win32WebControl::createWebView(const std::function<bool(std::string_view)>&
 #    if AX_TARGET_PLATFORM != AX_PLATFORM_WINRT
     do
     {
-        HWND hwnd           = ax::Director::getInstance()->getRenderView()->getWin32Window();
+        HWND hwnd           = (HWND)ax::Director::getInstance()->getRenderView()->getNativeWindow();
         HINSTANCE hInstance = GetModuleHandle(nullptr);
         WNDCLASSEX wc;
         ZeroMemory(&wc, sizeof(WNDCLASSEX));

--- a/templates/common/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/common/proj.ios_mac/ios/RootViewController.mm
@@ -84,7 +84,7 @@ customization that is not appropriate for viewDidLoad.
 
     if (renderView)
     {
-        EARenderView* eaView = (__bridge EARenderView*)renderView->getEARenderView();
+        EARenderView* eaView = (__bridge EARenderView*)renderView->getNativeDisplay();
 
         if (eaView)
         {


### PR DESCRIPTION
- Consolidated platform-specific window/display APIs (X11, Wayland) into two unified methods:
  - getNativeWindow()
  - getNativeDisplay()
- Removed conditional compilation blocks for AX_ENABLE_WAYLAND
- Simplified cross-platform abstraction for windowing systems
- Improved maintainability and reduced platform branching

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
