### PR TITLE
Improve RenderView for High DPI awareness

### DIFF
--- a/axmol/base/Director.h
+++ b/axmol/base/Director.h
@@ -704,7 +704,7 @@ protected:
 
     bool _childrenIndexerEnabled = false;
 
-    bool _debugLayerEnabled          = false;
+    bool _debugLayerEnabled = false;
 
     /* axmol thread id */
     std::thread::id _axmol_thread_id;

--- a/axmol/base/Director.h
+++ b/axmol/base/Director.h
@@ -69,9 +69,6 @@ class TextureCache;
 class Renderer;
 class Camera;
 
-using PowerPreference = rhi::PowerPreference;
-using RenderScaleMode = rhi::RenderScaleMode;
-
 /**
  @brief Class that creates and handles the main Window and manages how
  and when to execute the Scenes.
@@ -177,23 +174,6 @@ public:
      * @lua NA
      */
     void setRenderView(RenderView* renderView);
-
-    /**
-     * Sets GPU Power Preference, only affects d3d render API currently.
-     */
-    void setPowerPreference(PowerPreference value) { _powerPreference = value; }
-
-    /**
-     * Gets GPU Power Preference
-     */
-    PowerPreference getPowerPreference() const { return _powerPreference; }
-
-    /**
-    * Sets render scale mode
-    */
-    void setRenderScaleMode(RenderScaleMode mode) { _renderScaleMode = mode; }
-
-    RenderScaleMode getRenderScaleMode() const { return _renderScaleMode; }
 
     /**
      * @brief Enable or disable the graphics API debug layer.
@@ -725,8 +705,6 @@ protected:
     bool _childrenIndexerEnabled = false;
 
     bool _debugLayerEnabled          = false;
-    PowerPreference _powerPreference = PowerPreference::Auto;
-    RenderScaleMode _renderScaleMode = RenderScaleMode::Default;
 
     /* axmol thread id */
     std::thread::id _axmol_thread_id;

--- a/axmol/base/Director.h
+++ b/axmol/base/Director.h
@@ -70,6 +70,7 @@ class Renderer;
 class Camera;
 
 using PowerPreference = rhi::PowerPreference;
+using RenderScaleMode = rhi::RenderScaleMode;
 
 /**
  @brief Class that creates and handles the main Window and manages how
@@ -186,6 +187,13 @@ public:
      * Gets GPU Power Preference
      */
     PowerPreference getPowerPreference() const { return _powerPreference; }
+
+    /**
+    * Sets render scale mode
+    */
+    void setRenderScaleMode(RenderScaleMode mode) { _renderScaleMode = mode; }
+
+    RenderScaleMode getRenderScaleMode() const { return _renderScaleMode; }
 
     /**
      * @brief Enable or disable the graphics API debug layer.
@@ -718,6 +726,7 @@ protected:
 
     bool _debugLayerEnabled          = false;
     PowerPreference _powerPreference = PowerPreference::Auto;
+    RenderScaleMode _renderScaleMode = RenderScaleMode::Default;
 
     /* axmol thread id */
     std::thread::id _axmol_thread_id;

--- a/axmol/platform/RenderView.cpp
+++ b/axmol/platform/RenderView.cpp
@@ -120,7 +120,7 @@ RenderView::~RenderView() {}
 
 void RenderView::pollEvents() {}
 
-void RenderView::updateDesignResolutionSize()
+void RenderView::updateDesignResolution()
 {
     if (_windowSize.width > 0 && _windowSize.height > 0 && _designResolutionSize.width > 0 &&
         _designResolutionSize.height > 0)
@@ -175,7 +175,7 @@ void RenderView::setDesignResolutionSize(float width, float height, ResolutionPo
     _designResolutionSize.set(width, height);
     _resolutionPolicy = resolutionPolicy;
 
-    updateDesignResolutionSize();
+    updateDesignResolution();
 }
 
 const Vec2& RenderView::getDesignResolutionSize() const
@@ -196,6 +196,9 @@ void RenderView::setWindowSize(float width, float height)
     // only update the designResolution if it wasn't previously set
     if (_designResolutionSize.equals(Vec2::ZERO))
         _designResolutionSize = _windowSize;
+
+    if (_renderSize.equals(Vec2::ZERO))
+        _renderSize = _windowSize;
 }
 
 Rect RenderView::getVisibleRect() const
@@ -482,9 +485,10 @@ float RenderView::getScaleY() const
     return _viewScale.y;
 }
 
-void RenderView::onFramebufferResized(uint32_t fbWidth, uint32_t fbHeight)
+void RenderView::onRenderResized()
 {
-    Director::getInstance()->resizeSwapchain(fbWidth, fbHeight);
+    Director::getInstance()->resizeSwapchain(static_cast<uint32_t>(_renderSize.width),
+                                             static_cast<uint32_t>(_renderSize.height));
 
 #ifdef AX_ENABLE_VR
     if (_vrRenderer) [[unlikely]]

--- a/axmol/platform/RenderView.cpp
+++ b/axmol/platform/RenderView.cpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "axmol/2d/Camera.h"
 #include "axmol/2d/Scene.h"
 #include "axmol/renderer/Renderer.h"
+#include "axmol/rhi/DriverBase.h"
 
 namespace ax
 {
@@ -97,17 +98,14 @@ static void removeUsedIndexBit(int index)
 
 }  // namespace
 
-// default context attributions are set as follows
-GfxContextAttrs RenderView::_gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
-
 void RenderView::setGfxContextAttrs(GfxContextAttrs& gfxContextAttrs)
 {
-    _gfxContextAttrs = gfxContextAttrs;
+    rhi::DriverBase::setContextAttrs(gfxContextAttrs);
 }
 
 GfxContextAttrs& RenderView::getGfxContextAttrs()
 {
-    return _gfxContextAttrs;
+    return rhi::DriverBase::getContextAttrs();
 }
 
 RenderView::RenderView()

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -192,6 +192,8 @@ public:
      */
     virtual float getWindowZoomFactor() const { return 1.0; }
 
+    const Vec2& getRenderSize() const { return _renderSize; }
+
 #ifndef _AX_GEN_SCRIPT_BINDINGS
     /**
      * implicit deprecated APIs, use getWindowSize instead
@@ -464,7 +466,7 @@ protected:
     float transformInputX(float x) { return (x - _viewportRect.origin.x) / _viewScale.x; }
     float transformInputY(float y) { return (y - _viewportRect.origin.y) / _viewScale.y; }
 
-    void onFramebufferResized(uint32_t fbWidth, uint32_t fbHeight);
+    void onRenderResized();
 
     void setScissorRect(float x, float y, float w, float h);
     const ScissorRect& getScissorRect() const;
@@ -475,10 +477,11 @@ protected:
      */
     virtual void queueOperation(AsyncOperation op, void* param = nullptr);
 
-    void updateDesignResolutionSize();
+    void updateDesignResolution();
 
     void handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode, int num, intptr_t ids[], float xs[], float ys[]);
 
+    Vec2 _renderSize;
     // The window size aka logic size, may scaled by windowZoomFactor in high DPI display
     Vec2 _windowSize;
     // resolution size, it is the size appropriate for the app resources.

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -237,19 +237,13 @@ public:
      *
      * @return The render scale fbSize/windowSize
      */
-    virtual int getRenderScale() const { return 1; }
+    virtual float getRenderScale() const { return 1.0f; }
 
     /** Only works on ios platform. Set Content Scale of the Factor. */
     virtual bool setContentScaleFactor(float /*scaleFactor*/) { return false; }
 
     /** Only works on ios platform. Get Content Scale of the Factor. */
     virtual float getContentScaleFactor() const { return 1.0; }
-
-    /** Returns whether or not the view is in high DPI mode.
-     *
-     * @return Returns whether or not the view is in high DPI mode.
-     */
-    virtual bool isHighDPI() const { return false; }
 
     /**
      * Get the visible area size of render viewport.

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -43,6 +43,16 @@ THE SOFTWARE.
 #    define AX_ICON_SET_SUPPORT true
 #endif /* (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32) || (AX_TARGET_PLATFORM == AX_PLATFORM_LINUX) */
 
+namespace ax
+{
+
+using PowerPreference = rhi::PowerPreference;
+using RenderScaleMode = rhi::RenderScaleMode;
+
+class Scene;
+class Renderer;
+class Director;
+
 /** There are some Resolution Policy for Adapt to the screen. */
 enum class ResolutionPolicy
 {
@@ -74,41 +84,7 @@ enum class ResolutionPolicy
     UNKNOWN,
 };
 
-/** @struct GfxContextAttrs
- *
- * The graphics context attributes.
- */
-struct GfxContextAttrs
-{
-    int redBits;
-    int greenBits;
-    int blueBits;
-    int alphaBits;
-    int depthBits;
-    int stencilBits;
-    int multisamplingCount;
-    bool visible   = true;
-    bool decorated = true;
-    bool vsync     = true;
-#if defined(_WIN32)
-    void* viewParent = nullptr;
-#endif
-};
-
-namespace ax
-{
-#if AX_TARGET_PLATFORM == AX_PLATFORM_WINRT
-struct PresentTarget
-{
-    void* surface{nullptr};
-    float width{1};
-    float height{1};
-};
-#endif
-
-class Scene;
-class Renderer;
-class Director;
+using GfxContextAttrs = rhi::ContextAttrs;
 
 /**
  * @addtogroup platform
@@ -503,9 +479,6 @@ protected:
 
     void handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode, int num, intptr_t ids[], float xs[], float ys[]);
 
-    /** The graphics context attrs. */
-    static GfxContextAttrs _gfxContextAttrs;
-
     // The window size aka logic size, may scaled by windowZoomFactor in high DPI display
     Vec2 _windowSize;
     // resolution size, it is the size appropriate for the app resources.
@@ -527,6 +500,9 @@ private:
 
     bool _interactive;
 };
+
+using ResolutionPolicy = ax::ResolutionPolicy;
+using GfxContextAttrs  = ax::GfxContextAttrs;
 
 // end of platform group
 /// @}

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -98,7 +98,6 @@ THE SOFTWARE.
 
 namespace ax
 {
-
 class GLFWEventHandler
 {
 public:
@@ -559,8 +558,9 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     glfwWindowHint(GLFW_SCALE_TO_MONITOR, _renderScaleMode == RenderScaleMode::Physical ? GLFW_TRUE : GLFW_FALSE);
 #endif
 
-    _mainWindow = glfwCreateWindow(static_cast<int>(requestWinSize.width), static_cast<int>(requestWinSize.height),
-                                   _viewName.c_str(), _monitor, nullptr);
+    _mainWindow =
+        glfwCreateWindow(static_cast<int>(std::lround(requestWinSize.width)),
+                         static_cast<int>(std::lround(requestWinSize.height)), _viewName.c_str(), _monitor, nullptr);
     if (_mainWindow == nullptr)
     {
         std::string message = "Can't create window";
@@ -826,17 +826,6 @@ void RenderViewImpl::setCursorVisible(bool isVisible)
         glfwSetInputMode(_mainWindow, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 }
 
-void RenderViewImpl::setWindowZoomFactor(float zoomFactor)
-{
-    AXASSERT(zoomFactor > 0.0f, "zoomFactor must be larger than 0");
-
-    if (std::abs(_windowZoomFactor - zoomFactor) < FLT_EPSILON)
-        return;
-
-    _windowZoomFactor = zoomFactor;
-    resizePlatformWindow(_windowSize.width, _windowSize.height);
-}
-
 float RenderViewImpl::getWindowZoomFactor() const
 {
     return _windowZoomFactor;
@@ -1003,6 +992,50 @@ void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int
     Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
 }
 
+void RenderViewImpl::setWindowZoomFactor(float zoomFactor)
+{
+    AXASSERT(zoomFactor > 0.0f, "zoomFactor must be larger than 0");
+
+    if (std::abs(_windowZoomFactor - zoomFactor) < FLT_EPSILON)
+        return;
+
+    _windowZoomFactor  = zoomFactor;
+    _zoomFactorChanged = true;
+    resizePlatformWindow(_windowSize.width, _windowSize.height);
+
+    // process platform that window size callback not trigger(wayland)
+    if (_renderSizeChanged)
+    {
+        _renderSizeChanged = false;
+        onRenderResized();
+    }
+}
+
+void RenderViewImpl::setWindowSize(float width, float height)
+{
+    if (width == 0 || height == 0)
+        return;
+    Vec2 requestSize{width, height};
+    if (requestSize.equals(_windowSize))
+        return;
+
+    resizePlatformWindow(width, height);
+
+    // If platform (Wayland) not trigger windowSizeCallback, we update window
+    // and resolution at here
+    // Other platform may trigger framebuffer and window size callback delayed(x11)
+    if (!requestSize.equals(_windowSize))
+        updateWindowAndResolution(width, height);
+
+    // process platform that window size callback not trigger(wayland)
+    if (_renderSizeChanged)
+    {
+        _renderSizeChanged = false;
+        onRenderResized();
+    }
+}
+
+
 /*
  * Update scaled window (including fullscreen toggle, manual resize, HiDPI scaling).
  * Updates HiDPI flag, render scale, logical window size, and design resolution (viewport)
@@ -1038,18 +1071,29 @@ void RenderViewImpl::updateScaledWindowSize(int w, int h)
 
     updateRenderScale();
 
-    Vec2 scaledSize{w / _windowZoomFactor, h / _windowZoomFactor};
+    double scaledWidth  = w / (double)_windowZoomFactor;
+    double scaledHeight = h / (double)_windowZoomFactor;
 
     // Translate to logical size on platforms where pixels and screen coordinates always map 1:1
     if (_renderScaleMode == RenderScaleMode::Physical)
     {
         auto windowPlatform = getWindowPlatform();
         if (windowPlatform == WindowPlatform::Win32 || windowPlatform == WindowPlatform::X11)
-            scaledSize *= (1 / _renderScale);
+        {
+            const auto factor = (1 / (double)_renderScale);
+            scaledWidth *= factor;
+            scaledHeight *= factor;
+        }
     }
 
-    if (!scaledSize.equals(_windowSize))
+    Vec2 scaledSize{static_cast<float>(std::round(scaledWidth)), static_cast<float>(std::round(scaledHeight))};
+    if (!scaledSize.equals(_windowSize) || _zoomFactorChanged)
+    {
+        // updateWindowAndResolution additional operation update Camera viewport depends on _windowZoomFactor
+        // @see setViewportInPoints
+        _zoomFactorChanged = false;
         updateWindowAndResolution(scaledSize.width, scaledSize.height);
+    }
 
     // fire render resized event on platform that framebuffer & window size callback trigger delayed (x11)
     if (_renderSizeChanged)
@@ -1059,41 +1103,21 @@ void RenderViewImpl::updateScaledWindowSize(int w, int h)
     }
 }
 
-void RenderViewImpl::setWindowSize(float width, float height)
-{
-    if (width == 0 || height == 0)
-        return;
-    Vec2 requestSize{width, height};
-    if (requestSize.equals(_windowSize))
-        return;
-
-    resizePlatformWindow(width, height);
-
-    // If platform (Wayland) not trigger windowSizeCallback, we update window
-    // and resolution at here
-    // Other platform may trigger framebuffer and window size callback delayed(x11)
-    if (!requestSize.equals(_windowSize))
-        updateWindowAndResolution(width, height);
-
-    // process platform that window size callback not trigger(wayland)
-    if (_renderSizeChanged)
-    {
-        _renderSizeChanged = false;
-        onRenderResized();
-    }
-}
-
 void RenderViewImpl::resizePlatformWindow(float w, float h)
 {
-    Vec2 unscaledSize{w * _windowZoomFactor, h * _windowZoomFactor};
+    double unscaledWidth = w * _windowZoomFactor, unscaledHeight = h * _windowZoomFactor;
     // Translate to physical size on platforms where pixels and screen coordinates always map 1:1
     if (_renderScaleMode == RenderScaleMode::Physical)
     {
         auto windowPlatform = getWindowPlatform();
         if (windowPlatform == WindowPlatform::Win32 || windowPlatform == WindowPlatform::X11)
-            unscaledSize *= _renderScale;
+        {
+            unscaledWidth *= _renderScale;
+            unscaledHeight *= _renderScale;
+        }
     }
-    glfwSetWindowSize(_mainWindow, static_cast<int>(unscaledSize.width), static_cast<int>(unscaledSize.height));
+    glfwSetWindowSize(_mainWindow, static_cast<int>(std::lround(unscaledWidth)),
+                      static_cast<int>(std::lround(unscaledHeight)));
 }
 
 void RenderViewImpl::updateWindowAndResolution(float width, float height)
@@ -1140,24 +1164,22 @@ void RenderViewImpl::updateRenderScale()
 
 void RenderViewImpl::setViewportInPoints(float x, float y, float w, float h)
 {
+    const auto pixelScale = _renderScale * _windowZoomFactor;
     Viewport vp;
-    vp.x = (int)(x * _viewScale.x * _renderScale * _windowZoomFactor +
-                 _viewportRect.origin.x * _renderScale * _windowZoomFactor);
-    vp.y = (int)(y * _viewScale.y * _renderScale * _windowZoomFactor +
-                 _viewportRect.origin.y * _renderScale * _windowZoomFactor);
-    vp.w = (unsigned int)(w * _viewScale.x * _renderScale * _windowZoomFactor);
-    vp.h = (unsigned int)(h * _viewScale.y * _renderScale * _windowZoomFactor);
+    vp.x = (int)(x * _viewScale.x * pixelScale + _viewportRect.origin.x * pixelScale);
+    vp.y = (int)(y * _viewScale.y * pixelScale + _viewportRect.origin.y * pixelScale);
+    vp.w = (unsigned int)(w * _viewScale.x * pixelScale);
+    vp.h = (unsigned int)(h * _viewScale.y * pixelScale);
     Camera::setDefaultViewport(vp);
 }
 
 void RenderViewImpl::setScissorInPoints(float x, float y, float w, float h)
 {
-    auto x1      = (int)(x * _viewScale.x * _renderScale * _windowZoomFactor +
-                    _viewportRect.origin.x * _renderScale * _windowZoomFactor);
-    auto y1      = (int)(y * _viewScale.y * _renderScale * _windowZoomFactor +
-                    _viewportRect.origin.y * _renderScale * _windowZoomFactor);
-    auto width1  = (unsigned int)(w * _viewScale.x * _renderScale * _windowZoomFactor);
-    auto height1 = (unsigned int)(h * _viewScale.y * _renderScale * _windowZoomFactor);
+    const auto pixelScale = _renderScale * _windowZoomFactor;
+    auto x1               = (int)(x * _viewScale.x * pixelScale + _viewportRect.origin.x * pixelScale);
+    auto y1               = (int)(y * _viewScale.y * pixelScale + _viewportRect.origin.y * pixelScale);
+    auto width1           = (unsigned int)(w * _viewScale.x * pixelScale);
+    auto height1          = (unsigned int)(h * _viewScale.y * pixelScale);
 
     setScissorRect(x1, y1, width1, height1);
 }
@@ -1166,12 +1188,12 @@ ax::Rect RenderViewImpl::getScissorInPoints() const
 {
     auto& rect = getScissorRect();
 
-    float x = (rect.x - _viewportRect.origin.x * _renderScale * _windowZoomFactor) /
-              (_viewScale.x * _renderScale * _windowZoomFactor);
-    float y = (rect.y - _viewportRect.origin.y * _renderScale * _windowZoomFactor) /
-              (_viewScale.y * _renderScale * _windowZoomFactor);
-    float w = rect.width / (_viewScale.x * _renderScale * _windowZoomFactor);
-    float h = rect.height / (_viewScale.y * _renderScale * _windowZoomFactor);
+    const auto pixelScale = _renderScale * _windowZoomFactor;
+
+    float x = (rect.x - _viewportRect.origin.x * pixelScale) / (_viewScale.x * pixelScale);
+    float y = (rect.y - _viewportRect.origin.y * pixelScale) / (_viewScale.y * pixelScale);
+    float w = rect.width / (_viewScale.x * pixelScale);
+    float h = rect.height / (_viewScale.y * pixelScale);
     return ax::Rect(x, y, w, h);
 }
 
@@ -1235,13 +1257,9 @@ void RenderViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int
 
 void RenderViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, double y)
 {
-    _mouseX = (float)x;
-    _mouseY = (float)y;
-
-    _mouseX /= _windowZoomFactor;
-    _mouseY /= _windowZoomFactor;
-    _mouseX *= _inputScale;
-    _mouseY *= _inputScale;
+    const auto inputScale = _inputScale / _windowZoomFactor;
+    _mouseX               = static_cast<float>(x * inputScale);
+    _mouseY               = static_cast<float>(y * inputScale);
 
     if (!_isTouchDevice)
     {
@@ -1325,6 +1343,10 @@ void RenderViewImpl::onWebClickCallback()
 
 void RenderViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double y)
 {
+    const auto inputScale = _inputScale / _windowZoomFactor;
+    x *= inputScale;
+    y *= inputScale;
+
     EventMouse event(EventMouse::MouseEventType::MOUSE_SCROLL);
     float cursorX = transformInputX(_mouseX);
     float cursorY = transformInputY(_mouseY);

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -552,12 +552,6 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
 
     _mainWindow = glfwCreateWindow(static_cast<int>(requestWinSize.width), static_cast<int>(requestWinSize.height),
                                    _viewName.c_str(), _monitor, nullptr);
-
-    // BOOL yesok = IsProcessDPIAware();
-    // float xscale, yscale;
-    // glfwGetWindowContentScale(_mainWindow, &xscale, &yscale);
-    // bool dpiAwareness = xscale > 1.0f || yscale > 1.0f;
-
     if (_mainWindow == nullptr)
     {
         std::string message = "Can't create window";

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -1004,7 +1004,7 @@ void RenderViewImpl::handleWindowResized(int w, int h, int fbWidth, int fbHeight
 {
     updateRenderScale(w, fbWidth);
 
-    float width = w / _windowZoomFactor;
+    float width  = w / _windowZoomFactor;
     float height = h / _windowZoomFactor;
 
     // Translate to logical size on platforms where pixels and screen coordinates always map 1:1
@@ -1035,7 +1035,7 @@ void RenderViewImpl::applyWindowSize()
 {
     if (_windowSize.width > 0 && _windowSize.height > 0)
     {
-        float width = (_windowSize.width * _windowZoomFactor);
+        float width  = (_windowSize.width * _windowZoomFactor);
         float height = (_windowSize.height * _windowZoomFactor);
 
         // Translate to physical size on platforms where pixels and screen coordinates always map 1:1
@@ -1051,8 +1051,7 @@ void RenderViewImpl::applyWindowSize()
                 break;
             }
         }
-        glfwSetWindowSize(_mainWindow, static_cast<int>(width),
-                          static_cast<int>(height));
+        glfwSetWindowSize(_mainWindow, static_cast<int>(width), static_cast<int>(height));
     }
 }
 
@@ -1071,7 +1070,7 @@ void RenderViewImpl::updateRenderScale(int windowWidth, int framebufferWidth)
         }
     }
 
-    _inputScale = 1.0f;
+    _inputScale  = 1.0f;
     _renderScale = framebufferWidth / static_cast<float>(windowWidth);
 }
 

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -1035,7 +1035,6 @@ void RenderViewImpl::setWindowSize(float width, float height)
     }
 }
 
-
 /*
  * Update scaled window (including fullscreen toggle, manual resize, HiDPI scaling).
  * Updates HiDPI flag, render scale, logical window size, and design resolution (viewport)

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -983,6 +983,8 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
 void RenderViewImpl::onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWidth, int fbHeight)
 {
     AXLOGD("RenderViewImpl::onGLFWFramebufferSizeCallback: ({}, {})", fbWidth, fbHeight);
+    if (fbWidth == 0 || fbHeight == 0)
+        return;
 
     _renderSize.set(fbWidth, fbHeight);
     _renderSizeChanged = true;
@@ -991,14 +993,14 @@ void RenderViewImpl::onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWid
 void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
 {
     AXLOGD("RenderViewImpl::onGLFWWindowSizeCallback: ({}, {})", w, h);
-    if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
-    {
-        updateScaledWindowSize(w, h);
+    if (w == 0 || h == 0)
+        return;
 
-        Size size(w, h);
+    updateScaledWindowSize(w, h);
 
-        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
-    }
+    Size size(w, h);
+
+    Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
 }
 
 /*

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -603,7 +603,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     [layer setPixelFormat:MTLPixelFormatBGRA8Unorm];
     [layer setFramebufferOnly:YES];
     [layer setDrawableSize:size];
-    layer.displaySyncEnabled = _gfxContextAttrs.vsync;
+    layer.displaySyncEnabled = contextAttrs.vsync;
     [contentView setLayer:layer];
     rhi::mtl::DriverImpl::setCAMetalLayer(layer);
 #elif AX_RENDER_API == AX_RENDER_API_GL

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -520,21 +520,23 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 #endif
 
+    auto& contextAttrs = getGfxContextAttrs();
+
     glfwWindowHint(GLFW_RESIZABLE, resizable ? GL_TRUE : GL_FALSE);
-    glfwWindowHint(GLFW_RED_BITS, _gfxContextAttrs.redBits);
-    glfwWindowHint(GLFW_GREEN_BITS, _gfxContextAttrs.greenBits);
-    glfwWindowHint(GLFW_BLUE_BITS, _gfxContextAttrs.blueBits);
-    glfwWindowHint(GLFW_ALPHA_BITS, _gfxContextAttrs.alphaBits);
-    glfwWindowHint(GLFW_DEPTH_BITS, _gfxContextAttrs.depthBits);
-    glfwWindowHint(GLFW_STENCIL_BITS, _gfxContextAttrs.stencilBits);
+    glfwWindowHint(GLFW_RED_BITS, contextAttrs.redBits);
+    glfwWindowHint(GLFW_GREEN_BITS, contextAttrs.greenBits);
+    glfwWindowHint(GLFW_BLUE_BITS, contextAttrs.blueBits);
+    glfwWindowHint(GLFW_ALPHA_BITS, contextAttrs.alphaBits);
+    glfwWindowHint(GLFW_DEPTH_BITS, contextAttrs.depthBits);
+    glfwWindowHint(GLFW_STENCIL_BITS, contextAttrs.stencilBits);
 
-    glfwWindowHint(GLFW_SAMPLES, _gfxContextAttrs.multisamplingCount);
+    glfwWindowHint(GLFW_SAMPLES, contextAttrs.multisamplingCount);
 
-    glfwWindowHint(GLFW_VISIBLE, _gfxContextAttrs.visible);
-    glfwWindowHint(GLFW_DECORATED, _gfxContextAttrs.decorated);
+    glfwWindowHint(GLFW_VISIBLE, contextAttrs.visible);
+    glfwWindowHint(GLFW_DECORATED, contextAttrs.decorated);
 
 #if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
-    glfwWindowHintPointer(GLFW_WIN32_HWND_PARENT, _gfxContextAttrs.viewParent);
+    glfwWindowHintPointer(GLFW_WIN32_HWND_PARENT, contextAttrs.windowParent);
 #endif
 
 #if AX_RENDER_API == AX_RENDER_API_D3D
@@ -544,7 +546,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
 #endif
 
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32 || AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
-    _renderScaleMode = Director::getInstance()->getRenderScaleMode();
+    _renderScaleMode = contextAttrs.renderScaleMode;
     glfwWindowHint(GLFW_SCALE_TO_MONITOR, _renderScaleMode == RenderScaleMode::Physical ? GLFW_TRUE : GLFW_FALSE);
 #endif
 

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -656,7 +656,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
 
 #if AX_RENDER_API == AX_RENDER_API_GL
 #    if !defined(__EMSCRIPTEN__)
-    glfwSwapInterval(_gfxContextAttrs.vsync ? 1 : 0);
+    glfwSwapInterval(contextAttrs.vsync ? 1 : 0);
 #    endif
     // Will cause OpenGL error 0x0500 when use ANGLE-GLES on desktop
 #    if !AX_GLES_PROFILE
@@ -666,7 +666,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
 #        else
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE_ARB);
 #        endif
-    if (_gfxContextAttrs.multisamplingCount > 0)
+    if (contextAttrs.multisamplingCount > 0)
         glEnable(GL_MULTISAMPLE);
 #    endif
     CHECK_GL_ERROR_DEBUG();

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -364,7 +364,6 @@ static EventMouse::MouseButton checkMouseButton(GLFWwindow* window)
 
 RenderViewImpl::RenderViewImpl(bool initglfw)
     : _captured(false)
-    , _isHighDPI(false)
     , _renderScale(1.0f)
     , _windowZoomFactor(1.0f)
     , _mainWindow(nullptr)
@@ -544,8 +543,18 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     axdrv;
 #endif
 
+#if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32 || AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
+    _renderScaleMode = Director::getInstance()->getRenderScaleMode();
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, _renderScaleMode == RenderScaleMode::Physical ? GLFW_TRUE : GLFW_FALSE);
+#endif
+
     _mainWindow = glfwCreateWindow(static_cast<int>(requestWinSize.width), static_cast<int>(requestWinSize.height),
                                    _viewName.c_str(), _monitor, nullptr);
+
+    // BOOL yesok = IsProcessDPIAware();
+    // float xscale, yscale;
+    // glfwGetWindowContentScale(_mainWindow, &xscale, &yscale);
+    // bool dpiAwareness = xscale > 1.0f || yscale > 1.0f;
 
     if (_mainWindow == nullptr)
     {
@@ -965,12 +974,6 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
     glfwSetWindowSizeLimits(_mainWindow, minwidth, minheight, maxwidth, maxheight);
 }
 
-void RenderViewImpl::updateRenderScale(int windowWidth, int framebufferWidth)
-{
-    _isHighDPI   = framebufferWidth > windowWidth;
-    _renderScale = static_cast<float>(framebufferWidth) / windowWidth;
-}
-
 /*
  * Handle window resize events (including fullscreen toggle, manual resize, HiDPI scaling).
  * Updates HiDPI flag, render scale, logical window size, and design resolution (viewport)
@@ -999,7 +1002,24 @@ void RenderViewImpl::handleWindowResized(int w, int h, int fbWidth, int fbHeight
 {
     updateRenderScale(w, fbWidth);
 
-    RenderView::setWindowSize(w / _windowZoomFactor, h / _windowZoomFactor);
+    float width = w / _windowZoomFactor;
+    float height = h / _windowZoomFactor;
+
+    // Translate to logical size on platforms where pixels and screen coordinates always map 1:1
+    if (_renderScaleMode == RenderScaleMode::Physical)
+    {
+        auto windowPlatform = getWindowPlatform();
+        switch (windowPlatform)
+        {
+        case WindowPlatform::Win32:
+        case WindowPlatform::X11:
+            width /= _renderScale;
+            height /= _renderScale;
+            break;
+        }
+    }
+
+    RenderView::setWindowSize(width, height);
     updateDesignResolutionSize();
 }
 
@@ -1013,9 +1033,44 @@ void RenderViewImpl::applyWindowSize()
 {
     if (_windowSize.width > 0 && _windowSize.height > 0)
     {
-        glfwSetWindowSize(_mainWindow, (int)(_windowSize.width * _windowZoomFactor),
-                          (int)(_windowSize.height * _windowZoomFactor));
+        float width = (_windowSize.width * _windowZoomFactor);
+        float height = (_windowSize.height * _windowZoomFactor);
+
+        // Translate to physical size on platforms where pixels and screen coordinates always map 1:1
+        if (_renderScaleMode == RenderScaleMode::Physical)
+        {
+            auto windowPlatform = getWindowPlatform();
+            switch (windowPlatform)
+            {
+            case WindowPlatform::Win32:
+            case WindowPlatform::X11:
+                width *= _renderScale;
+                height *= _renderScale;
+                break;
+            }
+        }
+        glfwSetWindowSize(_mainWindow, static_cast<int>(width),
+                          static_cast<int>(height));
     }
+}
+
+void RenderViewImpl::updateRenderScale(int windowWidth, int framebufferWidth)
+{
+    if (_renderScaleMode == RenderScaleMode::Physical)
+    {
+        auto windowPlatform = getWindowPlatform();
+        switch (windowPlatform)
+        {
+        case WindowPlatform::Win32:
+        case WindowPlatform::X11:
+            glfwGetWindowContentScale(_mainWindow, &_renderScale, nullptr);
+            _inputScale = 1.0f / _renderScale;
+            return;
+        }
+    }
+
+    _inputScale = 1.0f;
+    _renderScale = framebufferWidth / static_cast<float>(windowWidth);
 }
 
 void RenderViewImpl::setViewportInPoints(float x, float y, float w, float h)
@@ -1120,6 +1175,8 @@ void RenderViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, doubl
 
     _mouseX /= _windowZoomFactor;
     _mouseY /= _windowZoomFactor;
+    _mouseX *= _inputScale;
+    _mouseY *= _inputScale;
 
     if (!_isTouchDevice)
     {

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -158,6 +158,12 @@ public:
             _view->onGLFWWindowPosCallback(windows, x, y);
     }
 
+    static void onGLFWFramebufferSizeCallback(GLFWwindow* window, int width, int height)
+    {
+        if (_view)
+            _view->onGLFWFramebufferSizeCallback(window, width, height);
+    }
+
     static void onGLFWWindowSizeCallback(GLFWwindow* window, int width, int height)
     {
         if (_view)
@@ -579,10 +585,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     int fbWidth, fbHeight;
     glfwGetFramebufferSize(_mainWindow, &fbWidth, &fbHeight);
 
-    int w, h;
-    glfwGetWindowSize(_mainWindow, &w, &h);
-
-    handleWindowResized(w, h, fbWidth, fbHeight);
+    handleFramebufferResized(fbWidth, fbHeight);
 
 #if AX_RENDER_API == AX_RENDER_API_MTL
     CGSize size;
@@ -641,6 +644,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     glfwSetCharCallback(_mainWindow, GLFWEventHandler::onGLFWCharCallback);
     glfwSetKeyCallback(_mainWindow, GLFWEventHandler::onGLFWKeyCallback);
     glfwSetWindowPosCallback(_mainWindow, GLFWEventHandler::onGLFWWindowPosCallback);
+    glfwSetFramebufferSizeCallback(_mainWindow, GLFWEventHandler::onGLFWFramebufferSizeCallback);
     glfwSetWindowSizeCallback(_mainWindow, GLFWEventHandler::onGLFWWindowSizeCallback);
     glfwSetWindowIconifyCallback(_mainWindow, GLFWEventHandler::onGLFWWindowIconifyCallback);
     glfwSetWindowFocusCallback(_mainWindow, GLFWEventHandler::onGLFWWindowFocusCallback);
@@ -971,7 +975,7 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
 }
 
 /*
- * Handle window resize events (including fullscreen toggle, manual resize, HiDPI scaling).
+ * Handle framebuffer resize events (including fullscreen toggle, manual resize, HiDPI scaling).
  * Updates HiDPI flag, render scale, logical window size, and design resolution (viewport)
  * based on logical window size (w,h) and framebuffer size (fbWidth, fbHeight).
  *
@@ -993,10 +997,19 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
  * Current GLFW fire event order:
  *  -> framebufferSize
  *  -> windowSize
+ * 
+ * Reason for handling render view design & window size here:
+ *  On Wayland, calling glfwSetWindowSize will not invoke windowSizeCallback,
+ *  so we must update them explicitly at this point.
  */
-void RenderViewImpl::handleWindowResized(int w, int h, int fbWidth, int fbHeight)
+void RenderViewImpl::handleFramebufferResized(int fbWidth, int fbHeight)
 {
-    updateRenderScale(w, fbWidth);
+    int w, h;
+    glfwGetWindowSize(_mainWindow, &w, &h);
+    if (w == 0 || h == 0 || fbWidth == 0 || fbHeight == 0)
+        return;
+
+    updateRenderScale();
 
     float width  = w / _windowZoomFactor;
     float height = h / _windowZoomFactor;
@@ -1049,23 +1062,44 @@ void RenderViewImpl::applyWindowSize()
     }
 }
 
-void RenderViewImpl::updateRenderScale(int windowWidth, int framebufferWidth)
+/**
+ * Updates the render scale and input scale factors based on the current platform
+ * and render scale mode.
+ *
+ * - On platforms where screen coordinates map 1:1 to physical pixels (Win32, X11),
+ *   high-DPI scaling is only applied when in Physical mode. In this case, _inputScale
+ *   converts from screen coordinates to the render view's logical coordinate space.
+ *
+ * - On other platforms (e.g., macOS, Wayland), input coordinates are already in logical
+ *   units, so _inputScale remains 1.0. However, _renderScale is still queried to adjust
+ *   rendering for high-DPI displays (e.g., viewport size).
+ *
+ * This function uses glfwGetWindowContentScale() to retrieve the current content scale
+ * factor, which may change when moving the window between monitors with different DPI
+ * settings.
+ */
+void RenderViewImpl::updateRenderScale()
 {
-    if (_renderScaleMode == RenderScaleMode::Physical)
+    auto windowPlatform = getWindowPlatform();
+    switch (windowPlatform)
     {
-        auto windowPlatform = getWindowPlatform();
-        switch (windowPlatform)
+    case WindowPlatform::Win32:
+    case WindowPlatform::X11:
+        if (_renderScaleMode == RenderScaleMode::Physical)
         {
-        case WindowPlatform::Win32:
-        case WindowPlatform::X11:
             glfwGetWindowContentScale(_mainWindow, &_renderScale, nullptr);
             _inputScale = 1.0f / _renderScale;
-            return;
         }
+        else
+        {
+            _inputScale = _renderScale = 1.0f;
+        }
+        break;
+    default:
+        glfwGetWindowContentScale(_mainWindow, &_renderScale, nullptr);
+        _inputScale = 1.0f;
+        break;
     }
-
-    _inputScale  = 1.0f;
-    _renderScale = framebufferWidth / static_cast<float>(windowWidth);
 }
 
 void RenderViewImpl::setViewportInPoints(float x, float y, float w, float h)
@@ -1345,17 +1379,19 @@ void RenderViewImpl::onGLFWWindowPosCallback(GLFWwindow* /*window*/, int x, int 
     director->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_POSITIONED, &pos);
 }
 
+void RenderViewImpl::onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWidth, int fbHeight)
+{
+    AXLOGI("RenderViewImpl::onGLFWFramebufferSizeCallback: ({}, {})", fbWidth, fbHeight);
+
+    handleFramebufferResized(fbWidth, fbHeight);
+    onFramebufferResized(fbWidth, fbHeight);
+}
+
 void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
 {
+    AXLOGI("RenderViewImpl::onGLFWWindowSizeCallback: ({}, {})", w, h);
     if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
     {
-        // Query the actual framebuffer size here to handle HiDPI displays.
-        // On macOS/Windows/Linux with Retina/HiDPI, framebuffer size may differ from window size.
-        int fbWidth = 0, fbHeight = 0;
-        glfwGetFramebufferSize(_mainWindow, &fbWidth, &fbHeight);
-
-        handleWindowResized(w, h, fbWidth, fbHeight);
-        onFramebufferResized(fbWidth, fbHeight);
         Size size(w, h);
         Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
     }

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -997,7 +997,7 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
  * Current GLFW fire event order:
  *  -> framebufferSize
  *  -> windowSize
- * 
+ *
  * Reason for handling render view design & window size here:
  *  On Wayland, calling glfwSetWindowSize will not invoke windowSizeCallback,
  *  so we must update them explicitly at this point.

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -584,9 +584,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
      */
     int fbWidth, fbHeight;
     glfwGetFramebufferSize(_mainWindow, &fbWidth, &fbHeight);
-
-    handleFramebufferResized(fbWidth, fbHeight);
-
+    _renderSize.set(fbWidth, fbHeight);
 #if AX_RENDER_API == AX_RENDER_API_MTL
     CGSize size;
     size.width  = static_cast<CGFloat>(fbWidth);
@@ -649,6 +647,10 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     glfwSetWindowIconifyCallback(_mainWindow, GLFWEventHandler::onGLFWWindowIconifyCallback);
     glfwSetWindowFocusCallback(_mainWindow, GLFWEventHandler::onGLFWWindowFocusCallback);
     glfwSetWindowCloseCallback(_mainWindow, GLFWEventHandler::onGLFWWindowCloseCallback);
+
+    int w, h;
+    glfwGetWindowSize(_mainWindow, &w, &h);
+    handleWindowResized(w, h);
 
 #if (AX_TARGET_PLATFORM != AX_PLATFORM_MAC)
 #    if AX_RENDER_API == AX_RENDER_API_GL
@@ -828,7 +830,7 @@ void RenderViewImpl::setWindowZoomFactor(float zoomFactor)
         return;
 
     _windowZoomFactor = zoomFactor;
-    applyWindowSize();
+    resizePlatformWindow(_windowSize.width, _windowSize.height);
 }
 
 float RenderViewImpl::getWindowZoomFactor() const
@@ -974,6 +976,27 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
     glfwSetWindowSizeLimits(_mainWindow, minwidth, minheight, maxwidth, maxheight);
 }
 
+void RenderViewImpl::onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWidth, int fbHeight)
+{
+    AXLOGD("RenderViewImpl::onGLFWFramebufferSizeCallback: ({}, {})", fbWidth, fbHeight);
+
+    _renderSize.set(fbWidth, fbHeight);
+    _renderSizeChanged = true;
+}
+
+void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
+{
+    AXLOGD("RenderViewImpl::onGLFWWindowSizeCallback: ({}, {})", w, h);
+    if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
+    {
+        handleWindowResized(w, h);
+
+        Size size(w, h);
+
+        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
+    }
+}
+
 /*
  * Handle framebuffer resize events (including fullscreen toggle, manual resize, HiDPI scaling).
  * Updates HiDPI flag, render scale, logical window size, and design resolution (viewport)
@@ -1002,63 +1025,64 @@ void RenderViewImpl::setWindowSizeLimits(int minwidth, int minheight, int maxwid
  *  On Wayland, calling glfwSetWindowSize will not invoke windowSizeCallback,
  *  so we must update them explicitly at this point.
  */
-void RenderViewImpl::handleFramebufferResized(int fbWidth, int fbHeight)
+void RenderViewImpl::handleWindowResized(int w, int h)
 {
-    int w, h;
-    glfwGetWindowSize(_mainWindow, &w, &h);
-    if (w == 0 || h == 0 || fbWidth == 0 || fbHeight == 0)
+    if (w == 0 || h == 0)
         return;
 
-    updateRenderScale();
-
-    float width  = w / _windowZoomFactor;
-    float height = h / _windowZoomFactor;
+    Vec2 scaledSize{w / _windowZoomFactor, h / _windowZoomFactor};
 
     // Translate to logical size on platforms where pixels and screen coordinates always map 1:1
     if (_renderScaleMode == RenderScaleMode::Physical)
     {
         auto windowPlatform = getWindowPlatform();
-        switch (windowPlatform)
-        {
-        case WindowPlatform::Win32:
-        case WindowPlatform::X11:
-            width /= _renderScale;
-            height /= _renderScale;
-            break;
-        }
+        if (windowPlatform == WindowPlatform::Win32 || windowPlatform == WindowPlatform::X11)
+            scaledSize *= (1 / _renderScale);
     }
 
-    RenderView::setWindowSize(width, height);
-    updateDesignResolutionSize();
+    if (!scaledSize.equals(_windowSize))
+        updateWindowAndResolution(scaledSize.width, scaledSize.height);
 }
 
 void RenderViewImpl::setWindowSize(float width, float height)
 {
-    RenderView::setWindowSize(width, height);
-    applyWindowSize();
+    if (width == 0 || height == 0)
+        return;
+    Vec2 requestSize{width, height};
+    if (requestSize.equals(_windowSize))
+        return;
+
+    resizePlatformWindow(width, height);
+
+    // If platform not trigger windowResized, we update window
+    // and resolution at here
+    if (!requestSize.equals(_windowSize))
+        updateWindowAndResolution(width, height);
 }
 
-void RenderViewImpl::applyWindowSize()
+void RenderViewImpl::resizePlatformWindow(float w, float h)
 {
-    if (_windowSize.width > 0 && _windowSize.height > 0)
+    Vec2 unscaledSize{w * _windowZoomFactor, h * _windowZoomFactor};
+    // Translate to physical size on platforms where pixels and screen coordinates always map 1:1
+    if (_renderScaleMode == RenderScaleMode::Physical)
     {
-        float width  = (_windowSize.width * _windowZoomFactor);
-        float height = (_windowSize.height * _windowZoomFactor);
+        auto windowPlatform = getWindowPlatform();
+        if (windowPlatform == WindowPlatform::Win32 || windowPlatform == WindowPlatform::X11)
+            unscaledSize *= _renderScale;
+    }
+    glfwSetWindowSize(_mainWindow, static_cast<int>(unscaledSize.width), static_cast<int>(unscaledSize.height));
+}
 
-        // Translate to physical size on platforms where pixels and screen coordinates always map 1:1
-        if (_renderScaleMode == RenderScaleMode::Physical)
-        {
-            auto windowPlatform = getWindowPlatform();
-            switch (windowPlatform)
-            {
-            case WindowPlatform::Win32:
-            case WindowPlatform::X11:
-                width *= _renderScale;
-                height *= _renderScale;
-                break;
-            }
-        }
-        glfwSetWindowSize(_mainWindow, static_cast<int>(width), static_cast<int>(height));
+void RenderViewImpl::updateWindowAndResolution(float width, float height)
+{
+    RenderView::setWindowSize(width, height);
+    updateRenderScale();
+    updateDesignResolution();
+
+    if (_renderSizeChanged)
+    {
+        _renderSizeChanged = false;
+        onRenderResized();
     }
 }
 
@@ -1081,24 +1105,20 @@ void RenderViewImpl::applyWindowSize()
 void RenderViewImpl::updateRenderScale()
 {
     auto windowPlatform = getWindowPlatform();
-    switch (windowPlatform)
+    if (windowPlatform == WindowPlatform::Win32 || windowPlatform == WindowPlatform::X11)
     {
-    case WindowPlatform::Win32:
-    case WindowPlatform::X11:
         if (_renderScaleMode == RenderScaleMode::Physical)
         {
             glfwGetWindowContentScale(_mainWindow, &_renderScale, nullptr);
             _inputScale = 1.0f / _renderScale;
         }
         else
-        {
             _inputScale = _renderScale = 1.0f;
-        }
-        break;
-    default:
+    }
+    else
+    {
         glfwGetWindowContentScale(_mainWindow, &_renderScale, nullptr);
         _inputScale = 1.0f;
-        break;
     }
 }
 
@@ -1377,24 +1397,6 @@ void RenderViewImpl::onGLFWWindowPosCallback(GLFWwindow* /*window*/, int x, int 
 
     Vec2 pos(x, y);
     director->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_POSITIONED, &pos);
-}
-
-void RenderViewImpl::onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWidth, int fbHeight)
-{
-    AXLOGI("RenderViewImpl::onGLFWFramebufferSizeCallback: ({}, {})", fbWidth, fbHeight);
-
-    handleFramebufferResized(fbWidth, fbHeight);
-    onFramebufferResized(fbWidth, fbHeight);
-}
-
-void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
-{
-    AXLOGI("RenderViewImpl::onGLFWWindowSizeCallback: ({}, {})", w, h);
-    if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
-    {
-        Size size(w, h);
-        Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(RenderViewImpl::EVENT_WINDOW_RESIZED, &size);
-    }
 }
 
 void RenderViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)

--- a/axmol/platform/RenderViewImpl.cpp
+++ b/axmol/platform/RenderViewImpl.cpp
@@ -552,6 +552,9 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
 #endif
 
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32 || AX_TARGET_PLATFORM == AX_PLATFORM_LINUX
+    // On Linux X11 platforms, GLFW does not support fractional DPI scaling (e.g., 1.5x).
+    // To ensure consistent rendering across high-DPI displays, we disable GLFW_SCALE_TO_MONITOR
+    // and apply custom scaling logic based on platform-specific DPI detection.
     _renderScaleMode = contextAttrs.renderScaleMode;
     glfwWindowHint(GLFW_SCALE_TO_MONITOR, _renderScaleMode == RenderScaleMode::Physical ? GLFW_TRUE : GLFW_FALSE);
 #endif
@@ -585,6 +588,11 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     int fbWidth, fbHeight;
     glfwGetFramebufferSize(_mainWindow, &fbWidth, &fbHeight);
     _renderSize.set(fbWidth, fbHeight);
+
+    int w, h;
+    glfwGetWindowSize(_mainWindow, &w, &h);
+    updateScaledWindowSize(w, h);
+
 #if AX_RENDER_API == AX_RENDER_API_MTL
     CGSize size;
     size.width  = static_cast<CGFloat>(fbWidth);
@@ -647,10 +655,6 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     glfwSetWindowIconifyCallback(_mainWindow, GLFWEventHandler::onGLFWWindowIconifyCallback);
     glfwSetWindowFocusCallback(_mainWindow, GLFWEventHandler::onGLFWWindowFocusCallback);
     glfwSetWindowCloseCallback(_mainWindow, GLFWEventHandler::onGLFWWindowCloseCallback);
-
-    int w, h;
-    glfwGetWindowSize(_mainWindow, &w, &h);
-    handleWindowResized(w, h);
 
 #if (AX_TARGET_PLATFORM != AX_PLATFORM_MAC)
 #    if AX_RENDER_API == AX_RENDER_API_GL
@@ -936,7 +940,7 @@ Vec2 RenderViewImpl::getNativeWindowSize() const
 
 void RenderViewImpl::getWindowPosition(int* xpos, int* ypos)
 {
-    if (_mainWindow != nullptr)
+    if (_mainWindow != nullptr && getWindowPlatform() != WindowPlatform::Wayland)
         glfwGetWindowPos(_mainWindow, xpos, ypos);
 }
 
@@ -989,7 +993,7 @@ void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int
     AXLOGD("RenderViewImpl::onGLFWWindowSizeCallback: ({}, {})", w, h);
     if (w && h && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
     {
-        handleWindowResized(w, h);
+        updateScaledWindowSize(w, h);
 
         Size size(w, h);
 
@@ -998,7 +1002,7 @@ void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int
 }
 
 /*
- * Handle framebuffer resize events (including fullscreen toggle, manual resize, HiDPI scaling).
+ * Update scaled window (including fullscreen toggle, manual resize, HiDPI scaling).
  * Updates HiDPI flag, render scale, logical window size, and design resolution (viewport)
  * based on logical window size (w,h) and framebuffer size (fbWidth, fbHeight).
  *
@@ -1025,10 +1029,12 @@ void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int
  *  On Wayland, calling glfwSetWindowSize will not invoke windowSizeCallback,
  *  so we must update them explicitly at this point.
  */
-void RenderViewImpl::handleWindowResized(int w, int h)
+void RenderViewImpl::updateScaledWindowSize(int w, int h)
 {
     if (w == 0 || h == 0)
         return;
+
+    updateRenderScale();
 
     Vec2 scaledSize{w / _windowZoomFactor, h / _windowZoomFactor};
 
@@ -1042,6 +1048,13 @@ void RenderViewImpl::handleWindowResized(int w, int h)
 
     if (!scaledSize.equals(_windowSize))
         updateWindowAndResolution(scaledSize.width, scaledSize.height);
+
+    // fire render resized event on platform that framebuffer & window size callback trigger delayed (x11)
+    if (_renderSizeChanged)
+    {
+        _renderSizeChanged = false;
+        onRenderResized();
+    }
 }
 
 void RenderViewImpl::setWindowSize(float width, float height)
@@ -1054,10 +1067,18 @@ void RenderViewImpl::setWindowSize(float width, float height)
 
     resizePlatformWindow(width, height);
 
-    // If platform not trigger windowResized, we update window
+    // If platform (Wayland) not trigger windowSizeCallback, we update window
     // and resolution at here
+    // Other platform may trigger framebuffer and window size callback delayed(x11)
     if (!requestSize.equals(_windowSize))
         updateWindowAndResolution(width, height);
+
+    // process platform that window size callback not trigger(wayland)
+    if (_renderSizeChanged)
+    {
+        _renderSizeChanged = false;
+        onRenderResized();
+    }
 }
 
 void RenderViewImpl::resizePlatformWindow(float w, float h)
@@ -1076,14 +1097,7 @@ void RenderViewImpl::resizePlatformWindow(float w, float h)
 void RenderViewImpl::updateWindowAndResolution(float width, float height)
 {
     RenderView::setWindowSize(width, height);
-    updateRenderScale();
     updateDesignResolution();
-
-    if (_renderSizeChanged)
-    {
-        _renderSizeChanged = false;
-        onRenderResized();
-    }
 }
 
 /**

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -161,16 +161,21 @@ protected:
     void onGLFWWindowCloseCallback(GLFWwindow* window);
 
 protected:
-    void handleFramebufferResized(int fbWidth, int fbHeigh);
+    void handleWindowResized(int w, int h);
 
-    /* update window size when user set zoomFactor, retina, frameSize */
-    void applyWindowSize();
+    // update window size, render scale, resolution(view layout)
+    void updateWindowAndResolution(float width, float height);
+
+    /* resize platform window when user set zoomFactor, windowSize */
+    void resizePlatformWindow(float w, float h);
 
     bool _isTouchDevice = false;
     bool _captured;
+    bool _renderSizeChanged{false};
 
     RenderScaleMode _renderScaleMode{};
 
+    // The render scale aka backingScaleFactor
     float _renderScale{1.0f};  // >=1
     float _inputScale{1.0f};
 

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -154,13 +154,14 @@ protected:
     void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
     void onGLFWCharCallback(GLFWwindow* window, unsigned int character);
     void onGLFWWindowPosCallback(GLFWwindow* windows, int x, int y);
+    void onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWidth, int fbHeight);
     void onGLFWWindowSizeCallback(GLFWwindow* window, int w, int h);
     void onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified);
     void onGLFWWindowFocusCallback(GLFWwindow* window, int focused);
     void onGLFWWindowCloseCallback(GLFWwindow* window);
 
 protected:
-    void handleWindowResized(int w, int h, int fbWidth, int fbHeigh);
+    void handleFramebufferResized(int fbWidth, int fbHeigh);
 
     /* update window size when user set zoomFactor, retina, frameSize */
     void applyWindowSize();
@@ -198,7 +199,7 @@ public:
     static const std::string EVENT_WINDOW_CLOSE;
 
 private:
-    void updateRenderScale(int windowWidth, int framebufferWidth);
+    void updateRenderScale();
     AX_DISALLOW_COPY_AND_ASSIGN(RenderViewImpl);
 };
 

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -125,9 +125,7 @@ public:
     void setCursorVisible(bool isVisible) override;
 
     /** Get render scale */
-    int getRenderScale() const override { return _renderScale; }
-
-    bool isHighDPI() const override { return _isHighDPI; }
+    float getRenderScale() const override { return _renderScale; }
 
     void* getNativeWindow() const override;
     void* getNativeDisplay() const override;
@@ -170,9 +168,10 @@ protected:
     bool _isTouchDevice = false;
     bool _captured;
 
-    bool _isHighDPI{false};
+    RenderScaleMode _renderScaleMode{};
 
-    float _renderScale;  // >=1
+    float _renderScale{1.0f};  // >=1
+    float _inputScale{1.0f};
 
     float _windowZoomFactor;
 

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -161,7 +161,7 @@ protected:
     void onGLFWWindowCloseCallback(GLFWwindow* window);
 
 protected:
-    void handleWindowResized(int w, int h);
+    void updateScaledWindowSize(int w, int h);
 
     // update window size, render scale, resolution(view layout)
     void updateWindowAndResolution(float width, float height);

--- a/axmol/platform/RenderViewImpl.h
+++ b/axmol/platform/RenderViewImpl.h
@@ -172,6 +172,7 @@ protected:
     bool _isTouchDevice = false;
     bool _captured;
     bool _renderSizeChanged{false};
+    bool _zoomFactorChanged{false};
 
     RenderScaleMode _renderScaleMode{};
 

--- a/axmol/platform/android/javaactivity-android.cpp
+++ b/axmol/platform/android/javaactivity-android.cpp
@@ -88,7 +88,7 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeInit(JNIEnv*, jcla
     if (!renderView)
     {
         renderView = ax::RenderViewImpl::create("axmol3");
-        renderView->setFrameSize(w, h);
+        renderView->setWindowSize(w, h);
         director->setRenderView(renderView);
 
         ax::Application::getInstance()->run();

--- a/axmol/platform/android/javaactivity-android.cpp
+++ b/axmol/platform/android/javaactivity-android.cpp
@@ -133,11 +133,11 @@ JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnContextLost(JNIE
 JNIEXPORT jintArray JNICALL Java_dev_axmol_lib_AxmolActivity_getGLContextAttrs(JNIEnv* env, jclass)
 {
     ax::Application::getInstance()->initGfxContextAttrs();
-    auto& _gfxContextAttrs = RenderView::getGfxContextAttrs();
+    const auto& contextAttrs = rhi::DriverBase::getContextAttrs();
 
-    int tmp[7] = {_gfxContextAttrs.redBits,           _gfxContextAttrs.greenBits, _gfxContextAttrs.blueBits,
-                  _gfxContextAttrs.alphaBits,         _gfxContextAttrs.depthBits, _gfxContextAttrs.stencilBits,
-                  _gfxContextAttrs.multisamplingCount};
+    int tmp[7] = {contextAttrs.redBits,           contextAttrs.greenBits, contextAttrs.blueBits,
+                  contextAttrs.alphaBits,         contextAttrs.depthBits, contextAttrs.stencilBits,
+                  contextAttrs.multisamplingCount};
 
     jintArray glContextAttrsJava = env->NewIntArray(7);
     env->SetIntArrayRegion(glContextAttrsJava, 0, 7, tmp);

--- a/axmol/platform/ios/RenderViewImpl-ios.h
+++ b/axmol/platform/ios/RenderViewImpl-ios.h
@@ -65,9 +65,6 @@ public:
     /** returns the content scale factor */
     float getContentScaleFactor() const override;
 
-    /** returns whether or not the view is in high DPI mode */
-    bool isHighDPI() const override { return getContentScaleFactor() == 2.0; }
-
     /** @since axmol-3.0, returns the objective-c UIWindow instance */
     void* getNativeWindow() const override { return _eaWindowHandle; }
 

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -147,7 +147,7 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
     [eaView setMultipleTouchEnabled:YES];
 #endif
 
-    RenderView::setWindowSize([eaView getWidth], [eaView getHeight])
+    RenderView::setWindowSize([eaView getWidth], [eaView getHeight]);
     //    _viewScale.x = _viewScale.y = [eaView contentScaleFactor];
 
     _eaViewHandle = eaView;

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -147,8 +147,7 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
     [eaView setMultipleTouchEnabled:YES];
 #endif
 
-    _windowSize.width = _designResolutionSize.width = [eaView getWidth];
-    _windowSize.height = _designResolutionSize.height = [eaView getHeight];
+    RenderView::setWindowSize([eaView getWidth], [eaView getHeight])
     //    _viewScale.x = _viewScale.y = [eaView contentScaleFactor];
 
     _eaViewHandle = eaView;

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -80,13 +80,15 @@ RenderViewImpl* RenderViewImpl::createWithFullscreen(std::string_view viewName)
 
 void RenderViewImpl::choosePixelFormats()
 {
-    if (_gfxContextAttrs.redBits == 8 && _gfxContextAttrs.greenBits == 8 && _gfxContextAttrs.blueBits == 8 &&
-        _gfxContextAttrs.alphaBits == 8)
+    const auto& contextAttrs = rhi::DriverBase::getContextAttrs();
+
+    if (contextAttrs.redBits == 8 && contextAttrs.greenBits == 8 && contextAttrs.blueBits == 8 &&
+        contextAttrs.alphaBits == 8)
     {
         _pixelFormat = PixelFormat::RGBA8;
     }
-    else if (_gfxContextAttrs.redBits == 5 && _gfxContextAttrs.greenBits == 6 && _gfxContextAttrs.blueBits == 5 &&
-             _gfxContextAttrs.alphaBits == 0)
+    else if (contextAttrs.redBits == 5 && contextAttrs.greenBits == 6 && contextAttrs.blueBits == 5 &&
+             contextAttrs.alphaBits == 0)
     {
         _pixelFormat = PixelFormat::RGB565;
     }
@@ -95,11 +97,11 @@ void RenderViewImpl::choosePixelFormats()
         AXASSERT(0, "Unsupported render buffer pixel format. Using default");
     }
 
-    if (_gfxContextAttrs.depthBits == 24 && _gfxContextAttrs.stencilBits == 8)
+    if (contextAttrs.depthBits == 24 && contextAttrs.stencilBits == 8)
     {
         _depthFormat = PixelFormat::D24S8;
     }
-    else if (_gfxContextAttrs.depthBits == 0 && _gfxContextAttrs.stencilBits == 0)
+    else if (contextAttrs.depthBits == 0 && contextAttrs.stencilBits == 0)
     {
         _depthFormat = PixelFormat::NONE;
     }
@@ -108,7 +110,7 @@ void RenderViewImpl::choosePixelFormats()
         AXASSERT(0, "Unsupported format for depth and stencil buffers. Using default");
     }
 
-    _multisamplingCount = _gfxContextAttrs.multisamplingCount;
+    _multisamplingCount = contextAttrs.multisamplingCount;
 }
 
 RenderViewImpl::RenderViewImpl() {}

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -29,6 +29,7 @@
 #include "axmol/platform/ios/EARenderView-ios.h"
 #include "axmol/platform/ios/DirectorCaller-ios.h"
 #include "axmol/platform/ios/RenderViewImpl-ios.h"
+#include "axmol/rhi/DriverBase.h"
 #include "axmol/base/Touch.h"
 #include "axmol/base/Director.h"
 

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -577,7 +577,6 @@ void RenderViewImpl::updateRenderScale()
     }
 #endif
     _renderScale = 1.0f;
-    _isHighDPI   = false;
 }
 
 void RenderViewImpl::setViewportInPoints(float x, float y, float w, float h)

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -137,6 +137,8 @@ RenderViewImpl::~RenderViewImpl()
 
 bool RenderViewImpl::initWithRect(std::string_view viewName, const Rect& rect, float /*frameZoomFactor*/)
 {
+    _renderScaleMode = getGfxContextAttrs().renderScaleMode;
+
     setViewName(viewName);
 
     m_width  = rect.size.width;
@@ -546,7 +548,8 @@ void RenderViewImpl::UpdateForWindowSizeChange(float width, float height)
         m_height = height;
         handleWindowResized();
 
-        onFramebufferResized(m_width * _renderScale, m_height * _renderScale);
+        _renderSize.set(m_width * _renderScale, m_height * _renderScale);
+        onRenderResized();
     }
 }
 
@@ -564,13 +567,13 @@ void RenderViewImpl::handleWindowResized()
 {
     RenderView::setWindowSize(m_width, m_height);
 
-    updateDesignResolutionSize();
+    updateDesignResolution();
 }
 
 void RenderViewImpl::updateRenderScale()
 {
 #if AX_RENDER_API == AX_RENDER_API_D3D
-    if (Director::getInstance()->getSurfaceScaleMode() == SurfaceScaleMode::Physical)
+    if (_renderScaleMode == RenderScaleMode::Physical)
     {
         _renderScale = m_dpi / 96.0f;
         return;

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -115,6 +115,7 @@ RenderViewImpl::RenderViewImpl()
     , m_windowVisible(true)
     , m_width(0)
     , m_height(0)
+    , m_dpi(0)
     , m_orientation(Windows::Graphics::Display::DisplayOrientations::Landscape)
     , m_appShouldExit(false)
     , _lastMouseButtonPressed(EventMouse::MouseButton::BUTTON_UNSET)
@@ -140,7 +141,7 @@ bool RenderViewImpl::initWithRect(std::string_view viewName, const Rect& rect, f
 
     m_width  = rect.size.width;
     m_height = rect.size.height;
-    UpdateWindowSize();
+    handleWindowResized();
 
     m_initialized = true;
 
@@ -532,7 +533,7 @@ void RenderViewImpl::UpdateOrientation(Windows::Graphics::Display::DisplayOrient
     if (m_orientation != orientation)
     {
         m_orientation = orientation;
-        UpdateWindowSize();
+        handleWindowResized();
     }
 }
 
@@ -543,17 +544,71 @@ void RenderViewImpl::UpdateForWindowSizeChange(float width, float height)
     {
         m_width  = width;
         m_height = height;
-        UpdateWindowSize();
+        handleWindowResized();
 
-        onFramebufferResized(static_cast<uint32_t>(width), static_cast<uint32_t>(height));
+        onFramebufferResized(m_width * _renderScale, m_height * _renderScale);
     }
 }
 
-void RenderViewImpl::UpdateWindowSize()
+void RenderViewImpl::SetDPI(float dpi)
+{
+    bool inital = m_dpi == 0;
+    if (m_dpi != dpi)
+    {
+        m_dpi = dpi;
+        updateRenderScale();
+    }
+}
+
+void RenderViewImpl::handleWindowResized()
 {
     RenderView::setWindowSize(m_width, m_height);
 
     updateDesignResolutionSize();
+}
+
+void RenderViewImpl::updateRenderScale()
+{
+#if AX_RENDER_API == AX_RENDER_API_D3D
+    if (Director::getInstance()->getSurfaceScaleMode() == SurfaceScaleMode::Physical)
+    {
+        _renderScale = m_dpi / 96.0f;
+        return;
+    }
+#endif
+    _renderScale = 1.0f;
+    _isHighDPI   = false;
+}
+
+void RenderViewImpl::setViewportInPoints(float x, float y, float w, float h)
+{
+    Viewport vp;
+    vp.x = (int)(x * _viewScale.x * _renderScale + _viewportRect.origin.x * _renderScale);
+    vp.y = (int)(y * _viewScale.y * _renderScale + _viewportRect.origin.y * _renderScale);
+    vp.w = (unsigned int)(w * _viewScale.x * _renderScale);
+    vp.h = (unsigned int)(h * _viewScale.y * _renderScale);
+    Camera::setDefaultViewport(vp);
+}
+
+void RenderViewImpl::setScissorInPoints(float x, float y, float w, float h)
+{
+    auto x1      = (int)(x * _viewScale.x * _renderScale + _viewportRect.origin.x * _renderScale);
+    auto y1      = (int)(y * _viewScale.y * _renderScale + _viewportRect.origin.y * _renderScale);
+    auto width1  = (unsigned int)(w * _viewScale.x * _renderScale);
+    auto height1 = (unsigned int)(h * _viewScale.y * _renderScale);
+
+    setScissorRect(x1, y1, width1, height1);
+}
+
+ax::Rect RenderViewImpl::getScissorInPoints() const
+{
+    auto& rect = getScissorRect();
+
+    float x = (rect.x - _viewportRect.origin.x * _renderScale) / (_viewScale.x * _renderScale);
+    float y = (rect.y - _viewportRect.origin.y * _renderScale) / (_viewScale.y * _renderScale);
+    float w = rect.width / (_viewScale.x * _renderScale);
+    float h = rect.height / (_viewScale.y * _renderScale);
+    return ax::Rect(x, y, w, h);
 }
 
 ax::Vec2 RenderViewImpl::TransformToOrientation(Windows::Foundation::Point const& p)

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -552,7 +552,7 @@ void RenderViewImpl::UpdateForWindowSizeChange(float width, float height)
 
 void RenderViewImpl::SetDPI(float dpi)
 {
-    bool inital = m_dpi == 0;
+    // bool inital = m_dpi == 0;
     if (m_dpi != dpi)
     {
         m_dpi = dpi;

--- a/axmol/platform/winrt/RenderViewImpl-winrt.h
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.h
@@ -179,6 +179,7 @@ private:
     Windows::Foundation::Point m_lastPoint{};
 
     float _renderScale{1.0f};
+    RenderScaleMode _renderScaleMode{};
 
     float m_width;
     float m_height;

--- a/axmol/platform/winrt/RenderViewImpl-winrt.h
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.h
@@ -130,7 +130,7 @@ public:
     void UpdateOrientation(Windows::Graphics::Display::DisplayOrientations orientation);
     void UpdateForWindowSizeChange(float width, float height);
 
-    void SetDPI(float dpi) { m_dpi = dpi; }
+    void SetDPI(float dpi);
     float GetDPI() { return m_dpi; }
     // static function
     /**
@@ -147,6 +147,12 @@ public:
     void* getNativeWindow() const override;
     WindowPlatform getWindowPlatform() const override { return WindowPlatform::CoreWindow; }
 
+    void setViewportInPoints(float x, float y, float w, float h) override;
+    void setScissorInPoints(float x, float y, float w, float h) override;
+    Rect getScissorInPoints() const override;
+
+    float getRenderScale() const override { return _renderScale; }
+
 protected:
     RenderViewImpl();
     ~RenderViewImpl() override;
@@ -161,20 +167,24 @@ private:
     AX_DISALLOW_COPY_AND_ASSIGN(RenderViewImpl);
 
     void OnRendering();
-    void UpdateWindowSize();
+
+    void handleWindowResized();
+    void updateRenderScale();
 
     ax::Vec2 TransformToOrientation(Windows::Foundation::Point const& point);
     ax::Vec2 GetPoint(Windows::UI::Core::PointerEventArgs const& args);
 
-    Windows::Foundation::Rect m_windowBounds;
+    Windows::Foundation::Rect m_windowBounds{};
     winrt::event_token m_eventToken;
-    Windows::Foundation::Point m_lastPoint;
+    Windows::Foundation::Point m_lastPoint{};
+
+    float _renderScale{1.0f};
 
     float m_width;
     float m_height;
     float m_dpi;
     Windows::Graphics::Display::DisplayOrientations m_orientation;
-    Windows::Foundation::Rect m_keyboardRect;
+    Windows::Foundation::Rect m_keyboardRect{};
 
     bool m_lastPointValid;
     bool m_windowClosed;

--- a/axmol/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/axmol/platform/winrt/xaml/AxmolRenderer.cpp
@@ -55,10 +55,13 @@ AxmolRenderer::~AxmolRenderer() {}
 void AxmolRenderer::Resume()
 {
     auto director = ax::Director::getInstance();
+    auto appInstance = Application::getInstance();
 
     auto renderView = static_cast<RenderViewImpl*>(director->getRenderView());
     if (!renderView)
     {
+        appInstance->initGfxContextAttrs();
+
         renderView = RenderViewImpl::createWithRect(
             "axmol3", ax::Rect{0, 0, static_cast<float>(m_width), static_cast<float>(m_height)});
         renderView->setPanel(m_panel);
@@ -66,10 +69,10 @@ void AxmolRenderer::Resume()
         renderView->SetDPI(m_dpi);
         renderView->setDispatcher(m_dispatcher);
         director->setRenderView(renderView);
-        Application::getInstance()->run();
+        appInstance->run();
     }
 
-    Application::getInstance()->applicationWillEnterForeground();
+    appInstance->applicationWillEnterForeground();
     ax::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
     ax::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent, true);
 }

--- a/axmol/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/axmol/platform/winrt/xaml/AxmolRenderer.cpp
@@ -54,7 +54,7 @@ AxmolRenderer::~AxmolRenderer() {}
 
 void AxmolRenderer::Resume()
 {
-    auto director = ax::Director::getInstance();
+    auto director    = ax::Director::getInstance();
     auto appInstance = Application::getInstance();
 
     auto renderView = static_cast<RenderViewImpl*>(director->getRenderView());

--- a/axmol/platform/winrt/xaml/SwapChainPage.cpp
+++ b/axmol/platform/winrt/xaml/SwapChainPage.cpp
@@ -146,12 +146,19 @@ void SwapChainPage::OnPageLoaded(Windows::Foundation::IInspectable const& /*send
 void SwapChainPage::OnPanelSizeChanged(Windows::Foundation::IInspectable const& /*sender*/,
                                        Windows::UI::Xaml::RoutedEventArgs const& /*e*/)
 {
-    UpdateCanvasSize();
+    if (!m_updateScheduled)
+    {
+        m_updateScheduled = true;
+        swapChainPanel().Dispatcher().RunAsync(CoreDispatcherPriority::Low, [this]() {
+            m_updateScheduled = false;
+            UpdatePanelSize();
+        });
+    }
 }
 
 void SwapChainPage::CreateRenderSurface()
 {
-    UpdateCanvasSize();
+    UpdatePanelSize();
 #if AX_RENDER_API == AX_RENDER_API_GL
     if (m_eglSurfaceProvider && m_eglSurface == EGL_NO_SURFACE)
     {
@@ -175,11 +182,11 @@ void SwapChainPage::CreateRenderSurface()
 #endif
 }
 
-void SwapChainPage::UpdateCanvasSize()
+void SwapChainPage::UpdatePanelSize()
 {
     auto panel     = swapChainPanel();
-    m_canvasWidth  = panel.ActualWidth();
-    m_canvasHeight = panel.ActualHeight();
+    m_panelWidth  = panel.ActualWidth();
+    m_panelHeight = panel.ActualHeight();
 }
 
 void SwapChainPage::DestroyRenderSurface()
@@ -248,20 +255,10 @@ void SwapChainPage::StartRenderLoop()
 
     // Create a task for rendering that will be run on a background thread.
     auto renderMainLoop = ([this, dispatcher](Windows::Foundation::IAsyncAction const& action) {
-#if AX_RENDER_API == AX_RENDER_API_GL
-        m_eglSurfaceProvider->MakeCurrent(m_eglSurface);
-
-        GLsizei panelWidth  = 0;
-        GLsizei panelHeight = 0;
-        m_eglSurfaceProvider->GetSurfaceDimensions(m_eglSurface, &panelWidth, &panelHeight);
-#else
-        size_t panelWidth  = static_cast<size_t>(m_canvasWidth);
-        size_t panelHeight = static_cast<size_t>(m_canvasHeight);
-#endif
 
         if (!m_renderer)
         {
-            m_renderer = std::make_shared<AxmolRenderer>(m_canvasWidth, m_canvasHeight, m_dpi, m_orientation,
+            m_renderer = std::make_shared<AxmolRenderer>(m_panelWidth, m_panelHeight, m_dpi, m_orientation,
                                                          dispatcher, swapChainPanel());
         }
 
@@ -307,13 +304,8 @@ void SwapChainPage::StartRenderLoop()
 
             ProcessOperations();
 
-#if AX_RENDER_API == AX_RENDER_API_GL
-            m_eglSurfaceProvider->GetSurfaceDimensions(m_eglSurface, &panelWidth, &panelHeight);
-#else
-            panelWidth  = static_cast<size_t>(m_canvasWidth);
-            panelHeight = static_cast<size_t>(m_canvasHeight);
-#endif
-            m_renderer->Draw(panelWidth, panelHeight, m_dpi, m_orientation);
+            m_renderer->Draw(static_cast<size_t>(m_panelWidth), static_cast<size_t>(m_panelHeight), m_dpi,
+                             m_orientation);
 
             // Recreate input dispatch
             if (RenderViewImpl::sharedRenderView() &&

--- a/axmol/platform/winrt/xaml/SwapChainPage.cpp
+++ b/axmol/platform/winrt/xaml/SwapChainPage.cpp
@@ -184,7 +184,7 @@ void SwapChainPage::CreateRenderSurface()
 
 void SwapChainPage::UpdatePanelSize()
 {
-    auto panel     = swapChainPanel();
+    auto panel    = swapChainPanel();
     m_panelWidth  = panel.ActualWidth();
     m_panelHeight = panel.ActualHeight();
 }
@@ -255,11 +255,10 @@ void SwapChainPage::StartRenderLoop()
 
     // Create a task for rendering that will be run on a background thread.
     auto renderMainLoop = ([this, dispatcher](Windows::Foundation::IAsyncAction const& action) {
-
         if (!m_renderer)
         {
-            m_renderer = std::make_shared<AxmolRenderer>(m_panelWidth, m_panelHeight, m_dpi, m_orientation,
-                                                         dispatcher, swapChainPanel());
+            m_renderer = std::make_shared<AxmolRenderer>(m_panelWidth, m_panelHeight, m_dpi, m_orientation, dispatcher,
+                                                         swapChainPanel());
         }
 
         // !!!Start the engine renderer on the render thread so that WICImageDecoder

--- a/axmol/platform/winrt/xaml/SwapChainPage.h
+++ b/axmol/platform/winrt/xaml/SwapChainPage.h
@@ -114,14 +114,15 @@ public:
 
 private:
     // must call at UI thread
-    void UpdateCanvasSize();
+    void UpdatePanelSize();
 
     std::condition_variable m_sleepCondition;
 
     Concurrency::concurrent_queue<std::function<void()>> m_operations;
 
-    double m_canvasWidth{0};
-    double m_canvasHeight{0};
+    double m_panelWidth{0};
+    double m_panelHeight{0};
+    bool m_updateScheduled{false};
 };
 }  // namespace winrt::AxmolAppWinRT::implementation
 

--- a/axmol/rhi/DriverBase.cpp
+++ b/axmol/rhi/DriverBase.cpp
@@ -34,6 +34,16 @@ DriverBase* DriverBase::_instance = nullptr;
 
 ContextAttrs DriverBase::_contextAttrs = ContextAttrs{};
 
+void DriverBase::setContextAttrs(const ContextAttrs& attrs)
+{
+    _contextAttrs = attrs;
+}
+
+ContextAttrs& DriverBase::getContextAttrs()
+{
+    return _contextAttrs;
+}
+
 VertexLayout* DriverBase::createVertexLayout(VertexLayoutDesc&& desc)
 {
     return new VertexLayout(std::forward<VertexLayoutDesc>(desc));

--- a/axmol/rhi/DriverBase.cpp
+++ b/axmol/rhi/DriverBase.cpp
@@ -32,6 +32,8 @@ namespace ax::rhi
 
 DriverBase* DriverBase::_instance = nullptr;
 
+ContextAttrs DriverBase::_contextAttrs = ContextAttrs{};
+
 VertexLayout* DriverBase::createVertexLayout(VertexLayoutDesc&& desc)
 {
     return new VertexLayout(std::forward<VertexLayoutDesc>(desc));

--- a/axmol/rhi/DriverBase.h
+++ b/axmol/rhi/DriverBase.h
@@ -81,6 +81,9 @@ public:
     friend class ShaderCache;
     friend class SamplerCache;
 
+    static void setContextAttrs(const ContextAttrs& attrs);
+    static ContextAttrs& getContextAttrs();
+
     /**
      * Returns a shared instance of the DriverBase.
      */
@@ -231,6 +234,10 @@ protected:
     int _maxTextureSize    = 0;  ///< Maximum texture size.
     int _maxTextureUnits   = 0;  ///< Maximum texture unit.
     int _maxSamplesAllowed = 0;  ///< Maximum sampler count.
+
+    
+    /** The grapihcs(GPU adapter, window, render) context attrs. */
+    static ContextAttrs _contextAttrs;
 
 private:
     static DriverBase* _instance;

--- a/axmol/rhi/DriverBase.h
+++ b/axmol/rhi/DriverBase.h
@@ -235,7 +235,6 @@ protected:
     int _maxTextureUnits   = 0;  ///< Maximum texture unit.
     int _maxSamplesAllowed = 0;  ///< Maximum sampler count.
 
-    
     /** The grapihcs(GPU adapter, window, render) context attrs. */
     static ContextAttrs _contextAttrs;
 

--- a/axmol/rhi/RHITypes.h
+++ b/axmol/rhi/RHITypes.h
@@ -562,6 +562,13 @@ enum class PowerPreference
     HighPerformance  // Prefer discrete GPU
 };
 
+enum class RenderScaleMode
+{
+    Default,  // Use the system's default scaling behavior
+    Logical,  // Use logical pixels (do not apply DPI scaling)
+    Physical  // Use logical pixels multiplied by the DPI scale factor
+};
+
 template <typename T, unsigned int N>
 inline void SafeRelease(T (&resourceBlock)[N])
 {

--- a/axmol/rhi/RHITypes.h
+++ b/axmol/rhi/RHITypes.h
@@ -569,6 +569,27 @@ enum class RenderScaleMode
     Physical  // Use logical pixels multiplied by the DPI scale factor
 };
 
+/** @struct ContextAttrs
+ *
+ * The context attributes.
+ */
+struct ContextAttrs
+{
+    int redBits{8};
+    int greenBits{8};
+    int blueBits{8};
+    int alphaBits{8};
+    int depthBits{24};
+    int stencilBits{8};
+    int multisamplingCount{0};
+    bool visible{true};
+    bool decorated{true};
+    bool vsync{true};
+    void* windowParent{nullptr};  // win32-spec
+    PowerPreference powerPreference{PowerPreference::Auto};
+    RenderScaleMode renderScaleMode{RenderScaleMode::Default};
+};
+
 template <typename T, unsigned int N>
 inline void SafeRelease(T (&resourceBlock)[N])
 {

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -196,6 +196,8 @@ CommandBufferImpl::CommandBufferImpl(DriverImpl* driver, void* surfaceContext)
 {
     _driverImpl = driver;
 
+    _renderScaleMode = driver->getContextAttrs().renderScaleMode;
+
     auto context         = driver->getContext();
     ID3D11Device* device = driver->getDevice();
 
@@ -311,12 +313,10 @@ CommandBufferImpl::CommandBufferImpl(DriverImpl* driver, void* surfaceContext)
             });
             AX_BREAK_IF(FAILED(hr));
 
-            auto scaleMode = Director::getInstance()->getSurfaceScaleMode();
-
             // create swapchain
             // The swapchain size can't be zero for WinRT, maybe SwapChainPanel::ActualWidth/Height * DPI
             DXGI_SWAP_CHAIN_DESC1 desc1 = {};
-            if (scaleMode == SurfaceScaleMode::Physical)
+            if (_renderScaleMode == RenderScaleMode::Physical)
             {
                 desc1.Width  = static_cast<UINT>(panelSize.Width * renderScale.x);
                 desc1.Height = static_cast<UINT>(panelSize.Height * renderScale.y);
@@ -348,7 +348,7 @@ CommandBufferImpl::CommandBufferImpl(DriverImpl* driver, void* surfaceContext)
             DXGI_SWAP_CHAIN_DESC1 actualDesc = {};
             swapChain1->GetDesc1(&actualDesc);
 
-            if (scaleMode == SurfaceScaleMode::Physical)
+            if (_renderScaleMode == RenderScaleMode::Physical)
             {
                 // Setup a scale matrix for the swap chain
                 DXGI_MATRIX_3X2_F scaleMatrix = {};

--- a/axmol/rhi/d3d/CommandBufferD3D.cpp
+++ b/axmol/rhi/d3d/CommandBufferD3D.cpp
@@ -30,6 +30,7 @@
 #include "axmol/rhi/d3d/ProgramD3D.h"
 #include "axmol/rhi/d3d/VertexLayoutD3D.h"
 #include <dxgi1_2.h>
+#include <dxgi1_3.h>
 #include <VersionHelpers.h>
 #include "axmol/base/Logging.h"
 
@@ -310,18 +311,28 @@ CommandBufferImpl::CommandBufferImpl(DriverImpl* driver, void* surfaceContext)
             });
             AX_BREAK_IF(FAILED(hr));
 
+            auto scaleMode = Director::getInstance()->getSurfaceScaleMode();
+
             // create swapchain
             // The swapchain size can't be zero for WinRT, maybe SwapChainPanel::ActualWidth/Height * DPI
             DXGI_SWAP_CHAIN_DESC1 desc1 = {};
-            desc1.Width                 = static_cast<UINT>(panelSize.Width);
-            desc1.Height                = static_cast<UINT>(panelSize.Height);
-            desc1.Format                = _AX_SWAPCHAIN_FORMAT;
-            desc1.SampleDesc.Count      = 1;  // Flip not support MSAA
-            desc1.BufferUsage           = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-            desc1.BufferCount           = 2;
-            desc1.SwapEffect            = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;  // UWP recommanded
-            desc1.Scaling               = DXGI_SCALING_STRETCH;
-            desc1.AlphaMode             = DXGI_ALPHA_MODE_IGNORE;
+            if (scaleMode == SurfaceScaleMode::Physical)
+            {
+                desc1.Width  = static_cast<UINT>(panelSize.Width * renderScale.x);
+                desc1.Height = static_cast<UINT>(panelSize.Height * renderScale.y);
+            }
+            else
+            {
+                desc1.Width  = static_cast<UINT>(panelSize.Width);
+                desc1.Height = static_cast<UINT>(panelSize.Height);
+            }
+            desc1.Format           = _AX_SWAPCHAIN_FORMAT;
+            desc1.SampleDesc.Count = 1;  // Flip not support MSAA
+            desc1.BufferUsage      = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            desc1.BufferCount      = 2;
+            desc1.SwapEffect       = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;  // UWP recommanded
+            desc1.Scaling          = DXGI_SCALING_STRETCH;
+            desc1.AlphaMode        = DXGI_ALPHA_MODE_IGNORE;
 
             ComPtr<IDXGISwapChain1> swapChain1;
             hr = factory2->CreateSwapChainForComposition(device, &desc1, nullptr, &swapChain1);
@@ -336,6 +347,21 @@ CommandBufferImpl::CommandBufferImpl(DriverImpl* driver, void* surfaceContext)
 
             DXGI_SWAP_CHAIN_DESC1 actualDesc = {};
             swapChain1->GetDesc1(&actualDesc);
+
+            if (scaleMode == SurfaceScaleMode::Physical)
+            {
+                // Setup a scale matrix for the swap chain
+                DXGI_MATRIX_3X2_F scaleMatrix = {};
+                scaleMatrix._11               = 1 / renderScale.x;
+                scaleMatrix._22               = 1 / renderScale.y;
+
+                ComPtr<IDXGISwapChain2> swapChain2;
+                hr = swapChain1.As(&swapChain2);
+                AX_BREAK_IF(FAILED(hr));
+
+                hr = swapChain2->SetMatrixTransform(&scaleMatrix);
+                AX_BREAK_IF(FAILED(hr));
+            }
 
             _screenWidth  = actualDesc.Width;
             _screenHeight = actualDesc.Height;

--- a/axmol/rhi/d3d/CommandBufferD3D.h
+++ b/axmol/rhi/d3d/CommandBufferD3D.h
@@ -240,6 +240,8 @@ protected:
 
     axstd::pod_vector<ID3D11ShaderResourceView*> _nullSRVs;
     UINT _textureBounds{0};
+
+    RenderScaleMode _renderScaleMode{};
 };
 
 /** @} */

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -106,16 +106,6 @@ std::string_view GetVendorString(uint32_t vendorId)
     }
 }
 
-void DriverBase::setContextAttrs(const ContextAttrs& attrs)
-{
-    _contextAttrs = attrs;
-}
-
-ContextAttrs& DriverBase::getContextAttrs()
-{
-    return _contextAttrs;
-}
-
 DriverBase* DriverBase::getInstance()
 {
     if (!_instance)

--- a/axmol/rhi/d3d/DriverD3D.cpp
+++ b/axmol/rhi/d3d/DriverD3D.cpp
@@ -106,6 +106,16 @@ std::string_view GetVendorString(uint32_t vendorId)
     }
 }
 
+void DriverBase::setContextAttrs(const ContextAttrs& attrs)
+{
+    _contextAttrs = attrs;
+}
+
+ContextAttrs& DriverBase::getContextAttrs()
+{
+    return _contextAttrs;
+}
+
 DriverBase* DriverBase::getInstance()
 {
     if (!_instance)
@@ -262,7 +272,7 @@ L_ReleaseRuntime:
 
 void DriverImpl::initializeAdapter()
 {
-    const auto powerPreferrence = Director::getInstance()->getPowerPreference();
+    const auto powerPreferrence = _contextAttrs.powerPreference;
 
     if (powerPreferrence == PowerPreference::Auto)
         return;

--- a/axmol/vr/VRGenericRenderer.cpp
+++ b/axmol/vr/VRGenericRenderer.cpp
@@ -117,13 +117,14 @@ const ScissorRect& VRGenericRenderer::getScissorRect() const
 
 void VRGenericRenderer::init(RenderView* rv)
 {
-    const auto windowSize = rv->getWindowSize();
-    _renderTexture        = RenderTexture::create(windowSize.width, windowSize.height);
+    // Use scaled window size as screenSize, maybe use rv->getRenderSize() for HiDPI rendering
+    const auto screenSize = rv->getWindowSize();
+    _renderTexture        = RenderTexture::create(screenSize.width, screenSize.height);
     _renderTexture->retain();
 
     // DO NOT offset eye viewports by default viewport.
     // Eye viewports in RT must be exact halves to match distortion mesh sampling.
-    fillEyeViewports(rv, windowSize);
+    fillEyeViewports(rv, screenSize);
 
     // Scissor transform: scale only, no translation in VR path.
     auto& screenVP = Camera::getDefaultViewport();
@@ -132,8 +133,8 @@ void VRGenericRenderer::init(RenderView* rv)
     _xfRight       = makeEyeScissorTransform(_rightEye.viewport, screenVP, rtSize);
 
     _distortion          = new Distortion();
-    _leftDistortionMesh  = createDistortionMesh(VREye::EyeType::LEFT, windowSize);
-    _rightDistortionMesh = createDistortionMesh(VREye::EyeType::RIGHT, windowSize);
+    _leftDistortionMesh  = createDistortionMesh(VREye::EyeType::LEFT, screenSize);
+    _rightDistortionMesh = createDistortionMesh(VREye::EyeType::RIGHT, screenSize);
 
     _leftEyeCmd.init(0);
     _leftEyeCmd.setVertexBuffer(_leftDistortionMesh->_vbo);

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -23975,53 +23975,6 @@ int lua_ax_base_RenderView_getContentScaleFactor(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_RenderView_isHighDPI(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::RenderView* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.RenderView",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::RenderView*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_RenderView_isHighDPI'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_RenderView_isHighDPI'", nullptr);
-            return 0;
-        }
-        auto&& ret = cobj->isHighDPI();
-        tolua_pushboolean(tolua_S,(bool)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.RenderView:isHighDPI",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_RenderView_isHighDPI'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_base_RenderView_getVisibleSize(lua_State* tolua_S)
 {
     int argc = 0;
@@ -24240,7 +24193,7 @@ int lua_ax_base_RenderView_setDesignResolutionSize(lua_State* tolua_S)
     {
         double arg0;
         double arg1;
-        ResolutionPolicy arg2;
+        ax::ResolutionPolicy arg2;
 
         ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.RenderView:setDesignResolutionSize");
 
@@ -25173,8 +25126,8 @@ int lua_ax_base_RenderView_setGfxContextAttrs(lua_State* tolua_S)
 
     if (argc == 1)
     {
-        GfxContextAttrs arg0;
-        #pragma warning NO CONVERSION TO NATIVE FOR GfxContextAttrs
+        ax::rhi::ContextAttrs arg0;
+        #pragma warning NO CONVERSION TO NATIVE FOR ContextAttrs
         ok = false;
         if(!ok)
         {
@@ -25216,7 +25169,7 @@ int lua_ax_base_RenderView_getGfxContextAttrs(lua_State* tolua_S)
             return 0;
         }
         auto&& ret = ax::RenderView::getGfxContextAttrs();
-        #pragma warning NO CONVERSION FROM NATIVE FOR GfxContextAttrs;
+        #pragma warning NO CONVERSION FROM NATIVE FOR ContextAttrs;
         return 1;
     }
     luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.RenderView:getGfxContextAttrs",argc, 0);
@@ -25254,7 +25207,6 @@ int lua_register_ax_base_RenderView(lua_State* tolua_S)
         tolua_function(tolua_S,"getRenderScale",lua_ax_base_RenderView_getRenderScale);
         tolua_function(tolua_S,"setContentScaleFactor",lua_ax_base_RenderView_setContentScaleFactor);
         tolua_function(tolua_S,"getContentScaleFactor",lua_ax_base_RenderView_getContentScaleFactor);
-        tolua_function(tolua_S,"isHighDPI",lua_ax_base_RenderView_isHighDPI);
         tolua_function(tolua_S,"getVisibleSize",lua_ax_base_RenderView_getVisibleSize);
         tolua_function(tolua_S,"getVisibleOrigin",lua_ax_base_RenderView_getVisibleOrigin);
         tolua_function(tolua_S,"getVisibleRect",lua_ax_base_RenderView_getVisibleRect);
@@ -25823,103 +25775,6 @@ int lua_ax_base_Director_setRenderView(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_setRenderView'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Director_setPowerPreference(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Director* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Director",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Director*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Director_setPowerPreference'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        ax::rhi::PowerPreference arg0;
-
-        ok &= luaval_to_int(tolua_S, 2, &arg0, "ax.Director:setPowerPreference");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Director_setPowerPreference'", nullptr);
-            return 0;
-        }
-        cobj->setPowerPreference(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Director:setPowerPreference",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_setPowerPreference'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_base_Director_getPowerPreference(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Director* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Director",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::Director*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj)
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_base_Director_getPowerPreference'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Director_getPowerPreference'", nullptr);
-            return 0;
-        }
-        int ret = (int)cobj->getPowerPreference();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Director:getPowerPreference",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Director_getPowerPreference'.",&tolua_err);
 #endif
 
     return 0;
@@ -28958,8 +28813,6 @@ int lua_register_ax_base_Director(lua_State* tolua_S)
         tolua_function(tolua_S,"setStatsAnchor",lua_ax_base_Director_setStatsAnchor);
         tolua_function(tolua_S,"getRenderView",lua_ax_base_Director_getRenderView);
         tolua_function(tolua_S,"setRenderView",lua_ax_base_Director_setRenderView);
-        tolua_function(tolua_S,"setPowerPreference",lua_ax_base_Director_setPowerPreference);
-        tolua_function(tolua_S,"getPowerPreference",lua_ax_base_Director_getPowerPreference);
         tolua_function(tolua_S,"setDebugLayerEnabled",lua_ax_base_Director_setDebugLayerEnabled);
         tolua_function(tolua_S,"isDebugLayerEnabled",lua_ax_base_Director_isDebugLayerEnabled);
         tolua_function(tolua_S,"getTextureCache",lua_ax_base_Director_getTextureCache);

--- a/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_rhi_auto.cpp
@@ -3143,6 +3143,77 @@ int lua_ax_rhi_DriverBase_getMaxSamplesAllowed(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_rhi_DriverBase_setContextAttrs(lua_State* tolua_S)
+{
+    int argc = 0;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertable(tolua_S,1,"axrhi.DriverBase",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    argc = lua_gettop(tolua_S) - 1;
+
+    if (argc == 1)
+    {
+        ax::rhi::ContextAttrs arg0;
+        #pragma warning NO CONVERSION TO NATIVE FOR ContextAttrs
+        ok = false;
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_DriverBase_setContextAttrs'", nullptr);
+            return 0;
+        }
+        ax::rhi::DriverBase::setContextAttrs(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "axrhi.DriverBase:setContextAttrs",argc, 1);
+    return 0;
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_DriverBase_setContextAttrs'.",&tolua_err);
+#endif
+    return 0;
+}
+int lua_ax_rhi_DriverBase_getContextAttrs(lua_State* tolua_S)
+{
+    int argc = 0;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertable(tolua_S,1,"axrhi.DriverBase",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    argc = lua_gettop(tolua_S) - 1;
+
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_rhi_DriverBase_getContextAttrs'", nullptr);
+            return 0;
+        }
+        auto&& ret = ax::rhi::DriverBase::getContextAttrs();
+        #pragma warning NO CONVERSION FROM NATIVE FOR ContextAttrs;
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "axrhi.DriverBase:getContextAttrs",argc, 0);
+    return 0;
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_rhi_DriverBase_getContextAttrs'.",&tolua_err);
+#endif
+    return 0;
+}
 int lua_ax_rhi_DriverBase_getInstance(lua_State* tolua_S)
 {
     int argc = 0;
@@ -3238,6 +3309,8 @@ int lua_register_ax_rhi_DriverBase(lua_State* tolua_S)
         tolua_function(tolua_S,"getMaxAttributes",lua_ax_rhi_DriverBase_getMaxAttributes);
         tolua_function(tolua_S,"getMaxTextureUnits",lua_ax_rhi_DriverBase_getMaxTextureUnits);
         tolua_function(tolua_S,"getMaxSamplesAllowed",lua_ax_rhi_DriverBase_getMaxSamplesAllowed);
+        tolua_function(tolua_S,"setContextAttrs", lua_ax_rhi_DriverBase_setContextAttrs);
+        tolua_function(tolua_S,"getContextAttrs", lua_ax_rhi_DriverBase_getContextAttrs);
         tolua_function(tolua_S,"getInstance", lua_ax_rhi_DriverBase_getInstance);
         tolua_function(tolua_S,"destroyInstance", lua_ax_rhi_DriverBase_destroyInstance);
     tolua_endmodule(tolua_S);

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -53,8 +53,10 @@ AppDelegate::~AppDelegate()
 void AppDelegate::initGfxContextAttrs()
 {
     // set graphics context attributes: red,green,blue,alpha,depth,stencil
-    GfxContextAttrs gfxContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GfxContextAttrs gfxContextAttrs = {.powerPreference = PowerPreference::HighPerformance};
 
+    // uncomment if your app need adapt high DPI scale monitors
+    // gfxContextAttrs.renderScaleMode = RenderScaleMode::Physical;
     RenderView::setGfxContextAttrs(gfxContextAttrs);
 }
 
@@ -73,7 +75,6 @@ bool AppDelegate::applicationDidFinishLaunching()
 
     // initialize director
     auto director = Director::getInstance();
-    director->setPowerPreference(PowerPreference::HighPerformance);
     auto renderView = director->getRenderView();
     if (!renderView)
     {

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -74,7 +74,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     Configuration::getInstance()->loadConfigFile("configs/config-example.plist");
 
     // initialize director
-    auto director = Director::getInstance();
+    auto director   = Director::getInstance();
     auto renderView = director->getRenderView();
     if (!renderView)
     {


### PR DESCRIPTION
## Describe your changes

- Added **High DPI awareness** support for RenderView on **Win32**, **UWP**, and **Linux** platforms.  
- Introduced a new `renderScaleMode` field in `GfxContextAttrs` to control DPI scaling behavior.  
- Moved the `powerPreference` setting into `GfxContextAttrs` for unified context configuration.  

## Note
- The current implementation assumes the DPI scale maintains the original aspect ratio.
- win32 and x11 window pixels and screen coordinates always map 1:1
- On Linux X11 platforms, GLFW does not support fractional DPI scaling (e.g., 1.5x).

## The behavior `RenderScaleMode::Default` on PC platforms

- x11, win32: windowsize/framebuffersize as-is
- macOS: retina display: framebuffersize > windowsize
- wayland: high DPI scale: framebuffersize > windowsize

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
