### PR TITLE
Add support for playing audio at any position in 3D space

### DIFF
--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -43,6 +43,8 @@
 namespace ax
 {
 
+float AudioPlayerSettings::distanceScale = 1.f;
+
 const int AudioEngine::INVALID_AUDIO_ID = -1;
 const float AudioEngine::TIME_UNKNOWN   = -1.0f;
 
@@ -255,7 +257,8 @@ AUDIO_ID AudioEngine::play3d(std::string_view filePath,
             volume = 1.0f;
         }
 
-        ret = _audioEngineImpl->play3d(filePath, settings.position, settings.loop, volume, settings.time);
+        ret = _audioEngineImpl->play3d(filePath, settings.position, settings.distanceScale, settings.loop, volume,
+                                       settings.time);
         if (ret != INVALID_AUDIO_ID)
         {
             _audioPathIDMap[filePath.data()].emplace_back(ret);
@@ -704,5 +707,18 @@ ax::Vec3 AudioEngine::getListenerPosition()
     }
 
     return _audioEngineImpl->getListenerPosition();
+}
+
+void AudioEngine::setDistanceScale(float scale)
+{
+    if (scale <= 0.f)
+        return;
+
+    AudioPlayerSettings::distanceScale = scale;
+}
+
+float AudioEngine::getDistanceScale()
+{
+    return AudioPlayerSettings::distanceScale;
 }
 }

--- a/core/audio/AudioEngine.cpp
+++ b/core/audio/AudioEngine.cpp
@@ -184,6 +184,100 @@ AUDIO_ID AudioEngine::play2d(std::string_view filePath, const AudioPlayerSetting
     return ret;
 }
 
+int AudioEngine::play3d(std::string_view filePath, const Vec3& position, bool loop, float volume, const AudioProfile* profile)
+{
+    return play3d(filePath, ax::AudioPlayerSettings{loop, volume, 0.0f, position});
+}
+
+AUDIO_ID AudioEngine::play3d(std::string_view filePath,
+                             const AudioPlayerSettings& settings,
+                             const AudioProfile* profile)
+{
+    AUDIO_ID ret = AudioEngine::INVALID_AUDIO_ID;
+
+    do
+    {
+        if (!isEnabled())
+        {
+            break;
+        }
+
+        if (!lazyInit())
+        {
+            break;
+        }
+
+        if (!FileUtils::getInstance()->isFileExist(filePath))
+        {
+            break;
+        }
+
+        auto profileHelper = _defaultProfileHelper;
+        if (profile && profile != &profileHelper->profile)
+        {
+            AX_ASSERT(!profile->name.empty());
+            profileHelper          = &_audioPathProfileHelperMap[profile->name];
+            profileHelper->profile = *profile;
+        }
+
+        if (_audioIDInfoMap.size() >= _maxInstances)
+        {
+            AXLOGE("Fail to play {} cause by limited max instance of AudioEngine", filePath);
+            break;
+        }
+        if (profileHelper)
+        {
+            if (profileHelper->profile.maxInstances != 0 &&
+                profileHelper->audioIDs.size() >= profileHelper->profile.maxInstances)
+            {
+                AXLOGE("Fail to play {} cause by limited max instance of AudioProfile", filePath);
+                break;
+            }
+            if (profileHelper->profile.minDelay > TIME_DELAY_PRECISION)
+            {
+                auto currTime = utils::gettime();
+                if (profileHelper->lastPlayTime > TIME_DELAY_PRECISION &&
+                    currTime - profileHelper->lastPlayTime <= profileHelper->profile.minDelay)
+                {
+                    AXLOGE("Fail to play {} cause by limited minimum delay", filePath);
+                    break;
+                }
+            }
+        }
+
+        float volume = settings.volume;
+        if (volume < 0.0f)
+        {
+            volume = 0.0f;
+        }
+        else if (volume > 1.0f)
+        {
+            volume = 1.0f;
+        }
+
+        ret = _audioEngineImpl->play3d(filePath, settings.position, settings.loop, volume, settings.time);
+        if (ret != INVALID_AUDIO_ID)
+        {
+            _audioPathIDMap[filePath.data()].emplace_back(ret);
+            auto it = _audioPathIDMap.find(filePath);
+
+            auto& audioRef    = _audioIDInfoMap[ret];
+            audioRef.volume   = volume;
+            audioRef.loop     = settings.loop;
+            audioRef.filePath = it->first;
+
+            if (profileHelper)
+            {
+                profileHelper->lastPlayTime = utils::gettime();
+                profileHelper->audioIDs.emplace_back(ret);
+            }
+            audioRef.profileHelper = profileHelper;
+        }
+    } while (0);
+
+    return ret;
+}
+
 void AudioEngine::setLoop(AUDIO_ID audioID, bool loop)
 {
     auto it = _audioIDInfoMap.find(audioID);
@@ -590,5 +684,25 @@ void AudioEngine::setSourcePosition(int audioId, const ax::Vec3& position)
     }
 
     _audioEngineImpl->setSourcePosition(audioId, position);
+}
+
+void AudioEngine::setListenerPosition(const ax::Vec3& position)
+{
+    if (!_audioEngineImpl)
+    {
+        return;
+    }
+
+    _audioEngineImpl->setListenerPosition(position);
+}
+
+ax::Vec3 AudioEngine::getListenerPosition()
+{
+    if (!_audioEngineImpl)
+    {
+        return {};
+    }
+
+    return _audioEngineImpl->getListenerPosition();
 }
 }

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -57,6 +57,7 @@ struct AX_DLL AudioPlayerSettings
     bool loop = false; // Whether audio instance loop or not.
     float volume = 1.0f; // Volume value (range from 0.0 to 1.0).
     float time = 0.0f; // The initial time offset when play audio
+    Vec3 position{}; // position of audio in 3d space relative to listener
 };
 
 /**
@@ -142,7 +143,7 @@ public:
                            float volume                = 1.0f,
                            const AudioProfile* profile = nullptr);
 
-     /**
+    /**
      * Play 2d sound.
      *
      * @param filePath The path of an audio file.
@@ -155,6 +156,39 @@ public:
     static AUDIO_ID play2d(std::string_view filePath,
                            const AudioPlayerSettings& settings,
                            const AudioProfile* profile = nullptr);
+
+    /**
+     * Play sound in 3d space.
+     *
+     * @param filePath The path of an audio file.
+     * @param position Position of audio source relative to listener
+     * @param loop Whether audio instance loop or not.
+     * @param volume Volume value (range from 0.0 to 1.0).
+     * @param profile A profile for audio instance. When profile is not specified, default profile will be used.
+     * @return An audio ID. It allows you to dynamically change the behavior of an audio instance on the fly.
+     *
+     * @see `AudioProfile`
+     */
+    static AUDIO_ID play3d(std::string_view filePath,
+                           const Vec3& position,
+                           bool loop                   = false,
+                           float volume                = 1.0f,
+                           const AudioProfile* profile = nullptr);
+
+    /**
+     * Play sound in 3d space.
+     *
+     * @param filePath The path of an audio file.
+     * @param settings The player settings for audio.
+     * @param profile A profile for audio instance. When profile is not specified, default profile will be used.
+     * @return An audio ID. It allows you to dynamically change the behavior of an audio instance on the fly.
+     *
+     * @see `AudioProfile`, `AudioPlayerSettings`
+     */
+    static AUDIO_ID play3d(std::string_view filePath,
+                           const AudioPlayerSettings& settings,
+                           const AudioProfile* profile = nullptr);
+
     /**
      * Sets whether an audio instance loop or not.
      *
@@ -380,6 +414,20 @@ public:
      * @param position position of source
      */
     static void setSourcePosition(AUDIO_ID audioId, const ax::Vec3& position);
+
+    /**
+     * Sets the position of the listener.
+     *
+     * @param position position of listener
+     */
+    static void setListenerPosition(const ax::Vec3& position);
+
+    /**
+     * Gets the position of the listener.
+     *
+     * @return Vec3 position of listener
+     */
+    static ax::Vec3 getListenerPosition();
 
 protected:
     static void addTask(const std::function<void()>& task);

--- a/core/audio/AudioEngine.h
+++ b/core/audio/AudioEngine.h
@@ -58,6 +58,7 @@ struct AX_DLL AudioPlayerSettings
     float volume = 1.0f; // Volume value (range from 0.0 to 1.0).
     float time = 0.0f; // The initial time offset when play audio
     Vec3 position{}; // position of audio in 3d space relative to listener
+    static float distanceScale; // scale used for distance calculations. Must be greater than 0, and defaults to 1.0f.
 };
 
 /**
@@ -428,6 +429,20 @@ public:
      * @return Vec3 position of listener
      */
     static ax::Vec3 getListenerPosition();
+
+    /**
+     * Sets the distance scale
+     *
+     * @param scale used for 3D audio source to listener calculations. Default is 1.0f, and must be greater than 0.f.
+     */
+    static void setDistanceScale(float scale);
+
+    /**
+     * Gets the distance scale
+     *
+     * @return float distance used for 3D audio source to listener calculations
+     */
+    static float getDistanceScale();
 
 protected:
     static void addTask(const std::function<void()>& task);

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -585,7 +585,12 @@ AUDIO_ID AudioEngineImpl::play2d(std::string_view filePath, bool loop, float vol
     return _currentAudioID;
 }
 
-int AudioEngineImpl::play3d(std::string_view filePath, const Vec3& position, bool loop, float volume, float time)
+int AudioEngineImpl::play3d(std::string_view filePath,
+                            const Vec3& position,
+                            float distanceScale,
+                            bool loop,
+                            float volume,
+                            float time)
 {
     if (s_ALDevice == nullptr)
     {
@@ -609,6 +614,7 @@ int AudioEngineImpl::play3d(std::string_view filePath, const Vec3& position, boo
     player->_volume         = volume;
     player->_pitch          = 1.0f;
     player->_sourcePosition.set(position);
+    player->_distanceScale = distanceScale;
     if (time > 0.0f)
     {
         player->_currTime  = time;

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -695,7 +695,7 @@ void AudioEngineImpl::_play3d(AudioCache* cache, int audioID)
     }
     else
     {
-        AXLOGD("AudioEngineImpl::_play2d, cache was destroyed or not ready!");
+        AXLOGD("AudioEngineImpl::_play3d, cache was destroyed or not ready!");
         player->_removeByAudioEngine = true;
     }
 }

--- a/core/audio/AudioEngineImpl.cpp
+++ b/core/audio/AudioEngineImpl.cpp
@@ -585,6 +585,59 @@ AUDIO_ID AudioEngineImpl::play2d(std::string_view filePath, bool loop, float vol
     return _currentAudioID;
 }
 
+int AudioEngineImpl::play3d(std::string_view filePath, const Vec3& position, bool loop, float volume, float time)
+{
+    if (s_ALDevice == nullptr)
+    {
+        return AudioEngine::INVALID_AUDIO_ID;
+    }
+
+    ALuint alSource = findValidSource();
+    if (alSource == AL_INVALID)
+    {
+        return AudioEngine::INVALID_AUDIO_ID;
+    }
+
+    auto player = new AudioPlayer;
+    if (player == nullptr)
+    {
+        return AudioEngine::INVALID_AUDIO_ID;
+    }
+
+    player->_alSource       = alSource;
+    player->_loop           = loop;
+    player->_volume         = volume;
+    player->_pitch          = 1.0f;
+    player->_sourcePosition.set(position);
+    if (time > 0.0f)
+    {
+        player->_currTime  = time;
+        player->_timeDirty = true;
+    }
+
+    auto audioCache = preload(filePath, nullptr);
+    if (audioCache == nullptr)
+    {
+        delete player;
+        return AudioEngine::INVALID_AUDIO_ID;
+    }
+
+    player->setCache(audioCache);
+    _threadMutex.lock();
+    _audioPlayers.emplace(++_currentAudioID, player);
+    _threadMutex.unlock();
+
+    audioCache->addPlayCallback(std::bind(&AudioEngineImpl::_play3d, this, audioCache, _currentAudioID));
+
+    if (!_scheduled)
+    {
+        _scheduled = true;
+        _scheduler->schedule(AX_SCHEDULE_SELECTOR(AudioEngineImpl::update), this, 0.05f, false);
+    }
+
+    return _currentAudioID;
+}
+
 void AudioEngineImpl::_play2d(AudioCache* cache, AUDIO_ID audioID)
 {
     std::unique_lock<std::recursive_mutex> lck(_threadMutex);
@@ -597,6 +650,34 @@ void AudioEngineImpl::_play2d(AudioCache* cache, AUDIO_ID audioID)
     if (!*cache->_isDestroyed && cache->_state == AudioCache::State::READY)
     {
         if (player->play2d())
+        {
+            _scheduler->runOnAxmolThread([audioID]() {
+                if (AudioEngine::_audioIDInfoMap.find(audioID) != AudioEngine::_audioIDInfoMap.end())
+                {
+                    AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
+                }
+            });
+        }
+    }
+    else
+    {
+        AXLOGD("AudioEngineImpl::_play2d, cache was destroyed or not ready!");
+        player->_removeByAudioEngine = true;
+    }
+}
+
+void AudioEngineImpl::_play3d(AudioCache* cache, int audioID)
+{
+    std::unique_lock<std::recursive_mutex> lck(_threadMutex);
+    auto iter = _audioPlayers.find(audioID);
+    if (iter == _audioPlayers.end())
+        return;
+    auto player = iter->second;
+
+    // Note: It maybe in sub thread or main thread :(
+    if (!*cache->_isDestroyed && cache->_state == AudioCache::State::READY)
+    {
+        if (player->play3d())
         {
             _scheduler->runOnAxmolThread([audioID]() {
                 if (AudioEngine::_audioIDInfoMap.find(audioID) != AudioEngine::_audioIDInfoMap.end())
@@ -976,6 +1057,20 @@ void AudioEngineImpl::setSourcePosition(int audioId, const ax::Vec3& position)
     player->_sourcePosition.set(position);
 
     alSource3f(player->_alSource, AL_POSITION, position.x, position.y, position.z);
+}
+
+void AudioEngineImpl::setListenerPosition(const ax::Vec3& position)
+{
+    alListener3f(AL_POSITION, position.x, position.y, position.z);
+}
+
+ax::Vec3 AudioEngineImpl::getListenerPosition()
+{
+    Vec3 pos;
+    
+    alGetListener3f(AL_POSITION, &pos.x, &pos.y, &pos.z);
+
+    return pos;
 }
 
 bool AudioEngineImpl::isExtensionPresent(const char* extensionId)

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -51,6 +51,7 @@ public:
 
     bool init();
     AUDIO_ID play2d(std::string_view fileFullPath, bool loop, float volume, float time);
+    AUDIO_ID play3d(std::string_view fileFullPath, const Vec3& position, bool loop, float volume, float time);
     void setVolume(AUDIO_ID audioID, float volume);
     void setPitch(AUDIO_ID audioID, float pitch);
     void setLoop(AUDIO_ID audioID, bool loop);
@@ -66,6 +67,8 @@ public:
     float getPan(AUDIO_ID audioId);
     ax::Vec3 getSourcePosition(AUDIO_ID audioId);
     void setSourcePosition(AUDIO_ID audioId, const ax::Vec3& position);
+    void setListenerPosition(const ax::Vec3& position);
+    ax::Vec3 getListenerPosition();
 
     void uncache(std::string_view filePath);
     void uncacheAll();
@@ -79,6 +82,7 @@ private:
     // query players state per frame and dispatch finish callback if possible
     void _updatePlayers(bool forStop);
     void _play2d(AudioCache* cache, AUDIO_ID audioID);
+    void _play3d(AudioCache* cache, AUDIO_ID audioID);
     void _unscheduleUpdate();
     ALuint findValidSource();
 #if defined(__APPLE__) && !AX_USE_ALSOFT

--- a/core/audio/AudioEngineImpl.h
+++ b/core/audio/AudioEngineImpl.h
@@ -51,7 +51,7 @@ public:
 
     bool init();
     AUDIO_ID play2d(std::string_view fileFullPath, bool loop, float volume, float time);
-    AUDIO_ID play3d(std::string_view fileFullPath, const Vec3& position, bool loop, float volume, float time);
+    AUDIO_ID play3d(std::string_view fileFullPath, const Vec3& position, float distanceScale, bool loop, float volume, float time);
     void setVolume(AUDIO_ID audioID, float volume);
     void setPitch(AUDIO_ID audioID, float pitch);
     void setLoop(AUDIO_ID audioID, bool loop);

--- a/core/audio/AudioPlayer.cpp
+++ b/core/audio/AudioPlayer.cpp
@@ -305,6 +305,8 @@ bool AudioPlayer::play3d()
         CHECK_AL_ERROR_DEBUG();
         alSource3f(_alSource, AL_VELOCITY, 0, 0, 0);
         CHECK_AL_ERROR_DEBUG();
+        alSourcef(_alSource, AL_REFERENCE_DISTANCE, _distanceScale);
+        CHECK_AL_ERROR_DEBUG();
 
         if (_audioCache->_queBufferFrames == 0)
         {

--- a/core/audio/AudioPlayer.cpp
+++ b/core/audio/AudioPlayer.cpp
@@ -273,6 +273,126 @@ bool AudioPlayer::play2d()
     return ret;
 }
 
+bool AudioPlayer::play3d()
+{
+    std::unique_lock<std::mutex> lck(_play2dMutex);
+    AXLOGV("AudioPlayer::play2d, _alSource: {}, player id={}", _alSource, _id);
+
+    if (_isDestroyed)
+        return false;
+
+    /*********************************************************************/
+    /*       Note that it may be in sub thread or in main thread.       **/
+    /*********************************************************************/
+    bool ret = false;
+    do
+    {
+        if (_audioCache->_state != AudioCache::State::READY)
+        {
+            AXLOGE("{}", "alBuffer isn't ready for play!");
+            break;
+        }
+
+        alSourcei(_alSource, AL_BUFFER, 0);
+        CHECK_AL_ERROR_DEBUG();
+        alSourcef(_alSource, AL_PITCH, 1.0f);
+        CHECK_AL_ERROR_DEBUG();
+        alSourcef(_alSource, AL_GAIN, _volume);
+        CHECK_AL_ERROR_DEBUG();
+        alSourcei(_alSource, AL_LOOPING, AL_FALSE);
+        CHECK_AL_ERROR_DEBUG();
+        alSource3f(_alSource, AL_POSITION, _sourcePosition.x, _sourcePosition.y, _sourcePosition.z);
+        CHECK_AL_ERROR_DEBUG();
+        alSource3f(_alSource, AL_VELOCITY, 0, 0, 0);
+        CHECK_AL_ERROR_DEBUG();
+
+        if (_audioCache->_queBufferFrames == 0)
+        {
+            if (_loop)
+            {
+                alSourcei(_alSource, AL_LOOPING, AL_TRUE);
+                CHECK_AL_ERROR_DEBUG();
+            }
+        }
+        else
+        {
+            alGenBuffers(QUEUEBUFFER_NUM, _bufferIds);
+
+            auto alError = alGetError();
+            if (alError == AL_NO_ERROR)
+            {
+                for (int index = 0; index < QUEUEBUFFER_NUM; ++index)
+                {
+                    alBufferData(_bufferIds[index], _audioCache->_format, _audioCache->_queBuffers[index],
+                                 _audioCache->_queBufferSize[index], _audioCache->_sampleRate);
+                }
+                CHECK_AL_ERROR_DEBUG();
+            }
+            else
+            {
+                AXLOGE("{}:alGenBuffers error code: {:#x}", __FUNCTION__, alError);
+                break;
+            }
+            _streamingSource = true;
+        }
+
+        {
+            std::unique_lock<std::mutex> lk(_sleepMutex);
+            if (_isDestroyed)
+                break;
+
+            if (_streamingSource)
+            {
+                // To continuously stream audio from a source without interruption, buffer queuing is required.
+                alSourceQueueBuffers(_alSource, QUEUEBUFFER_NUM, _bufferIds);
+                CHECK_AL_ERROR_DEBUG();
+                _rotateBufferThread = new std::thread(&AudioPlayer::rotateBufferThread, this,
+                                                      _audioCache->_queBufferFrames * QUEUEBUFFER_NUM + 1);
+            }
+            else
+            {
+                alSourcei(_alSource, AL_BUFFER, _audioCache->_alBufferId);
+                CHECK_AL_ERROR_DEBUG();
+            }
+
+            alSourcePlay(_alSource);
+        }
+
+        auto alError = alGetError();
+        if (alError != AL_NO_ERROR)
+        {
+            AXLOGE("{}:alSourcePlay error code:{:#x}", __FUNCTION__, (int)alError);
+            break;
+        }
+
+        ALint state;
+        alGetSourcei(_alSource, AL_SOURCE_STATE, &state);
+        if (state != AL_PLAYING)
+            AXLOGE("state isn't playing, {}, {}, cache id={}, player id={}", state, _audioCache->_fileFullPath,
+                   _audioCache->_id, _id);
+
+        // OpenAL framework: sometime when switch audio too fast, the result state will error, but there is no any
+        // alError, so just skip for workaround.
+        assert(state == AL_PLAYING);
+
+        if (!_streamingSource && _currTime >= 0.0f)
+        {
+            alSourcef(_alSource, AL_SEC_OFFSET, _currTime);
+            CHECK_AL_ERROR_DEBUG();
+        }
+
+        _ready = true;
+        ret    = true;
+    } while (false);
+
+    if (!ret)
+    {
+        _removeByAudioEngine = true;
+    }
+
+    return ret;
+}
+
 // rotateBufferThread is used to rotate alBufferData for _alSource when playing big audio file
 void AudioPlayer::rotateBufferThread(int offsetFrame)
 {

--- a/core/audio/AudioPlayer.h
+++ b/core/audio/AudioPlayer.h
@@ -77,6 +77,7 @@ protected:
     float _pitch;
     bool _loop;
     float _pan{};
+    float _distanceScale;
     Vec3 _sourcePosition;
 
     std::function<void(AUDIO_ID, std::string_view)> _finishCallbak;

--- a/core/audio/AudioPlayer.h
+++ b/core/audio/AudioPlayer.h
@@ -66,6 +66,7 @@ protected:
     void setCache(AudioCache* cache);
     void rotateBufferThread(int offsetFrame);
     bool play2d();
+    bool play3d();
 #if defined(__APPLE__)
     void wakeupRotateThread();
 #endif

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -29,6 +29,7 @@
 #include "renderer/RenderState.h"
 #include <spine/spine-axmol.h>
 
+#include "AudioEngine.h"
 #include "../testResource.h"
 #include "../TerrainTest/TerrainTest.h"
 
@@ -87,6 +88,7 @@ private:
     Scene3DTestScene();
     ~Scene3DTestScene() override;
     bool init() override;
+    void update(float) override;
 
     void createWorld3D();
     void createUI();
@@ -106,6 +108,7 @@ private:
     ax::Terrain* _terrain;
     Player* _player;
     Node* _monsters[2];
+    int _audioId = -1;
 
     // init in createUI()
     Node* _playerItem;
@@ -119,6 +122,7 @@ private:
     Node* _detailDlg;
     // init in createDescDlg()
     Node* _descDlg;
+
     enum SkinType
     {
         HAIR = 0,
@@ -236,7 +240,11 @@ Scene3DTestScene::Scene3DTestScene()
     _monsters[0] = _monsters[1] = nullptr;
 }
 
-Scene3DTestScene::~Scene3DTestScene() {}
+Scene3DTestScene::~Scene3DTestScene()
+{
+    AudioEngine::stopAll();
+    AudioEngine::setListenerPosition(Vec3()); // reset listener position
+}
 
 bool Scene3DTestScene::init()
 {
@@ -357,10 +365,22 @@ bool Scene3DTestScene::init()
         listener->onTouchEnded = AX_CALLBACK_2(Scene3DTestScene::onTouchEnd, this);
         _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 
+        scheduleUpdate();
+
         ret = true;
     } while (0);
 
     return ret;
+}
+
+void Scene3DTestScene::update(float x)
+{
+    TestCase::update(x);
+
+    if (_player)
+    {
+        AudioEngine::setListenerPosition(_player->getPosition3D());
+    }
 }
 
 void Scene3DTestScene::createWorld3D()
@@ -436,6 +456,8 @@ void Scene3DTestScene::createWorld3D()
     monster->setRotation3D(Vec3(0, 180, 0));
     monster->setPosition3D(_player->getPosition3D() + Vec3(-50, -5, 0));
     _monsters[1] = monster;
+
+    _audioId = AudioEngine::play3d("background.mp3", monster->getPosition3D(), true);
 }
 
 void Scene3DTestScene::createUI()
@@ -472,6 +494,32 @@ void Scene3DTestScene::createUI()
     auto menu = Menu::create(showPlayerDlgItem, descItem, nullptr);
     menu->setPosition(Vec2::ZERO);
     _ui->addChild(menu);
+
+    auto audioCheckbox = ui::CheckBox::create("cocosui/check_box_normal.png", "cocosui/check_box_normal_press.png",
+                           "cocosui/check_box_active.png", "cocosui/check_box_normal_disable.png",
+                           "cocosui/check_box_active_disable.png");
+    audioCheckbox->setSelected(true);
+    audioCheckbox->setName("Audio");
+    audioCheckbox->setAnchorPoint(Vec2::ANCHOR_BOTTOM_RIGHT);
+    audioCheckbox->setScale(0.8f);
+    audioCheckbox->addEventListener(
+        [this](ax::Object* sender, ax::ui::CheckBox::EventType eventType) {
+            if (eventType == ui::CheckBox::EventType::UNSELECTED)
+            {
+                AudioEngine::pause(_audioId);
+            }
+            else
+            {
+                AudioEngine::resume(_audioId);
+            }
+        });
+    auto label = ui::Text::create();
+    label->setString("Positional Audio");
+    label->setAnchorPoint(Vec2(0, 0));
+    label->setPositionX(audioCheckbox->getContentSize().width);
+    audioCheckbox->addChild(label);
+    audioCheckbox->setPosition(VisibleRect::right() - Vec2(audioCheckbox->getContentSize().width + label->getContentSize().width, 0));
+    _ui->addChild(audioCheckbox);
 
     // second, add cameras control button to ui
     auto createCameraButton = [this](int tag, const char* text) -> Node* {

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -244,6 +244,7 @@ Scene3DTestScene::~Scene3DTestScene()
 {
     AudioEngine::stopAll();
     AudioEngine::setListenerPosition(Vec3()); // reset listener position
+    AudioEngine::setDistanceScale(1.f);
 }
 
 bool Scene3DTestScene::init()
@@ -457,6 +458,7 @@ void Scene3DTestScene::createWorld3D()
     monster->setPosition3D(_player->getPosition3D() + Vec3(-50, -5, 0));
     _monsters[1] = monster;
 
+    AudioEngine::setDistanceScale(5);
     _audioId = AudioEngine::play3d("background.mp3", monster->getPosition3D(), true);
 }
 


### PR DESCRIPTION
## Describe your changes

This is initial support for playing a sound at a specific position in 3D space.  It will be relative to the listener.  The position of the listener can also be set, allowing the listener position to be modified, such as when a player object is moving around.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [x] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
