### PR TITLE
Changing the size of a ProgressTimer changes the size of the sprite too.

### DIFF
--- a/axmol/2d/ProgressTimer.cpp
+++ b/axmol/2d/ProgressTimer.cpp
@@ -146,7 +146,7 @@ void ProgressTimer::setSprite(Sprite* sprite)
         AX_SAFE_RETAIN(sprite);
         AX_SAFE_RELEASE(_sprite);
         _sprite = sprite;
-        setContentSize(_sprite->getContentSize());
+        Node::setContentSize(_sprite->getContentSize());
 
         //    Every time we set a new sprite, we free the current vertex data
         if (!_vertexData.empty())
@@ -321,6 +321,15 @@ uint8_t ProgressTimer::getOpacity() const
 uint8_t ProgressTimer::getDisplayedOpacity() const
 {
     return _sprite->getDisplayedOpacity();
+}
+
+void ProgressTimer::setContentSize(const ax::Vec2& size)
+{
+    if (size == getContentSize())
+        return;
+
+    _sprite->setContentSize(size);
+    Node::setContentSize(size);
 }
 
 void ProgressTimer::setMidpoint(const Vec2& midPoint)

--- a/axmol/2d/ProgressTimer.h
+++ b/axmol/2d/ProgressTimer.h
@@ -159,6 +159,8 @@ public:
     uint8_t getOpacity() const override;
     uint8_t getDisplayedOpacity() const override;
 
+    void setContentSize(const ax::Vec2& size) override;
+
     /**
      */
     ProgressTimer() = default;


### PR DESCRIPTION
ProgressTimer::setSprite() used to set the size of the ProgressTimer to match the size of the sprite, but if one wanted to change the size of the sprite once it has been added in the ProgressTimer, they had to either remove the sprite, then change its size, then add it back in the ProgressTimer. Now the size of the ProgressTimer can be changed directly and the display adapts.
