### PR TITLE
Fix format specifiers in logging calls

### DIFF
--- a/templates/cpp/Source/MainScene.cpp
+++ b/templates/cpp/Source/MainScene.cpp
@@ -169,14 +169,14 @@ void MainScene::onTouchesEnded(const std::vector<ax::Touch*>& touches, ax::Event
 bool MainScene::onMouseDown(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
-    // AXLOGD("onMouseDown detected, Key: %d", static_cast<int>(e->getMouseButton()));
+    // AXLOGD("onMouseDown detected, button: {}", static_cast<int>(e->getMouseButton()));
     return true;
 }
 
 bool MainScene::onMouseUp(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
-    AXLOGD("onMouseUp detected, Key: %d", static_cast<int>(e->getMouseButton()));
+    AXLOGD("onMouseUp detected, button: {}", static_cast<int>(e->getMouseButton()));
     return true;
 }
 
@@ -201,7 +201,7 @@ void MainScene::onKeyPressed(EventKeyboard::KeyCode code, Event* event)
 
 void MainScene::onKeyReleased(EventKeyboard::KeyCode code, Event* event)
 {
-    AXLOGD("onKeyReleased, keycode: %d", static_cast<int>(code));
+    AXLOGD("onKeyReleased, keycode: {}", static_cast<int>(code));
 }
 
 void MainScene::update(float delta)

--- a/templates/cpp/Source/MainScene.cpp
+++ b/templates/cpp/Source/MainScene.cpp
@@ -183,7 +183,7 @@ bool MainScene::onMouseUp(Event* event)
 bool MainScene::onMouseMove(Event* event)
 {
     EventMouse* e = static_cast<EventMouse*>(event);
-    // AXLOGD("onMouseMove detected, X:{}  Y:{}", e->getCursorX(), e->getCursorY());
+    // AXLOGD("onMouseMove detected, X:{}  Y:{}", e->getLocation().x, e->getLocation().y);
     return true;
 }
 


### PR DESCRIPTION
## Describe your changes

Fix for a few format specifiers in the CPP project template.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
