### PR TITLE
Handling screen orientation change for all platforms

### DIFF
--- a/axmol/platform/Application.h
+++ b/axmol/platform/Application.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/ApplicationBase.cpp
+++ b/axmol/platform/ApplicationBase.cpp
@@ -36,4 +36,6 @@ ApplicationBase::~ApplicationBase()
     Director::destroyInstance();
 }
 
+void ApplicationBase::applicationScreenSizeChanged(int newWidth, int newHeight) {}
+
 }  // namespace ax

--- a/axmol/platform/ApplicationBase.h
+++ b/axmol/platform/ApplicationBase.h
@@ -138,6 +138,8 @@ public:
      * @lua NA
      */
     virtual bool openURL(std::string_view url) = 0;
+
+    virtual void applicationScreenSizeChanged(int newWidth, int newHeight);
 };
 
 using ApplicationProtocol = ApplicationBase;

--- a/axmol/platform/ApplicationBase.h
+++ b/axmol/platform/ApplicationBase.h
@@ -39,8 +39,11 @@ namespace ax
  * @{
  */
 
+class RenderView;
 class AX_DLL ApplicationBase
 {
+    friend class RenderView;
+
 public:
     /** Since WINDOWS and ANDROID are defined as macros, we could not just use these keywords in enumeration(Platform).
      *  Therefore, we use C# code style to define Platform enums to avoid conflicts with the definitions of system
@@ -139,6 +142,18 @@ public:
      */
     virtual bool openURL(std::string_view url) = 0;
 
+protected:
+    /**
+     * @brief Called when the application screen size changes.
+     *
+     * Users can override this method to listen for screen size changes,
+     * including device rotation events. It is recommended to update the
+     * designResolutionSize and adjust the layout of objects in the scene
+     * accordingly when this callback is triggered.
+     *
+     * @param newWidth  The new width of the application screen in pixels.
+     * @param newHeight The new height of the application screen in pixels.
+     */
     virtual void applicationScreenSizeChanged(int newWidth, int newHeight);
 };
 

--- a/axmol/platform/RenderView.cpp
+++ b/axmol/platform/RenderView.cpp
@@ -183,20 +183,45 @@ const Vec2& RenderView::getDesignResolutionSize() const
     return _designResolutionSize;
 }
 
-void RenderView::setRenderSize(float width, float height)
+void RenderView::updateRenderSurface(float width, float height, uint8_t updateFlag)
 {
-    _renderSize.set(width, height);
+    if (width == 0 || height == 0)
+        return;
 
-    if (_windowSize.equals(Vec2::ZERO))
-        _windowSize = _renderSize;
+    if (updateFlag & SurfaceUpdateFlag::WindowSizeChanged)
+        _windowSize.set(width, height);
 
-    // Github issue #16003 and #16485
-    // only update the designResolution if it wasn't previously set
-    if (_designResolutionSize.equals(Vec2::ZERO))
-        _designResolutionSize = _renderSize;
+    if (updateFlag & SurfaceUpdateFlag::RenderSizeChanged)
+    {
+        _renderSize.set(width, height);
 
-    if (!_renderSize.equals(Vec2::ZERO))
+        // If designResolutionSize hasn't been set, default to renderSize
+        if (_designResolutionSize.equals(Vec2::ZERO))
+            _designResolutionSize.set(width, height);
+
         updateDesignResolution();
+    }
+
+    // check does all updateed
+    maybeDispatchResizeEvent(updateFlag);
+}
+
+void RenderView::maybeDispatchResizeEvent(uint8_t updateFlag)
+{
+    const bool silentUpdate = (updateFlag & SurfaceUpdateFlag::SilentUpdate) != 0;
+    updateFlag &= ~SurfaceUpdateFlag::SilentUpdate;  // Remove temporary flag
+
+    _surfaceUpdateFlags |= updateFlag;
+
+    constexpr uint8_t requiredFlags = SurfaceUpdateFlag::WindowSizeChanged | SurfaceUpdateFlag::RenderSizeChanged;
+
+    const bool readyToDispatch = (_surfaceUpdateFlags == requiredFlags);
+
+    if (readyToDispatch && !silentUpdate)
+    {
+        _surfaceUpdateFlags = 0;
+        onSurfaceResized();
+    }
 }
 
 Rect RenderView::getVisibleRect() const
@@ -483,17 +508,19 @@ float RenderView::getScaleY() const
     return _viewScale.y;
 }
 
-void RenderView::onRenderResized()
+void RenderView::onSurfaceResized()
 {
-    AXLOGD("RenderView::onRenderResized");
+    AXLOGD("RenderView::onSurfaceResized");
 
-    Director::getInstance()->resizeSwapchain(static_cast<uint32_t>(_renderSize.width),
-                                             static_cast<uint32_t>(_renderSize.height));
+    int screenWidth  = static_cast<uint32_t>(_renderSize.width);
+    int screenHeight = static_cast<uint32_t>(_renderSize.height);
+    Director::getInstance()->resizeSwapchain(screenWidth, screenHeight);
 
 #ifdef AX_ENABLE_VR
     if (_vrRenderer) [[unlikely]]
         _vrRenderer->onRenderViewResized(this);
 #endif
+    ax::Application::getInstance()->applicationScreenSizeChanged(screenWidth, screenHeight);
 }
 
 void RenderView::renderScene(Scene* scene, Renderer* renderer)

--- a/axmol/platform/RenderView.cpp
+++ b/axmol/platform/RenderView.cpp
@@ -175,7 +175,8 @@ void RenderView::setDesignResolutionSize(float width, float height, ResolutionPo
     _designResolutionSize.set(width, height);
     _resolutionPolicy = resolutionPolicy;
 
-    updateDesignResolution();
+    if (!_isResolutionUpdateLocked)
+        updateDesignResolution();
 }
 
 const Vec2& RenderView::getDesignResolutionSize() const
@@ -188,18 +189,29 @@ void RenderView::updateRenderSurface(float width, float height, uint8_t updateFl
     if (width == 0 || height == 0)
         return;
 
+    Vec2 value{width, height};
+
     if (updateFlag & SurfaceUpdateFlag::WindowSizeChanged)
-        _windowSize.set(width, height);
+        _windowSize = value;
 
     if (updateFlag & SurfaceUpdateFlag::RenderSizeChanged)
     {
-        _renderSize.set(width, height);
+        _isResolutionUpdateLocked = true;
+
+        _renderSize = value;
 
         // If designResolutionSize hasn't been set, default to renderSize
         if (_designResolutionSize.equals(Vec2::ZERO))
-            _designResolutionSize.set(width, height);
+            _designResolutionSize = value;
 
+        // Notify the application that the screen size has changed.
+        // This gives the user a chance to re-layout scene content or reset designResolutionSize if needed.
+        ax::Application::getInstance()->applicationScreenSizeChanged(width, height);
+
+        // then we update resolution and viewport
         updateDesignResolution();
+
+        _isResolutionUpdateLocked = false;
     }
 
     // check does all updateed
@@ -520,7 +532,6 @@ void RenderView::onSurfaceResized()
     if (_vrRenderer) [[unlikely]]
         _vrRenderer->onRenderViewResized(this);
 #endif
-    ax::Application::getInstance()->applicationScreenSizeChanged(screenWidth, screenHeight);
 }
 
 void RenderView::renderScene(Scene* scene, Renderer* renderer)

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -112,6 +112,16 @@ class AX_DLL RenderView : public Object
     friend class Director;
 
 public:
+    enum SurfaceUpdateFlag : uint8_t
+    {
+        WindowSizeChanged = 1,       // Indicates that window size has changed
+        RenderSizeChanged = 1 << 1,  // Indicates that render surface size has changed
+        SilentUpdate      = 1 << 2,  // Temporary flag: suppresses event dispatch for this update only.
+                                     // Should be stripped before accumulating into persistent state.
+        AllUpdates         = WindowSizeChanged | RenderSizeChanged,
+        AllUpdatesSilently = AllUpdates | SilentUpdate
+    };
+
     /**
      */
     RenderView();
@@ -456,29 +466,39 @@ public:
     const std::unique_ptr<IVRRenderer>& getVR() const { return _vrRenderer; }
 #endif
 
+    /**
+     * @brief Updates the render surface size (framebuffer/render target) and synchronizes related view parameters.
+     *
+     * This method performs the following actions:
+     * - Sets `_renderSize` to the specified dimensions;
+     * - On mobile platforms (Android/iOS), `_windowSize` is synchronized to match `_renderSize`;
+     * - On desktop platforms, `_windowSize` is only initialized to `_renderSize` if it hasn't been set yet;
+     * - If `_designResolutionSize` is unset (`Vec2::ZERO`), it is initialized to `_renderSize`;
+     * - Calls `updateDesignResolution()` to recalculate `_viewScale` and `_viewportRect` based on the current
+     *   `ResolutionPolicy`, and updates the Director's logical size and projection matrix accordingly.
+     *
+     * @param width      The target width of the render surface. Its meaning depends on `updateFlag`:
+     *                   it may represent the framebuffer width, logical window width, or design resolution width.
+     * @param height     The target height of the render surface. Its meaning depends on `updateFlag`:
+     *                   it may represent the framebuffer height, logical window height, or design resolution height.
+     * @param updateFlag Optional flags to control which parts of the view should be updated.
+     *                   Defaults to `SurfaceUpdateFlag::AllUpdates`.
+     *
+     * @warning This method may initialize `_windowSize` and `_designResolutionSize` on first invocation.
+     * @note No update will occur if the given size is (0, 0).
+     *
+     * @internal This method is intended for internal use by platform-specific window or surface managers.
+     *           It should be called when the native surface size changes (e.g., orientation change, resize event).
+     *
+     * @see updateDesignResolution(), setDesignResolutionSize()
+     */
+    void updateRenderSurface(float width, float height, uint8_t updateFlag);
+
 protected:
     float transformInputX(float x) { return (x - _viewportRect.origin.x) / _viewScale.x; }
     float transformInputY(float y) { return (y - _viewportRect.origin.y) / _viewScale.y; }
 
-    /**
-     * @brief Sets the render size (framebuffer/render target size) and updates the viewport and scaling.
-     *
-     * This method will:
-     * - Overwrite `_renderSize` with the given dimensions;
-     * - If `_windowSize` has not been initialized (equals `Vec2::ZERO`), initialize it to `_renderSize`;
-     * - If `_designResolutionSize` has not been initialized (equals `Vec2::ZERO`), initialize it to `_renderSize`;
-     * - Call `updateDesignResolution()` to compute `_viewScale` and `_viewportRect` based on the current
-     *   `ResolutionPolicy`, and synchronize the Director's logical size and projection.
-     *
-     * @param width  The width of the render size.
-     * @param height The height of the render size.
-     *
-     * @warning This method has side effects: on the first call, it may initialize `_windowSize`
-     *          and `_designResolutionSize`.
-     * @note If the given size is (0,0), no update will be performed.
-     * @see updateDesignResolution(), setDesignResolutionSize()
-     */
-    void setRenderSize(float width, float height);
+    void maybeDispatchResizeEvent(uint8_t updateFlag);
 
     /**
      * @brief Callback invoked after the RenderView size has changed and all related updates are complete.
@@ -488,7 +508,7 @@ protected:
      * It serves as a notification hook for any components that need to respond
      * to the final, settled render size.
      */
-    void onRenderResized();
+    void onSurfaceResized();
 
     void setScissorRect(float x, float y, float w, float h);
     const ScissorRect& getScissorRect() const;
@@ -515,6 +535,11 @@ protected:
 
     Vec2 _viewScale;
     ResolutionPolicy _resolutionPolicy;
+
+    // Flags indicating whether the window or framebuffer size was updated.
+    // On desktop platforms, callback order is: framebufferSize => windowSize.
+    // On WebAssembly, the order is reversed: windowSize => framebufferSize.
+    uint8_t _surfaceUpdateFlags{0};
 
 #ifdef AX_ENABLE_VR
     std::unique_ptr<IVRRenderer> _vrRenderer{nullptr};

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -264,7 +264,8 @@ public:
      * ratio, two areas of your game view will be cut. [3] SHOW_ALL  Full screen with black border: if the design
      * resolution ratio of width to height is different from the screen resolution ratio, two black borders will be
      * shown.
-     * @remark You shoud only set once
+     * @remark For applications with a static design resolution, this method should typically be called only once during
+     * initialization.
      */
     virtual void setDesignResolutionSize(float width, float height, ResolutionPolicy resolutionPolicy);
 
@@ -540,6 +541,8 @@ protected:
     // On desktop platforms, callback order is: framebufferSize => windowSize.
     // On WebAssembly, the order is reversed: windowSize => framebufferSize.
     uint8_t _surfaceUpdateFlags{0};
+
+    bool _isResolutionUpdateLocked{false};
 
 #ifdef AX_ENABLE_VR
     std::unique_ptr<IVRRenderer> _vrRenderer{nullptr};

--- a/axmol/platform/SAXParser.h
+++ b/axmol/platform/SAXParser.h
@@ -2,6 +2,9 @@
  Copyright (c) 2010 cocos2d-x.org
  Copyright (c) 2010 Максим Аксенов
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+ https://axmol.dev/
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/axmol/platform/android/Application-android.cpp
+++ b/axmol/platform/android/Application-android.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/android/Application-android.cpp
+++ b/axmol/platform/android/Application-android.cpp
@@ -110,8 +110,6 @@ bool Application::openURL(std::string_view url)
     return JniHelper::callStaticBooleanMethod(applicationHelperClassName, "openURL", url);
 }
 
-void Application::applicationScreenSizeChanged(int newWidth, int newHeight) {}
-
 }  // namespace ax
 
 #undef LOGD

--- a/axmol/platform/android/Application-android.h
+++ b/axmol/platform/android/Application-android.h
@@ -89,13 +89,6 @@ public:
      */
     bool openURL(std::string_view url) override;
 
-    /**
-    @brief  This function will be called when the application screen size is changed.
-    @param new width
-    @param new height
-    */
-    virtual void applicationScreenSizeChanged(int newWidth, int newHeight);
-
 protected:
     static Application* sm_pSharedApplication;
 };

--- a/axmol/platform/android/RenderViewImpl-android.cpp
+++ b/axmol/platform/android/RenderViewImpl-android.cpp
@@ -95,7 +95,7 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
                                   float /*frameZoomFactor*/,
                                   bool /*resizable*/)
 {
-    setRenderSize(rect.size.width, rect.size.height);
+    updateRenderSurface(rect.size.width, rect.size.height, SurfaceUpdateFlag::AllUpdatesSilently);
     return true;
 }
 

--- a/axmol/platform/android/javaactivity-android.cpp
+++ b/axmol/platform/android/javaactivity-android.cpp
@@ -147,7 +147,9 @@ JNIEXPORT jintArray JNICALL Java_dev_axmol_lib_AxmolActivity_getGLContextAttrs(J
 
 JNIEXPORT void JNICALL Java_dev_axmol_lib_AxmolRenderer_nativeOnSurfaceChanged(JNIEnv*, jclass, jint w, jint h)
 {
-    ax::Application::getInstance()->applicationScreenSizeChanged(w, h);
+    auto renderView = ax::Director::getInstance()->getRenderView();
+    if (renderView)
+        renderView->updateRenderSurface(w, h, ax::RenderView::AllUpdates);
 }
 }
 #undef LOGD

--- a/axmol/platform/apple/Device-apple.h
+++ b/axmol/platform/apple/Device-apple.h
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/apple/Device-apple.mm
+++ b/axmol/platform/apple/Device-apple.mm
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/apple/FileUtils-apple.h
+++ b/axmol/platform/apple/FileUtils-apple.h
@@ -3,6 +3,7 @@
  Copyright (c) 2011      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/desktop/Device-desktop.cpp
+++ b/axmol/platform/desktop/Device-desktop.cpp
@@ -21,7 +21,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-****************************************************************************/#include "axmol/platform/Device.h"
+****************************************************************************/ \
+#include "axmol/platform/Device.h"
 #include "GLFW/glfw3.h"
 
 namespace ax

--- a/axmol/platform/desktop/Device-desktop.cpp
+++ b/axmol/platform/desktop/Device-desktop.cpp
@@ -1,4 +1,27 @@
-#include "axmol/platform/Device.h"
+
+/****************************************************************************
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+https://axmol.dev/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/#include "axmol/platform/Device.h"
 #include "GLFW/glfw3.h"
 
 namespace ax

--- a/axmol/platform/desktop/RenderViewImpl.cpp
+++ b/axmol/platform/desktop/RenderViewImpl.cpp
@@ -1074,7 +1074,6 @@ void RenderViewImpl::updateScaledWindowSize(int w, int h, uint8_t updateFlag)
     Vec2 scaledSize{static_cast<float>(std::round(scaledWidth)), static_cast<float>(std::round(scaledHeight))};
     if (!scaledSize.equals(_windowSize))
         updateRenderSurface(scaledSize.width, scaledSize.height, updateFlag);
-    
 }
 
 void RenderViewImpl::applyWindowSize()

--- a/axmol/platform/desktop/RenderViewImpl.cpp
+++ b/axmol/platform/desktop/RenderViewImpl.cpp
@@ -639,11 +639,11 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
 
     int fbWidth, fbHeight;
     glfwGetFramebufferSize(_mainWindow, &fbWidth, &fbHeight);
-    setRenderSize(fbWidth, fbHeight);
+    updateRenderSurface(fbWidth, fbHeight, SurfaceUpdateFlag::RenderSizeChanged | SurfaceUpdateFlag::SilentUpdate);
 
     int w, h;
     glfwGetWindowSize(_mainWindow, &w, &h);
-    updateScaledWindowSize(w, h);
+    updateScaledWindowSize(w, h, SurfaceUpdateFlag::WindowSizeChanged | SurfaceUpdateFlag::SilentUpdate);
 
 #if AX_RENDER_API == AX_RENDER_API_GL
     glfwMakeContextCurrent(_mainWindow);
@@ -1009,9 +1009,7 @@ void RenderViewImpl::onGLFWFramebufferSizeCallback(GLFWwindow* window, int fbWid
     if (fbWidth == 0 || fbHeight == 0)
         return;
 
-    setRenderSize(fbWidth, fbHeight);
-
-    maybeDispatchResizeEvent(WindowUpdateFlag::FramebufferSizeChanged);
+    updateRenderSurface(fbWidth, fbHeight, SurfaceUpdateFlag::RenderSizeChanged);
 }
 
 void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int h)
@@ -1020,7 +1018,7 @@ void RenderViewImpl::onGLFWWindowSizeCallback(GLFWwindow* /*window*/, int w, int
     if (w == 0 || h == 0)
         return;
 
-    updateScaledWindowSize(w, h);
+    updateScaledWindowSize(w, h, SurfaceUpdateFlag::WindowSizeChanged);
 
     Size size(w, h);
 
@@ -1050,7 +1048,7 @@ void RenderViewImpl::setWindowSize(float width, float height)
     applyWindowSize();
 }
 
-void RenderViewImpl::updateScaledWindowSize(int w, int h)
+void RenderViewImpl::updateScaledWindowSize(int w, int h, uint8_t updateFlag)
 {
     if (w == 0 || h == 0)
         return;
@@ -1075,13 +1073,8 @@ void RenderViewImpl::updateScaledWindowSize(int w, int h)
 
     Vec2 scaledSize{static_cast<float>(std::round(scaledWidth)), static_cast<float>(std::round(scaledHeight))};
     if (!scaledSize.equals(_windowSize))
-    {
-        _windowSize.set(scaledSize.width, scaledSize.height);
-    }
-
-    // fire render resized event on platform that framebuffer & window size callback trigger delayed (x11)
-    // if zoom factor changed, the renderSize also should changed
-    maybeDispatchResizeEvent(WindowUpdateFlag::WindowSizeChanged);
+        updateRenderSurface(scaledSize.width, scaledSize.height, updateFlag);
+    
 }
 
 void RenderViewImpl::applyWindowSize()
@@ -1102,23 +1095,7 @@ void RenderViewImpl::applyWindowSize()
                       static_cast<int>(std::lround(unscaledHeight)));
 
     // process platform that window size callback not trigger(wayland)
-    maybeDispatchResizeEvent(WindowUpdateFlag::WindowSizeChanged);
-}
-
-void RenderViewImpl::maybeDispatchResizeEvent(uint8_t updateFlag)
-{
-    auto flags = _windowUpdateFlags;
-    flags |= updateFlag;
-
-    if (flags != WindowUpdateFlag::AllUpdates)
-    {
-        _windowUpdateFlags = flags;
-    }
-    else
-    {
-        _windowUpdateFlags = 0;
-        onRenderResized();
-    }
+    maybeDispatchResizeEvent(SurfaceUpdateFlag::WindowSizeChanged);
 }
 
 /**

--- a/axmol/platform/desktop/RenderViewImpl.h
+++ b/axmol/platform/desktop/RenderViewImpl.h
@@ -161,27 +161,13 @@ protected:
     void onGLFWWindowCloseCallback(GLFWwindow* window);
 
 protected:
-    void updateScaledWindowSize(int w, int h);
+    void updateScaledWindowSize(int w, int h, uint8_t updaetFlag);
 
     /* resize platform window when user set zoomFactor, windowSize */
     void applyWindowSize();
 
-    void maybeDispatchResizeEvent(uint8_t updateFlag);
-
     bool _isTouchDevice = false;
     bool _captured;
-
-    enum WindowUpdateFlag : uint8_t
-    {
-        WindowSizeChanged      = 1 << 0,
-        FramebufferSizeChanged = 1 << 1,
-        AllUpdates             = WindowSizeChanged | FramebufferSizeChanged
-    };
-
-    // Flags indicating whether the window or framebuffer size was updated.
-    // On desktop platforms, callback order is: framebufferSize => windowSize.
-    // On WebAssembly, the order is reversed: windowSize => framebufferSize.
-    uint8_t _windowUpdateFlags{0};
 
     RenderScaleMode _renderScaleMode{};
 

--- a/axmol/platform/ios/Application-ios.h
+++ b/axmol/platform/ios/Application-ios.h
@@ -89,13 +89,6 @@ public:
      */
     bool openURL(std::string_view url) override;
 
-    /**
-    @brief  This function will be called when the application screen size is changed.
-    @param new width
-    @param new height
-    */
-    virtual void applicationScreenSizeChanged(int newWidth, int newHeight);
-
 protected:
     static Application* sm_pSharedApplication;
 };

--- a/axmol/platform/ios/Application-ios.mm
+++ b/axmol/platform/ios/Application-ios.mm
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/ios/Application-ios.mm
+++ b/axmol/platform/ios/Application-ios.mm
@@ -129,6 +129,4 @@ bool Application::openURL(std::string_view url)
     [application openURL:nsUrl options:@{} completionHandler:nil];
 }
 
-void Application::applicationScreenSizeChanged(int newWidth, int newHeight) {}
-
 }  // namespace ax

--- a/axmol/platform/ios/DirectorCaller-ios.h
+++ b/axmol/platform/ios/DirectorCaller-ios.h
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/ios/DirectorCaller-ios.mm
+++ b/axmol/platform/ios/DirectorCaller-ios.mm
@@ -2,6 +2,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/ios/EARenderView-ios.h
+++ b/axmol/platform/ios/EARenderView-ios.h
@@ -1,19 +1,8 @@
 /*
 
-===== IMPORTANT =====
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
-This is sample code demonstrating API, technology or techniques in development.
-Although this sample code has been reviewed for technical accuracy, it is not
-final. Apple is supplying this information to help you plan for the adoption of
-the technologies and programming interfaces described herein. This information
-is subject to change, and software implemented based on this sample code should
-be tested with final operating system software and final documentation. Newer
-versions of this sample code may be provided with future seeds of the API or
-technology. For information about updates to this and other developer
-documentation, view the New & Updated sidebars in subsequent documentation
-seeds.
-
-=====================
+ https://axmol.dev/
 
 File: EARenderView.h
 Abstract: Convenience class that wraps the CAEAGLLayer from CoreAnimation into a

--- a/axmol/platform/ios/EARenderView-ios.mm
+++ b/axmol/platform/ios/EARenderView-ios.mm
@@ -1,17 +1,8 @@
 /*
 
-===== IMPORTANT =====
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
-This is sample code demonstrating API, technology or techniques in development.
-Although this sample code has been reviewed for technical accuracy, it is not
-final. Apple is supplying this information to help you plan for the adoption of
-the technologies and programming interfaces described herein. This information
-is subject to change, and software implemented based on this sample code should
-be tested with final operating system software and final documentation. Newer
-versions of this sample code may be provided with future seeds of the API or
-technology. For information about updates to this and other developer
-documentation, view the New & Updated sidebars in subsequent documentation
-seeds.
+ https://axmol.dev/
 
 =====================
 

--- a/axmol/platform/ios/EARenderView-ios.mm
+++ b/axmol/platform/ios/EARenderView-ios.mm
@@ -291,7 +291,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 - (void)layoutSubviews
 {
-    if (!ax::Director::getInstance()->isValid())
+    auto director = ax::Director::getInstance();
+    if (!director->isValid())
         return;
 
 #if AX_RENDER_API == AX_RENDER_API_MTL
@@ -301,18 +302,15 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #else
     [renderer_ resizeFromLayer:(CAEAGLLayer*)self.layer];
     size_ = [renderer_ backingSize];
-    ax::Size size;
-    size.width  = size_.width;
-    size.height = size_.height;
 #endif
 
-    // TODO: resizeSwapchain?
+    auto renderView = director->getRenderView();
+    if (renderView)
+        renderView->updateRenderSurface(size_.width, size_.height, ax::RenderView::AllUpdates);
 
     // Avoid flicker. Issue #350
     if ([NSThread isMainThread])
-    {
-        ax::Director::getInstance()->drawScene();
-    }
+        director->drawScene();
 }
 
 - (void)swapBuffers

--- a/axmol/platform/ios/ES3Renderer-ios.h
+++ b/axmol/platform/ios/ES3Renderer-ios.h
@@ -4,6 +4,7 @@
  Corpyight (c) 2011      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/ios/ES3Renderer-ios.m
+++ b/axmol/platform/ios/ES3Renderer-ios.m
@@ -3,6 +3,7 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Corpyight (c) 2011      Zynga Inc.
  Copyright (c) 2013-2017 Chukong Technologies Inc.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/ios/ESRenderer-ios.h
+++ b/axmol/platform/ios/ESRenderer-ios.h
@@ -4,6 +4,7 @@
  Corpyight (c) 2011      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -150,7 +150,7 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
     const auto backingScaleFactor = [eaView contentScaleFactor];
 
     // simply set renderSize, renderSize to framebufferSize with renderScale=1.0
-    setRenderSize(size.width * backingScaleFactor, size.height * backingScaleFactor);
+    updateRenderSurface(size.width * backingScaleFactor, size.height * backingScaleFactor, SurfaceUpdateFlag::AllUpdatesSilently);
 
     _eaViewHandle = eaView;
 

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -150,7 +150,8 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
     const auto backingScaleFactor = [eaView contentScaleFactor];
 
     // simply set renderSize, renderSize to framebufferSize with renderScale=1.0
-    updateRenderSurface(size.width * backingScaleFactor, size.height * backingScaleFactor, SurfaceUpdateFlag::AllUpdatesSilently);
+    updateRenderSurface(size.width * backingScaleFactor, size.height * backingScaleFactor,
+                        SurfaceUpdateFlag::AllUpdatesSilently);
 
     _eaViewHandle = eaView;
 

--- a/axmol/platform/linux/Application-linux.cpp
+++ b/axmol/platform/linux/Application-linux.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Laschweinski
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/linux/FileUtils-linux.h
+++ b/axmol/platform/linux/FileUtils-linux.h
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Laschweinski
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/linux/GL-linux.h
+++ b/axmol/platform/linux/GL-linux.h
@@ -1,6 +1,7 @@
 /****************************************************************************
 Copyright (c) 2010 cocos2d-x.org
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/linux/StdC-linux.h
+++ b/axmol/platform/linux/StdC-linux.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/mac/Application-mac.mm
+++ b/axmol/platform/mac/Application-mac.mm
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/mac/GL-mac.h
+++ b/axmol/platform/mac/GL-mac.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/mac/StdC-mac.h
+++ b/axmol/platform/mac/StdC-mac.h
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/wasm/Application-wasm.h
+++ b/axmol/platform/wasm/Application-wasm.h
@@ -3,7 +3,6 @@ Copyright (c) 2011      Laschweinski
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
-Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/wasm/devtools-wasm.h
+++ b/axmol/platform/wasm/devtools-wasm.h
@@ -1,3 +1,26 @@
+/****************************************************************************
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+https://axmol.dev/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
 #pragma once
 
 #include "axmol/platform/PlatformConfig.h"

--- a/axmol/platform/win32/StdC-win32.cpp
+++ b/axmol/platform/win32/StdC-win32.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
 Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
 https://axmol.dev/
 

--- a/axmol/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/axmol/platform/winrt/RenderViewImpl-winrt.cpp
@@ -543,9 +543,6 @@ void RenderViewImpl::UpdateForWindowSizeChange(float width, float height)
         m_width  = width;
         m_height = height;
         handleWindowResized();
-
-        setRenderSize(m_width * _renderScale, m_height * _renderScale);
-        onRenderResized();
     }
 }
 
@@ -558,16 +555,15 @@ void RenderViewImpl::SetDPI(float dpi)
         updateRenderScale();
         if (!inital)
         {
-            setRenderSize(m_width * _renderScale, m_height * _renderScale);
+            updateRenderSurface(m_width * _renderScale, m_height * _renderScale, SurfaceUpdateFlag::RenderSizeChanged);
         }
     }
 }
 
 void RenderViewImpl::handleWindowResized()
 {
-    _windowSize.set(m_width, m_height);
-
-    setRenderSize(m_width * _renderScale, m_height * _renderScale);
+    updateRenderSurface(m_width, m_height, SurfaceUpdateFlag::WindowSizeChanged);
+    updateRenderSurface(m_width * _renderScale, m_height * _renderScale, SurfaceUpdateFlag::RenderSizeChanged);
 }
 
 void RenderViewImpl::updateRenderScale()

--- a/templates/common/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/common/proj.ios_mac/ios/RootViewController.mm
@@ -79,19 +79,6 @@ customization that is not appropriate for viewDidLoad.
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
 {
     [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-
-    auto renderView = ax::Director::getInstance()->getRenderView();
-
-    if (renderView)
-    {
-        EARenderView* eaView = (__bridge EARenderView*)renderView->getNativeDisplay();
-
-        if (eaView)
-        {
-            CGSize s = CGSizeMake([eaView getWidth], [eaView getHeight]);
-            ax::Application::getInstance()->applicationScreenSizeChanged((int)s.width, (int)s.height);
-        }
-    }
 }
 
 // fix not hide status on ios7

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -179,3 +179,8 @@ void AppDelegate::applicationWillEnterForeground()
 
     Director::getInstance()->startAnimation();
 }
+
+void AppDelegate::applicationScreenSizeChanged(int newWidth, int newHeight)
+{
+    AXLOGI("AppDelegate::applicationScreenSizeChanged: ({},{})", newWidth, newHeight);
+}

--- a/tests/cpp-tests/Source/AppDelegate.h
+++ b/tests/cpp-tests/Source/AppDelegate.h
@@ -41,26 +41,28 @@ public:
     AppDelegate();
     virtual ~AppDelegate();
 
-    virtual void initGfxContextAttrs();
+    void initGfxContextAttrs() override;
 
     /**
     @brief    Implement Director and ax::Scene* init code here.
     @return true    Initialize success, app continue.
     @return false   Initialize failed, app terminate.
     */
-    virtual bool applicationDidFinishLaunching();
+    bool applicationDidFinishLaunching() override;
 
     /**
     @brief  Called when the application moves to the background
     @param  the pointer of the application
     */
-    virtual void applicationDidEnterBackground();
+    void applicationDidEnterBackground() override;
 
     /**
     @brief  Called when the application reenters the foreground
     @param  the pointer of the application
     */
-    virtual void applicationWillEnterForeground();
+    void applicationWillEnterForeground() override;
+
+    void applicationScreenSizeChanged(int newWidth, int newHeight) override;
 
 private:
     TestController* _testController;

--- a/tests/cpp-tests/proj.android/app/build.gradle
+++ b/tests/cpp-tests/proj.android/app/build.gradle
@@ -29,7 +29,7 @@ android {
         externalNativeBuild {
             cmake {
                 targets 'cpp-tests'
-                arguments = []
+                arguments = ["-DAX_ENABLE_VR=ON"]
                 arguments.addAll(cmakeOptions)
                 cppFlags "-frtti -fexceptions -fsigned-char"
             }


### PR DESCRIPTION
## Describe your changes

- [x] Mobile platforms: when recive screen size changed, re-layout RenderView first, then invoke applicationScreenSizeChanged
    - [x] Android
    - [x] iOS 
- [x] Desktop platforms: add missing applicationScreenSizeChanged calls

## Issue ticket number and link

- #2761

## Additional issue

This PR will also fix #2763, and FAQ in wiki: https://github.com/axmolengine/axmol/wiki/FAQ#q-in-my-landscape-app-for-android-after-coming-back-from-the-background-to-the-foreground-sometimes-the-image-is-shifted-to-the-top-left-is-there-something-i-can-do-to-avoid-it

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [x] I have checked readme and add important infos to this PR.
- [x] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
