### PR TITLE
fix(wasm): improve frame timing and runtime compatibility

### DIFF
--- a/1k/build.profiles
+++ b/1k/build.profiles
@@ -88,6 +88,6 @@ guava=33.3.1
 # - since emsdk-4.0.0+ can't be debugging via chrome properly on windows (macos and linux no this issue)
 # - axmol can build with emsdk-3.1.73+
 # - please use emsdk-3.1.73 if you want debug axmol wasm app properly
-emsdk=3.1.73+
+emsdk=3.1.73~4.0.15+
 
 # --- endregion

--- a/axmol/platform/Device.h
+++ b/axmol/platform/Device.h
@@ -79,8 +79,8 @@ public:
     };
 
     // Reasonable refresh rate range and fallback
-    static constexpr int MIN_REFRESH_RATE = 15;
-    static constexpr int MAX_REFRESH_RATE = 1000;
+    static constexpr int MIN_REFRESH_RATE     = 15;
+    static constexpr int MAX_REFRESH_RATE     = 1000;
     static constexpr int DEFAULT_REFRESH_RATE = 60;
 
     /**

--- a/axmol/platform/Device.h
+++ b/axmol/platform/Device.h
@@ -78,6 +78,11 @@ public:
         NotificationFeedbackTypeError
     };
 
+    // Reasonable refresh rate range and fallback
+    static constexpr int MIN_REFRESH_RATE = 15;
+    static constexpr int MAX_REFRESH_RATE = 1000;
+    static constexpr int DEFAULT_REFRESH_RATE = 60;
+
     /**
      *  Gets the DPI of device
      *  @return The DPI of device.

--- a/axmol/platform/android/Device-android.cpp
+++ b/axmol/platform/android/Device-android.cpp
@@ -214,8 +214,8 @@ void Device::selectionChanged()
 int Device::getDisplayRefreshRate()
 {
     int hz = static_cast<int>(JniHelper::callStaticFloatMethod(deviceHelperClassName, "getDisplayRefreshRate"));
-    if (hz < 20 || hz > 1000)
-        hz = 60;
+    if (hz < MIN_REFRESH_RATE || hz > MAX_REFRESH_RATE)
+        hz = DEFAULT_REFRESH_RATE;
     return hz;
 }
 

--- a/axmol/platform/android/Device-android.cpp
+++ b/axmol/platform/android/Device-android.cpp
@@ -214,6 +214,8 @@ void Device::selectionChanged()
 int Device::getDisplayRefreshRate()
 {
     int hz = static_cast<int>(JniHelper::callStaticFloatMethod(deviceHelperClassName, "getDisplayRefreshRate"));
+    if (hz < 20 || hz > 1000)
+        hz = 60;
     return hz;
 }
 

--- a/axmol/platform/desktop/Device-desktop.cpp
+++ b/axmol/platform/desktop/Device-desktop.cpp
@@ -35,10 +35,10 @@ int Device::getDisplayRefreshRate()
     //   - emsdk 4.x: glfwGetVideoMode() may return 0
     //
     // Apply a safety clamp: if the reported value is out of a reasonable range
-    // (e.g. <20 Hz or >1000 Hz), fall back to 60 Hz as a safe default.
+    // (e.g. <MIN_REFRESH_RATE Hz or >MAX_REFRESH_RATE Hz), fall back to DEFAULT_REFRESH_RATE Hz as a safe default.
     auto hz = glfwGetVideoMode(glfwGetPrimaryMonitor())->refreshRate;
-    if (hz < 20 || hz > 1000)
-        hz = 60;
+    if (hz < MIN_REFRESH_RATE || hz > MAX_REFRESH_RATE)
+        hz = DEFAULT_REFRESH_RATE;
     return hz;
 }
 }  // namespace ax

--- a/axmol/platform/desktop/Device-desktop.cpp
+++ b/axmol/platform/desktop/Device-desktop.cpp
@@ -29,6 +29,13 @@ namespace ax
 {
 int Device::getDisplayRefreshRate()
 {
+    // Retrieve the display refresh rate from GLFW.
+    // Known behavior when targeting WebAssembly with emsdk:
+    //   - emsdk 3.x: glfwGetVideoMode() returns 60 Hz
+    //   - emsdk 4.x: glfwGetVideoMode() may return 0
+    //
+    // Apply a safety clamp: if the reported value is out of a reasonable range
+    // (e.g. <20 Hz or >1000 Hz), fall back to 60 Hz as a safe default.
     auto hz = glfwGetVideoMode(glfwGetPrimaryMonitor())->refreshRate;
     if (hz < 20 || hz > 1000)
         hz = 60;

--- a/axmol/platform/desktop/Device-desktop.cpp
+++ b/axmol/platform/desktop/Device-desktop.cpp
@@ -29,6 +29,9 @@ namespace ax
 {
 int Device::getDisplayRefreshRate()
 {
-    return glfwGetVideoMode(glfwGetPrimaryMonitor())->refreshRate;
+    auto hz = glfwGetVideoMode(glfwGetPrimaryMonitor())->refreshRate;
+    if (hz < 20 || hz > 1000)
+        hz = 60;
+    return hz;
 }
 }  // namespace ax

--- a/axmol/platform/ios/Device-ios.mm
+++ b/axmol/platform/ios/Device-ios.mm
@@ -775,6 +775,8 @@ int Device::getDisplayRefreshRate()
 {
     UIScreen* mainScreen = [UIScreen mainScreen];
     int hz               = static_cast<int>(mainScreen.maximumFramesPerSecond);
+    if (hz < 20 || hz > 1000)
+        hz = 60;
     return hz;
 }
 

--- a/axmol/platform/ios/Device-ios.mm
+++ b/axmol/platform/ios/Device-ios.mm
@@ -775,8 +775,8 @@ int Device::getDisplayRefreshRate()
 {
     UIScreen* mainScreen = [UIScreen mainScreen];
     int hz               = static_cast<int>(mainScreen.maximumFramesPerSecond);
-    if (hz < 20 || hz > 1000)
-        hz = 60;
+    if (hz < MIN_REFRESH_RATE || hz > MAX_REFRESH_RATE)
+        hz = DEFAULT_REFRESH_RATE;
     return hz;
 }
 

--- a/axmol/platform/wasm/Application-wasm.cpp
+++ b/axmol/platform/wasm/Application-wasm.cpp
@@ -146,7 +146,7 @@ static void updateFrame()
         s_accumulator -= targetInterval;
         if (s_accumulator < 0.0) [[unlikely]]  // floating-point safety
             s_accumulator = 0.0;
-    } // else onIdle
+    }  // else onIdle
 }
 
 static void renderFrame()

--- a/axmol/platform/wasm/Application-wasm.cpp
+++ b/axmol/platform/wasm/Application-wasm.cpp
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #    include "axmol/base/Director.h"
 #    include "axmol/base/Utils.h"
 #    include "axmol/platform/FileUtils.h"
+#    include "axmol/platform/Device.h"
 #    include "yasio/utils.hpp"
 #    include <emscripten/emscripten.h>
 
@@ -97,10 +98,56 @@ static int64_t NANOSECONDSPERSECOND      = 1000000000LL;
 static int64_t NANOSECONDSPERMICROSECOND = 1000000LL;
 static int64_t FPS_CONTROL_THRESHOLD     = static_cast<int64_t>(1.0f / 1200.0f * NANOSECONDSPERSECOND);
 
-static int64_t s_animationInterval = static_cast<int64_t>(1 / 60.0 * NANOSECONDSPERSECOND);
-
 static Director* __director;
-static int64_t mLastTickInNanoSeconds = 0;
+
+static int s_targetFPS        = 0;    // 0 = follow browser refresh rate
+static double s_lastFrameTime = 0.0;  // ms
+static double s_accumulator   = 0.0;  // ms
+
+static void renderFrame();
+
+static void updateFrame()
+{
+    double now = emscripten_get_now();  // current time in ms
+
+    // First frame: render immediately
+    if (s_lastFrameTime <= 0.0) [[unlikely]]
+    {
+        renderFrame();
+        s_lastFrameTime = now;
+        return;
+    }
+
+    double delta    = now - s_lastFrameTime;
+    s_lastFrameTime = now;
+
+    // Protect against long suspension (e.g. tab inactive for seconds/minutes)
+    if (delta > 1000.0) [[unlikely]]
+    {
+        s_accumulator = 0.0;
+        renderFrame();
+        return;
+    }
+
+    s_accumulator += delta;
+
+    // If targetFPS is 0, follow browser refresh rate directly
+    if (s_targetFPS <= 0)
+    {
+        renderFrame();
+        return;
+    }
+
+    // Frame skipping logic based on accumulator
+    double targetInterval = 1000.0 / s_targetFPS;
+    if (s_accumulator >= targetInterval)
+    {
+        renderFrame();
+        s_accumulator -= targetInterval;
+        if (s_accumulator < 0.0) [[unlikely]]  // floating-point safety
+            s_accumulator = 0.0;
+    } // else onIdle
+}
 
 static void renderFrame()
 {
@@ -124,26 +171,6 @@ static void renderFrame()
 
         axmol_wasm_app_exit();
     }
-}
-
-static void updateFrame(void)
-{
-    const auto now = yasio::xhighp_clock();
-    /*
-     * No need to use algorithm in default(60,90,120... FPS) situation,
-     * since onDrawFrame() was called by system 60 times per second by default.
-     */
-    if (s_animationInterval > FPS_CONTROL_THRESHOLD)
-    {
-        auto interval = now - mLastTickInNanoSeconds;
-
-        // If not enough time has passed since the last frame, skip rendering
-        if (interval < s_animationInterval)
-            return;
-    }
-
-    mLastTickInNanoSeconds = now;
-    renderFrame();
 }
 
 static void getCurrentLangISO2(char buf[16])
@@ -200,8 +227,7 @@ int Application::run()
     that lines up properly with the browser and monitor.
     */
 #    if AX_WASM_TIMING_USE_TIMEOUT
-    double fps = ceil(1.0 / (static_cast<double>(s_animationInterval) / NANOSECONDSPERSECOND));
-    emscripten_set_main_loop(updateFrame, static_cast<int>(fps), false);
+    emscripten_set_main_loop(updateFrame, s_targetFPS, false);
 #    else
     emscripten_set_main_loop(updateFrame, -1, false);
 #    endif
@@ -211,7 +237,14 @@ int Application::run()
 
 void Application::setAnimationInterval(float interval)
 {
-    s_animationInterval = static_cast<int64_t>(interval * NANOSECONDSPERSECOND);
+    if (interval <= 0.0) [[unlikely]]
+    {
+        // 0 or negative means follow browser refresh rate
+        s_targetFPS = 0;
+        return;
+    }
+    const auto desiredFPS = static_cast<int>(std::lround(1 / interval));
+    s_targetFPS           = std::clamp(desiredFPS, Device::MIN_REFRESH_RATE, Device::MAX_REFRESH_RATE);
 }
 
 Application::Platform Application::getTargetPlatform()

--- a/axmol/platform/wasm/Application-wasm.cpp
+++ b/axmol/platform/wasm/Application-wasm.cpp
@@ -128,23 +128,22 @@ static void renderFrame()
 
 static void updateFrame(void)
 {
-    renderFrame();
-
+    const auto now = yasio::xhighp_clock();
     /*
      * No need to use algorithm in default(60,90,120... FPS) situation,
      * since onDrawFrame() was called by system 60 times per second by default.
      */
     if (s_animationInterval > FPS_CONTROL_THRESHOLD)
     {
-        auto interval = yasio::xhighp_clock() - mLastTickInNanoSeconds;
+        auto interval = now - mLastTickInNanoSeconds;
 
+        // If not enough time has passed since the last frame, skip rendering
         if (interval < s_animationInterval)
-        {
-            std::this_thread::sleep_for(std::chrono::nanoseconds(s_animationInterval - interval));
-        }
-
-        mLastTickInNanoSeconds = yasio::xhighp_clock();
+            return;
     }
+
+    mLastTickInNanoSeconds = now;
+    renderFrame();
 }
 
 static void getCurrentLangISO2(char buf[16])

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -632,7 +632,7 @@ macro(ax_setup_app_props app_name)
     set(CMAKE_EXECUTABLE_SUFFIX ".html")
     target_link_options(${app_name} PRIVATE
       "-sEXPORTED_FUNCTIONS=[${AX_WASM_EXPORTS}]"
-      "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,HEAPU8]"
+      "-sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,HEAPU8,requestFullscreen]"
     )
     set(EMSCRIPTEN_LINK_FLAGS "-lidbfs.js -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 -s STACK_SIZE=4mb --shell-file ${AX_WASM_SHELL_FILE} --use-preload-cache")
 

--- a/cmake/Modules/AXConfigDefine.cmake
+++ b/cmake/Modules/AXConfigDefine.cmake
@@ -185,7 +185,7 @@ endif()
 
 if(EMSCRIPTEN)
   # Tell emcc build port libjpeg(not in sysroot)
-  list(APPEND _ax_compile_opts "-sUSE_LIBJPEG=1")
+  list(APPEND _ax_c_flags "-sUSE_LIBJPEG=1")
 
   # fix build fail on windows host when cmake invoking emscan-deps (raise unknown options)
   list(APPEND _ax_link_opts  "-ljpeg")

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
@@ -428,8 +428,8 @@ void HoleDemo::pokeHoleAtPoint(Vec2 point)
 void HoleDemo::onTouchesBegan(const std::vector<Touch*>& touches, Event* event)
 {
     Touch* touch = (Touch*)touches[0];
-    Vec2 point   = _outerClipper->convertToNodeSpace(Director::getInstance()->screenToWorld(touch->getLocationInView()));
-    auto rect    = Rect(0, 0, _outerClipper->getContentSize().width, _outerClipper->getContentSize().height);
+    Vec2 point = _outerClipper->convertToNodeSpace(Director::getInstance()->screenToWorld(touch->getLocationInView()));
+    auto rect  = Rect(0, 0, _outerClipper->getContentSize().width, _outerClipper->getContentSize().height);
     if (!rect.containsPoint(point))
         return;
     this->pokeHoleAtPoint(point);


### PR DESCRIPTION
- Added display refresh rate detection with range protection
- Removed std::sleep_for from main_loop to avoid blocking in browser
- Exported requestFullscreen in EXPORTED_RUNTIME_METHODS for fullscreen support
- Set emsdk to prefer the latest 4.0.15 release

These changes improve runtime stability and ensure smoother rendering when running under emsdk 4.0.0+.

They also prevent potential application hangs (freezes) when building with emsdk 4.0+.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
