### PR TITLE
Fix effekseer & imgui render resource state

### DIFF
--- a/axmol/base/Types.h
+++ b/axmol/base/Types.h
@@ -485,42 +485,8 @@ public:
 extern const std::string AX_DLL STD_STRING_EMPTY;
 extern const ssize_t AX_DLL AX_INVALID_INDEX;
 
-struct RectI
-{
-    RectI() { this->x = this->y = this->w = this->h = 0; }
-    int x;
-    int y;
-
-    union
-    {
-        struct
-        {
-            int width;
-            int height;
-        };
-        struct
-        {
-            int w;
-            int h;
-        };
-    };
-
-    inline bool operator==(const RectI& v) const
-    {
-        return this->x == v.x && this->y == v.y && this->width == v.width && this->height == v.height;
-    }
-    inline RectI& set(int x, int y, int w, int h)
-    {
-        this->x      = x;
-        this->y      = y;
-        this->width  = w;
-        this->height = h;
-        return *this;
-    }
-};
-
-using Viewport    = RectI;
-using ScissorRect = RectI;  // both GL & Metal is integer type, GL: int, Metal: NSUInteger
+using Viewport    = rhi::Viewport;
+using ScissorRect = rhi::ScissorRect;  // both GL & Metal is integer type, GL: int, Metal: NSUInteger
 
 using TextureUsage = rhi::TextureUsage;
 using PixelFormat  = rhi::PixelFormat;

--- a/axmol/platform/desktop/RenderViewImpl.cpp
+++ b/axmol/platform/desktop/RenderViewImpl.cpp
@@ -626,6 +626,17 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
         return false;
     }
 
+#if AX_RENDER_API == AX_RENDER_API_GL
+    glfwMakeContextCurrent(_mainWindow);
+
+#    if (AX_TARGET_PLATFORM != AX_PLATFORM_MAC)
+    loadGL();
+#    endif
+    // Init driver after load GL
+    axdrv;
+    glfwSetWindowUserPointer(_mainWindow, rhi::gl::__state);
+#endif
+
     /*
      *  Note that the created window and context may differ from what you requested,
      *  as not all parameters and hints are
@@ -644,11 +655,6 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     int w, h;
     glfwGetWindowSize(_mainWindow, &w, &h);
     updateScaledWindowSize(w, h, SurfaceUpdateFlag::WindowSizeChanged | SurfaceUpdateFlag::SilentUpdate);
-
-#if AX_RENDER_API == AX_RENDER_API_GL
-    glfwMakeContextCurrent(_mainWindow);
-    glfwSetWindowUserPointer(_mainWindow, rhi::gl::__state);
-#endif
 
     glfwSetMouseButtonCallback(_mainWindow, GLFWEventHandler::onGLFWMouseCallBack);
     glfwSetCursorPosCallback(_mainWindow, GLFWEventHandler::onGLFWMouseMoveCallBack);
@@ -689,14 +695,6 @@ bool RenderViewImpl::initWithRect(std::string_view viewName,
     glfwSetWindowIconifyCallback(_mainWindow, GLFWEventHandler::onGLFWWindowIconifyCallback);
     glfwSetWindowFocusCallback(_mainWindow, GLFWEventHandler::onGLFWWindowFocusCallback);
     glfwSetWindowCloseCallback(_mainWindow, GLFWEventHandler::onGLFWWindowCloseCallback);
-
-#if (AX_TARGET_PLATFORM != AX_PLATFORM_MAC)
-#    if AX_RENDER_API == AX_RENDER_API_GL
-    loadGL();
-    // Init driver after load GL
-    axdrv;
-#    endif
-#endif
 
 #if AX_RENDER_API == AX_RENDER_API_GL
 #    if !defined(__EMSCRIPTEN__)

--- a/axmol/platform/linux/Application-linux.cpp
+++ b/axmol/platform/linux/Application-linux.cpp
@@ -54,7 +54,7 @@ Application::~Application()
 int Application::run()
 {
     initGfxContextAttrs();
-    // Initialize instance and cocos2d.
+    // Initialize instance and axmol.
     if (!applicationDidFinishLaunching())
     {
         return 0;

--- a/axmol/platform/wasm/Application-wasm.cpp
+++ b/axmol/platform/wasm/Application-wasm.cpp
@@ -207,7 +207,7 @@ Application::~Application()
 int Application::run()
 {
     initGfxContextAttrs();
-    // Initialize instance and cocos2d.
+    // Initialize instance and axmol.
     if (!applicationDidFinishLaunching())
     {
         return 1;

--- a/axmol/platform/win32/Application-win32.cpp
+++ b/axmol/platform/win32/Application-win32.cpp
@@ -79,7 +79,7 @@ int Application::run()
 
     initGfxContextAttrs();
 
-    // Initialize instance and cocos2d.
+    // Initialize instance and axmol.
     if (!applicationDidFinishLaunching())
     {
         return 1;

--- a/axmol/platform/winrt/Application-winrt.cpp
+++ b/axmol/platform/winrt/Application-winrt.cpp
@@ -75,7 +75,7 @@ Application::~Application()
 
 int Application::run()
 {
-    // Initialize instance and cocos2d.
+    // Initialize instance and axmol.
     if (!applicationDidFinishLaunching())
     {
         return 0;

--- a/axmol/rhi/RHITypes.h
+++ b/axmol/rhi/RHITypes.h
@@ -554,6 +554,43 @@ struct ProgramType
 };
 // clang-format on
 
+struct RectI
+{
+    RectI() { this->x = this->y = this->w = this->h = 0; }
+    int x;
+    int y;
+
+    union
+    {
+        struct
+        {
+            int width;
+            int height;
+        };
+        struct
+        {
+            int w;
+            int h;
+        };
+    };
+
+    inline bool operator==(const RectI& v) const
+    {
+        return this->x == v.x && this->y == v.y && this->width == v.width && this->height == v.height;
+    }
+    inline RectI& set(int x, int y, int w, int h)
+    {
+        this->x      = x;
+        this->y      = y;
+        this->width  = w;
+        this->height = h;
+        return *this;
+    }
+};
+
+using Viewport    = RectI;
+using ScissorRect = RectI;
+
 // d3d RHI spec
 enum class PowerPreference
 {

--- a/axmol/rhi/opengl/CommandBufferGL.cpp
+++ b/axmol/rhi/opengl/CommandBufferGL.cpp
@@ -169,7 +169,7 @@ void CommandBufferImpl::setCullMode(CullMode mode)
 
 void CommandBufferImpl::setWinding(Winding winding)
 {
-    __state->winding(winding);
+    __state->winding(UtilsGL::toGLFrontFace(winding));
 }
 
 void CommandBufferImpl::setVertexBuffer(Buffer* buffer)

--- a/axmol/rhi/opengl/DriverGL.cpp
+++ b/axmol/rhi/opengl/DriverGL.cpp
@@ -171,9 +171,10 @@ DriverImpl::DriverImpl()
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_defaultFBO);
 
     // reset gl state
+    resetState();
+    
     // NOT GLES2.0, need generate shared VAO clearly
     glGenVertexArrays(1, &_sharedVAO);
-    resetState();
     __state->bindVertexArray(_sharedVAO);
 
     CHECK_GL_ERROR_DEBUG();

--- a/axmol/rhi/opengl/DriverGL.cpp
+++ b/axmol/rhi/opengl/DriverGL.cpp
@@ -171,12 +171,19 @@ DriverImpl::DriverImpl()
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_defaultFBO);
 
     // reset gl state
+    // NOT GLES2.0, need generate shared VAO clearly
+    glGenVertexArrays(1, &_sharedVAO);
     resetState();
+    __state->bindVertexArray(_sharedVAO);
 
     CHECK_GL_ERROR_DEBUG();
 }
 
-DriverImpl::~DriverImpl() {}
+DriverImpl::~DriverImpl()
+{
+    if (_sharedVAO)
+        glDeleteVertexArrays(1, &_sharedVAO);
+}
 
 GLint DriverImpl::getDefaultFBO() const
 {

--- a/axmol/rhi/opengl/DriverGL.cpp
+++ b/axmol/rhi/opengl/DriverGL.cpp
@@ -172,7 +172,7 @@ DriverImpl::DriverImpl()
 
     // reset gl state
     resetState();
-    
+
     // NOT GLES2.0, need generate shared VAO clearly
     glGenVertexArrays(1, &_sharedVAO);
     __state->bindVertexArray(_sharedVAO);

--- a/axmol/rhi/opengl/DriverGL.h
+++ b/axmol/rhi/opengl/DriverGL.h
@@ -61,6 +61,8 @@ public:
 
     GLint getDefaultFBO() const;
 
+    GLuint getSharedVAO() const { return _sharedVAO; }
+
     /**
      * Create a CommandBuffer object, not auto released.
      * @return A CommandBuffer object.
@@ -166,6 +168,7 @@ protected:
     void destroySampler(SamplerHandle&) override;
 
     GLint _defaultFBO = 0;  // The value gets from glGetIntegerv, so need to use GLint
+    GLuint _sharedVAO = 0;  // The shared VAO for all vertex layouts
 
 private:
     std::set<uint32_t> _glExtensions;

--- a/axmol/rhi/opengl/OpenGLState.cpp
+++ b/axmol/rhi/opengl/OpenGLState.cpp
@@ -1,4 +1,5 @@
 #include "axmol/rhi/opengl/OpenGLState.h"
+#include <unordered_set>
 
 namespace ax::rhi::gl
 {
@@ -10,17 +11,18 @@ std::unique_ptr<OpenGLState> g_defaultOpenGLState;
 
 AX_DLL OpenGLState* __state{nullptr};
 
-OpenGLState::OpenGLState()
-{
-    // NOT GLES2.0, need generate VAO clearly
-    glGenVertexArrays(1, &_defaultVAO);
-    glBindVertexArray(_defaultVAO);
-}
-
 void OpenGLState::reset()
 {
     g_defaultOpenGLState = std::make_unique<OpenGLState>();
     __state              = g_defaultOpenGLState.get();
+}
+
+OpenGLState::OpenGLState()
+{
+}
+
+OpenGLState::~OpenGLState()
+{
 }
 
 }  // namespace ax::rhi::gl

--- a/axmol/rhi/opengl/OpenGLState.cpp
+++ b/axmol/rhi/opengl/OpenGLState.cpp
@@ -4,10 +4,7 @@
 namespace ax::rhi::gl
 {
 
-namespace
-{
-std::unique_ptr<OpenGLState> g_defaultOpenGLState;
-}
+static std::unique_ptr<OpenGLState> g_defaultOpenGLState;
 
 AX_DLL OpenGLState* __state{nullptr};
 

--- a/axmol/rhi/opengl/OpenGLState.cpp
+++ b/axmol/rhi/opengl/OpenGLState.cpp
@@ -14,12 +14,8 @@ void OpenGLState::reset()
     __state              = g_defaultOpenGLState.get();
 }
 
-OpenGLState::OpenGLState()
-{
-}
+OpenGLState::OpenGLState() {}
 
-OpenGLState::~OpenGLState()
-{
-}
+OpenGLState::~OpenGLState() {}
 
 }  // namespace ax::rhi::gl

--- a/extensions/Effekseer/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.Renderer.cpp
+++ b/extensions/Effekseer/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.Renderer.cpp
@@ -1,4 +1,4 @@
-﻿
+
 //----------------------------------------------------------------------------------
 // Include
 //----------------------------------------------------------------------------------
@@ -37,6 +37,8 @@
 #include "ShaderHeader/sprite_distortion_vs.h"
 #include "ShaderHeader/sprite_lit_vs.h"
 #include "ShaderHeader/sprite_unlit_vs.h"
+
+#include "axmol/rhi/opengl/OpenGLState.h"
 
 #include "GraphicsDevice.h"
 
@@ -601,6 +603,8 @@ bool RendererImplemented::EndRendering()
 			{
 				glBindSampler(i, 0);
 			}
+
+            ax::rhi::gl::__state->invalidateSamplerState();
 		}
 	}
 

--- a/extensions/Effekseer/EffekseerRendererLLGI/Common.cpp
+++ b/extensions/Effekseer/EffekseerRendererLLGI/Common.cpp
@@ -1,4 +1,4 @@
-#include "axmol/platform/Common.h"
+#include "Common.h"
 #include "EffekseerRendererLLGI.RendererImplemented.h"
 #include "GraphicsDevice.h"
 

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -97,8 +97,8 @@ static void ImGui_ImplAxmol_UpdateTexture(ImTextureData* tex)
         const void* pixels = tex->GetPixels();
 
         auto texture = new Texture2D();
-        texture->initWithData(pixels, tex->Width * tex->Height * 4, rhi::PixelFormat::RGBA8, tex->Width,
-                              tex->Height, true);
+        texture->initWithData(pixels, tex->Width * tex->Height * 4, rhi::PixelFormat::RGBA8, tex->Width, tex->Height,
+                              true);
 
         rhi::SamplerDesc desc{};
         texture->getRHITexture()->updateSamplerDesc(desc);
@@ -373,32 +373,64 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_RenderPlatform()
 #if AX_RENDER_API == AX_RENDER_API_GL && !defined(__ANDROID__)
         // restore context
         GLFWwindow* prev_current_context = glfwGetCurrentContext();
-        ImGui_ImplAxmol_PostCommand([=]() { ImGui_ImplAxmol_MakeCurrent(prev_current_context); });
+        ImGui_ImplAxmol_PostCommand([=]() { ImGui_ImplAxmol_MakeCurrent(prev_current_context, nullptr); });
 #endif
     }
 }
 
-IMGUI_IMPL_API void ImGui_ImplAxmol_MakeCurrent(GLFWwindow* window)
+IMGUI_IMPL_API void ImGui_ImplAxmol_MakeCurrent(GLFWwindow* window, ImGuiViewport* viewport)
 {
 #if !defined(__ANDROID__)
     glfwMakeContextCurrent(window);
 
 #    if AX_RENDER_API == AX_RENDER_API_GL
-    auto currentState = glfwGetWindowUserPointer(window);
-    if (!currentState)
-    { // create gl state for imgui mutli-viewport window
-        currentState = new gl::OpenGLState();
-        glfwSetWindowUserPointer(window, currentState);
+    auto state = static_cast<gl::OpenGLState*>(glfwGetWindowUserPointer(window));
+    if (!state)
+    {
+        assert(viewport);  // must be valid for new window when state is null
+        // create gl state for imgui mutli-viewport window
+        // this is a new OpenGLContext, create default VAO for it when core profile enabled
+        GLuint vao;
+        glGenVertexArrays(1, &vao);
+        state = new gl::OpenGLState();
+        glfwSetWindowUserPointer(window, state);
+        state->bindVertexArray(vao);
+        viewport->RendererUserData = reinterpret_cast<void*>(static_cast<uintptr_t>(vao));
     }
 
     // switch state for current gl context
-    if (gl::__state != currentState)
+    if (gl::__state != state)
     {
-        gl::__state->resetVAO();
-        gl::__state = (rhi::gl::OpenGLState*)currentState;
+        gl::__state->invalidateVertexArrayState();
+        gl::__state = state;
     }
 #    endif
 #endif
+}
+
+IMGUI_IMPL_API void ImGui_ImplAxmol_OnDestroyWindow(GLFWwindow* window, ImGuiViewport* viewport)
+{
+    if (viewport->RendererUserData)
+    {
+#if AX_RENDER_API == AX_RENDER_API_GL
+        auto prev_context = glfwGetCurrentContext();
+        if (prev_context != window)
+        {
+            // ensure context to viewport avoid delete VAO from wrong context
+            glfwMakeContextCurrent(window);
+            GLuint vao = static_cast<GLuint>(reinterpret_cast<uintptr_t>(viewport->RendererUserData));
+            glDeleteVertexArrays(1, &vao);
+
+            glfwMakeContextCurrent(prev_context);
+        }
+
+        viewport->RendererUserData = nullptr;
+#endif
+    }
+
+    auto state = static_cast<gl::OpenGLState*>(glfwGetWindowUserPointer(window));
+    if (state)
+        delete state;
 }
 
 IMGUI_IMPL_API void ImGui_ImplAxmol_PostCommand(std::function<void()>&& func)

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -380,10 +380,8 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_RenderPlatform()
 
 IMGUI_IMPL_API void ImGui_ImplAxmol_MakeCurrent(GLFWwindow* window, ImGuiViewport* viewport)
 {
-#if !defined(__ANDROID__)
+#    if AX_RENDER_API == AX_RENDER_API_GL && defined(GLFW_VERSION_MAJOR)
     glfwMakeContextCurrent(window);
-
-#    if AX_RENDER_API == AX_RENDER_API_GL
     auto state = static_cast<gl::OpenGLState*>(glfwGetWindowUserPointer(window));
     if (!state)
     {
@@ -405,14 +403,13 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_MakeCurrent(GLFWwindow* window, ImGuiViewpor
         gl::__state = state;
     }
 #    endif
-#endif
 }
 
 IMGUI_IMPL_API void ImGui_ImplAxmol_OnDestroyWindow(GLFWwindow* window, ImGuiViewport* viewport)
 {
+#if AX_RENDER_API == AX_RENDER_API_GL && defined(GLFW_VERSION_MAJOR)
     if (viewport->RendererUserData)
     {
-#if AX_RENDER_API == AX_RENDER_API_GL
         auto prev_context = glfwGetCurrentContext();
         if (prev_context != window)
         {
@@ -425,12 +422,12 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_OnDestroyWindow(GLFWwindow* window, ImGuiVie
         }
 
         viewport->RendererUserData = nullptr;
-#endif
-    }
 
+    }
     auto state = static_cast<gl::OpenGLState*>(glfwGetWindowUserPointer(window));
     if (state)
         delete state;
+#endif
 }
 
 IMGUI_IMPL_API void ImGui_ImplAxmol_PostCommand(std::function<void()>&& func)

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.h
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.h
@@ -22,7 +22,9 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_NewFrame();
 IMGUI_IMPL_API void ImGui_ImplAxmol_RenderDrawData(ImDrawData* draw_data);
 IMGUI_IMPL_API void ImGui_ImplAxmol_RenderPlatform();
 
-IMGUI_IMPL_API void ImGui_ImplAxmol_MakeCurrent(GLFWwindow* window);
+IMGUI_IMPL_API void ImGui_ImplAxmol_MakeCurrent(GLFWwindow* window, ImGuiViewport* viewport);
+
+IMGUI_IMPL_API void ImGui_ImplAxmol_OnDestroyWindow(GLFWwindow* window, ImGuiViewport* viewport);
 
 IMGUI_IMPL_API void ImGui_ImplAxmol_PostCommand(std::function<void()>&& func);
 

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_glfw.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_glfw.cpp
@@ -1251,8 +1251,8 @@ static void ImGui_ImplGlfw_CreateWindow(ImGuiViewport* viewport)
     if (bd->ClientApi == GlfwClientApi_OpenGL)
     {
         // axmol spec
-        ImGui_ImplAxmol_PostCommand([vd] {
-            ImGui_ImplAxmol_MakeCurrent(vd->Window);
+        ImGui_ImplAxmol_PostCommand([vd, viewport] {
+            ImGui_ImplAxmol_MakeCurrent(vd->Window, viewport);
             glfwSwapInterval(0);
         });
     }
@@ -1276,11 +1276,8 @@ static void ImGui_ImplGlfw_DestroyWindow(ImGuiViewport* viewport)
                 if (bd->KeyOwnerWindows[i] == vd->Window)
                     ImGui_ImplGlfw_KeyCallback(vd->Window, i, 0, GLFW_RELEASE, 0); // Later params are only used for main viewport, on which this function is never called.
 #if AX_RENDER_API == AX_RENDER_API_GL // axmol spec
-            using namespace ax::rhi;
-            // destroy imgui multi-viewport window gl state
-            auto isolated = (gl::OpenGLState*)glfwGetWindowUserPointer(vd->Window);
-            if (isolated)
-                delete isolated;
+            ImGui_ImplAxmol_OnDestroyWindow(vd->Window, viewport);
+
 #endif
             ImGui_ImplGlfw_ContextMap_Remove(vd->Window);
             glfwDestroyWindow(vd->Window);
@@ -1419,8 +1416,8 @@ static void ImGui_ImplGlfw_RenderWindow(ImGuiViewport* viewport, void*)
     if (bd->ClientApi == GlfwClientApi_OpenGL)
     {
         // axmol spec
-        ImGui_ImplAxmol_PostCommand([vd] {
-            ImGui_ImplAxmol_MakeCurrent(vd->Window);
+        ImGui_ImplAxmol_PostCommand([vd, viewport] {
+            ImGui_ImplAxmol_MakeCurrent(vd->Window, viewport);
         });
     }
 }
@@ -1432,8 +1429,8 @@ static void ImGui_ImplGlfw_SwapBuffers(ImGuiViewport* viewport, void*)
     if (bd->ClientApi == GlfwClientApi_OpenGL)
     {
         // axmol spec
-        ImGui_ImplAxmol_PostCommand([vd]() {
-            ImGui_ImplAxmol_MakeCurrent(vd->Window);
+        ImGui_ImplAxmol_PostCommand([vd, viewport]() {
+            ImGui_ImplAxmol_MakeCurrent(vd->Window, viewport);
             glfwSwapBuffers(vd->Window);
         });
     }

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -91254,7 +91254,7 @@ int lua_ax_base_Camera_setDefaultViewport(lua_State* tolua_S)
 
     if (argc == 1)
     {
-        ax::RectI arg0;
+        ax::rhi::RectI arg0;
         #pragma warning NO CONVERSION TO NATIVE FOR RectI
         ok = false;
         if(!ok)


### PR DESCRIPTION
## Describe your changes

- rhi::gl provide an internal API: `OpenGLState::invalidateSamplerState` for extensions
- reame `OpenGLState::resetVAO` to ``OpenGLState::invalidateVertexArrayState`
- invalidateSamplerState after unbind all sampler slot in endRendering of efekseer
- Destory properly VAO from ImGui multiview-port gl context


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
