### PR TITLE
Add Device::resolveOrientation and compact resolution logic

### DIFF
--- a/core/platform/Device.h
+++ b/core/platform/Device.h
@@ -262,6 +262,32 @@ public:
      */
     static Orientation getPhysicalOrientation();
 
+    /**
+     * Resolve the orientation of the application window.
+     *
+     * This method combines three sources of information:
+     *   1. Supported orientations (from getSupportedOrientations)
+     *   2. Preferred orientation (from getPreferredOrientation)
+     *   3. Current physical device orientation (from getPhysicalOrientation)
+     *
+     * Resolution rules:
+     *   - If the preferred orientation is a concrete value (Portrait, Landscape, etc.)
+     *     and is included in the supported mask, it will be used.
+     *   - If the preferred orientation is a sensor-based value (SensorPortrait,
+     *     SensorLandscape, Sensor, FullSensor), the physical orientation is used
+     *     if it is supported; otherwise a fallback orientation is chosen.
+     *   - If no valid orientation can be resolved, the first available orientation
+     *     from the supported mask is used as a fallback.
+     *
+     * The returned Orientation is guaranteed to be compatible with the supported
+     * orientation mask, and can be used by RenderViewImpl-ios to compute the
+     * logical screen size and viewport before app->run().
+     *
+     * @return Orientation  The resolved final orientation for the application.
+     * @since axmol-2.9.0
+     */
+    static Orientation resolveOrientation();
+
 #pragma endregion Orientation control support
 
 private:

--- a/core/platform/android/Device-android.cpp
+++ b/core/platform/android/Device-android.cpp
@@ -243,6 +243,11 @@ Device::Orientation Device::getPhysicalOrientation()
     return static_cast<Device::Orientation>(orientation);
 }
 
+Device::Orientation Device::resolveOrientation()
+{
+    return s_preferredOrientation;
+}
+
 }
 
 // this method is called by BitmapHelper

--- a/core/platform/desktop/Device-desktop.cpp
+++ b/core/platform/desktop/Device-desktop.cpp
@@ -50,4 +50,9 @@ Device::Orientation Device::getPhysicalOrientation()
     return Orientation::Unknown;
 }
 
+Device::Orientation Device::resolveOrientation()
+{
+    return Orientation::Unknown;
+}
+
 }  // namespace ax

--- a/core/platform/ios/Device-ios.mm
+++ b/core/platform/ios/Device-ios.mm
@@ -850,11 +850,12 @@ Device::Orientation Device::getCurrentOrientation()
             return Orientation::ReverseLandscape;
         case UIInterfaceOrientationPortraitUpsideDown:
             return Orientation::ReversePortrait;
-        default:;
+        default:
+            break;
     }
-#else
-    return Orientation::Unknown;
 #endif
+    
+    return Orientation::Unknown;
 }
 
 Device::Orientation Device::getPhysicalOrientation()
@@ -867,11 +868,100 @@ Device::Orientation Device::getPhysicalOrientation()
         case UIDeviceOrientationPortraitUpsideDown: return Orientation::ReversePortrait;
         case UIDeviceOrientationLandscapeLeft: return Orientation::Landscape;
         case UIDeviceOrientationLandscapeRight: return Orientation::ReverseLandscape;
-        default: return Orientation::Unknown;
+        default:
+            break;
     }
-#else
-    return Orientation::Unknown;
 #endif
+    
+    return Orientation::Unknown;
+}
+
+// Convert Orientation to OrientationMask
+static Device::OrientationMask toMask(Device::Orientation o)
+{
+    switch (o)
+    {
+    case Device::Orientation::Portrait:         return Device::OrientationMask::Portrait;
+    case Device::Orientation::ReversePortrait:  return Device::OrientationMask::ReversePortrait;
+    case Device::Orientation::Landscape:        return Device::OrientationMask::Landscape;
+    case Device::Orientation::ReverseLandscape: return Device::OrientationMask::ReverseLandscape;
+    default:                            return Device::OrientationMask::All;
+    }
+}
+
+// Pick the first supported orientation from OrientationMask
+static Device::Orientation pickFirstSupported(Device::OrientationMask mask)
+{
+    if ((mask & Device::OrientationMask::Portrait) == Device::OrientationMask::Portrait)
+        return Device::Orientation::Portrait;
+    if ((mask & Device::OrientationMask::Landscape) == Device::OrientationMask::Landscape)
+        return Device::Orientation::Landscape;
+    if ((mask & Device::OrientationMask::ReverseLandscape) == Device::OrientationMask::ReverseLandscape)
+        return Device::Orientation::ReverseLandscape;
+    if ((mask & Device::OrientationMask::ReversePortrait) == Device::OrientationMask::ReversePortrait)
+        return Device::Orientation::ReversePortrait;
+
+    return Device::Orientation::Portrait; // fallback
+}
+
+Device::Orientation Device::resolveOrientation()
+{
+    auto supported = getSupportedOrientations();
+    auto preferred = getPreferredOrientation();
+    auto physical  = getPhysicalOrientation();
+
+    auto tryUse = [&](Orientation o) -> Orientation {
+        return ((supported & toMask(o)) == toMask(o)) ? o : Orientation::Unknown;
+    };
+
+    Orientation resolvedOrientation = Orientation::Unknown;
+
+    switch (preferred)
+    {
+    // Case 1: Preferred is a concrete orientation
+    case Orientation::Portrait:
+    case Orientation::ReversePortrait:
+    case Orientation::Landscape:
+    case Orientation::ReverseLandscape:
+        resolvedOrientation = tryUse(preferred);
+        break;
+
+    // Case 2: SensorPortrait
+    case Orientation::SensorPortrait:
+        resolvedOrientation = tryUse(physical);
+        if (resolvedOrientation == Orientation::Unknown)
+            resolvedOrientation = (supported & OrientationMask::Portrait)
+                                    ? Orientation::Portrait
+                                    : Orientation::ReversePortrait;
+        break;
+
+    // Case 3: SensorLandscape
+    case Orientation::SensorLandscape:
+        resolvedOrientation = tryUse(physical);
+        if (resolvedOrientation == Orientation::Unknown)
+            resolvedOrientation = (supported & OrientationMask::Landscape)
+                                    ? Orientation::Landscape
+                                    : Orientation::ReverseLandscape;
+        break;
+
+    // Case 4: Sensor / FullSensor
+    case Orientation::Sensor:
+    case Orientation::FullSensor:
+        resolvedOrientation = tryUse(physical);
+        if (resolvedOrientation == Orientation::Unknown)
+            resolvedOrientation = pickFirstSupported(supported);
+        break;
+
+    // Default / Unknown
+    default:
+        break;
+    }
+
+    // Final fallback
+    if (resolvedOrientation == Orientation::Unknown)
+        resolvedOrientation = pickFirstSupported(supported);
+
+    return resolvedOrientation;
 }
 
 }

--- a/core/platform/ios/Device-ios.mm
+++ b/core/platform/ios/Device-ios.mm
@@ -930,7 +930,7 @@ Device::Orientation Device::resolveOrientation()
     case Orientation::SensorPortrait:
         resolvedOrientation = tryUse(physical);
         if (resolvedOrientation == Orientation::Unknown)
-            resolvedOrientation = (supported & OrientationMask::Portrait)
+            resolvedOrientation = bool(supported & OrientationMask::Portrait)
                                     ? Orientation::Portrait
                                     : Orientation::ReversePortrait;
         break;
@@ -939,7 +939,7 @@ Device::Orientation Device::resolveOrientation()
     case Orientation::SensorLandscape:
         resolvedOrientation = tryUse(physical);
         if (resolvedOrientation == Orientation::Unknown)
-            resolvedOrientation = (supported & OrientationMask::Landscape)
+            resolvedOrientation = bool(supported & OrientationMask::Landscape)
                                     ? Orientation::Landscape
                                     : Orientation::ReverseLandscape;
         break;

--- a/core/platform/ios/EARenderView-ios.mm
+++ b/core/platform/ios/EARenderView-ios.mm
@@ -317,7 +317,6 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     if (!ax::Director::getInstance()->isValid())
         return;
 
-    auto bounds = [self bounds];
     self.textInputView.bounds = originalRect_ = [self bounds];
 
 #if defined(AX_USE_METAL)

--- a/core/platform/ios/RenderViewImpl-ios.mm
+++ b/core/platform/ios/RenderViewImpl-ios.mm
@@ -58,17 +58,15 @@ RenderViewImpl* RenderViewImpl::createWithEARenderView(void* viewHandle)
 static CGSize computeLogicalScreenSize()
 {
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
-    auto resolvedOrientation = Device::resolveFinalOrientation();
+    auto resolvedOrientation = Device::resolveOrientation();
 
     bool isLandscapeSize = screenSize.width > screenSize.height;
     bool shouldBeLandscape = (resolvedOrientation == Device::Orientation::Landscape ||
                               resolvedOrientation == Device::Orientation::ReverseLandscape);
 
     // If orientation and actual size basis mismatch, swap
-    if (shouldBeLandscape && !isLandscapeSize)
-        screenSize = CGSizeMake(screenSize.height, screenSize.width);
-    else if (!shouldBeLandscape && isLandscapeSize)
-        screenSize = CGSizeMake(screenSize.height, screenSize.width);
+    if ((shouldBeLandscape && !isLandscapeSize) || (!shouldBeLandscape && isLandscapeSize))
+        std::swap(screenSize.width, screenSize.height);
 
     return screenSize;
 }

--- a/core/platform/ios/RenderViewImpl-ios.mm
+++ b/core/platform/ios/RenderViewImpl-ios.mm
@@ -58,13 +58,18 @@ RenderViewImpl* RenderViewImpl::createWithEARenderView(void* viewHandle)
 static CGSize computeLogicalScreenSize()
 {
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
-    auto finalOrientation = Device::resolveFinalOrientation();
+    auto resolvedOrientation = Device::resolveFinalOrientation();
 
-    if (finalOrientation == Device::Orientation::Landscape ||
-        finalOrientation == Device::Orientation::ReverseLandscape)
-    {
+    bool isLandscapeSize = screenSize.width > screenSize.height;
+    bool shouldBeLandscape = (resolvedOrientation == Device::Orientation::Landscape ||
+                              resolvedOrientation == Device::Orientation::ReverseLandscape);
+
+    // If orientation and actual size basis mismatch, swap
+    if (shouldBeLandscape && !isLandscapeSize)
         screenSize = CGSizeMake(screenSize.height, screenSize.width);
-    }
+    else if (!shouldBeLandscape && isLandscapeSize)
+        screenSize = CGSizeMake(screenSize.height, screenSize.width);
+
     return screenSize;
 }
 

--- a/core/platform/ios/RenderViewImpl-ios.mm
+++ b/core/platform/ios/RenderViewImpl-ios.mm
@@ -29,6 +29,7 @@
 #include "platform/ios/EARenderView-ios.h"
 #include "platform/ios/DirectorCaller-ios.h"
 #include "platform/ios/RenderViewImpl-ios.h"
+#include "platform/Device.h"
 #include "base/Touch.h"
 #include "base/Director.h"
 
@@ -52,6 +53,20 @@ RenderViewImpl* RenderViewImpl::createWithEARenderView(void* viewHandle)
     return nullptr;
 }
 #endif
+
+// helper to compute the logical screen size based on the current orientation
+static CGSize computeLogicalScreenSize()
+{
+    CGSize screenSize = [UIScreen mainScreen].bounds.size;
+    auto finalOrientation = Device::resolveFinalOrientation();
+
+    if (finalOrientation == Device::Orientation::Landscape ||
+        finalOrientation == Device::Orientation::ReverseLandscape)
+    {
+        screenSize = CGSizeMake(screenSize.height, screenSize.width);
+    }
+    return screenSize;
+}
 
 RenderViewImpl* RenderViewImpl::create(std::string_view viewName)
 {
@@ -169,8 +184,10 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/, const Rect& rec
     [eaView setMultipleTouchEnabled:YES];
 #endif
 
-    _screenSize.width = _designResolutionSize.width = [eaView getWidth];
-    _screenSize.height = _designResolutionSize.height = [eaView getHeight];
+    auto logicalSize = computeLogicalScreenSize();
+
+    _screenSize.width = _designResolutionSize.width = logicalSize.width;
+    _screenSize.height = _designResolutionSize.height = logicalSize.height;
     //    _scaleX = _scaleY = [eaView contentScaleFactor];
 
     _eaViewHandle = eaView;

--- a/core/platform/winrt/Device-winrt.cpp
+++ b/core/platform/winrt/Device-winrt.cpp
@@ -592,6 +592,11 @@ Device::Orientation Device::getPhysicalOrientation()
     return Orientation::Unknown;
 }
 
+Device::Orientation Device::resolveOrientation()
+{
+    return Orientation::Unknown;
+}
+
 }
 
 #endif  // (AX_TARGET_PLATFORM == AX_PLATFORM_WINRT)


### PR DESCRIPTION
Introduce Device::resolveOrientation to deterministically choose the app’s effective orientation from supported, preferred, and physical orientations. The logic guarantees the result is always compatible with the supported mask and avoids transient incorrect sizes at startup (notably on iOS).

Key points:
- Add resolveOrientation() in Device as the single public API for orientation decision.
- iOS uses this to compute logical screen size before app->run(); Android can return current orientation for parity.

Why:
- Centralize orientation decision in Device, decoupling it from view/sizing code.
- Prevent initial flicker and wrong layout caused by UIKit’s portrait-based bounds at launch.
- Improve readability and maintainability across platforms.

Impact:
- No breaking changes to callers; RenderViewImpl-ios now consumes Device::resolveOrientation.
- Orientation result is stable and in-mask; downstream size/viewport code becomes simpler.

Test plan:
- Unit test matrix across (preferred x physical x supported) including Sensor*, concrete, and unknown cases.
- Validate FaceUp/FaceDown → fallback behavior.
- Manual on iOS: cold start in portrait/landscape/flat; verify initial frame matches resolved orientation.
- Manual on Android: ensure parity and no regression in Activity orientation.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
