### PR TITLE
Add support for extracting the previous scene from the scene stack

### DIFF
--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -966,6 +966,44 @@ void Director::popToSceneStackLevel(int level)
     _sendCleanupToScene = true;
 }
 
+Scene* Director::extractPreviousScene()
+{
+    if (_nextScene)
+    {
+        return nullptr;
+    }
+
+    const auto numScenes = _scenesStack.size();
+
+    if (numScenes < 2)
+    {
+        return nullptr;
+    }
+
+    const auto previousSceneIndex = numScenes - 2;
+
+    auto previousScene = _scenesStack.at(previousSceneIndex);
+    if (previousScene == _runningScene)
+    {
+        return nullptr;
+    }
+
+    previousScene->retain();
+    previousScene->autorelease();
+
+#if AX_ENABLE_GC_FOR_NATIVE_OBJECTS
+    auto sEngine = ScriptEngineManager::getInstance()->getScriptEngine();
+    if (sEngine)
+    {
+        sEngine->releaseScriptObject(this, previousScene);
+    }
+#endif  // AX_ENABLE_GC_FOR_NATIVE_OBJECTS
+
+    _scenesStack.erase(previousSceneIndex);
+
+    return previousScene;
+}
+
 void Director::end()
 {
     _cleanupDirectorInNextLoop = true;

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -966,7 +966,7 @@ void Director::popToSceneStackLevel(int level)
     _sendCleanupToScene = true;
 }
 
-Scene* Director::extractPreviousScene()
+Scene* Director::popPreviousSceneOut()
 {
     if (_nextScene)
     {

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -983,11 +983,6 @@ Scene* Director::extractPreviousScene()
     const auto previousSceneIndex = numScenes - 2;
 
     auto previousScene = _scenesStack.at(previousSceneIndex);
-    if (previousScene == _runningScene)
-    {
-        return nullptr;
-    }
-
     previousScene->retain();
     previousScene->autorelease();
 

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -323,7 +323,7 @@ public:
      *
      * Returns previous scene or nullptr if invalid
      */
-    Scene* extractPreviousScene();
+    Scene* popPreviousSceneOut();
 
     /** Ends the execution, releases the running scene.
      * @lua endToLua

--- a/core/base/Director.h
+++ b/core/base/Director.h
@@ -316,6 +316,15 @@ public:
      */
     void replaceScene(Scene* scene);
 
+    /** Removes the previous scene from the stack if it exists, and returns it
+     * If there are less than 2 scenes in the stack, or if there is a 
+     * scene switch about to occur, then this call would be invalid, and a nullptr
+     * will be returned.
+     *
+     * Returns previous scene or nullptr if invalid
+     */
+    Scene* extractPreviousScene();
+
     /** Ends the execution, releases the running scene.
      * @lua endToLua
      */


### PR DESCRIPTION
## Describe your changes

This PR adds support for extracting the previous scene from the scene stack.  This would allow transitions from the current scene to the previous scene, such as:

```
auto director = Director::getInstance();
auto previousScene = director->popPreviousSceneOut();
auto transition = Transition::create(2, previousScene);
director->replaceScene(transition);
```

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
