### PR TITLE
Make Director::getRunningScene() return the expected result for any type of scene switch when called from Node::onEnter()

### DIFF
--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1165,41 +1165,42 @@ void Director::setNextScene()
 {
     _eventDispatcher->dispatchEvent(_beforeSetNextScene);
 
-    bool runningIsTransition = dynamic_cast<TransitionScene*>(_runningScene) != nullptr;
-    bool newIsTransition     = dynamic_cast<TransitionScene*>(_nextScene) != nullptr;
+    auto outgoingScene = _runningScene;
+    _runningScene      = _nextScene;
+    _nextScene         = nullptr;
 
-    // If it is not a transition, call onExit/cleanup
-    if (!newIsTransition)
+    bool outgoingSceneIsTransition = dynamic_cast<TransitionScene*>(outgoingScene) != nullptr;
+
+    if (outgoingScene)
     {
-        if (_runningScene)
+        bool incomingSceneIsTransition = dynamic_cast<TransitionScene*>(_runningScene) != nullptr;
+
+        // If it is not a transition, call onExit/cleanup
+        if (!incomingSceneIsTransition)
         {
-            _runningScene->onExitTransitionDidStart();
-            _runningScene->onExit();
+            outgoingScene->onExitTransitionDidStart();
+            outgoingScene->onExit();
+
+            // issue #709. the root node (scene) should receive the cleanup message too
+            // otherwise it might be leaked.
+            if (_sendCleanupToScene)
+            {
+                outgoingScene->cleanup();
+            }
         }
 
-        // issue #709. the root node (scene) should receive the cleanup message too
-        // otherwise it might be leaked.
-        if (_sendCleanupToScene && _runningScene)
-        {
-            _runningScene->cleanup();
-        }
+        outgoingScene->release();
     }
 
     if (_runningScene)
     {
-        _runningScene->release();
-    }
-    _runningScene = _nextScene;
-    if (_nextScene)
-    {
-        _nextScene->retain();
-    }
-    _nextScene = nullptr;
+        _runningScene->retain();
 
-    if ((!runningIsTransition) && _runningScene)
-    {
-        _runningScene->onEnter();
-        _runningScene->onEnterTransitionDidFinish();
+        if (!outgoingSceneIsTransition)
+        {
+            _runningScene->onEnter();
+            _runningScene->onEnterTransitionDidFinish();
+        }
     }
 
     _eventDispatcher->dispatchEvent(_afterSetNextScene);


### PR DESCRIPTION
## Describe your changes

This PR addresses the issue described in issue #2798, where the return value of `Director::getRunningScene()` is not consistent between instant scene switches and transitions if called in `onEnter()` of the new (incoming) scene.

The value of `getRunningScene()` when called from `onEnter()` will now always be the new scene. 

The value of `getRunningScene()` when called from `onExit()` will now also be the new scene.

## Issue ticket number and link

#2798 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
