### PR TITLE
Fix for crash when director is reset during scene transition

### DIFF
--- a/core/2d/Transition.cpp
+++ b/core/2d/Transition.cpp
@@ -211,6 +211,14 @@ void TransitionScene::onExit()
     // only the onEnterTransitionDidFinish
     _inScene->onEnterTransitionDidFinish();
 
+    // Ensure that a valid scene exists, otherwise
+    // the director is being reset, so the transition
+    // is responsible for the cleanup of the _inScene
+    if (!Director::getInstance()->getRunningScene())
+    {
+        _inScene->onExit();
+    }
+
 #if AX_ENABLE_SCRIPT_BINDING
     if (ScriptEngineManager::getInstance()->getScriptEngine())
         ScriptEngineManager::getInstance()->getScriptEngine()->garbageCollect();

--- a/core/base/Director.cpp
+++ b/core/base/Director.cpp
@@ -1015,21 +1015,22 @@ void Director::reset()
     auto sEngine = ScriptEngineManager::getInstance()->getScriptEngine();
 #endif  // AX_ENABLE_GC_FOR_NATIVE_OBJECTS
 
-    if (_runningScene)
+    auto currentScene = _runningScene;
+    _runningScene     = nullptr;
+    _nextScene        = nullptr;
+
+    if (currentScene)
     {
 #if AX_ENABLE_GC_FOR_NATIVE_OBJECTS
         if (sEngine)
         {
-            sEngine->releaseScriptObject(this, _runningScene);
+            sEngine->releaseScriptObject(this, currentScene);
         }
 #endif  // AX_ENABLE_GC_FOR_NATIVE_OBJECTS
-        _runningScene->onExit();
-        _runningScene->cleanup();
-        _runningScene->release();
+        currentScene->onExit();
+        currentScene->cleanup();
+        currentScene->release();
     }
-
-    _runningScene = nullptr;
-    _nextScene    = nullptr;
 
     if (_eventDispatcher)
         _eventDispatcher->dispatchEvent(_eventResetDirector);


### PR DESCRIPTION
## Describe your changes

If the application is closed during certain scene transitions, such as TransitionFade, the application will crash in Node::~Node() since the incoming scene is still active (Node::_running == true). This is due to the Node::onExit() not being called on the incoming scene in the transition.

This PR address that issue, by making it the responsibility of the transition to ensure that the incoming scene is correctly deactivated (Node::_running == false) if it detects that the Director has been reset, meaning that the app is shutting down.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
