### PR TITLE
feat(http): add setDataCallback for streaming data support

### DIFF
--- a/core/network/HttpClient.cpp
+++ b/core/network/HttpClient.cpp
@@ -259,7 +259,13 @@ void HttpClient::handleNetworkEvent(yasio::io_event* event)
         if (!responseFinished)
         {
             auto&& pkt = event->packet_view();
-            response->handleInput(pkt.data(), pkt.size());
+            auto err = response->input(pkt.data(), pkt.size());
+            if (err != HPE_OK)
+            {
+                response->updateInternalCode(err);
+                _service->close(event->cindex());
+                break;
+            }
         }
         if (response->isFinished())
         {
@@ -390,7 +396,7 @@ void HttpClient::handleNetworkEvent(yasio::io_event* event)
         }
         break;
     case YEK_ON_CLOSE:
-        response->finish();
+        response->on_close();
         handleNetworkEOF(response, channel, event->status());
         break;
     }
@@ -462,8 +468,8 @@ void HttpClient::finishResponse(HttpResponse* response)
 
 void HttpClient::invokeResposneCallbackAndRelease(HttpResponse* response)
 {
-    HttpRequest* request                  = response->getHttpRequest();
-    const ccHttpRequestCallback& callback = request->getCallback();
+    auto request   = response->getHttpRequest();
+    auto& callback = request->getCompleteCallback();
 
     if (callback != nullptr)
         callback(this, response);

--- a/core/network/HttpClient.cpp
+++ b/core/network/HttpClient.cpp
@@ -396,7 +396,7 @@ void HttpClient::handleNetworkEvent(yasio::io_event* event)
         }
         break;
     case YEK_ON_CLOSE:
-        response->on_close();
+        response->handleConnectionClose();
         handleNetworkEOF(response, channel, event->status());
         break;
     }

--- a/core/network/HttpClient.h
+++ b/core/network/HttpClient.h
@@ -120,7 +120,7 @@ public:
      *      https://stackoverflow.com/questions/23714383/what-are-all-the-possible-values-for-http-content-type-header
      */
     void send(HttpRequest* request);
-    void sendImmediate(HttpRequest* request){ this->send(request); }
+    AX_DEPRECATED(2.9) void sendImmediate(HttpRequest* request){ this->send(request); }
 
     /**
      * Set the timeout value for connecting.

--- a/core/network/HttpResponse.h
+++ b/core/network/HttpResponse.h
@@ -131,6 +131,8 @@ public:
 
     const std::string& getStatusText() const { return _statusText; }
 
+    uint64_t getContentLength() const { return _context.content_length; }
+
 private:
     void setResponseCode(int value) { _responseCode = value; }
 
@@ -145,13 +147,9 @@ private:
      */
     bool isFinished() const { return _finished; }
 
-    void handleInput(const char* d, size_t n)
+    llhttp_errno_t input(const char* d, size_t n)
     {
-        enum llhttp_errno err = llhttp_execute(&_context, d, n);
-        if (err != HPE_OK)
-        {
-            _finished = true;
-        }
+        return llhttp_execute(&_context, d, n);
     }
 
     bool tryRedirect()
@@ -194,6 +192,7 @@ private:
             /* Resets response status */
             _responseHeaders.clear();
             _finished = false;
+            _contentLength = 0;
             _responseData.clear();
             _currentHeader.clear();
             _statusText.clear();
@@ -216,6 +215,7 @@ private:
             _contextSettings.on_header_field_complete = on_header_field_complete;
             _contextSettings.on_header_value          = on_header_value;
             _contextSettings.on_header_value_complete = on_header_value_complete;
+            _contextSettings.on_headers_complete      = on_headers_complete;
             _contextSettings.on_body                  = on_body;
             _contextSettings.on_status                = on_status;
             _contextSettings.on_message_complete      = on_complete;
@@ -228,10 +228,14 @@ private:
 
     const Uri& getRequestUri() const { return _requestUri; }
 
-    void finish()
+    void on_close()
     {
-        if (!_finished)
+        if (_finished)
+            return;
+        if (llhttp_message_needs_eof(&_context))
             llhttp_finish(&_context);
+        else
+            _internalCode = -1;
     }
 
     static int on_status(llhttp_t* context, const char* at, size_t length)
@@ -264,12 +268,27 @@ private:
     {
         auto thiz = (HttpResponse*)context->data;
         thiz->_responseHeaders.emplace(std::move(thiz->_currentHeader), std::move(thiz->_currentHeaderValue));
+        
+        return 0;
+    }
+    static int on_headers_complete(llhttp_t* context)
+    {
+        auto thiz            = (HttpResponse*)context->data;
+        thiz->_contentLength = context->content_length;
+        auto request         = thiz->getHttpRequest();
+        if (!request->getDataCallback() && thiz->_contentLength > 0)
+            thiz->_responseData.reserve(thiz->_contentLength);
         return 0;
     }
     static int on_body(llhttp_t* context, const char* at, size_t length)
     {
         auto thiz = (HttpResponse*)context->data;
-        thiz->_responseData.insert(thiz->_responseData.end(), at, at + length);
+        auto request = thiz->getHttpRequest();
+        auto dataCallback = request->getDataCallback();
+        if (!dataCallback)
+            thiz->_responseData.insert(thiz->_responseData.end(), at, at + length);
+        else
+            dataCallback(thiz, at, length);
         return 0;
     }
     static int on_complete(llhttp_t* context)
@@ -287,6 +306,7 @@ protected:
 
     Uri _requestUri;
     bool _finished = false;             /// to indicate if the http request is successful simply
+    uint64_t _contentLength{0};
     yasio::sbyte_buffer _responseData;  /// the returned raw data. You can also dump it as a string
     std::string _currentHeader;
     std::string _currentHeaderValue;

--- a/core/network/HttpResponse.h
+++ b/core/network/HttpResponse.h
@@ -228,7 +228,7 @@ private:
 
     const Uri& getRequestUri() const { return _requestUri; }
 
-    void on_close()
+    void handleConnectionClose()
     {
         if (_finished)
             return;


### PR DESCRIPTION
- Add HttpDataCallback type for handling incoming data chunks
- Implement setDataCallback method in HttpRequest class
- When data callback is set, response data is not accumulated in _responseData
- Enable progressive data processing for large file downloads and streaming
- Maintain backward compatibility - existing code continues to work unchanged

This allows:
- Memory-efficient handling of large responses
- Real-time processing of data streams
- Progress tracking during downloads
- Custom data storage strategies

Usage:
request->setDataCallback([](HttpResponse* response, const char* data, size_t size) {
    // Process data chunks as they arrive
    fwrite(data, 1, size, outputFile);
});

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
