### PR TITLE
chooseSpriteProgramType(): Add missing PixelFormat::RGB8

### DIFF
--- a/axmol/renderer/ProgramManager.cpp
+++ b/axmol/renderer/ProgramManager.cpp
@@ -61,8 +61,10 @@ int ProgramManager::chooseSpriteProgramType(rhi::PixelFormat pixelFormat)
         return rhi::ProgramType::POSITION_TEXTURE_GRAY;
     case PixelFormat::RG8:
         return rhi::ProgramType::POSITION_TEXTURE_GRAY_ALPHA;
-    case PixelFormat::RGBA8:
+    case PixelFormat::RGB8:
         return rhi::ProgramType::POSITION_TEXTURE_COLOR;
+    case PixelFormat::RGBA8:
+        return rhi::ProgramType::POSITION_TEXTURE_COLOR_ALPHA_TEST;
     default:
         AXLOGW("Warning: chooseSpriteProgramType() unhandled pixel format {}", (int)pixelFormat);
         return rhi::ProgramType::POSITION_TEXTURE_COLOR;


### PR DESCRIPTION
## Describe your changes

see diff

1) Missed:  PixelFormat::RGB8 returns POSITION_TEXTURE_COLOR
2) Maybe Im wrong, but I think    RGBA8 should return "POSITION_TEXTURE_COLOR_ALPHA_TEST"


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
