### PR TITLE
AutoPolygon::findFirstNoneTransparentPixel() detected Y pos is 1 pixe…

### DIFF
--- a/core/2d/AutoPolygon.cpp
+++ b/core/2d/AutoPolygon.cpp
@@ -202,8 +202,6 @@ Vec2 AutoPolygon::findFirstNoneTransparentPixel(const Rect& rect, float threshol
     Vec2 i;
     for (i.y = rect.origin.y; i.y < rect.origin.y + rect.size.height; i.y++)
     {
-        if (found)
-            break;
         for (i.x = rect.origin.x; i.x < rect.origin.x + rect.size.width; i.x++)
         {
             auto alpha = getAlphaByPos(i);
@@ -213,6 +211,8 @@ Vec2 AutoPolygon::findFirstNoneTransparentPixel(const Rect& rect, float threshol
                 break;
             }
         }
+        if (found)
+            break;
     }
     AXASSERT(found, "image is all transparent!");
     return i;


### PR DESCRIPTION
…l to much.
e.g.: correct is {2,2} but returning {2,3}

## Describe your changes

see diff.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
