### PR TITLE
Fix memory leak in extension::GUI ScrollView.

### DIFF
--- a/extensions/GUI/src/GUI/ScrollView/ScrollView.cpp
+++ b/extensions/GUI/src/GUI/ScrollView/ScrollView.cpp
@@ -67,7 +67,11 @@ ScrollView::ScrollView()
     , _animatedScrollAction(nullptr)
 {}
 
-ScrollView::~ScrollView() {}
+ScrollView::~ScrollView()
+{
+    if (_animatedScrollAction)
+        _animatedScrollAction->release();
+}
 
 ScrollView* ScrollView::create(Size size, Node* container /* = nullptr*/)
 {


### PR DESCRIPTION
_animatedScrollAction is retained but was not released on destruction of the ScrollView.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
