### PR TITLE
fix: [ui::Text] Overflow::SHRINK does not restore the original font size when text is shortened

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -2574,6 +2574,9 @@ const Vec2& Label::getContentSize() const
 {
     if (_systemFontDirty || _contentDirty)
     {
+        if (_overflow == Overflow::SHRINK && this->getRenderingFontSize() < _originalFontSize)
+            const_cast<Label*>(this)->rescaleWithOriginalFontSize();
+
         const_cast<Label*>(this)->updateContent();
     }
     return _contentSize;


### PR DESCRIPTION
fix: https://github.com/axmolengine/axmol/issues/2830