### PR TITLE
Fix: FastTMXLayer: reset draw counts when layer becomes empty

### DIFF
--- a/core/2d/FastTMXLayer.cpp
+++ b/core/2d/FastTMXLayer.cpp
@@ -425,6 +425,12 @@ Mat4 FastTMXLayer::tileToNodeTransform()
 
 void FastTMXLayer::updatePrimitives()
 {
+    
+    for (auto& e : _customCommands)
+    {
+        e.second->setIndexDrawInfo(0, 0);
+    }
+    
     auto blendfunc =
         _texture->hasPremultipliedAlpha() ? BlendFunc::ALPHA_PREMULTIPLIED : BlendFunc::ALPHA_NON_PREMULTIPLIED;
     for (const auto& iter : _indicesVertexZNumber)


### PR DESCRIPTION
[Backport to stable] FastTMXLayer: reset draw counts when layer becomes empty #2710
Prevent removed tiles from rendering when a TMX layer becomes empty by zeroing existing CustomCommand index draw counts at the start of updatePrimitives() and then setting counts only for the current frame.