### PR TITLE
Improve SDF text outline rendering

### DIFF
--- a/core/2d/FontAtlas.cpp
+++ b/core/2d/FontAtlas.cpp
@@ -158,7 +158,7 @@ FontAtlas::FontAtlas(Font* theFont, int atlasWidth, int atlasHeight, float scale
 
         if (_fontFreeType->isDistanceFieldEnabled())
         {
-            _letterPadding += 2 * FontFreeType::DistanceMapSpread;
+            _letterPadding += 2 * FontFreeType::DistanceMapSpread * AX_CONTENT_SCALE_FACTOR();
         }
 
 #if AX_ENABLE_CACHE_TEXTURE_DATA

--- a/core/2d/FontFreeType.cpp
+++ b/core/2d/FontFreeType.cpp
@@ -157,7 +157,7 @@ bool FontFreeType::initFreeType()
         if (FT_Init_FreeType(&_FTlibrary))
             return false;
 
-        const FT_Int spread = DistanceMapSpread;
+        const FT_Int spread = DistanceMapSpread * AX_CONTENT_SCALE_FACTOR();
         FT_Property_Set(_FTlibrary, "sdf", "spread", &spread);
         FT_Property_Set(_FTlibrary, "bsdf", "spread", &spread);
 

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -775,8 +775,8 @@ void Label::updateUniformLocations()
     _textureLocation     = _programState->getUniformLocation(backend::Uniform::TEXTURE);
     _textColorLocation   = _programState->getUniformLocation(backend::Uniform::TEXT_COLOR);
     _effectColorLocation = _programState->getUniformLocation(backend::Uniform::EFFECT_COLOR);
-    _effectTypeLocation  = _programState->getUniformLocation(backend::Uniform::EFFECT_TYPE);
-    _spreadLocation      = _programState->getUniformLocation("u_spread");
+    _textPassLocation    = _programState->getUniformLocation(backend::Uniform::TEXT_PASS);
+    _distanceSpreadLocation = _programState->getUniformLocation(backend::Uniform::DISTANCE_SPREAD);
 }
 
 bool Label::setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled /* = false */, bool useA8Shader /* = false */)
@@ -1951,66 +1951,66 @@ void Label::updateEffectUniforms(BatchCommand& batch,
         {
         case LabelEffect::OUTLINE:
         {
-            int effectType = 0;
+            int textPass = 0;
             Vec4 effectColor(_effectColorF.r, _effectColorF.g, _effectColorF.b, _effectColorF.a);
             // draw shadow
             if (_shadowEnabled)
             {
-                effectType               = 2;
+                textPass                 = 2;
                 Vec4 shadowColor         = Vec4(_shadowColor4F.r, _shadowColor4F.g, _shadowColor4F.b, _shadowColor4F.a);
                 auto* programStateShadow = batch.shadowCommand.getPipelineDescriptor().programState;
                 programStateShadow->setUniform(_effectColorLocation, &shadowColor, sizeof(Vec4));
-                programStateShadow->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                programStateShadow->setUniform(_textPassLocation, &textPass, sizeof(textPass));
                 batch.shadowCommand.init(_globalZOrder);
                 renderer->addCommand(&batch.shadowCommand);
             }
 
             if (_useDistanceField)
             {  // distance field
-                // outline
+                // outline pass
                 {
-                    effectType    = 1;
+                    textPass      = 1;
                     effectColor.w = (_outlineSize > 0 ? _outlineSize : _fontConfig.outlineSize) *
                                     _director->getContentScaleFactor();
                     auto& outlinePS = batch.outLineCommand.getPipelineDescriptor().programState;
                     updateBuffer(textureAtlas, batch.outLineCommand);
                     outlinePS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
-                    outlinePS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    outlinePS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
                     float distanceFieldSpread = FontFreeType::DistanceMapSpread * _director->getContentScaleFactor();
-                    outlinePS->setUniform(_spreadLocation, &distanceFieldSpread, sizeof(distanceFieldSpread));
+                    outlinePS->setUniform(_distanceSpreadLocation, &distanceFieldSpread, sizeof(distanceFieldSpread));
                     batch.outLineCommand.init(_globalZOrder);
                     renderer->addCommand(&batch.outLineCommand);
                 }
 
-                // draw text
+                // text pass
                 {
-                    effectType   = 0;
+                    textPass     = 0;
                     auto* textPS = batch.textCommand.getPipelineDescriptor().programState;
 
                     textPS->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
-                    textPS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    textPS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
                 }
             }
             else
             {
-                // draw outline
+                // outline pass
                 {
-                    effectType = 1;
+                    textPass = 1;
                     updateBuffer(textureAtlas, batch.outLineCommand);
                     auto* outlinePS = batch.outLineCommand.getPipelineDescriptor().programState;
                     outlinePS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
-                    outlinePS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    outlinePS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
                     batch.outLineCommand.init(_globalZOrder);
                     renderer->addCommand(&batch.outLineCommand);
                 }
 
-                // draw text
+                // text pass
                 {
-                    effectType             = 0;
+                    textPass     = 0;
                     auto* textPS = batch.textCommand.getPipelineDescriptor().programState;
 
                     textPS->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
-                    textPS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    textPS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
                 }
             }
         }

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -776,6 +776,7 @@ void Label::updateUniformLocations()
     _textColorLocation   = _programState->getUniformLocation(backend::Uniform::TEXT_COLOR);
     _effectColorLocation = _programState->getUniformLocation(backend::Uniform::EFFECT_COLOR);
     _effectTypeLocation  = _programState->getUniformLocation(backend::Uniform::EFFECT_TYPE);
+    _spreadLocation      = _programState->getUniformLocation("u_spread");
 }
 
 bool Label::setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled /* = false */, bool useA8Shader /* = false */)
@@ -1414,7 +1415,7 @@ void Label::enableGlow(const Color4B& glowColor)
     }
 }
 
-void Label::enableOutline(const Color4B& outlineColor, int outlineSize /* = -1 */)
+void Label::enableOutline(const Color4B& outlineColor, float outlineSize /* = -1 */)
 {
     AXASSERT(_currentLabelType == LabelType::STRING_TEXTURE || _currentLabelType == LabelType::TTF,
              "Only supported system font and TTF!");
@@ -1431,7 +1432,7 @@ void Label::enableOutline(const Color4B& outlineColor, int outlineSize /* = -1 *
             if (outlineSize > 0 && _fontConfig.outlineSize != outlineSize)
             {
                 
-                _fontConfig.outlineSize = outlineSize;
+                _fontConfig.outlineSize = static_cast<int>(outlineSize);
                 setTTFConfig(_fontConfig);
             }
             if (_useDistanceField && outlineSize > 0)
@@ -1965,10 +1966,30 @@ void Label::updateEffectUniforms(BatchCommand& batch,
             }
 
             if (_useDistanceField)
-            {  // distance outline
-                effectColor.w = _outlineSize > 0 ? _outlineSize : _fontConfig.outlineSize;
-                batch.textCommand.getPipelineDescriptor().programState->setUniform(_effectColorLocation, &effectColor,
-                                                                                   sizeof(Vec4));
+            {  // distance field
+                // outline
+                {
+                    effectType    = 1;
+                    effectColor.w = (_outlineSize > 0 ? _outlineSize : _fontConfig.outlineSize) *
+                                    _director->getContentScaleFactor();
+                    auto& outlinePS = batch.outLineCommand.getPipelineDescriptor().programState;
+                    updateBuffer(textureAtlas, batch.outLineCommand);
+                    outlinePS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
+                    outlinePS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    float distanceFieldSpread = FontFreeType::DistanceMapSpread * _director->getContentScaleFactor();
+                    outlinePS->setUniform(_spreadLocation, &distanceFieldSpread, sizeof(distanceFieldSpread));
+                    batch.outLineCommand.init(_globalZOrder);
+                    renderer->addCommand(&batch.outLineCommand);
+                }
+
+                // draw text
+                {
+                    effectType   = 0;
+                    auto* textPS = batch.textCommand.getPipelineDescriptor().programState;
+
+                    textPS->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
+                    textPS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                }
             }
             else
             {
@@ -1976,9 +1997,9 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                 {
                     effectType = 1;
                     updateBuffer(textureAtlas, batch.outLineCommand);
-                    auto* programStateOutline = batch.outLineCommand.getPipelineDescriptor().programState;
-                    programStateOutline->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
-                    programStateOutline->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    auto* outlinePS = batch.outLineCommand.getPipelineDescriptor().programState;
+                    outlinePS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
+                    outlinePS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
                     batch.outLineCommand.init(_globalZOrder);
                     renderer->addCommand(&batch.outLineCommand);
                 }
@@ -1986,10 +2007,10 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                 // draw text
                 {
                     effectType             = 0;
-                    auto* programStateText = batch.textCommand.getPipelineDescriptor().programState;
+                    auto* textPS = batch.textCommand.getPipelineDescriptor().programState;
 
-                    programStateText->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
-                    programStateText->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
+                    textPS->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
+                    textPS->setUniform(_effectTypeLocation, &effectType, sizeof(effectType));
                 }
             }
         }

--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -775,7 +775,7 @@ void Label::updateUniformLocations()
     _textureLocation     = _programState->getUniformLocation(backend::Uniform::TEXTURE);
     _textColorLocation   = _programState->getUniformLocation(backend::Uniform::TEXT_COLOR);
     _effectColorLocation = _programState->getUniformLocation(backend::Uniform::EFFECT_COLOR);
-    _textPassLocation    = _programState->getUniformLocation(backend::Uniform::TEXT_PASS);
+    _passLocation        = _programState->getUniformLocation(backend::Uniform::LABEL_PASS);
     _distanceSpreadLocation = _programState->getUniformLocation(backend::Uniform::DISTANCE_SPREAD);
 }
 
@@ -1431,7 +1431,7 @@ void Label::enableOutline(const Color4B& outlineColor, float outlineSize /* = -1
 
             if (outlineSize > 0 && _fontConfig.outlineSize != outlineSize)
             {
-                
+
                 _fontConfig.outlineSize = static_cast<int>(outlineSize);
                 setTTFConfig(_fontConfig);
             }
@@ -1951,16 +1951,16 @@ void Label::updateEffectUniforms(BatchCommand& batch,
         {
         case LabelEffect::OUTLINE:
         {
-            int textPass = 0;
+            int pass = 0;
             Vec4 effectColor(_effectColorF.r, _effectColorF.g, _effectColorF.b, _effectColorF.a);
             // draw shadow
             if (_shadowEnabled)
             {
-                textPass                 = 2;
+                pass                 = 2;
                 Vec4 shadowColor         = Vec4(_shadowColor4F.r, _shadowColor4F.g, _shadowColor4F.b, _shadowColor4F.a);
                 auto* programStateShadow = batch.shadowCommand.getPipelineDescriptor().programState;
                 programStateShadow->setUniform(_effectColorLocation, &shadowColor, sizeof(Vec4));
-                programStateShadow->setUniform(_textPassLocation, &textPass, sizeof(textPass));
+                programStateShadow->setUniform(_passLocation, &pass, sizeof(pass));
                 batch.shadowCommand.init(_globalZOrder);
                 renderer->addCommand(&batch.shadowCommand);
             }
@@ -1969,13 +1969,13 @@ void Label::updateEffectUniforms(BatchCommand& batch,
             {  // distance field
                 // outline pass
                 {
-                    textPass      = 1;
+                    pass      = 1;
                     effectColor.w = (_outlineSize > 0 ? _outlineSize : _fontConfig.outlineSize) *
                                     _director->getContentScaleFactor();
                     auto& outlinePS = batch.outLineCommand.getPipelineDescriptor().programState;
                     updateBuffer(textureAtlas, batch.outLineCommand);
                     outlinePS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
-                    outlinePS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
+                    outlinePS->setUniform(_passLocation, &pass, sizeof(pass));
                     float distanceFieldSpread = FontFreeType::DistanceMapSpread * _director->getContentScaleFactor();
                     outlinePS->setUniform(_distanceSpreadLocation, &distanceFieldSpread, sizeof(distanceFieldSpread));
                     batch.outLineCommand.init(_globalZOrder);
@@ -1984,33 +1984,33 @@ void Label::updateEffectUniforms(BatchCommand& batch,
 
                 // text pass
                 {
-                    textPass     = 0;
+                    pass     = 0;
                     auto* textPS = batch.textCommand.getPipelineDescriptor().programState;
 
                     textPS->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
-                    textPS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
+                    textPS->setUniform(_passLocation, &pass, sizeof(pass));
                 }
             }
             else
             {
                 // outline pass
                 {
-                    textPass = 1;
+                    pass = 1;
                     updateBuffer(textureAtlas, batch.outLineCommand);
                     auto* outlinePS = batch.outLineCommand.getPipelineDescriptor().programState;
                     outlinePS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
-                    outlinePS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
+                    outlinePS->setUniform(_passLocation, &pass, sizeof(pass));
                     batch.outLineCommand.init(_globalZOrder);
                     renderer->addCommand(&batch.outLineCommand);
                 }
 
                 // text pass
                 {
-                    textPass     = 0;
+                    pass     = 0;
                     auto* textPS = batch.textCommand.getPipelineDescriptor().programState;
 
                     textPS->setUniform(_effectColorLocation, &effectColor, sizeof(effectColor));
-                    textPS->setUniform(_textPassLocation, &textPass, sizeof(textPass));
+                    textPS->setUniform(_passLocation, &pass, sizeof(pass));
                 }
             }
         }

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -943,7 +943,7 @@ protected:
     backend::UniformLocation _textureLocation;
     backend::UniformLocation _textColorLocation;
     backend::UniformLocation _effectColorLocation;
-    backend::UniformLocation _textPassLocation;
+    backend::UniformLocation _passLocation;
     backend::UniformLocation _distanceSpreadLocation;
 
 private:

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -436,7 +436,7 @@ public:
      * Enable outline effect to Label.
      * @warning Limiting use to only when the Label created with true type font or system font.
      */
-    virtual void enableOutline(const Color4B& outlineColor, int outlineSize = -1);
+    virtual void enableOutline(const Color4B& outlineColor, float outlineSize = -1);
 
     /**
      * Enable glow effect to Label.
@@ -944,6 +944,7 @@ protected:
     backend::UniformLocation _textColorLocation;
     backend::UniformLocation _effectColorLocation;
     backend::UniformLocation _effectTypeLocation;
+    backend::UniformLocation _spreadLocation;
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(Label);

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -943,8 +943,8 @@ protected:
     backend::UniformLocation _textureLocation;
     backend::UniformLocation _textColorLocation;
     backend::UniformLocation _effectColorLocation;
-    backend::UniformLocation _effectTypeLocation;
-    backend::UniformLocation _spreadLocation;
+    backend::UniformLocation _textPassLocation;
+    backend::UniformLocation _distanceSpreadLocation;
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(Label);

--- a/core/renderer/backend/ShaderModule.h
+++ b/core/renderer/backend/ShaderModule.h
@@ -47,8 +47,8 @@ enum Uniform : uint32_t
     TEXTURE2,
     TEXTURE3,
     TEXT_COLOR,
-    TEXT_PASS,
     EFFECT_COLOR,
+    LABEL_PASS,
     DISTANCE_SPREAD,
     UNIFORM_MAX  // Maximum uniforms
 };

--- a/core/renderer/backend/ShaderModule.h
+++ b/core/renderer/backend/ShaderModule.h
@@ -47,8 +47,9 @@ enum Uniform : uint32_t
     TEXTURE2,
     TEXTURE3,
     TEXT_COLOR,
-    EFFECT_TYPE,
+    TEXT_PASS,
     EFFECT_COLOR,
+    DISTANCE_SPREAD,
     UNIFORM_MAX  // Maximum uniforms
 };
 

--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -113,7 +113,8 @@ static constexpr auto UNIFORM_NAME_TEXTURE2     = "u_tex2"sv;
 static constexpr auto UNIFORM_NAME_TEXTURE3     = "u_tex3"sv;
 static constexpr auto UNIFORM_NAME_TEXT_COLOR   = "u_textColor"sv;
 static constexpr auto UNIFORM_NAME_EFFECT_COLOR = "u_effectColor"sv;
-static constexpr auto UNIFORM_NAME_EFFECT_TYPE  = "u_effectType"sv;
+static constexpr auto UNIFORM_NAME_TEXT_PASS    = "u_textPass"sv;
+static constexpr auto UNIFORM_NAME_DISTANCE_SPREAD  = "u_distanceSpread"sv;
 
 /// built-in attribute name
 static constexpr auto ATTRIBUTE_NAME_POSITION  = "a_position"sv;

--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -113,7 +113,7 @@ static constexpr auto UNIFORM_NAME_TEXTURE2     = "u_tex2"sv;
 static constexpr auto UNIFORM_NAME_TEXTURE3     = "u_tex3"sv;
 static constexpr auto UNIFORM_NAME_TEXT_COLOR   = "u_textColor"sv;
 static constexpr auto UNIFORM_NAME_EFFECT_COLOR = "u_effectColor"sv;
-static constexpr auto UNIFORM_NAME_TEXT_PASS    = "u_textPass"sv;
+static constexpr auto UNIFORM_NAME_LABEL_PASS   = "u_labelPass"sv;
 static constexpr auto UNIFORM_NAME_DISTANCE_SPREAD  = "u_distanceSpread"sv;
 
 /// built-in attribute name

--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -307,8 +307,11 @@ void ShaderModuleMTL::setBuiltinLocations()
     /// u_effectColor
     _builtinUniforms[Uniform::EFFECT_COLOR] = getUniformInfo(UNIFORM_NAME_EFFECT_COLOR);
 
-    /// u_effectType
-    _builtinUniforms[Uniform::EFFECT_TYPE] = getUniformInfo(UNIFORM_NAME_EFFECT_TYPE);
+    /// u_textPass
+    _builtinUniformLocation[Uniform::TEXT_PASS] = getUniformLocation(UNIFORM_NAME_TEXT_PASS);
+
+    /// u_distanceSpread
+    _builtinUniformLocation[Uniform::DISTANCE_SPREAD] = getUniformLocation(UNIFORM_NAME_DISTANCE_SPREAD);
 }
 
 int ShaderModuleMTL::getAttributeLocation(Attribute name) const

--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -308,10 +308,10 @@ void ShaderModuleMTL::setBuiltinLocations()
     _builtinUniforms[Uniform::EFFECT_COLOR] = getUniformInfo(UNIFORM_NAME_EFFECT_COLOR);
 
     /// u_textPass
-    _builtinUniformLocation[Uniform::TEXT_PASS] = getUniformLocation(UNIFORM_NAME_TEXT_PASS);
+    _builtinUniforms[Uniform::TEXT_PASS] = getUniformInfo(UNIFORM_NAME_TEXT_PASS);
 
     /// u_distanceSpread
-    _builtinUniformLocation[Uniform::DISTANCE_SPREAD] = getUniformLocation(UNIFORM_NAME_DISTANCE_SPREAD);
+    _builtinUniforms[Uniform::DISTANCE_SPREAD] = getUniformInfo(UNIFORM_NAME_DISTANCE_SPREAD);
 }
 
 int ShaderModuleMTL::getAttributeLocation(Attribute name) const

--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -308,7 +308,7 @@ void ShaderModuleMTL::setBuiltinLocations()
     _builtinUniforms[Uniform::EFFECT_COLOR] = getUniformInfo(UNIFORM_NAME_EFFECT_COLOR);
 
     /// u_textPass
-    _builtinUniforms[Uniform::TEXT_PASS] = getUniformInfo(UNIFORM_NAME_TEXT_PASS);
+    _builtinUniforms[Uniform::LABEL_PASS] = getUniformInfo(UNIFORM_NAME_LABEL_PASS);
 
     /// u_distanceSpread
     _builtinUniforms[Uniform::DISTANCE_SPREAD] = getUniformInfo(UNIFORM_NAME_DISTANCE_SPREAD);

--- a/core/renderer/backend/opengl/ProgramGL.cpp
+++ b/core/renderer/backend/opengl/ProgramGL.cpp
@@ -257,8 +257,11 @@ void ProgramGL::setBuiltinLocations()
     /// u_effectColor
     _builtinUniformLocation[Uniform::EFFECT_COLOR] = getUniformLocation(UNIFORM_NAME_EFFECT_COLOR);
 
-    /// u_effectType
-    _builtinUniformLocation[Uniform::EFFECT_TYPE] = getUniformLocation(UNIFORM_NAME_EFFECT_TYPE);
+    /// u_textPass
+    _builtinUniformLocation[Uniform::TEXT_PASS] = getUniformLocation(UNIFORM_NAME_TEXT_PASS);
+
+    /// u_distanceSpread
+    _builtinUniformLocation[Uniform::DISTANCE_SPREAD] = getUniformLocation(UNIFORM_NAME_DISTANCE_SPREAD);
 }
 
 const hlookup::string_map<AttributeBindInfo>& ProgramGL::getActiveAttributes() const
@@ -455,38 +458,6 @@ int ProgramGL::getAttributeLocation(Attribute name) const
 int ProgramGL::getAttributeLocation(std::string_view name) const
 {
     return glGetAttribLocation(_program, name.data());
-}
-
-inline std::string_view mapLocationEnumToUBO(backend::Uniform name)
-{
-    switch (name)
-    {
-    case Uniform::MVP_MATRIX:
-        return UNIFORM_NAME_MVP_MATRIX;
-        break;
-    case Uniform::TEXTURE:
-        return UNIFORM_NAME_TEXTURE;
-        break;
-    case Uniform::TEXTURE1:
-        return UNIFORM_NAME_TEXTURE1;
-        break;
-    case Uniform::TEXTURE2:
-        return UNIFORM_NAME_TEXTURE2;
-        break;
-    case Uniform::TEXTURE3:
-        return UNIFORM_NAME_TEXTURE3;
-        break;
-    case Uniform::TEXT_COLOR:
-        return UNIFORM_NAME_TEXT_COLOR;
-        break;
-    case Uniform::EFFECT_COLOR:
-        return UNIFORM_NAME_EFFECT_COLOR;
-        break;
-    case Uniform::EFFECT_TYPE:
-        return UNIFORM_NAME_EFFECT_TYPE;
-        break;
-    }
-    return ""sv;
 }
 
 UniformLocation ProgramGL::getUniformLocation(backend::Uniform name) const

--- a/core/renderer/backend/opengl/ProgramGL.cpp
+++ b/core/renderer/backend/opengl/ProgramGL.cpp
@@ -258,7 +258,7 @@ void ProgramGL::setBuiltinLocations()
     _builtinUniformLocation[Uniform::EFFECT_COLOR] = getUniformLocation(UNIFORM_NAME_EFFECT_COLOR);
 
     /// u_textPass
-    _builtinUniformLocation[Uniform::TEXT_PASS] = getUniformLocation(UNIFORM_NAME_TEXT_PASS);
+    _builtinUniformLocation[Uniform::LABEL_PASS] = getUniformLocation(UNIFORM_NAME_LABEL_PASS);
 
     /// u_distanceSpread
     _builtinUniformLocation[Uniform::DISTANCE_SPREAD] = getUniformLocation(UNIFORM_NAME_DISTANCE_SPREAD);

--- a/core/renderer/shaders/label_distanceOutline.frag
+++ b/core/renderer/shaders/label_distanceOutline.frag
@@ -2,14 +2,7 @@
 precision highp float;
 #include "base.glsl"
 
-// Maximum distance (in pixels) encoded in the SDF texture.
-// Must match the spread value used when generating the font atlas with FreeType.
-const float spread = 6.0;
-
-// Global correction factor to visually match SDF outline thickness
-// with non‑SDF (bitmap/vector) rendering. Adjust this to make outlines
-// look consistent across different rendering methods.
-const float outlineScale = 1.5;
+const float outlineScale = 0.75;
 
 layout(location = COLOR0) in vec4 v_color;
 layout(location = TEXCOORD0) in vec2 v_texCoord;
@@ -19,7 +12,8 @@ layout(binding = 0) uniform sampler2D u_tex0;
 layout(std140) uniform fs_ub {
     vec4 u_textColor;
     vec4 u_effectColor;
-    int u_effectType; // 0 = text+outline, 2 = shadow
+    int u_effectType; // 0: text, 1: outline, 2: shadow
+    float u_spread; // default: 6.0
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -30,19 +24,25 @@ void main()
     float smoothing = fwidth(dist);
 
     if (u_effectType == 2) {
-        // Shadow: only need alpha from distance field, no outline calculation
+        // Shadow pass: pure color fill
         float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
         FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * alpha);
-    } else {
-        // Text + outline
-        float outlineSize = clamp(u_effectColor.w * outlineScale, 0.0, spread * 0.5);
-        float thickness   = outlineSize / (2.0 * spread);
+    }
+    else if (u_effectType == 1) {
+        // Outline pass: only draw outer ring, exclude text core
+        float outlineSize = clamp(u_effectColor.w * outlineScale, 0.0, u_spread * 0.5);
+        float thickness   = outlineSize / (2.0 * u_spread);
         float pivot       = 0.5 - thickness;
 
-        float alpha  = smoothstep(pivot - smoothing, pivot + smoothing, dist);
-        float border = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
+        float textAlpha    = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
+        float outlineAlpha = smoothstep(pivot - smoothing, pivot + smoothing, dist);
 
-        // Mix outline color and text color based on border value
-        FragColor = v_color * vec4(mix(u_effectColor.rgb, u_textColor.rgb, border), alpha);
+        float alpha = outlineAlpha * (1.0 - textAlpha); // exclude inner text
+        FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * alpha);
+    }
+    else {
+        // Text pass: draw solid text core
+        float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
+        FragColor = v_color * vec4(u_textColor.rgb, u_textColor.a * alpha);
     }
 }

--- a/core/renderer/shaders/label_distanceOutline.frag
+++ b/core/renderer/shaders/label_distanceOutline.frag
@@ -15,7 +15,7 @@ layout(binding = 0) uniform sampler2D u_tex0;
 layout(std140) uniform fs_ub {
     vec4 u_textColor;
     vec4 u_effectColor;
-    int u_textPass; // 0: text, 1: outline, 2: shadow
+    int u_labelPass; // 0: text, 1: outline, 2: shadow
     float u_distanceSpread; // default: 6.0
 };
 
@@ -26,12 +26,12 @@ void main()
     float dist = texture(u_tex0, v_texCoord).x;
     float smoothing = fwidth(dist);
 
-    if (u_textPass == 0) {
+    if (u_labelPass == 0) {
         // Text pass: draw solid text core
         float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
         FragColor = v_color * vec4(u_textColor.rgb, u_textColor.a * alpha);
     }
-    else if (u_textPass == 1) {
+    else if (u_labelPass == 1) {
         // Outline pass: only draw outer ring, exclude text core
         float outlineSize = clamp(u_effectColor.w * outlineScale, 0.0, u_distanceSpread * 0.5);
         float thickness   = outlineSize / (2.0 * u_distanceSpread);

--- a/core/renderer/shaders/label_distanceOutline.frag
+++ b/core/renderer/shaders/label_distanceOutline.frag
@@ -2,6 +2,9 @@
 precision highp float;
 #include "base.glsl"
 
+// Empirical correction factor to visually match SDF outline thickness
+// with non‑SDF (bitmap/vector) text rendering. Adjusting this value
+// makes the two rendering methods look nearly identical in outline weight.
 const float outlineScale = 0.75;
 
 layout(location = COLOR0) in vec4 v_color;

--- a/core/renderer/shaders/label_distanceOutline.frag
+++ b/core/renderer/shaders/label_distanceOutline.frag
@@ -12,8 +12,8 @@ layout(binding = 0) uniform sampler2D u_tex0;
 layout(std140) uniform fs_ub {
     vec4 u_textColor;
     vec4 u_effectColor;
-    int u_effectType; // 0: text, 1: outline, 2: shadow
-    float u_spread; // default: 6.0
+    int u_textPass; // 0: text, 1: outline, 2: shadow
+    float u_distanceSpread; // default: 6.0
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -23,15 +23,15 @@ void main()
     float dist = texture(u_tex0, v_texCoord).x;
     float smoothing = fwidth(dist);
 
-    if (u_effectType == 2) {
-        // Shadow pass: pure color fill
+    if (u_textPass == 0) {
+        // Text pass: draw solid text core
         float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
-        FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * alpha);
+        FragColor = v_color * vec4(u_textColor.rgb, u_textColor.a * alpha);
     }
-    else if (u_effectType == 1) {
+    else if (u_textPass == 1) {
         // Outline pass: only draw outer ring, exclude text core
-        float outlineSize = clamp(u_effectColor.w * outlineScale, 0.0, u_spread * 0.5);
-        float thickness   = outlineSize / (2.0 * u_spread);
+        float outlineSize = clamp(u_effectColor.w * outlineScale, 0.0, u_distanceSpread * 0.5);
+        float thickness   = outlineSize / (2.0 * u_distanceSpread);
         float pivot       = 0.5 - thickness;
 
         float textAlpha    = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
@@ -41,8 +41,8 @@ void main()
         FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * alpha);
     }
     else {
-        // Text pass: draw solid text core
+        // Shadow pass: pure color fill
         float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
-        FragColor = v_color * vec4(u_textColor.rgb, u_textColor.a * alpha);
+        FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * alpha);
     }
 }

--- a/core/renderer/shaders/label_outline.frag
+++ b/core/renderer/shaders/label_outline.frag
@@ -10,7 +10,7 @@ layout(binding = 0) uniform sampler2D u_tex0;
 layout(std140) uniform fs_ub {
     vec4 u_effectColor;
     vec4 u_textColor;
-    int u_effectType;
+    int u_textPass; // 0: text, 1: outline, 2: shadow
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -32,11 +32,11 @@ void main()
     // outlineAlpha == (0, 1) means the edge of outline
     float outlineAlpha = texColor.x;
 
-    if (u_effectType == 0) // draw text
+    if (u_textPass == 0) // draw text
     {
         FragColor = v_color * vec4(u_textColor.rgb, u_textColor.a * fontAlpha);
     }
-    else if (u_effectType == 1) // draw outline
+    else if (u_textPass == 1) // draw outline
     {
         // multipy (1.0 - fontAlpha) to make the inner edge of outline smoother and make the text itself transparent.
         FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * outlineAlpha * (1.0 - fontAlpha));

--- a/core/renderer/shaders/label_outline.frag
+++ b/core/renderer/shaders/label_outline.frag
@@ -10,7 +10,7 @@ layout(binding = 0) uniform sampler2D u_tex0;
 layout(std140) uniform fs_ub {
     vec4 u_effectColor;
     vec4 u_textColor;
-    int u_textPass; // 0: text, 1: outline, 2: shadow
+    int u_labelPass; // 0: text, 1: outline, 2: shadow
 };
 
 layout(location = SV_Target0) out vec4 FragColor;
@@ -32,11 +32,11 @@ void main()
     // outlineAlpha == (0, 1) means the edge of outline
     float outlineAlpha = texColor.x;
 
-    if (u_textPass == 0) // draw text
+    if (u_labelPass == 0) // draw text
     {
         FragColor = v_color * vec4(u_textColor.rgb, u_textColor.a * fontAlpha);
     }
-    else if (u_textPass == 1) // draw outline
+    else if (u_labelPass == 1) // draw outline
     {
         // multipy (1.0 - fontAlpha) to make the inner edge of outline smoother and make the text itself transparent.
         FragColor = v_color * vec4(u_effectColor.rgb, u_effectColor.a * outlineAlpha * (1.0 - fontAlpha));

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -55159,11 +55159,11 @@ int lua_ax_base_Label_enableOutline(lua_State* tolua_S)
     if (argc == 2) 
     {
         ax::Color4B arg0;
-        int arg1;
+        double arg1;
 
         ok &=luaval_to_color4b(tolua_S, 2, &arg0, "ax.Label:enableOutline");
 
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ax.Label:enableOutline");
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "ax.Label:enableOutline");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Label_enableOutline'", nullptr);


### PR DESCRIPTION
## Describe your changes

Label: separate text and outline passes in SDF shader

- Renamed shader uniform u_effectType => u_labelPass to better reflect its role as a rendering pass selector (0 = text, 1 = outline, 2 = shadow).
- Split text and outline into distinct branches:
  * Text pass draws solid glyph core without outline interference.
  * Outline pass draws only the outer ring, excluding the text core.
  * Shadow pass remains unchanged as pure color fill.
- Introduced u_distanceSpread uniform (default 6.0) for flexible spread control.
- Added outlineScale empirical factor (0.75) to visually match SDF outline thickness
  with non-SDF text rendering.

This change ensures SDF rendering matches non-SDF behavior: text core is never
overwritten by outline, and passes are explicitly separated for clarity.

## Before this PR

<img width="1900" height="397" alt="image" src="https://github.com/user-attachments/assets/2124d001-7779-497b-a30c-a0470c970775" />


## After this PR

<img width="1874" height="162" alt="image" src="https://github.com/user-attachments/assets/57cc4fab-5234-448a-8f7a-628e8e2b7d48" />

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
