### PR TITLE
Android template fails to build

### DIFF
--- a/templates/common/proj.android/app/build.gradle
+++ b/templates/common/proj.android/app/build.gradle
@@ -116,6 +116,7 @@ android.applicationVariants.configureEach { variant ->
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':libaxmol')
+	implementation 'androidx.appcompat:appcompat:1.7.1'
 }
 
 project.afterEvaluate {


### PR DESCRIPTION
**Description**
A fresh Android build of the HelloCpp template fails to compile because `AppActivity`
uses methods that require `AppCompatActivity`, but `AxmolActivity` does not extend it,
and the template is missing the `androidx.appcompat` dependency. So the Android
template does not build out of the box.