### PR TITLE
Fix: allow ASTC formats to return true in testFormatForPvr3TCSupport

### DIFF
--- a/core/platform/Image.cpp
+++ b/core/platform/Image.cpp
@@ -584,7 +584,7 @@ bool testFormatForPvr3TCSupport(PVR3TexturePixelFormat format)
     case PVR3TexturePixelFormat::ASTC_10x10:
     case PVR3TexturePixelFormat::ASTC_12x10:
     case PVR3TexturePixelFormat::ASTC_12x12:
-        return Configuration::getInstance()->supportsASTC();
+        return true;
 
     default:
         return false;


### PR DESCRIPTION
## Describe your changes

Fix: allow ASTC formats to return true in testFormatForPvr3TCSupport to enable software fallback when hardware support is missing

