### PR TITLE
Mark FontFreeType::setShareDistanceFieldEnabled deprecated

### DIFF
--- a/core/2d/FontFreeType.cpp
+++ b/core/2d/FontFreeType.cpp
@@ -48,7 +48,7 @@ FT_Library FontFreeType::_FTlibrary;
 bool FontFreeType::_FTInitialized             = false;
 bool FontFreeType::_streamParsingEnabled      = true;
 bool FontFreeType::_doNativeBytecodeHinting   = true;
-bool FontFreeType::_shareDistanceFieldEnabled = false;
+bool FontFreeType::_globalSDFEnabled          = false;
 const int FontFreeType::DistanceMapSpread     = 6;
 
 // By default, will render square when character glyph missing in current font

--- a/core/2d/FontFreeType.h
+++ b/core/2d/FontFreeType.h
@@ -70,12 +70,15 @@ public:
     static void setMissingGlyphCharacter(char32_t charCode) { _mssingGlyphCharacter = charCode; };
 
     /**
-     * @brief Whether enable SDF font rendering globally, by default: disabled, since axmol-2.1.0
+     * @brief Whether enable SDF text rendering globally, by default: disabled, since axmol-2.1.0
      *
      * @param enabled
      */
-    static void setShareDistanceFieldEnabled(bool enabled) { _shareDistanceFieldEnabled = enabled; }
-    static bool isShareDistanceFieldEnabled() { return _shareDistanceFieldEnabled; }
+    static void setGlobalSDFEnabled(bool enabled) { _globalSDFEnabled = enabled; }
+    static bool isGlobalSDFEnabled() { return _globalSDFEnabled; }
+
+    AX_DEPRECATED(2.9.2) static void setShareDistanceFieldEnabled(bool enabled) { setGlobalSDFEnabled(enabled); }
+    AX_DEPRECATED(2.9.2) static bool isShareDistanceFieldEnabled() { return isGlobalSDFEnabled(); }
 
     /**
      * @brief TrueType fonts with native bytecode hinting * *
@@ -149,7 +152,7 @@ private:
     static bool _FTInitialized;
     static bool _streamParsingEnabled;
     static bool _doNativeBytecodeHinting;
-    static bool _shareDistanceFieldEnabled;
+    static bool _globalSDFEnabled;
     static char32_t _mssingGlyphCharacter;
 
     static bool initFreeType();

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -68,7 +68,7 @@ typedef struct _ttfConfig
                float size                             = AX_DEFAULT_FONT_LABEL_SIZE,
                const GlyphCollection& glyphCollection = GlyphCollection::DYNAMIC,
                const char* customGlyphCollection      = nullptr, /* nullable */
-               bool useDistanceField                  = FontFreeType::isShareDistanceFieldEnabled(),
+               bool useDistanceField                  = FontFreeType::isGlobalSDFEnabled(),
                int outline                            = 0,
                bool useItalics                        = false,
                bool useBold                           = false,

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -63,7 +63,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     ax::setLogFmtFlag(ax::LogFmtFlag::Full);
 
     // whether enable global SDF font render support, since axmol-2.0.1
-    FontFreeType::setShareDistanceFieldEnabled(true);
+    FontFreeType::setGlobalSDFEnabled(true);
 
     // As an example, load config file
     // FIXME:: This should be loaded before the Director is initialized,

--- a/tests/cpp-tests/Source/LabelTest/LabelTest.cpp
+++ b/tests/cpp-tests/Source/LabelTest/LabelTest.cpp
@@ -1336,7 +1336,7 @@ LabelTitleButtonTTFDistanceField::LabelTitleButtonTTFDistanceField()
 {
     auto size = Director::getInstance()->getWinSize();
 
-    FontFreeType::setShareDistanceFieldEnabled(false);
+    FontFreeType::setGlobalSDFEnabled(false);
     auto button = ax::ui::Button::create();
     button->setTitleText("Should be the same size");
     button->setTitleFontName("fonts/Marker Felt.ttf");
@@ -1344,7 +1344,7 @@ LabelTitleButtonTTFDistanceField::LabelTitleButtonTTFDistanceField()
     this->addChild(button);
     button->setPosition(Vec2(size.width / 2, size.height * 0.7f));
 
-    FontFreeType::setShareDistanceFieldEnabled(true);
+    FontFreeType::setGlobalSDFEnabled(true);
     button = ax::ui::Button::create();
     button->setTitleText("Should be the same size");
     button->setTitleFontName("fonts/Marker Felt.ttf");
@@ -1352,7 +1352,7 @@ LabelTitleButtonTTFDistanceField::LabelTitleButtonTTFDistanceField()
     this->addChild(button);
     button->setPosition(Vec2(size.width / 2, size.height * 0.55f));
 
-    FontFreeType::setShareDistanceFieldEnabled(false);
+    FontFreeType::setGlobalSDFEnabled(false);
     button = ax::ui::Button::create();
     button->setTitleText("Should be the same size");
     button->setTitleColor(Color3B::RED);
@@ -1361,7 +1361,7 @@ LabelTitleButtonTTFDistanceField::LabelTitleButtonTTFDistanceField()
     this->addChild(button);
     button->setPosition(Vec2(size.width / 2, size.height * 0.4f));
 
-    FontFreeType::setShareDistanceFieldEnabled(true);
+    FontFreeType::setGlobalSDFEnabled(true);
     button = ax::ui::Button::create();
     button->setTitleText("Should be the same size");
     button->setTitleColor(Color3B::RED);
@@ -1384,7 +1384,7 @@ LabelTTFSDF::LabelTTFSDF()
 {
     auto size = Director::getInstance()->getWinSize();
 
-    FontFreeType::setShareDistanceFieldEnabled(false);
+    FontFreeType::setGlobalSDFEnabled(false);
     Label* title = Label::createWithTTF("Normal", "fonts/Marker Felt.ttf", 20);
     this->addChild(title);
     title->setPosition(Vec2(size.width * 3 / 4, size.height * 0.75));
@@ -1392,7 +1392,7 @@ LabelTTFSDF::LabelTTFSDF()
     this->addChild(_labelNormal);
     _labelNormal->setPosition(Vec2(size.width * 3 / 4, size.height * 0.65));
 
-    FontFreeType::setShareDistanceFieldEnabled(true);
+    FontFreeType::setGlobalSDFEnabled(true);
     title = Label::createWithTTF("SDF", "fonts/Marker Felt.ttf", 20);
     this->addChild(title);
     title->setPosition(Vec2(size.width / 4, size.height * 0.75));

--- a/tests/unit-tests/Source/AppDelegate.cpp
+++ b/tests/unit-tests/Source/AppDelegate.cpp
@@ -50,7 +50,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     ax::setLogFmtFlag(ax::LogFmtFlag::Full);
 
     // whether enable global SDF font render support, since axmol-2.0.1
-    FontFreeType::setShareDistanceFieldEnabled(true);
+    FontFreeType::setGlobalSDFEnabled(true);
 
     // initialize director
     auto director = Director::getInstance();


### PR DESCRIPTION
## Describe your changes

- Use `FontFreeType::setGlobalSDFEnabled instead`

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
