### PR TITLE
Fix desktop EventMouse getDelta / getPreviousLocation

### DIFF
--- a/axmol/2d/CameraBackgroundBrush.cpp
+++ b/axmol/2d/CameraBackgroundBrush.cpp
@@ -210,9 +210,7 @@ void CameraBackgroundDepthBrush::onAfterDraw()
 
 CameraBackgroundColorBrush::CameraBackgroundColorBrush() : _color(0.f, 0.f, 0.f, 0.f) {}
 
-CameraBackgroundColorBrush::~CameraBackgroundColorBrush()
-{
-}
+CameraBackgroundColorBrush::~CameraBackgroundColorBrush() {}
 
 bool CameraBackgroundColorBrush::init()
 {

--- a/axmol/2d/FontFreeType.cpp
+++ b/axmol/2d/FontFreeType.cpp
@@ -45,11 +45,11 @@ namespace ax
 {
 
 FT_Library FontFreeType::_FTlibrary;
-bool FontFreeType::_FTInitialized             = false;
-bool FontFreeType::_streamParsingEnabled      = true;
-bool FontFreeType::_doNativeBytecodeHinting   = true;
-bool FontFreeType::_globalSDFEnabled          = false;
-const int FontFreeType::DistanceMapSpread     = 6;
+bool FontFreeType::_FTInitialized           = false;
+bool FontFreeType::_streamParsingEnabled    = true;
+bool FontFreeType::_doNativeBytecodeHinting = true;
+bool FontFreeType::_globalSDFEnabled        = false;
+const int FontFreeType::DistanceMapSpread   = 6;
 
 // By default, will render square when character glyph missing in current font
 char32_t FontFreeType::_mssingGlyphCharacter = 0;

--- a/axmol/2d/Label.cpp
+++ b/axmol/2d/Label.cpp
@@ -742,12 +742,12 @@ void Label::updateBatchCommand(Label::BatchCommand& batch)
 
 void Label::updateUniformLocations()
 {
-    _mvpMatrixLocation      = _programState->getUniformLocation(rhi::Uniform::MVP_MATRIX);
-    _textureLocation        = _programState->getUniformLocation(rhi::Uniform::TEXTURE);
-    _textColorLocation      = _programState->getUniformLocation(rhi::Uniform::TEXT_COLOR);
-    _effectColorLocation    = _programState->getUniformLocation(rhi::Uniform::EFFECT_COLOR);
-    _effectWidthLocation    = _programState->getUniformLocation(rhi::Uniform::EFFECT_WIDTH);
-    _passLocation           = _programState->getUniformLocation(rhi::Uniform::LABEL_PASS);
+    _mvpMatrixLocation   = _programState->getUniformLocation(rhi::Uniform::MVP_MATRIX);
+    _textureLocation     = _programState->getUniformLocation(rhi::Uniform::TEXTURE);
+    _textColorLocation   = _programState->getUniformLocation(rhi::Uniform::TEXT_COLOR);
+    _effectColorLocation = _programState->getUniformLocation(rhi::Uniform::EFFECT_COLOR);
+    _effectWidthLocation = _programState->getUniformLocation(rhi::Uniform::EFFECT_WIDTH);
+    _passLocation        = _programState->getUniformLocation(rhi::Uniform::LABEL_PASS);
 }
 
 bool Label::setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled /* = false */, bool useA8Shader /* = false */)
@@ -1926,7 +1926,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
             {  // distance field
                 // outline pass
                 {
-                    pass      = 1;
+                    pass = 1;
 
                     const float effectWidth =
                         (_outlineSize > 0 ? _outlineSize : _fontConfig.outlineSize) / FontFreeType::DistanceMapSpread;
@@ -2000,7 +2000,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
 
             // glow pass
             {
-                pass = 1;
+                pass                    = 1;
                 const float effectWidth = _glowRadius / FontFreeType::DistanceMapSpread;
                 updateBuffer(textureAtlas, batch.effectCommand);
                 auto effectPS = batch.effectCommand.unsafePS();

--- a/axmol/2d/Label.h
+++ b/axmol/2d/Label.h
@@ -54,9 +54,9 @@ typedef struct _ttfConfig
     std::string customGlyphs;
 
     GlyphCollection glyphs;
-    float fontSize;  // The desired render font size
-    int faceSize;    // The original face size of font, used when distanceFieldEnabled == true
-    int outlineSize; // The Outline width used in non‑SDF rendering; ignored when distance field is enabled
+    float fontSize;   // The desired render font size
+    int faceSize;     // The original face size of font, used when distanceFieldEnabled == true
+    int outlineSize;  // The Outline width used in non‑SDF rendering; ignored when distance field is enabled
 
     bool distanceFieldEnabled;
     bool italics;
@@ -736,7 +736,7 @@ protected:
         std::array<CustomCommand*, 3> getCommandArray();
 
         CustomCommand textCommand;
-        CustomCommand effectCommand; // effect: outline or glow 
+        CustomCommand effectCommand;  // effect: outline or glow
         CustomCommand shadowCommand;
     };
 

--- a/axmol/platform/desktop/RenderViewImpl.cpp
+++ b/axmol/platform/desktop/RenderViewImpl.cpp
@@ -417,6 +417,8 @@ RenderViewImpl::RenderViewImpl(bool initglfw)
     , _monitor(nullptr)
     , _mouseX(0.0f)
     , _mouseY(0.0f)
+    , _previousMouseX(0.0f)
+    , _previousMouseY(0.0f)
 {
     _viewName = "axmol3";
     g_keyCodeMap.clear();
@@ -1182,16 +1184,20 @@ void RenderViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int
 
     float cursorX = transformInputX(_mouseX);
     float cursorY = transformInputY(_mouseY);
+    float prevCursorX = transformInputX(_previousMouseX);
+    float prevCursorY = transformInputY(_previousMouseY);
 
     if (GLFW_PRESS == action)
     {
         EventMouse event(EventMouse::MouseEventType::MOUSE_DOWN);
+        event.setMouseInfo(prevCursorX, prevCursorY, ax::EventMouse::MouseButton::BUTTON_UNSET);
         event.setMouseInfo(cursorX, cursorY, static_cast<ax::EventMouse::MouseButton>(button));
         Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
     }
     else if (GLFW_RELEASE == action)
     {
         EventMouse event(EventMouse::MouseEventType::MOUSE_UP);
+        event.setMouseInfo(prevCursorX, prevCursorY, ax::EventMouse::MouseButton::BUTTON_UNSET);
         event.setMouseInfo(cursorX, cursorY, static_cast<ax::EventMouse::MouseButton>(button));
         Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
     }
@@ -1216,10 +1222,15 @@ void RenderViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, doubl
 
     float cursorX = transformInputX(_mouseX);
     float cursorY = transformInputY(_mouseY);
+    float prevCursorX = transformInputX(_previousMouseX);
+    float prevCursorY = transformInputY(_previousMouseY);
+    _previousMouseX = _mouseX;
+    _previousMouseY = _mouseY;
 
     EventMouse event(EventMouse::MouseEventType::MOUSE_MOVE);
     // Set current button
     EventMouse::MouseButton mouseButton{EventMouse::MouseButton::BUTTON_UNSET};
+    event.setMouseInfo(prevCursorX, prevCursorY, mouseButton);
     event.setMouseInfo(cursorX, cursorY, checkMouseButton(window));
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }

--- a/axmol/platform/desktop/RenderViewImpl.cpp
+++ b/axmol/platform/desktop/RenderViewImpl.cpp
@@ -1182,8 +1182,8 @@ void RenderViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int
         }
     }
 
-    float cursorX = transformInputX(_mouseX);
-    float cursorY = transformInputY(_mouseY);
+    float cursorX     = transformInputX(_mouseX);
+    float cursorY     = transformInputY(_mouseY);
     float prevCursorX = transformInputX(_previousMouseX);
     float prevCursorY = transformInputY(_previousMouseY);
 
@@ -1220,12 +1220,12 @@ void RenderViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, doubl
         }
     }
 
-    float cursorX = transformInputX(_mouseX);
-    float cursorY = transformInputY(_mouseY);
+    float cursorX     = transformInputX(_mouseX);
+    float cursorY     = transformInputY(_mouseY);
     float prevCursorX = transformInputX(_previousMouseX);
     float prevCursorY = transformInputY(_previousMouseY);
-    _previousMouseX = _mouseX;
-    _previousMouseY = _mouseY;
+    _previousMouseX   = _mouseX;
+    _previousMouseY   = _mouseY;
 
     EventMouse event(EventMouse::MouseEventType::MOUSE_MOVE);
     // Set current button

--- a/axmol/platform/desktop/RenderViewImpl.h
+++ b/axmol/platform/desktop/RenderViewImpl.h
@@ -196,6 +196,8 @@ protected:
     axstd::pod_vector<float> _touchesY;
 #endif
 
+    float _previousMouseX;
+    float _previousMouseY;
     float _mouseX;
     float _mouseY;
 

--- a/tests/cpp-tests/Source/LabelTest/LabelTest.cpp
+++ b/tests/cpp-tests/Source/LabelTest/LabelTest.cpp
@@ -1474,7 +1474,7 @@ LabelTTFSDF::LabelTTFSDF()
     _sliderOutline->setOpacity(100);
 
     _sliderGlow = initSlider("Glow", Vec2(size.width * 0.5, size.height * 0.35),
-                                [=, this](Object* obj, ui::Slider::EventType type) {
+                             [=, this](Object* obj, ui::Slider::EventType type) {
         Slider* slider = (Slider*)obj;
         float size     = 1 + slider->getPercent() / 10.0f;
         if (!slider->isEnabled())
@@ -1565,7 +1565,7 @@ void LabelTTFSDF::onChangedRadioButtonSelect(RadioButton* radioButton, RadioButt
     switch (radioButton->getTag())
     {
     case 0:
-        
+
         break;
     case 1:
         _labelNormal->enableGlow(Color32::RED, 1);


### PR DESCRIPTION
## Describe your changes

Make EventMouse getDelta / getPreviousLocation return correct value by calling setMouseInfo twice

## Checklist before requesting a review
### For each PR
- [X] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [X] I have performed a self-review of my code.
