### PR TITLE
Box2D-TestBed: Same window size as the cpp-test app

### DIFF
--- a/tests/cpp-tests/Source/Box2DTestBed/Box2DTestBed.cpp
+++ b/tests/cpp-tests/Source/Box2DTestBed/Box2DTestBed.cpp
@@ -75,9 +75,9 @@ static void SortTests()
 Box2DTestBedTests::Box2DTestBedTests()
 {
     // TODO: determine properly view size
-    g_camera.m_width  = 1920;
-    g_camera.m_height = 1080;
-    g_camera.m_zoom   = 150;
+    g_camera.m_width  = g_resourceSize.width;
+    g_camera.m_height = g_resourceSize.height;
+    g_camera.m_zoom   = 80;
     g_camera.m_center = b2Vec2_zero;
 
     ImGuiPresenter::getInstance()->setViewResolution(g_camera.m_width, g_camera.m_height);


### PR DESCRIPTION
## Describe your changes

Same window size as the cpp-test app
=> better look and feel (I think)

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
