### PR TITLE
Switch default audio backend on iOS/macOS from OpenAL.framework to openal-soft

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -253,7 +253,7 @@ endif()
 
 if(AX_ENABLE_AUDIO)
   # The openal-soft(LGPL 2.1)
-  if(AX_USE_ALSOFT AND NOT EMSCRIPTEN)
+  if(NOT EMSCRIPTEN)
     set(alsoft_opts "ALSOFT_DLOPEN OFF" "ALSOFT_UTILS OFF" "ALSOFT_EXAMPLES OFF" "ALSOFT_INSTALL OFF")
 
     if(AX_USE_ALSOFT_STATIC)
@@ -289,7 +289,6 @@ if(AX_ENABLE_AUDIO)
     ax_add_3rd(openal EXCLUDE_FROM_ALL TARGETS alcommon;OpenAL OPTIONS ${alsoft_opts})
 
     target_include_directories(3rdparty INTERFACE openal)
-    target_compile_definitions(3rdparty INTERFACE AX_USE_ALSOFT=1)
     set_target_properties(OpenAL alcommon PROPERTIES CXX_STANDARD ${_AX_CXX_STD})
 
     if(AX_USE_ALSOFT_STATIC)

--- a/CMakeOptions.md
+++ b/CMakeOptions.md
@@ -16,9 +16,6 @@
   - AX_ENABLE_CONSOLE: whether to enable debug tool console support, default: `TRUE`
   - AX_ENABLE_OPUS: whether to enable audio engine play .opus files support, default: `TRUE`
 - AX_USE_XXX:
-  - AX_USE_ALSOFT: whether use openal-soft for all platforms
-    - Apple platform: Use openal-soft instead system deprecated: `OpenAL.framework`
-    - Other platforms: Always use openal-soft even this option not enabled
   - AX_USE_LUAJIT: whether use luajit, default: `FALSE`, use plainlua
 - AX_ENABLE_EXT_XXX for extensions
   - AX_ENABLE_EXT_GUI: the traditional GUI extension, default: `TRUE`

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -519,7 +519,7 @@ function(ax_setup_app_config app_name)
 
   target_link_libraries(${app_name} ${_AX_EXTENSION_LIBS})
 
-  if(XCODE AND AX_ENABLE_AUDIO AND AX_USE_ALSOFT AND ALSOFT_OSX_FRAMEWORK)
+  if(XCODE AND AX_ENABLE_AUDIO AND ALSOFT_OSX_FRAMEWORK)
     # Embedded soft_oal embedded framework
     # XCODE_LINK_BUILD_PHASE_MODE BUILT_ONLY
     # ???Xcode limition: XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY works for first app

--- a/cmake/Modules/AXConfigDepend.cmake
+++ b/cmake/Modules/AXConfigDepend.cmake
@@ -2,8 +2,6 @@ macro(ax_depend)
   # confim the libs, prepare to link
   set(PLATFORM_SPECIFIC_LIBS)
 
-  message(STATUS "AX_USE_ALSOFT=${AX_USE_ALSOFT}")
-
   if(WINDOWS)
     list(APPEND PLATFORM_SPECIFIC_LIBS ws2_32 userenv psapi winmm Version Iphlpapi)
 
@@ -47,14 +45,6 @@ macro(ax_depend)
       ${AVFOUNDATION_LIBRARY}
       ${COREMEDIA_LIBRARY}
     )
-
-    if(AX_ENABLE_AUDIO AND NOT AX_USE_ALSOFT)
-      find_library(OPENAL_LIBRARY OpenAL)
-      set(_AX_APPLE_LIBS
-        ${OPENAL_LIBRARY}
-        ${_AX_APPLE_LIBS}
-      )
-    endif()
 
     if(MACOSX)
       list(APPEND PREBUILT_SPECIFIC_LIBS GLFW3)

--- a/cmake/Modules/AXLinkHelpers.cmake
+++ b/cmake/Modules/AXLinkHelpers.cmake
@@ -58,7 +58,6 @@ function(ax_link_cxx_prebuilt APP_NAME AX_ROOT_DIR AX_PREBUILT_DIR)
     PRIVATE CP_USE_CGTYPES=0
   )
 
-  ax_config_pred(${APP_NAME} AX_USE_ALSOFT)
   ax_config_pred(${APP_NAME} AX_ENABLE_MSEDGE_WEBVIEW2)
   ax_config_pred(${APP_NAME} AX_ENABLE_PHYSICS)
   ax_config_pred(${APP_NAME} AX_ENABLE_3D)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -99,12 +99,6 @@ cmake_dependent_option(AX_ENABLE_MSEDGE_WEBVIEW2 "Use Microsoft Edge webview2" O
 cmake_dependent_option(AX_ENABLE_MFMEDIA "Enabling microsoft media foundation" ON "WIN32" OFF)
 cmake_dependent_option(AX_ENABLE_VLC_MEDIA "Enabling vlc media" OFF "(WIN32 AND NOT WINRT) OR LINUX" OFF)
 
-if(NOT APPLE AND(NOT EMSCRIPTEN))
-  set(AX_USE_ALSOFT ON CACHE BOOL "" FORCE)
-else()
-  option(AX_USE_ALSOFT "Use ALSOFT on apple" OFF)
-endif()
-
 option(AX_ENABLE_PHYSICS "Build Physics support" ON)
 cmake_dependent_option(AX_ENABLE_MEDIA "Build media support" ON "AX_ENABLE_MFMEDIA OR AX_ENABLE_VLC_MEDIA OR APPLE OR ANDROID" OFF)
 option(AX_ENABLE_AUDIO "Build audio support" ON)

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -24,7 +24,7 @@ set(_AX_AUDIO_SRC
   audio/AudioEngineImpl.cpp
 )
 
-if (AX_USE_ALSOFT)
+if (NOT EMSCRIPTEN)
   set(_AX_AUDIO_HEADER ${_AX_AUDIO_HEADER}
     audio/AudioEffectsExtension.h
   )


### PR DESCRIPTION
- OpenAL.framework has long been deprecated by Apple
- openal-soft is now the enforced default backend for native platforms
- Removed obsolete CMake option `-DAX_USE_ALSOFT`

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
