### PR TITLE
Fix invalid AL_STOPPED transition caused by background route changes on iOS

### DIFF
--- a/core/audio/AudioPlayer.cpp
+++ b/core/audio/AudioPlayer.cpp
@@ -457,6 +457,16 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
 
         while (!_isDestroyed)
         {
+
+#if AX_TARGET_PLATFORM == AX_PLATFORM_IOS && !AX_USE_ALSOFT
+            if (alcGetCurrentContext() == nullptr)
+            {
+                std::unique_lock<std::mutex> lk(_sleepMutex);
+                _sleepCondition.wait_for(lk, std::chrono::milliseconds(rotateSleepTime));
+                continue;
+            }
+#endif
+
             alGetSourcei(_alSource, AL_SOURCE_STATE, &sourceState);
             if (sourceState == AL_PLAYING)
             {


### PR DESCRIPTION
In some iOS environments, when the app is in the background, inserting or removing headphones can trigger AVAudioSessionRouteChangeNotification. After returning to the foreground, AudioEngine::resumeAll restores the source state from AL_PAUSED back to AL_PLAYING. However, at the moment resumeAudioDevice is invoked during UIApplicationDidBecomeActiveNotification, the source state may unexpectedly transition to AL_STOPPED. As a result, rotateBufferThread attempts to restart playback and triggers "Error restarting playback!".

This fix makes rotateBufferThread skip all OpenAL buffer operations while the current context is NULL, avoiding invalid context access during this period and preventing incorrect state transitions that occur when returning from the background.