### PR TITLE
[Linux ] Fix missing shared OpenAL library issue

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -115,11 +115,20 @@ function(ax_add_3rd source_dir)
 
     if (NOT is_imported_lib)
       if(tgt_type STREQUAL "SHARED_LIBRARY")
-        set_target_properties(${tgt} PROPERTIES
-          ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-          RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"        
-          FOLDER "3rdparty"
-        )
+        if(LINUX)
+          set_target_properties(${tgt} PROPERTIES
+            ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"        
+            FOLDER "3rdparty"
+          )
+        else()      
+          set_target_properties(${tgt} PROPERTIES
+            ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"         
+            FOLDER "3rdparty"
+          )
+        endif()
       elseif(NOT(tgt_type STREQUAL "INTERFACE_LIBRARY"))
         set_target_properties(${tgt} PROPERTIES
           ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"


### PR DESCRIPTION
## Describe your changes


## Issue ticket number and link
Related to #2876 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
