### PR TITLE
[vulkan] Optimize disposalQueue with std::vector + swap-erase

### DIFF
--- a/axmol/rhi/vulkan/DriverVK.h
+++ b/axmol/rhi/vulkan/DriverVK.h
@@ -47,6 +47,7 @@ struct DisposableResource
         Buffer,
         Memory
     };
+    uint32_t frameMask;
     Type type;
     union
     {
@@ -157,7 +158,7 @@ public:
     void queueDisposal(VkDeviceMemory memory);
     void queueDisposal(VkSampler sampler);
 
-    void releaseDisposalResources();
+    void processDisposalQueue(uint32_t completedMask);
 
     void rebuildSwapchainAttachments(const axstd::pod_vector<VkImage>& images,
                                      const axstd::pod_vector<VkImageView>&,
@@ -177,6 +178,7 @@ public:
     void waitDeviceIdle() { vkDeviceWaitIdle(_device); }
 
 protected:
+    void queueDisposalInternal(DisposableResource&& res);
     ShaderModule* createShaderModule(ShaderStage stage, std::string_view source) override;
     SamplerHandle createSampler(const SamplerDesc& desc) override;
     void destroySampler(SamplerHandle& h) override;
@@ -203,7 +205,7 @@ private:
     VkCommandPool _commandPool{VK_NULL_HANDLE};
     std::mutex _commandPoolMutex;
 
-    std::deque<DisposableResource> _disposalQueue;
+    axstd::pod_vector<DisposableResource> _disposalQueue;
 
     uint32_t _graphicsQueueFamily{0};
     uint32_t _presentQueueFamily{0};

--- a/axmol/rhi/vulkan/RenderContextVK.cpp
+++ b/axmol/rhi/vulkan/RenderContextVK.cpp
@@ -579,6 +579,8 @@ bool RenderContextImpl::beginFrame()
 
     // wait for previous frame to finish
     vkWaitForFences(_device, 1, &_inFlightFences[_currentFrame], VK_TRUE, UINT64_MAX);
+    vkResetFences(_device, 1, &_inFlightFences[_currentFrame]);
+    _driver->processDisposalQueue( 1 << _currentFrame);
 
     // Reset uniform ring write head for this frame
     resetUniformRingForCurrentFrame();
@@ -590,18 +592,12 @@ bool RenderContextImpl::beginFrame()
     VkResult result =
         vkAcquireNextImageKHR(_device, _swapchain, UINT64_MAX, _acquireCompleteSemaphores[_semaphoreIndex],
                               VK_NULL_HANDLE, &_currentImageIndex);
-    while (_currentImageIndex > maxImageIndex && (result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR))
-    {
-        result = vkAcquireNextImageKHR(_device, _swapchain, UINT64_MAX, _acquireCompleteSemaphores[_semaphoreIndex],
-                                       VK_NULL_HANDLE, &_currentImageIndex);
-    }
-
     if (!handleSwapchainResult(result, SwapchainOp::Acquire, prevSemaphoreIndex))
         return false;
 
-    _inFrame = true;
+    AXASSERT(_currentImageIndex < maxImageIndex, "swapchain image index out of range!");
 
-    vkResetFences(_device, 1, &_inFlightFences[_currentFrame]);
+    _inFrame = true;
 
     _driver->setSwapchainCurrentImageIndex(_currentImageIndex);
 
@@ -715,8 +711,6 @@ void RenderContextImpl::endFrame()
 
         _postFrameOps.clear();
     }
-
-    _driver->releaseDisposalResources();
 
     // Advance frame index for multi-frame-in-flight
     if (succeed)

--- a/axmol/rhi/vulkan/RenderContextVK.cpp
+++ b/axmol/rhi/vulkan/RenderContextVK.cpp
@@ -580,7 +580,7 @@ bool RenderContextImpl::beginFrame()
     // wait for previous frame to finish
     vkWaitForFences(_device, 1, &_inFlightFences[_currentFrame], VK_TRUE, UINT64_MAX);
     vkResetFences(_device, 1, &_inFlightFences[_currentFrame]);
-    _driver->processDisposalQueue( 1 << _currentFrame);
+    _driver->processDisposalQueue(1 << _currentFrame);
 
     // Reset uniform ring write head for this frame
     resetUniformRingForCurrentFrame();

--- a/axmol/rhi/vulkan/RenderContextVK.h
+++ b/axmol/rhi/vulkan/RenderContextVK.h
@@ -128,6 +128,8 @@ public:
 
     void removeCachedPipelines(VkRenderPass rp);
 
+    uint32_t getCurrentFrame() const { return _currentFrame; }
+
 private:
     void recreateSwapchain();
     void createCommandBuffers();


### PR DESCRIPTION
- Replace std::deque with std::vector for disposalQueue storage
  * Better cache locality and faster iteration
- Implement swap-erase deletion pattern
  * O(1) removal by overwriting with back() and pop_back()
  * Avoids linear element shifting cost of vector::erase
- Adjust releaseDisposalResources() to use index-based loop
  * Ensure correctness by re-checking swapped element
- Maintain frameMask check logic for completed frames
- Improves performance of deferred resource destruction in Vulkan RHI
  * Especially under heavy Buffer/Image disposal workloads

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
