### PR TITLE
Fix version check: add fbx-conv v0.7 support

### DIFF
--- a/axmol/3d/Bundle3D.cpp
+++ b/axmol/3d/Bundle3D.cpp
@@ -1807,7 +1807,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(simdjson::simdjson_result<simdjson
 
     // set transform
     if (_version == "0.1" || _version == "0.2" || _version == "0.3" || _version == "0.4" || _version == "0.5" ||
-        _version == "0.6")
+        _version == "0.6" || _version == "0.7")
     {
         if (isSkin || singleSprite)
         {
@@ -1976,7 +1976,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
 
         // set transform
         if (_version == "0.1" || _version == "0.2" || _version == "0.3" || _version == "0.4" || _version == "0.5" ||
-            _version == "0.6")
+            _version == "0.6" || _version == "0.7")
         {
             if (isSkin || singleSprite)
             {


### PR DESCRIPTION
## Describe your changes
This PR fixes the version check in Bundle3D.

The current code only checks:
- "0.1"
- "0.2"
- "0.3"
- "0.4"
- "0.5"
- "0.6"

However, the latest fbx-conv tool generates version "0.7",
and this version is not recognized due to hard-coded version checks.

This PR updates the version check to include "0.7".

## Issue ticket number and link
#2901
https://github.com/axmolengine/axmol/issues/2901

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
