### PR TITLE
Allows to override FileUtils::getWritablePath() on Linux.

### DIFF
--- a/core/platform/FileUtils.cpp
+++ b/core/platform/FileUtils.cpp
@@ -779,6 +779,9 @@ const std::vector<std::string>& FileUtils::getOriginalSearchPaths() const
 void FileUtils::setWritablePath(std::string_view writablePath)
 {
     _writablePath = writablePath;
+
+    if (!_writablePath.empty() && (_writablePath.back() != '/'))
+      _writablePath += '/';
 }
 
 const std::string& FileUtils::getDefaultResourceRootPath() const

--- a/core/platform/linux/FileUtils-linux.cpp
+++ b/core/platform/linux/FileUtils-linux.cpp
@@ -39,11 +39,13 @@ using namespace std;
 namespace ax
 {
 
-static std::string _checkPath(const char* path) {
+static std::string _checkPath(const char* path)
+{
     std::string ret;
     ret.resize(PATH_MAX - 1);
     int n = readlink(path, &ret.front(), PATH_MAX);
-    if (n > 0) {
+    if (n > 0)
+    {
         ret.resize(n);
         return ret;
     }
@@ -72,8 +74,9 @@ FileUtilsLinux::FileUtilsLinux() {}
 bool FileUtilsLinux::init()
 {
     // application path
-    if (s_exeDir.empty()) {
-        s_exeDir = _checkPath("/proc/self/exe");
+    if (s_exeDir.empty())
+    {
+        s_exeDir   = _checkPath("/proc/self/exe");
         auto slash = s_exeDir.find_last_of('/');
         assert(slash != std::string::npos);
         s_exeName = s_exeDir.substr(slash + 1);
@@ -104,9 +107,9 @@ bool FileUtilsLinux::init()
         xdgConfigPath = xdg_config_path;
     }
     _writablePath = xdgConfigPath;
-    _writablePath += "/";
+    _writablePath += '/';
     _writablePath += s_exeName;
-    _writablePath += "/";
+    _writablePath += '/';
 
     bool ret = FileUtils::init();
 
@@ -140,4 +143,4 @@ bool FileUtilsLinux::isFileExistInternal(std::string_view path) const
     return (stat(path.data(), &sts) == 0) && S_ISREG(sts.st_mode);
 }
 
-}
+}  // namespace ax

--- a/core/platform/linux/FileUtils-linux.h
+++ b/core/platform/linux/FileUtils-linux.h
@@ -47,9 +47,6 @@ class AX_DLL FileUtilsLinux : public FileUtils
 protected:
     FileUtilsLinux();
 
-private:
-    std::string _writablePath;
-
 public:
     /* override functions */
     bool init() override;


### PR DESCRIPTION
Windows and Mac both have a way to override the writable path via `FileUtils::setWritablePath()`. Linux had not, until this commit.

I use this to run multiple instances of my game and have them accessing different files.
