### PR TITLE
Add Node::getHashOfName().

### DIFF
--- a/core/2d/Node.cpp
+++ b/core/2d/Node.cpp
@@ -54,13 +54,13 @@ THE SOFTWARE.
 #    define RENDER_IN_SUBPIXEL(__ARGS__) (ceil(__ARGS__))
 #endif
 
-/*
- * 4.5x faster than std::hash in release mode
- */
-#define AX_HASH_NODE_NAME(name) (!name.empty() ? XXH3_64bits(name.data(), name.length()) : 0)
-
 namespace ax
 {
+AX_DLL uint64_t hashNodeName(std::string_view name)
+{
+  // 4.5x faster than std::hash in release mode.
+  return !name.empty() ? XXH3_64bits(name.data(), name.length()) : 0;
+}
 
 // FIXME:: Yes, nodes might have a sort problem once every 30 days if the game runs at 60 FPS and each frame sprites are
 // reordered.
@@ -717,6 +717,11 @@ void Node::setName(std::string_view name)
     _name = name;
 }
 
+uint64_t Node::getHashOfName() const
+{
+  return _hashOfName;
+}
+
 void Node::updateParentChildrenIndexer(int tag)
 {
     auto parentChildrenIndexer = getParentChildrenIndexer();
@@ -730,11 +735,11 @@ void Node::updateParentChildrenIndexer(int tag)
 
 void Node::updateParentChildrenIndexer(std::string_view name)
 {
-    uint64_t newHash           = AX_HASH_NODE_NAME(name);
+    uint64_t newHash           = hashNodeName(name);
     auto parentChildrenIndexer = getParentChildrenIndexer();
     if (parentChildrenIndexer)
     {
-        auto oldHash = AX_HASH_NODE_NAME(_name);
+        auto oldHash = hashNodeName(_name);
         if (oldHash != newHash)
             parentChildrenIndexer->erase(oldHash);
         (*parentChildrenIndexer)[newHash] = this;
@@ -831,7 +836,7 @@ Node* Node::getChildByTag(int tag) const
 Node* Node::getChildByName(std::string_view name) const
 {
     // AXASSERT(!name.empty(), "Invalid name");
-    auto hash = AX_HASH_NODE_NAME(name);
+    auto hash = hashNodeName(name);
     if (_childrenIndexer)
     {
         auto it = _childrenIndexer->find(hash);

--- a/core/2d/Node.h
+++ b/core/2d/Node.h
@@ -86,6 +86,8 @@ class EventListener;
 
 typedef std::map<uint64_t, Node*> NodeIndexerMap_t;
 
+AX_DLL uint64_t hashNodeName(std::string_view);
+
 /** @class Node
 * @brief Node is the base element of the Scene Graph. Elements of the Scene Graph must be Node objects or subclasses of
 it. The most common Node objects are: Scene, Layer, Sprite, Menu, Label.
@@ -980,6 +982,8 @@ public:
      * @since v3.2
      */
     virtual void setName(std::string_view name);
+
+    uint64_t getHashOfName() const;
 
     /**
      * Returns a custom user data pointer.


### PR DESCRIPTION
`ax::Node` maintains a hash of the node's name internally for faster lookup of the children. Exposing the hash allows to benefit from faster look-up from outside Axmol too.