### PR TITLE
AX_CORE_PROFILE fix usage of "ifndef AX_CORE_PROFILE"

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -111,7 +111,7 @@ cmake_dependent_option(AX_ENABLE_NAVMESH "Build NavMesh support" ON "AX_ENABLE_3
 
 option(AX_UPDATE_BUILD_VERSION "Update build version" ON)
 option(AX_DISABLE_GLES2 "Whether disable GLES2 support" OFF)
-option(AX_CORE_PROFILE "Whether strip deprecated features" ON)
+option(AX_CORE_PROFILE "Whether strip deprecated features" OFF)
 
 # default value for axmol extensions modules to Build
 # total supported extensions count: 13

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -111,7 +111,7 @@ cmake_dependent_option(AX_ENABLE_NAVMESH "Build NavMesh support" ON "AX_ENABLE_3
 
 option(AX_UPDATE_BUILD_VERSION "Update build version" ON)
 option(AX_DISABLE_GLES2 "Whether disable GLES2 support" OFF)
-option(AX_CORE_PROFILE "Whether strip deprecated features" OFF)
+option(AX_CORE_PROFILE "Whether strip deprecated features" ON)
 
 # default value for axmol extensions modules to Build
 # total supported extensions count: 13

--- a/core/platform/linux/Application-linux.cpp
+++ b/core/platform/linux/Application-linux.cpp
@@ -132,11 +132,13 @@ Application* Application::getInstance()
     return sm_pSharedApplication;
 }
 
+#ifndef AX_CORE_PROFILE
 // @deprecated Use getInstance() instead
 Application* Application::sharedApplication()
 {
     return Application::getInstance();
 }
+#endif
 
 const char* Application::getCurrentLanguageCode()
 {

--- a/core/platform/wasm/Application-wasm.cpp
+++ b/core/platform/wasm/Application-wasm.cpp
@@ -211,6 +211,7 @@ void Application::setAnimationInterval(float interval)
     s_animationInterval = static_cast<int64_t>(interval * NANOSECONDSPERSECOND);
 }
 
+#ifndef AX_CORE_PROFILE
 void Application::setResourceRootPath(const std::string& rootResDir)
 {
     _resourceRootPath = rootResDir;
@@ -228,6 +229,7 @@ const std::string& Application::getResourceRootPath()
 {
     return _resourceRootPath;
 }
+#endif
 
 Application::Platform Application::getTargetPlatform()
 {

--- a/core/platform/wasm/Application-wasm.cpp
+++ b/core/platform/wasm/Application-wasm.cpp
@@ -257,11 +257,13 @@ Application* Application::getInstance()
     return sm_pSharedApplication;
 }
 
+#ifndef AX_CORE_PROFILE
 // @deprecated Use getInstance() instead
 Application* Application::sharedApplication()
 {
     return Application::getInstance();
 }
+#endif
 
 const char* Application::getCurrentLanguageCode()
 {


### PR DESCRIPTION
## Describe your changes
compilatin fails after enablaing ifndef AX_CORE_PROFILE

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
