### PR TITLE
Optimize EventDispatcher touch lambda with context struct

### DIFF
--- a/axmol/base/EventDispatcher.cpp
+++ b/axmol/base/EventDispatcher.cpp
@@ -996,7 +996,7 @@ void EventDispatcher::dispatchEvent(Event* event, bool forced)
     {
         auto listeners = iter->second;
 
-        auto onEvent = [&event](EventListener* listener) -> bool {
+        auto onEvent = [event](EventListener* listener) -> bool {
             event->setCurrentTarget(listener->getAssociatedNode());
             listener->_onEvent(event);
             return event->isStopped();
@@ -1032,29 +1032,50 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
     if (nullptr == oneByOneListeners && nullptr == allAtOnceListeners)
         return;
 
-    bool isNeedsMutableSet = (oneByOneListeners && allAtOnceListeners);
+    struct TouchContext
+    {
+        EventTouch* event;
+        Touch* touch;
+        std::vector<Touch*>* pTouches;
+        std::vector<Touch*> mutableTouches;
+        std::vector<Touch*>::iterator touchesIter;
+        bool isNeedsMutableSet;
+        bool isSwallowed;
+    };
+
+    TouchContext touchContext;
+    touchContext.event             = event;
+    touchContext.isNeedsMutableSet = (oneByOneListeners && allAtOnceListeners);
 
     const std::vector<Touch*>& originalTouches = event->getTouches();
-    auto mutableTouches                        = originalTouches;
+    if (!touchContext.isNeedsMutableSet)
+        touchContext.pTouches = const_cast<std::vector<Touch*>*>(&originalTouches);
+    else
+    {
+        touchContext.mutableTouches = originalTouches;
+        touchContext.pTouches       = &touchContext.mutableTouches;
+    }
 
     //
     // process the target handlers 1st
     //
     if (oneByOneListeners)
     {
-        auto mutableTouchesIter = mutableTouches.begin();
+        touchContext.touchesIter = touchContext.pTouches->begin();
 
-        for (auto&& touches : originalTouches)
+        for (auto&& touch : originalTouches)
         {
-            bool isSwallowed = false;
+            touchContext.isSwallowed = false;
+            touchContext.touch       = touch;
 
-            auto onTouchEvent = [&](EventListener* l) -> bool {  // Return true to break
+            auto onTouchEvent = [this, &touchContext](EventListener* l) -> bool {  // Return true to break
                 EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(l);
 
                 // Skip if the listener was removed.
                 if (!listener->_isRegistered)
                     return false;
 
+                const auto event = touchContext.event;
                 event->setCurrentTarget(listener->_node);
 
                 bool isClaimed = false;
@@ -1066,16 +1087,16 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                 {
                     if (listener->onTouchBegan)
                     {
-                        isClaimed = listener->onTouchBegan(touches, event);
+                        isClaimed = listener->onTouchBegan(touchContext.touch, event);
                         if (isClaimed && listener->_isRegistered)
                         {
-                            listener->_claimedTouches.emplace_back(touches);
+                            listener->_claimedTouches.emplace_back(touchContext.touch);
                         }
                     }
                 }
                 else if (!listener->_claimedTouches.empty() &&
                          ((removedIter = std::find(listener->_claimedTouches.begin(), listener->_claimedTouches.end(),
-                                                   touches)) != listener->_claimedTouches.end()))
+                                                   touchContext.touch)) != listener->_claimedTouches.end()))
                 {
                     isClaimed = true;
 
@@ -1084,13 +1105,13 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     case EventTouch::EventCode::MOVED:
                         if (listener->onTouchMoved)
                         {
-                            listener->onTouchMoved(touches, event);
+                            listener->onTouchMoved(touchContext.touch, event);
                         }
                         break;
                     case EventTouch::EventCode::ENDED:
                         if (listener->onTouchEnded)
                         {
-                            listener->onTouchEnded(touches, event);
+                            listener->onTouchEnded(touchContext.touch, event);
                         }
                         if (listener->_isRegistered)
                         {
@@ -1100,7 +1121,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     case EventTouch::EventCode::CANCELLED:
                         if (listener->onTouchCancelled)
                         {
-                            listener->onTouchCancelled(touches, event);
+                            listener->onTouchCancelled(touchContext.touch, event);
                         }
                         if (listener->_isRegistered)
                         {
@@ -1120,15 +1141,15 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     return true;
                 }
 
-                AXASSERT(touches->getID() == (*mutableTouchesIter)->getID(),
+                AXASSERT(touchContext.touch->getID() == (*touchContext.touchesIter)->getID(),
                          "touches ID should be equal to mutableTouchesIter's ID.");
 
                 if (isClaimed && listener->_isRegistered && listener->_needSwallow)
                 {
-                    if (isNeedsMutableSet)
+                    if (touchContext.isNeedsMutableSet)
                     {
-                        mutableTouchesIter = mutableTouches.erase(mutableTouchesIter);
-                        isSwallowed        = true;
+                        touchContext.touchesIter = touchContext.mutableTouches.erase(touchContext.touchesIter);
+                        touchContext.isSwallowed = true;
                     }
                     return true;
                 }
@@ -1143,22 +1164,24 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                 return;
             }
 
-            if (!isSwallowed)
-                ++mutableTouchesIter;
+            if (!touchContext.isSwallowed)
+                ++touchContext.touchesIter;
         }
     }
 
     //
     // process standard handlers 2nd
     //
-    if (allAtOnceListeners && !mutableTouches.empty())
+    if (allAtOnceListeners && !touchContext.pTouches->empty())
     {
-
-        auto onTouchesEvent = [&](EventListener* l) -> bool {
+        auto onTouchesEvent = [this, &touchContext](EventListener* l) -> bool {
             EventListenerTouchAllAtOnce* listener = static_cast<EventListenerTouchAllAtOnce*>(l);
             // Skip if the listener was removed.
             if (!listener->_isRegistered)
                 return false;
+
+            auto& remainingTouches = *touchContext.pTouches;
+            const auto event       = touchContext.event;
 
             event->setCurrentTarget(listener->_node);
 
@@ -1167,25 +1190,25 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
             case EventTouch::EventCode::BEGAN:
                 if (listener->onTouchesBegan)
                 {
-                    listener->onTouchesBegan(mutableTouches, event);
+                    listener->onTouchesBegan(remainingTouches, event);
                 }
                 break;
             case EventTouch::EventCode::MOVED:
                 if (listener->onTouchesMoved)
                 {
-                    listener->onTouchesMoved(mutableTouches, event);
+                    listener->onTouchesMoved(remainingTouches, event);
                 }
                 break;
             case EventTouch::EventCode::ENDED:
                 if (listener->onTouchesEnded)
                 {
-                    listener->onTouchesEnded(mutableTouches, event);
+                    listener->onTouchesEnded(remainingTouches, event);
                 }
                 break;
             case EventTouch::EventCode::CANCELLED:
                 if (listener->onTouchesCancelled)
                 {
-                    listener->onTouchesCancelled(mutableTouches, event);
+                    listener->onTouchesCancelled(remainingTouches, event);
                 }
                 break;
             default:
@@ -1223,7 +1246,7 @@ void EventDispatcher::dispatchMouseEvent(EventMouse* event)
     if (nullptr == listeners)
         return;
 
-    auto onMouseEvent = [&](EventListener* l) -> bool {  // Return true to break
+    auto onMouseEvent = [this, event](EventListener* l) -> bool {  // Return true to break
         EventListenerMouse* listener = static_cast<EventListenerMouse*>(l);
 
         // Skip if the listener was removed.

--- a/axmol/base/EventDispatcher.cpp
+++ b/axmol/base/EventDispatcher.cpp
@@ -1076,6 +1076,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     return false;
 
                 const auto event = touchContext.event;
+                auto touch       = touchContext.touch;
                 event->setCurrentTarget(listener->_node);
 
                 bool isClaimed = false;
@@ -1087,16 +1088,16 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                 {
                     if (listener->onTouchBegan)
                     {
-                        isClaimed = listener->onTouchBegan(touchContext.touch, event);
+                        isClaimed = listener->onTouchBegan(touch, event);
                         if (isClaimed && listener->_isRegistered)
                         {
-                            listener->_claimedTouches.emplace_back(touchContext.touch);
+                            listener->_claimedTouches.emplace_back(touch);
                         }
                     }
                 }
                 else if (!listener->_claimedTouches.empty() &&
                          ((removedIter = std::find(listener->_claimedTouches.begin(), listener->_claimedTouches.end(),
-                                                   touchContext.touch)) != listener->_claimedTouches.end()))
+                                                   touch)) != listener->_claimedTouches.end()))
                 {
                     isClaimed = true;
 
@@ -1105,13 +1106,13 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     case EventTouch::EventCode::MOVED:
                         if (listener->onTouchMoved)
                         {
-                            listener->onTouchMoved(touchContext.touch, event);
+                            listener->onTouchMoved(touch, event);
                         }
                         break;
                     case EventTouch::EventCode::ENDED:
                         if (listener->onTouchEnded)
                         {
-                            listener->onTouchEnded(touchContext.touch, event);
+                            listener->onTouchEnded(touch, event);
                         }
                         if (listener->_isRegistered)
                         {
@@ -1121,7 +1122,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     case EventTouch::EventCode::CANCELLED:
                         if (listener->onTouchCancelled)
                         {
-                            listener->onTouchCancelled(touchContext.touch, event);
+                            listener->onTouchCancelled(touch, event);
                         }
                         if (listener->_isRegistered)
                         {
@@ -1141,7 +1142,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     return true;
                 }
 
-                AXASSERT(touchContext.touch->getID() == (*touchContext.touchesIter)->getID(),
+                AXASSERT(touch->getID() == (*touchContext.touchesIter)->getID(),
                          "touches ID should be equal to mutableTouchesIter's ID.");
 
                 if (isClaimed && listener->_isRegistered && listener->_needSwallow)


### PR DESCRIPTION
- Introduced TouchContext struct to encapsulate event, touch, iterator, and swallow state, reducing lambda capture size.
- Lambdas now capture only &touchContext instead of multiple variables, avoiding large closure objects and improving compiler optimization.
- Conditional copy of originalTouches:
    * If both OneByOne and AllAtOnce listeners exist, create mutableTouches for swallow logic.
    * Otherwise, directly reference originalTouches to skip unnecessary vector copy.
- Overall improvements:
    * Reduced closure object size, helping SSO/small object optimization.
    * Clearer code structure with centralized context.
    * Avoided redundant vector copy when swallow logic not needed.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
