### PR TITLE
Add iOS simulator builds for arm64 architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
         path: |
           templates/**/*.apk
           tests/**/*.apk
-  ios:
+  ios-sim-x64:
     runs-on: macos-latest
     strategy:
       matrix:
@@ -239,6 +239,22 @@ jobs:
     - name: Build
       shell: pwsh
       run: ./tools/cmdline/axmol -p $env:TARGET_OS -a 'x64'
+  ios-sim-arm64:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target_os:
+          - ios
+          - tvos
+    env:
+      TARGET_OS: ${{ matrix.target_os }}
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Build
+      shell: pwsh
+      # axmol cmdline can't guess ios arm64 as simulator, so need specify by option '-sdk'
+      run: ./tools/cmdline/axmol -p $env:TARGET_OS -a 'arm64' -sdk 'simulator'
   wasm:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Added iOS simulator build configurations for arm64 architecture.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
