### PR TITLE
Fix Bugs around Particle System in  Release/2.10.0

### DIFF
--- a/core/2d/ParticleSystem.cpp
+++ b/core/2d/ParticleSystem.cpp
@@ -942,13 +942,9 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
     SET_DELTA_COLOR(_particleData.colorG, _particleData.deltaColorG);
     SET_DELTA_COLOR(_particleData.colorB, _particleData.deltaColorB);
     SET_DELTA_COLOR(_particleData.colorA, _particleData.deltaColorA);
-
-    ///[2025.12.07]//////////////////////////////////////////////
-    /// BUG From WUCJ638 : when OpacityFadeIn or ScaleFadeIn  ///
-    /// equals to zero, source would't emit any particles.    ///
-    /////////////////////////////////////////////////////////////
-    ///// FIX begin
-
+    
+    // Should skip these initialization when OpacityFadeIn or ScaleFadeIn is 0, otherwise
+    // particles would fail to show up.
     // opacity fade in
     if (_isOpacityFadeInAllocated && _spawnFadeIn + _spawnFadeInVar > 0)
     {
@@ -968,8 +964,6 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
         }
         std::fill_n(_particleData.scaleInDelta + start, _particleCount - start, 0.0F);
     }
-    ///// Fix end
-    //////////////////////////////////////////////////////////////
 
     // hue saturation value color
     if (_isHSVAllocated)
@@ -1550,16 +1544,9 @@ void ParticleSystem::resetSystem()
 {
     _isActive = true;
     _elapsed  = 0;
-
-    // [2025.12.09] Bug from WUCJ638:
-    //   Visually, resetting System would actually remove all existed particles
-    // before emitting them again. Therefore just simply set _particleCount
-    // to zero.
-    //   Without doing so, particles with loop animation enabled would crash,
-    // for particleData.animIndex are junk and would cause Out-of-Range excep-
-    // -tion in update() function
+    // Setting _particleCount to zero could prevent Out-of-Range exception when updating
+    // particle's loop animation after calling setTotalParticle().
     _particleCount = 0;
-    //std::fill_n(_particleData.timeToLive, _particleCount, 0.0F);
 }
 
 bool ParticleSystem::isFull()
@@ -2118,21 +2105,11 @@ void ParticleSystem::useHSV(bool hsv)
         deallocHSVMem();
 };
 
-///[2025.12.06]/////////////////////////////////////////////////////////
-/// BUG from WUCJ638 : modification would get ignored after memory   ///
-/// is allocated, that is "nothing happens", we only have one change ///
-/// to change the value.                                             ///
-/// Same problem has been found inside this FIX block:               ///
-/// 1. setSpawnFadeInVar  2. setSpawnScaleIn   3. setSpawnScaleInVar ///
-/// [WARNING] setAnimation wasn't fixed yet but they have the same   ///
-/// behavior in allocatinng memory.                                  ///
-////////////////////////////////////////////////////////////////////////
-////////// Fix begin
 void ParticleSystem::setSpawnFadeIn(float time)
 {
 // Modification is allowed when:
-//  - memory hasn't allocated, time neq 0.0F and allocation has done successfully;
-//  - or memory has allocated.
+//  - memory hasn't been allocated, time != 0.0F and allocation has done successfully; OR
+//  - memory has allocated.
     if(!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
         return;
 
@@ -2162,8 +2139,6 @@ void ParticleSystem::setSpawnScaleInVar(float time)
 
     _spawnScaleInVar = time;
 }
-////////// Fix end
-////////////////////////////////////////////////////////////////////////
 
 int ParticleSystem::getTotalParticles() const
 {

--- a/core/2d/ParticleSystem.cpp
+++ b/core/2d/ParticleSystem.cpp
@@ -138,7 +138,6 @@ bool ParticleData::init(int count)
     modeB.deltaRadius      = (float*)malloc(count * sizeof(float));
     modeB.radius           = (float*)malloc(count * sizeof(float));
 
-
     return posx && posy && startPosX && startPosY && colorR && colorG && colorB && colorA && deltaColorR &&
            deltaColorG && deltaColorB && deltaColorA && size && deltaSize && rotation && staticRotation &&
            deltaRotation && totalTimeToLive && timeToLive && atlasIndex && modeA.dirX && modeA.dirY &&

--- a/core/2d/ParticleSystem.cpp
+++ b/core/2d/ParticleSystem.cpp
@@ -2109,7 +2109,7 @@ void ParticleSystem::setSpawnFadeIn(float time)
     // Modification is allowed when:
     //  - memory hasn't been allocated, time != 0.0F and allocation has done successfully; OR
     //  - memory has allocated.
-    if(!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
+    if (!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
         return;
 
     _spawnFadeIn = time;
@@ -2117,7 +2117,7 @@ void ParticleSystem::setSpawnFadeIn(float time)
 
 void ParticleSystem::setSpawnFadeInVar(float time)
 {
-    if(!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
+    if (!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
         return;
 
     _spawnFadeInVar = time;
@@ -2125,7 +2125,7 @@ void ParticleSystem::setSpawnFadeInVar(float time)
 
 void ParticleSystem::setSpawnScaleIn(float time)
 {
-    if(!_isScaleInAllocated && (time == 0.0F || !allocScaleInMem()))
+    if (!_isScaleInAllocated && (time == 0.0F || !allocScaleInMem()))
         return;
 
     _spawnScaleIn = time;
@@ -2133,7 +2133,7 @@ void ParticleSystem::setSpawnScaleIn(float time)
 
 void ParticleSystem::setSpawnScaleInVar(float time)
 {
-    if(!_isScaleInAllocated && (time == 0.0F || !allocScaleInMem()))
+    if (!_isScaleInAllocated && (time == 0.0F || !allocScaleInMem()))
         return;
 
     _spawnScaleInVar = time;

--- a/core/2d/ParticleSystem.cpp
+++ b/core/2d/ParticleSystem.cpp
@@ -118,7 +118,7 @@ bool ParticleData::init(int count)
     deltaColorG = (float*)malloc(count * sizeof(float));
     deltaColorB = (float*)malloc(count * sizeof(float));
     deltaColorA = (float*)malloc(count * sizeof(float));
-    
+
     size            = (float*)malloc(count * sizeof(float));
     deltaSize       = (float*)malloc(count * sizeof(float));
     rotation        = (float*)malloc(count * sizeof(float));
@@ -862,8 +862,8 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
         }
     }
 
-     if (animationCellIndex != -1 || animationIndex != -1)
-         allocAnimationMem();
+    if (animationCellIndex != -1 || animationIndex != -1)
+        allocAnimationMem();
 
     if (_isAnimAllocated)
     {
@@ -2107,9 +2107,9 @@ void ParticleSystem::useHSV(bool hsv)
 
 void ParticleSystem::setSpawnFadeIn(float time)
 {
-// Modification is allowed when:
-//  - memory hasn't been allocated, time != 0.0F and allocation has done successfully; OR
-//  - memory has allocated.
+    // Modification is allowed when:
+    //  - memory hasn't been allocated, time != 0.0F and allocation has done successfully; OR
+    //  - memory has allocated.
     if(!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
         return;
 

--- a/core/2d/ParticleSystem.cpp
+++ b/core/2d/ParticleSystem.cpp
@@ -118,7 +118,7 @@ bool ParticleData::init(int count)
     deltaColorG = (float*)malloc(count * sizeof(float));
     deltaColorB = (float*)malloc(count * sizeof(float));
     deltaColorA = (float*)malloc(count * sizeof(float));
-
+    
     size            = (float*)malloc(count * sizeof(float));
     deltaSize       = (float*)malloc(count * sizeof(float));
     rotation        = (float*)malloc(count * sizeof(float));
@@ -137,6 +137,7 @@ bool ParticleData::init(int count)
     modeB.degreesPerSecond = (float*)malloc(count * sizeof(float));
     modeB.deltaRadius      = (float*)malloc(count * sizeof(float));
     modeB.radius           = (float*)malloc(count * sizeof(float));
+
 
     return posx && posy && startPosX && startPosY && colorR && colorG && colorB && colorA && deltaColorR &&
            deltaColorG && deltaColorB && deltaColorA && size && deltaSize && rotation && staticRotation &&
@@ -374,6 +375,7 @@ void ParticleSystem::deallocOpacityFadeInMem()
     _isOpacityFadeInAllocated = false;
 }
 
+// @return true if succeed in allocating
 bool ParticleSystem::allocScaleInMem()
 {
     if (!_isScaleInAllocated)
@@ -860,8 +862,8 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
         }
     }
 
-    if (animationCellIndex != -1 || animationIndex != -1)
-        allocAnimationMem();
+     if (animationCellIndex != -1 || animationIndex != -1)
+         allocAnimationMem();
 
     if (_isAnimAllocated)
     {
@@ -941,8 +943,14 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
     SET_DELTA_COLOR(_particleData.colorB, _particleData.deltaColorB);
     SET_DELTA_COLOR(_particleData.colorA, _particleData.deltaColorA);
 
+    ///[2025.12.07]//////////////////////////////////////////////
+    /// BUG From WUCJ638 : when OpacityFadeIn or ScaleFadeIn  ///
+    /// equals to zero, source would't emit any particles.    ///
+    /////////////////////////////////////////////////////////////
+    ///// FIX begin
+
     // opacity fade in
-    if (_isOpacityFadeInAllocated)
+    if (_isOpacityFadeInAllocated && _spawnFadeIn + _spawnFadeInVar > 0)
     {
         for (int i = start; i < _particleCount; ++i)
         {
@@ -952,7 +960,7 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
     }
 
     // scale fade in
-    if (_isScaleInAllocated)
+    if (_isScaleInAllocated && _spawnScaleIn + _spawnScaleInVar > 0)
     {
         for (int i = start; i < _particleCount; ++i)
         {
@@ -960,6 +968,8 @@ void ParticleSystem::addParticles(int count, int animationIndex, int animationCe
         }
         std::fill_n(_particleData.scaleInDelta + start, _particleCount - start, 0.0F);
     }
+    ///// Fix end
+    //////////////////////////////////////////////////////////////
 
     // hue saturation value color
     if (_isHSVAllocated)
@@ -1540,7 +1550,16 @@ void ParticleSystem::resetSystem()
 {
     _isActive = true;
     _elapsed  = 0;
-    std::fill_n(_particleData.timeToLive, _particleCount, 0.0F);
+
+    // [2025.12.09] Bug from WUCJ638:
+    //   Visually, resetting System would actually remove all existed particles
+    // before emitting them again. Therefore just simply set _particleCount
+    // to zero.
+    //   Without doing so, particles with loop animation enabled would crash,
+    // for particleData.animIndex are junk and would cause Out-of-Range excep-
+    // -tion in update() function
+    _particleCount = 0;
+    //std::fill_n(_particleData.timeToLive, _particleCount, 0.0F);
 }
 
 bool ParticleSystem::isFull()
@@ -2099,9 +2118,22 @@ void ParticleSystem::useHSV(bool hsv)
         deallocHSVMem();
 };
 
+///[2025.12.06]/////////////////////////////////////////////////////////
+/// BUG from WUCJ638 : modification would get ignored after memory   ///
+/// is allocated, that is "nothing happens", we only have one change ///
+/// to change the value.                                             ///
+/// Same problem has been found inside this FIX block:               ///
+/// 1. setSpawnFadeInVar  2. setSpawnScaleIn   3. setSpawnScaleInVar ///
+/// [WARNING] setAnimation wasn't fixed yet but they have the same   ///
+/// behavior in allocatinng memory.                                  ///
+////////////////////////////////////////////////////////////////////////
+////////// Fix begin
 void ParticleSystem::setSpawnFadeIn(float time)
 {
-    if (time != 0.0F && !allocOpacityFadeInMem())
+// Modification is allowed when:
+//  - memory hasn't allocated, time neq 0.0F and allocation has done successfully;
+//  - or memory has allocated.
+    if(!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
         return;
 
     _spawnFadeIn = time;
@@ -2109,7 +2141,7 @@ void ParticleSystem::setSpawnFadeIn(float time)
 
 void ParticleSystem::setSpawnFadeInVar(float time)
 {
-    if (time != 0.0F && !allocOpacityFadeInMem())
+    if(!_isOpacityFadeInAllocated && (time == 0.0F || !allocOpacityFadeInMem()))
         return;
 
     _spawnFadeInVar = time;
@@ -2117,7 +2149,7 @@ void ParticleSystem::setSpawnFadeInVar(float time)
 
 void ParticleSystem::setSpawnScaleIn(float time)
 {
-    if (time != 0.0F && !allocScaleInMem())
+    if(!_isScaleInAllocated && (time == 0.0F || !allocScaleInMem()))
         return;
 
     _spawnScaleIn = time;
@@ -2125,11 +2157,13 @@ void ParticleSystem::setSpawnScaleIn(float time)
 
 void ParticleSystem::setSpawnScaleInVar(float time)
 {
-    if (time != 0.0F && !allocScaleInMem())
+    if(!_isScaleInAllocated && (time == 0.0F || !allocScaleInMem()))
         return;
 
     _spawnScaleInVar = time;
 }
+////////// Fix end
+////////////////////////////////////////////////////////////////////////
 
 int ParticleSystem::getTotalParticles() const
 {

--- a/core/2d/ParticleSystemQuad.cpp
+++ b/core/2d/ParticleSystemQuad.cpp
@@ -701,14 +701,7 @@ void ParticleSystemQuad::setTotalParticles(int tp)
         size_t quadsSize   = sizeof(_quads[0]) * tp * 1;
         size_t indicesSize = sizeof(_indices[0]) * tp * 6 * 1;
 
-        _particleData.release();
-
-///[2025.12.02]/////////////////////////////////////////////////////////////////////
-/// BUG from WUCJ638: Even with _isSpawnScaleIn or _isSpawnFadeIn (and the other ///
-/// alike) set, their memory aren't allocated after resetting total particles,   ///
-/// causing nullptr exception on updating new particle later                     ///
-////////////////////////////////////////////////////////////////////////////////////
-//////// Fix Begin
+        _particleData.release();                     
 
         if (!_particleData.init(tp))
         {
@@ -745,6 +738,11 @@ void ParticleSystemQuad::setTotalParticles(int tp)
 
         _totalParticles = tp;
 
+        // Reallocation of OpacityFadeIn, ScaleIn, Animation and HSV is independent of
+        // _particleData.init(), but relies on _totalParticles; before doing so, we have
+        // to delete their previous memory first, as allocation would check if allocation
+        // flag is false.
+        
         bool hasOpacityFadeInAllocated = _isOpacityFadeInAllocated,
              hasScaleInAllocated       = _isScaleInAllocated,
              hasAnimAllocated          = _isAnimAllocated,
@@ -761,12 +759,10 @@ void ParticleSystemQuad::setTotalParticles(int tp)
                                       (!hasHSVAllocated           || allocHSVMem()           );
         if (!isExtraAllocSuccessful){
             AXLOGW("Particle system: not enough memory");
-            _particleData.release();    // WUCJ638
+            _particleData.release();
             return;
         }
-
-//////// Fix End
-//////////////////////////////////////////////////////////////////////////////////////
+        
         // Init particles
         if (_batchNode)
         {

--- a/core/2d/ParticleSystemQuad.cpp
+++ b/core/2d/ParticleSystemQuad.cpp
@@ -692,7 +692,7 @@ void ParticleSystemQuad::setTotalParticles(int tp)
         "Adding more than 10000 particles will crash the renderer, the mesh generated has an index format of "
         "U_SHORT (uint16_t).");
 
-    tp = std::min(tp, 10000);
+    tp = (std::min)(tp, 10000);
     // If we are setting the total number of particles to a number higher
     // than what is allocated, we need to allocate new arrays
     if (tp > _allocatedParticles)
@@ -706,7 +706,7 @@ void ParticleSystemQuad::setTotalParticles(int tp)
         if (!_particleData.init(tp))
         {
             AXLOGW("Particle system: not enough memory");
-            _particleData.release();    // WUCJ638
+            _particleData.release();
             return;
         }
         V3F_C4B_T2F_Quad* quadsNew = (V3F_C4B_T2F_Quad*)realloc(_quads, quadsSize);

--- a/core/2d/ParticleSystemQuad.cpp
+++ b/core/2d/ParticleSystemQuad.cpp
@@ -90,7 +90,9 @@ ParticleSystemQuad* ParticleSystemQuad::createWithTotalParticles(int numberOfPar
 {
     AXASSERT(numberOfParticles <= 10000,
              "Adding more than 10000 particles will crash the renderer, the mesh generated has an index format of "
-             "U_SHORT (uint16_t)");
+             "U_SHORT (uint16_t).");
+
+    numberOfParticles = std::min(numberOfParticles, 10000);
 
     ParticleSystemQuad* ret = new ParticleSystemQuad();
     if (ret->initWithTotalParticles(numberOfParticles))
@@ -686,6 +688,11 @@ void ParticleSystemQuad::draw(Renderer* renderer, const Mat4& transform, uint32_
 
 void ParticleSystemQuad::setTotalParticles(int tp)
 {
+    AXASSERT(tp <= 10000,
+        "Adding more than 10000 particles will crash the renderer, the mesh generated has an index format of "
+        "U_SHORT (uint16_t).");
+
+    tp = std::min(tp, 10000);
     // If we are setting the total number of particles to a number higher
     // than what is allocated, we need to allocate new arrays
     if (tp > _allocatedParticles)
@@ -695,9 +702,18 @@ void ParticleSystemQuad::setTotalParticles(int tp)
         size_t indicesSize = sizeof(_indices[0]) * tp * 6 * 1;
 
         _particleData.release();
+
+///[2025.12.02]/////////////////////////////////////////////////////////////////////
+/// BUG from WUCJ638: Even with _isSpawnScaleIn or _isSpawnFadeIn (and the other ///
+/// alike) set, their memory aren't allocated after resetting total particles,   ///
+/// causing nullptr exception on updating new particle later                     ///
+////////////////////////////////////////////////////////////////////////////////////
+//////// Fix Begin
+
         if (!_particleData.init(tp))
         {
             AXLOGW("Particle system: not enough memory");
+            _particleData.release();    // WUCJ638
             return;
         }
         V3F_C4B_T2F_Quad* quadsNew = (V3F_C4B_T2F_Quad*)realloc(_quads, quadsSize);
@@ -729,6 +745,28 @@ void ParticleSystemQuad::setTotalParticles(int tp)
 
         _totalParticles = tp;
 
+        bool hasOpacityFadeInAllocated = _isOpacityFadeInAllocated,
+             hasScaleInAllocated       = _isScaleInAllocated,
+             hasAnimAllocated          = _isAnimAllocated,
+             hasHSVAllocated           = _isHSVAllocated;
+
+        deallocOpacityFadeInMem();
+        deallocScaleInMem();
+        deallocAnimationMem();
+        deallocHSVMem();
+
+        bool isExtraAllocSuccessful = (!hasOpacityFadeInAllocated || allocOpacityFadeInMem() ) &&
+                                      (!hasScaleInAllocated       || allocScaleInMem()       ) &&
+                                      (!hasAnimAllocated          || allocAnimationMem()     ) &&
+                                      (!hasHSVAllocated           || allocHSVMem()           );
+        if (!isExtraAllocSuccessful){
+            AXLOGW("Particle system: not enough memory");
+            _particleData.release();    // WUCJ638
+            return;
+        }
+
+//////// Fix End
+//////////////////////////////////////////////////////////////////////////////////////
         // Init particles
         if (_batchNode)
         {


### PR DESCRIPTION
# 2025.12.09 Fix Bugs around Particle System in Release/2.10.0

### Summary

This PR fixes several particle system bugs in **Axmol 2.10.0**, specifically related to:

- **SpawnFadeIn / SpawnScaleIn**:  
  - Memory not reallocated after `setTotalParticles()`, causing null pointer crashes.  
  - New values ignored after initial allocation.  
  - Particles become invisible if `_spawnFadeIn` or `_spawnScaleIn` is set to `0.0f`.

- **Loop Animation crash**:  
  - After `setTotalParticles()`, `_particleCount` wasn’t set to 0, leading to invalid access in `_animations.at(_particleData.animIndex[i])`.

### Changes

- Reallocate attribute memory (fade/scale/HSV) in `ParticleSystemQuad::setTotalParticles()` if enabled.
- Allow updating spawn fade/scale values even after allocation.
- Skip fade/scale logic when value is `0.0f` to avoid invisible particles.
- Reset `_particleCount = 0` in `setTotalParticles()` and `resetSystem()` to prevent stale animation indices.

### Testing

- Verified on **Windows 10** with Visual Studio 2026 (MSVC 19.50).
- ParticleTest from 42 to 55 pass without crash; emission shape unaffected, by simply adding

    ```cpp
        this->runAction(Sequence::create(
            DelayTime::create(3.0f),
            CallFunc::create([this](){
                _emitter->setTotalParticles(2000);
                }),
            nullptr
        ));
    ```

    at the end of `onEnter()`

- HSV & advanced animations not fully tested (because I haven't used them in my projects).

> Note: 
> 1. Huge comments (`//// BUG from WUCJ638... //`) are removed to reduce space.
> 2. Since I'm a student who is occupied with heavy academic tasks and preparing for final exam, **delayed response may be unavoidable**. Thanks for your understanding!