### PR TITLE
Improve FairyGUI shared object memory management and add gfx drop events

### DIFF
--- a/axmol/base/Director.h
+++ b/axmol/base/Director.h
@@ -85,28 +85,33 @@ class AX_DLL Director
 {
 public:
     /** Director will trigger an event before set next scene. */
-    static const char* EVENT_BEFORE_SET_NEXT_SCENE;
+    static std::string_view EVENT_BEFORE_SET_NEXT_SCENE;
     /** Director will trigger an event after set next scene. */
-    static const char* EVENT_AFTER_SET_NEXT_SCENE;
+    static std::string_view EVENT_AFTER_SET_NEXT_SCENE;
 
     /** Director will trigger an event when projection type is changed. */
-    static const char* EVENT_PROJECTION_CHANGED;
+    static std::string_view EVENT_PROJECTION_CHANGED;
     /** Director will trigger an event before Schedule::update() is invoked. */
-    static const char* EVENT_BEFORE_UPDATE;
+    static std::string_view EVENT_BEFORE_UPDATE;
     /** Director will trigger an event after Schedule::update() is invoked. */
-    static const char* EVENT_AFTER_UPDATE;
+    static std::string_view EVENT_AFTER_UPDATE;
 
     /** Director will trigger an event after Scene::render() is invoked. */
-    static const char* EVENT_AFTER_VISIT;
+    static std::string_view EVENT_AFTER_VISIT;
     /** Director will trigger an event after a scene is drawn, the data is sent to GPU. */
-    static const char* EVENT_AFTER_DRAW;
+    static std::string_view EVENT_AFTER_DRAW;
     /** Director will trigger an event before a scene is drawn, right after clear. */
-    static const char* EVENT_BEFORE_DRAW;
+    static std::string_view EVENT_BEFORE_DRAW;
 
     /** Director will trigger an event while resetting Director */
-    static const char* EVENT_RESET;
+    static std::string_view EVENT_RESET;
     /** Director will trigger an event while destroying Director */
-    static const char* EVENT_DESTROY;
+    static std::string_view EVENT_DESTROY;
+
+    /** Director will trigger an event before dropping the graphics subsystem */
+    static std::string_view EVENT_BEFORE_GFX_DROP;
+    /** Director will trigger an event after dropping the graphics subsystem */
+    static std::string_view EVENT_AFTER_GFX_DROP;
 
     /**
      * @brief Possible projection types used by the director.
@@ -601,6 +606,8 @@ protected:
     EventCustom* _afterSetNextScene      = nullptr;
     EventCustom* _eventResetDirector     = nullptr;
     EventCustom* _eventDestroyDirector   = nullptr;
+    EventCustom* _eventBeforeGfxDrop     = nullptr;
+    EventCustom* _eventAfterGfxDrop      = nullptr;
 
     /* delta time since last tick to main loop */
     float _deltaTime              = 0.0f;

--- a/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
+++ b/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
@@ -34,20 +34,18 @@ using namespace ax;
 
 using namespace std;
 
-class HtmlObjectContext;
-
-static HtmlObjectContext* s_htmlContext;
 static bool s_isGfxDidDrop = false;
 
+HtmlObjectContext* HtmlObjectContext::s_htmlObjContext;
 HtmlObjectContext* HtmlObjectContext::getInstance()
 {
-    if (s_htmlContext) [[likely]]
-        return s_htmlContext;
+    if (s_htmlObjContext) [[likely]]
+        return s_htmlObjContext;
 
     if (s_isGfxDidDrop)
         return nullptr;
 
-    s_htmlContext = new HtmlObjectContext();
+    s_htmlObjContext = new HtmlObjectContext();
 
     Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_BEFORE_GFX_DROP,
                                                                           [](EventCustom*) {
@@ -55,16 +53,16 @@ HtmlObjectContext* HtmlObjectContext::getInstance()
         HtmlObjectContext::destroyInstance();
     });
 
-    return s_htmlContext;
+    return s_htmlObjContext;
 }
 
 void HtmlObjectContext::destroyInstance()
 {
-    if (s_htmlContext)
+    if (s_htmlObjContext)
     {
         Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(Director::EVENT_BEFORE_GFX_DROP);
-        delete s_htmlContext;
-        s_htmlContext = nullptr;
+        delete s_htmlObjContext;
+        s_htmlObjContext = nullptr;
     }
 }
 

--- a/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
+++ b/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
@@ -34,17 +34,85 @@ using namespace ax;
 
 using namespace std;
 
-std::string HtmlObject::buttonResource;
-std::string HtmlObject::inputResource;
-std::string HtmlObject::selectResource;
-bool HtmlObject::usePool = true;
+class HtmlObjectContext;
 
-GObjectPool HtmlObject::objectPool;
-ax::Vector<GObject*> HtmlObject::loaderPool;
+static HtmlObjectContext* s_htmlContext;
+static bool s_isGfxDidDrop = false;
 
-HtmlObject::HtmlObject() :_ui(nullptr), _hidden(false)
+HtmlObjectContext* HtmlObjectContext::getInstance()
 {
+    if (s_htmlContext || s_isGfxDidDrop) [[likely]]
+        return s_htmlContext;
+
+    s_htmlContext = new HtmlObjectContext();
+
+    Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_BEFORE_GFX_DROP,
+                                                                          [](EventCustom*) {
+        s_isGfxDidDrop = true;
+        HtmlObjectContext::destroyInstance();
+    });
+
+    return s_htmlContext;
 }
+
+void HtmlObjectContext::destroyInstance()
+{
+    if (s_htmlContext)
+    {
+        Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(Director::EVENT_BEFORE_GFX_DROP);
+        delete s_htmlContext;
+        s_htmlContext = nullptr;
+    }
+}
+
+void HtmlObjectContext::recycleObject(GObject* obj)
+{
+    this->objectPool.returnObject(obj);
+}
+
+void HtmlObjectContext::recycleLoader(GObject* loader)
+{
+    this->loaderPool.pushBack(loader);
+}
+
+GObject* HtmlObjectContext::acquireObject(const std::string& src, std::string_view dedicatedResourceHint)
+{
+    GObject* obj;
+    if (!src.empty())
+        obj = this->objectPool.getObject(src);
+    else
+    {
+        if (!dedicatedResourceHint.empty())
+            AXLOGW("Set HtmlObject.{} first", dedicatedResourceHint);
+        obj = GComponent::create();
+    }
+    obj->retain();
+    return obj;
+}
+
+GLoader* HtmlObjectContext::acquireLoader()
+{
+    GLoader* loader;
+    if (!isLoaderPoolEmpty())
+    {
+        loader = (GLoader*)this->loaderPool.back();
+        loader->retain();
+        this->loaderPool.popBack();
+    }
+    else
+    {
+        loader = GLoader::create();
+        loader->retain();
+    }
+    return loader;
+}
+
+bool HtmlObjectContext::isLoaderPoolEmpty() const
+{
+    return this->loaderPool.empty();
+}
+
+HtmlObject::HtmlObject() : _ui(nullptr), _hidden(false) {}
 
 HtmlObject::~HtmlObject()
 {
@@ -52,12 +120,14 @@ HtmlObject::~HtmlObject()
     {
         destroy();
 
-        if (usePool)
+        auto context = HtmlObjectContext::getInstance();
+
+        if (context && context->usePool)
         {
             if (!_ui->getResourceURL().empty())
-                objectPool.returnObject(_ui);
+                context->recycleObject(_ui);
             else if (dynamic_cast<GLoader*>(_ui) != nullptr)
-                loaderPool.pushBack(_ui);
+                context->recycleLoader(_ui);
         }
     }
 
@@ -66,7 +136,7 @@ HtmlObject::~HtmlObject()
 
 void HtmlObject::create(FUIRichText* owner, HtmlElement* element)
 {
-    _owner = owner;
+    _owner   = owner;
     _element = element;
 
     switch (element->type)
@@ -77,7 +147,7 @@ void HtmlObject::create(FUIRichText* owner, HtmlElement* element)
 
     case HtmlElement::Type::INPUT:
     {
-        string type = element->getString("type");
+        std::string type = element->getString("type");
         transform(type.begin(), type.end(), type.begin(), ::tolower);
         if (type == "button" || type == "submit")
             createButton();
@@ -108,15 +178,11 @@ void HtmlObject::destroy()
 
 void HtmlObject::createCommon()
 {
-    string src = _element->getString("src");
-    if (!src.empty())
-        _ui = objectPool.getObject(src);
-    else
-        _ui = GComponent::create();
+    std::string src = _element->getString("src");
 
-    _ui->retain();
+    _ui = HtmlObjectContext::getInstance()->acquireObject(src, ""sv);
 
-    int width = _element->getInt("width", _ui->sourceSize.width);
+    int width  = _element->getInt("width", _ui->sourceSize.width);
     int height = _element->getInt("height", _ui->sourceSize.height);
 
     _ui->setSize(width, height);
@@ -126,35 +192,24 @@ void HtmlObject::createCommon()
 
 void HtmlObject::createImage()
 {
-    int width = 0;
-    int height = 0;
-    string src = _element->getString("src");
-    if (!src.empty()) {
+    int width       = 0;
+    int height      = 0;
+    std::string src = _element->getString("src");
+    if (!src.empty())
+    {
         PackageItem* pi = UIPackage::getItemByURL(src);
         if (pi)
         {
-            width = pi->width;
+            width  = pi->width;
             height = pi->height;
         }
     }
 
-    width = _element->getInt("width", width);
+    width  = _element->getInt("width", width);
     height = _element->getInt("height", height);
 
-    GLoader* loader;
-    if (!loaderPool.empty())
-    {
-        loader = (GLoader*)loaderPool.back();
-        loader->retain();
-        loaderPool.popBack();
-    }
-    else
-    {
-        loader = GLoader::create();
-        loader->retain();
-    }
-
-    _ui = loader;
+    GLoader* loader = HtmlObjectContext::getInstance()->acquireLoader();
+    _ui             = loader;
 
     loader->setSize(width, height);
     loader->setFill(LoaderFillType::SCALE_FREE);
@@ -163,23 +218,17 @@ void HtmlObject::createImage()
 
 void HtmlObject::createButton()
 {
-    if (!buttonResource.empty())
-        _ui = objectPool.getObject(buttonResource);
-    else
-    {
-        _ui = GComponent::create();
-        AXLOGW("Set HtmlObject.buttonResource first");
-    }
+    auto context = HtmlObjectContext::getInstance();
 
-    _ui->retain();
+    _ui = context->acquireObject(context->buttonResource, "buttonResource"sv);
 
-    int width = _element->getInt("width", _ui->sourceSize.width);
+    int width  = _element->getInt("width", _ui->sourceSize.width);
     int height = _element->getInt("height", _ui->sourceSize.height);
 
     _ui->setSize(width, height);
     _ui->setText(_element->getString("value"));
 
-    GButton *button = dynamic_cast<GButton*>(_ui);
+    GButton* button = dynamic_cast<GButton*>(_ui);
     if (button != nullptr)
     {
         button->setSelected(_element->getString("checked") == "true");
@@ -188,21 +237,15 @@ void HtmlObject::createButton()
 
 void HtmlObject::createInput()
 {
-    if (!inputResource.empty())
-        _ui = objectPool.getObject(inputResource);
-    else
-    {
-        _ui = GComponent::create();
-        AXLOGW("Set HtmlObject.inputResource first");
-    }
+    auto context = HtmlObjectContext::getInstance();
 
-    _ui->retain();
+    _ui = context->acquireObject(context->inputResource, "inputResource"sv);
 
     string type = _element->getString("type");
     transform(type.begin(), type.end(), type.begin(), ::tolower);
     _hidden = type == "hidden";
 
-    int width = _element->getInt("width");
+    int width  = _element->getInt("width");
     int height = _element->getInt("height");
 
     if (width == 0)
@@ -218,7 +261,7 @@ void HtmlObject::createInput()
     _ui->setSize(width, height);
     _ui->setText(_element->getString("value"));
 
-    GLabel *label = dynamic_cast<GLabel*>(_ui);
+    GLabel* label = dynamic_cast<GLabel*>(_ui);
     if (label != nullptr)
     {
         GTextInput* input = dynamic_cast<GTextInput*>(label->getTextField());
@@ -231,17 +274,11 @@ void HtmlObject::createInput()
 
 void HtmlObject::createSelect()
 {
-    if (!selectResource.empty())
-        _ui = objectPool.getObject(selectResource);
-    else
-    {
-        _ui = GComponent::create();
-        AXLOGW("Set HtmlObject.selectResource first");
-    }
+    auto context = HtmlObjectContext::getInstance();
 
-    _ui->retain();
+    _ui = context->acquireObject(context->selectResource, "selectResource"sv);
 
-    int width = _element->getInt("width", _ui->sourceSize.width);
+    int width  = _element->getInt("width", _ui->sourceSize.width);
     int height = _element->getInt("height", _ui->sourceSize.height);
 
     _ui->setSize(width, height);
@@ -249,7 +286,7 @@ void HtmlObject::createSelect()
     GComboBox* comboBox = dynamic_cast<GComboBox*>(_ui);
     if (comboBox != nullptr)
     {
-        auto& items = _element->getArray("items");
+        auto& items  = _element->getArray("items");
         auto& values = _element->getArray("values");
         comboBox->getItems().clear();
         comboBox->getValues().clear();

--- a/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
+++ b/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
@@ -32,8 +32,6 @@ THE SOFTWARE.
 NS_FGUI_BEGIN
 using namespace ax;
 
-using namespace std;
-
 static bool s_isGfxDidDrop = false;
 
 HtmlObjectContext* HtmlObjectContext::s_htmlObjContext;
@@ -113,7 +111,7 @@ bool HtmlObjectContext::isLoaderPoolEmpty() const
     return this->loaderPool.empty();
 }
 
-HtmlObject::HtmlObject() : _ui(nullptr), _hidden(false) {}
+HtmlObject::HtmlObject() : _element(nullptr), _owner(nullptr), _ui(nullptr), _hidden(false) {}
 
 HtmlObject::~HtmlObject()
 {
@@ -242,8 +240,8 @@ void HtmlObject::createInput()
 
     _ui = context->acquireObject(context->inputResource, "inputResource"sv);
 
-    string type = _element->getString("type");
-    transform(type.begin(), type.end(), type.begin(), ::tolower);
+    std::string type = _element->getString("type");
+    std::transform(type.begin(), type.end(), type.begin(), ::tolower);
     _hidden = type == "hidden";
 
     int width  = _element->getInt("width");

--- a/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
+++ b/extensions/fairygui/src/fairygui/utils/html/HtmlObject.cpp
@@ -41,8 +41,11 @@ static bool s_isGfxDidDrop = false;
 
 HtmlObjectContext* HtmlObjectContext::getInstance()
 {
-    if (s_htmlContext || s_isGfxDidDrop) [[likely]]
+    if (s_htmlContext) [[likely]]
         return s_htmlContext;
+
+    if (s_isGfxDidDrop)
+        return nullptr;
 
     s_htmlContext = new HtmlObjectContext();
 

--- a/extensions/fairygui/src/fairygui/utils/html/HtmlObject.h
+++ b/extensions/fairygui/src/fairygui/utils/html/HtmlObject.h
@@ -36,6 +36,8 @@ protected:
     GObjectPool objectPool;
     ax::Vector<GObject*> loaderPool;
 
+    static HtmlObjectContext* s_htmlObjContext;
+
     HtmlObjectContext()  = default;
     ~HtmlObjectContext() = default;
 

--- a/extensions/fairygui/src/fairygui/utils/html/HtmlObject.h
+++ b/extensions/fairygui/src/fairygui/utils/html/HtmlObject.h
@@ -10,18 +10,42 @@ NS_FGUI_BEGIN
 class FUIRichText;
 class HtmlElement;
 class GObject;
+class GLoader;
+
+class HtmlObjectContext
+{
+public:
+    static HtmlObjectContext* getInstance();
+    static void destroyInstance();
+
+    GObject* acquireObject(const std::string& src, std::string_view dedicatedResourceHint);
+
+    GLoader* acquireLoader();
+
+    void recycleObject(GObject* obj);
+    void recycleLoader(GObject* loader);
+
+    bool isLoaderPoolEmpty() const;
+
+    std::string buttonResource;
+    std::string inputResource;
+    std::string selectResource;
+    bool usePool = true;
+
+protected:
+    GObjectPool objectPool;
+    ax::Vector<GObject*> loaderPool;
+
+    HtmlObjectContext()  = default;
+    ~HtmlObjectContext() = default;
+
+    HtmlObjectContext(const HtmlObjectContext&)            = delete;
+    HtmlObjectContext& operator=(const HtmlObjectContext&) = delete;
+};
 
 class HtmlObject
 {
 public:
-    static std::string buttonResource;
-    static std::string inputResource;
-    static std::string selectResource;
-    static bool usePool;
-
-    static GObjectPool objectPool;
-    static ax::Vector<GObject*> loaderPool;
-
     HtmlObject();
     virtual ~HtmlObject();
 


### PR DESCRIPTION
- Enhanced lifecycle handling of FairyGUI shared objects to prevent crashes caused by accessing GPU buffers after the graphics context has already been destroyed during engine shutdown.

- Added two new Director events to allow extensions to safely release graphics-related resources before/after the graphics subsystem teardown:
    * EVENT_BEFORE_GFX_DROP
    * EVENT_AFTER_GFX_DROP

- Updated all Director event names from `const char*` to `std::string_view` for better efficiency, reduced static storage, and zero-allocation access.

This change improves engine stability during shutdown and provides a more robust extension point for graphics resource cleanup.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
