### PR TITLE
D3D12: Add DXC availability detection and automatic FXC fallback

### DIFF
--- a/axmol/rhi/DXUtils.cpp
+++ b/axmol/rhi/DXUtils.cpp
@@ -178,7 +178,7 @@ DXGI_FORMAT getUAVCompatibleFormat(DXGI_FORMAT format)
 
 void fatalError(std::string_view op, HRESULT hr)
 {
-    auto msg = fmt::format("{}: 0x{:08X}", op, static_cast<unsigned>(hr));
+    auto msg = fmt::format("{}: 0x{:08x}", op, static_cast<unsigned>(hr));
 #if AX_RENDER_API == AX_RENDER_API_D3D12
     showAlert(msg, "axmol: D3D12: Fatal Error", AlertStyle::IconError | AlertStyle::RequireSync);
 #else

--- a/axmol/rhi/d3d12/Driver12.cpp
+++ b/axmol/rhi/d3d12/Driver12.cpp
@@ -1290,70 +1290,54 @@ bool DriverImpl::detectDXCAvailability()
         return false;
     }
 
-    // --- 1. Minimal VS shader ---
-    static constexpr std::string_view kVS = R"(
-        struct VSIn { float3 pos : POSITION; };
-        struct VSOut { float4 pos : SV_Position; };
-        VSOut main(VSIn input)
-        {
-            VSOut o;
-            o.pos = float4(input.pos, 1.0);
-            return o;
-        }
+    // --- 1. Minimal compute shader ---
+    static constexpr std::string_view kCS = R"(
+        [numthreads(1,1,1)]
+        void main() {}
     )"sv;
 
-    // --- 2. Minimal PS shader ---
-    static constexpr std::string_view kPS = R"(
-        float4 main() : SV_Target
-        {
-            return float4(1, 0, 0, 1);
-        }
-    )"sv;
+    // --- 2. Compile CS via DXC ---
+    ComPtr<IDxcBlobEncoding> srcBlob;
+    HRESULT hr = _dxcLibrary->CreateBlobWithEncodingOnHeapCopy(kCS.data(), (UINT)kCS.size(), CP_UTF8, &srcBlob);
 
-    auto&& _compileShader = [this](std::string_view src, LPCWSTR entry, LPCWSTR profile,
-                                   ComPtr<IDxcBlob>& outBlob) -> bool {
-        ComPtr<IDxcBlobEncoding> srcBlob;
-        HRESULT hr = _dxcLibrary->CreateBlobWithEncodingOnHeapCopy(src.data(), (UINT)src.size(), CP_UTF8, &srcBlob);
-        if (FAILED(hr))
-            return false;
-
-        ComPtr<IDxcOperationResult> result;
-        hr = _dxcCompiler->Compile(srcBlob.Get(), nullptr, entry, profile, _dxcArguments.data(),
-                                   (UINT)_dxcArguments.size(), nullptr, 0, nullptr, &result);
-        if (FAILED(hr))
-            return false;
-
-        HRESULT status;
-        result->GetStatus(&status);
-        if (FAILED(status))
-            return false;
-
-        result->GetResult(&outBlob);
-        return outBlob != nullptr;
-    };
-
-    // Compile VS
-    ComPtr<IDxcBlob> vsBlob;
-    if (!_compileShader(kVS, L"main", L"vs_6_0", vsBlob))
+    if (FAILED(hr))
     {
-        AXLOGW("DXC unavailable: VS compile failed.");
+        AXLOGW("DXC unavailable: failed to create source blob.");
         return false;
     }
 
-    // Compile PS
-    ComPtr<IDxcBlob> psBlob;
-    if (!_compileShader(kPS, L"main", L"ps_6_0", psBlob))
+    ComPtr<IDxcOperationResult> result;
+    hr = _dxcCompiler->Compile(srcBlob.Get(), nullptr, L"main", L"cs_6_0", _dxcArguments.data(),
+                               (UINT)_dxcArguments.size(), nullptr, 0, nullptr, &result);
+
+    if (FAILED(hr))
     {
-        AXLOGW("DXC unavailable: PS compile failed.");
+        AXLOGW("DXC unavailable: compile invocation failed.");
         return false;
     }
 
-    // --- 3. Create minimal root signature ---
+    HRESULT status = E_FAIL;
+    result->GetStatus(&status);
+    if (FAILED(status))
+    {
+        AXLOGW("DXC unavailable: compile failed.");
+        return false;
+    }
+
+    ComPtr<IDxcBlob> csBlob;
+    result->GetResult(&csBlob);
+    if (!csBlob)
+    {
+        AXLOGW("DXC unavailable: no DXIL blob returned.");
+        return false;
+    }
+
+    // --- 3. Create minimal root signature (empty) ---
     D3D12_ROOT_SIGNATURE_DESC rsDesc{};
-    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
 
     ComPtr<ID3DBlob> sigBlob, errBlob;
-    HRESULT hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &sigBlob, &errBlob);
+    hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &sigBlob, &errBlob);
     if (FAILED(hr))
     {
         AXLOGW("DXC unavailable: root signature serialization failed.");
@@ -1362,45 +1346,24 @@ bool DriverImpl::detectDXCAvailability()
 
     ComPtr<ID3D12RootSignature> rootSig;
     hr = _device->CreateRootSignature(0, sigBlob->GetBufferPointer(), sigBlob->GetBufferSize(), IID_PPV_ARGS(&rootSig));
+
     if (FAILED(hr))
     {
         AXLOGW("DXC unavailable: root signature creation failed.");
         return false;
     }
 
-    // --- 4. Build minimal PSO ---
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc{};
+    // --- 4. Build minimal compute PSO ---
+    D3D12_COMPUTE_PIPELINE_STATE_DESC psoDesc{};
     psoDesc.pRootSignature = rootSig.Get();
+    psoDesc.CS             = {csBlob->GetBufferPointer(), csBlob->GetBufferSize()};
 
-    psoDesc.VS = {vsBlob->GetBufferPointer(), vsBlob->GetBufferSize()};
-    psoDesc.PS = {psBlob->GetBufferPointer(), psBlob->GetBufferSize()};
-
-    // Input layout for POSITION
-    D3D12_INPUT_ELEMENT_DESC layout[] = {
-        {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0}};
-    psoDesc.InputLayout = {layout, _countof(layout)};
-
-    // Rasterizer / Blend / Depth
-    psoDesc.RasterizerState   = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    psoDesc.BlendState        = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-    psoDesc.DSVFormat         = DXGI_FORMAT_D24_UNORM_S8_UINT;
-
-    psoDesc.SampleMask            = UINT_MAX;
-    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-
-    psoDesc.NumRenderTargets = 1;
-    psoDesc.RTVFormats[0]    = DXGI_FORMAT_R8G8B8A8_UNORM;
-
-    psoDesc.SampleDesc.Count = 1;
-
-    // --- 5. Try creating PSO (this validates DXIL acceptance) ---
     ComPtr<ID3D12PipelineState> pso;
-    hr = _device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pso));
+    hr = _device->CreateComputePipelineState(&psoDesc, IID_PPV_ARGS(&pso));
 
     if (FAILED(hr))
     {
-        AXLOGW("DXC unavailable: driver rejected DXIL, hr=0x{:08x}", static_cast<unsigned>(hr));
+        AXLOGW("DXC unavailable: driver rejected DXIL, hr=0x{:08x}", (unsigned)hr);
         return false;
     }
 

--- a/axmol/rhi/d3d12/Driver12.cpp
+++ b/axmol/rhi/d3d12/Driver12.cpp
@@ -200,138 +200,6 @@ static inline const char* stageToProfileFXC(ShaderStage s)
     }
 }
 
-// ------------------------------------------------------------
-// Detect whether DXC is usable on this machine.
-// 1. DXC must compile a minimal shader
-// 2. Driver must accept the DXIL (PSO creation test)
-// ------------------------------------------------------------
-static bool detectDXCAvailability(ID3D12Device* device,
-                                  IDxcLibrary* lib,
-                                  IDxcCompiler* compiler,
-                                  std::span<LPCWSTR> args)
-{
-    if (!device || !lib || !compiler)
-    {
-        AXLOGW("DXC unavailable: missing compiler or library.");
-        return false;
-    }
-
-    // --- 1. Minimal VS shader ---
-    static constexpr std::string_view kVS = R"(
-        struct VSIn { float3 pos : POSITION; };
-        struct VSOut { float4 pos : SV_Position; };
-        VSOut main(VSIn input)
-        {
-            VSOut o;
-            o.pos = float4(input.pos, 1.0);
-            return o;
-        }
-    )"sv;
-
-    // --- 2. Minimal PS shader ---
-    static constexpr std::string_view kPS = R"(
-        float4 main() : SV_Target
-        {
-            return float4(1, 0, 0, 1);
-        }
-    )"sv;
-
-    auto compileShader = [&](std::string_view src, LPCWSTR entry, LPCWSTR profile, ComPtr<IDxcBlob>& outBlob) -> bool {
-        ComPtr<IDxcBlobEncoding> srcBlob;
-        HRESULT hr = lib->CreateBlobWithEncodingOnHeapCopy(src.data(), (UINT)src.size(), CP_UTF8, &srcBlob);
-        if (FAILED(hr))
-            return false;
-
-        ComPtr<IDxcOperationResult> result;
-        hr = compiler->Compile(srcBlob.Get(), nullptr, entry, profile, args.data(), (UINT)args.size(), nullptr, 0,
-                               nullptr, &result);
-        if (FAILED(hr))
-            return false;
-
-        HRESULT status;
-        result->GetStatus(&status);
-        if (FAILED(status))
-            return false;
-
-        result->GetResult(&outBlob);
-        return outBlob != nullptr;
-    };
-
-    // Compile VS
-    ComPtr<IDxcBlob> vsBlob;
-    if (!compileShader(kVS, L"main", L"vs_6_0", vsBlob))
-    {
-        AXLOGW("DXC unavailable: VS compile failed.");
-        return false;
-    }
-
-    // Compile PS
-    ComPtr<IDxcBlob> psBlob;
-    if (!compileShader(kPS, L"main", L"ps_6_0", psBlob))
-    {
-        AXLOGW("DXC unavailable: PS compile failed.");
-        return false;
-    }
-
-    // --- 3. Create minimal root signature ---
-    D3D12_ROOT_SIGNATURE_DESC rsDesc{};
-    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
-
-    ComPtr<ID3DBlob> sigBlob, errBlob;
-    HRESULT hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &sigBlob, &errBlob);
-    if (FAILED(hr))
-    {
-        AXLOGW("DXC unavailable: root signature serialization failed.");
-        return false;
-    }
-
-    ComPtr<ID3D12RootSignature> rootSig;
-    hr = device->CreateRootSignature(0, sigBlob->GetBufferPointer(), sigBlob->GetBufferSize(), IID_PPV_ARGS(&rootSig));
-    if (FAILED(hr))
-    {
-        AXLOGW("DXC unavailable: root signature creation failed.");
-        return false;
-    }
-
-    // --- 4. Build minimal PSO ---
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc{};
-    psoDesc.pRootSignature = rootSig.Get();
-
-    psoDesc.VS = {vsBlob->GetBufferPointer(), vsBlob->GetBufferSize()};
-    psoDesc.PS = {psBlob->GetBufferPointer(), psBlob->GetBufferSize()};
-
-    // Input layout for POSITION
-    D3D12_INPUT_ELEMENT_DESC layout[] = {
-        {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0}};
-    psoDesc.InputLayout = {layout, _countof(layout)};
-
-    // Rasterizer / Blend / Depth
-    psoDesc.RasterizerState   = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    psoDesc.BlendState        = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-
-    psoDesc.SampleMask            = UINT_MAX;
-    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-
-    psoDesc.NumRenderTargets = 1;
-    psoDesc.RTVFormats[0]    = DXGI_FORMAT_R8G8B8A8_UNORM;
-
-    psoDesc.SampleDesc.Count = 1;
-
-    // --- 5. Try creating PSO (this validates DXIL acceptance) ---
-    ComPtr<ID3D12PipelineState> pso;
-    hr = device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pso));
-
-    if (FAILED(hr))
-    {
-        AXLOGW("DXC unavailable: driver rejected DXIL, hr=0x{:08x}", static_cast<unsigned>(hr));
-        return false;
-    }
-
-    AXLOGI("DXC is available and DXIL is accepted by driver.");
-    return true;
-}
-
 static constexpr auto kUploadQueueType = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
 void IsolateSubmission::create(ID3D12Device* device)
@@ -508,7 +376,7 @@ void DriverImpl::init()
     _dxcArguments = {L"-Zi", L"-Od"};
 #endif
 
-    _dxcAvailable = detectDXCAvailability(_device.Get(), _dxcLibrary.Get(), _dxcCompiler.Get(), _dxcArguments);
+    _dxcAvailable = detectDXCAvailability();
 }
 
 void DriverImpl::initializeDevice()
@@ -1412,6 +1280,132 @@ bool DriverImpl::checkFormatSupport(DXGI_FORMAT format)
     D3D12_FEATURE_DATA_FORMAT_SUPPORT support = {format};
     HRESULT hr = _device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT, &support, sizeof(support));
     return SUCCEEDED(hr) && (support.Support1 & D3D12_FORMAT_SUPPORT1_TEXTURE2D) != 0;
+}
+
+bool DriverImpl::detectDXCAvailability()
+{
+    if (!_device || !_dxcLibrary || !_dxcCompiler)
+    {
+        AXLOGW("DXC unavailable: missing compiler or library.");
+        return false;
+    }
+
+    // --- 1. Minimal VS shader ---
+    static constexpr std::string_view kVS = R"(
+        struct VSIn { float3 pos : POSITION; };
+        struct VSOut { float4 pos : SV_Position; };
+        VSOut main(VSIn input)
+        {
+            VSOut o;
+            o.pos = float4(input.pos, 1.0);
+            return o;
+        }
+    )"sv;
+
+    // --- 2. Minimal PS shader ---
+    static constexpr std::string_view kPS = R"(
+        float4 main() : SV_Target
+        {
+            return float4(1, 0, 0, 1);
+        }
+    )"sv;
+
+    auto&& _compileShader = [this](std::string_view src, LPCWSTR entry, LPCWSTR profile,
+                                   ComPtr<IDxcBlob>& outBlob) -> bool {
+        ComPtr<IDxcBlobEncoding> srcBlob;
+        HRESULT hr = _dxcLibrary->CreateBlobWithEncodingOnHeapCopy(src.data(), (UINT)src.size(), CP_UTF8, &srcBlob);
+        if (FAILED(hr))
+            return false;
+
+        ComPtr<IDxcOperationResult> result;
+        hr = _dxcCompiler->Compile(srcBlob.Get(), nullptr, entry, profile, _dxcArguments.data(),
+                                   (UINT)_dxcArguments.size(), nullptr, 0, nullptr, &result);
+        if (FAILED(hr))
+            return false;
+
+        HRESULT status;
+        result->GetStatus(&status);
+        if (FAILED(status))
+            return false;
+
+        result->GetResult(&outBlob);
+        return outBlob != nullptr;
+    };
+
+    // Compile VS
+    ComPtr<IDxcBlob> vsBlob;
+    if (!_compileShader(kVS, L"main", L"vs_6_0", vsBlob))
+    {
+        AXLOGW("DXC unavailable: VS compile failed.");
+        return false;
+    }
+
+    // Compile PS
+    ComPtr<IDxcBlob> psBlob;
+    if (!_compileShader(kPS, L"main", L"ps_6_0", psBlob))
+    {
+        AXLOGW("DXC unavailable: PS compile failed.");
+        return false;
+    }
+
+    // --- 3. Create minimal root signature ---
+    D3D12_ROOT_SIGNATURE_DESC rsDesc{};
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    ComPtr<ID3DBlob> sigBlob, errBlob;
+    HRESULT hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &sigBlob, &errBlob);
+    if (FAILED(hr))
+    {
+        AXLOGW("DXC unavailable: root signature serialization failed.");
+        return false;
+    }
+
+    ComPtr<ID3D12RootSignature> rootSig;
+    hr = _device->CreateRootSignature(0, sigBlob->GetBufferPointer(), sigBlob->GetBufferSize(), IID_PPV_ARGS(&rootSig));
+    if (FAILED(hr))
+    {
+        AXLOGW("DXC unavailable: root signature creation failed.");
+        return false;
+    }
+
+    // --- 4. Build minimal PSO ---
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc{};
+    psoDesc.pRootSignature = rootSig.Get();
+
+    psoDesc.VS = {vsBlob->GetBufferPointer(), vsBlob->GetBufferSize()};
+    psoDesc.PS = {psBlob->GetBufferPointer(), psBlob->GetBufferSize()};
+
+    // Input layout for POSITION
+    D3D12_INPUT_ELEMENT_DESC layout[] = {
+        {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0}};
+    psoDesc.InputLayout = {layout, _countof(layout)};
+
+    // Rasterizer / Blend / Depth
+    psoDesc.RasterizerState   = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    psoDesc.BlendState        = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+    psoDesc.DSVFormat         = DXGI_FORMAT_D24_UNORM_S8_UINT;
+
+    psoDesc.SampleMask            = UINT_MAX;
+    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+
+    psoDesc.NumRenderTargets = 1;
+    psoDesc.RTVFormats[0]    = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    psoDesc.SampleDesc.Count = 1;
+
+    // --- 5. Try creating PSO (this validates DXIL acceptance) ---
+    ComPtr<ID3D12PipelineState> pso;
+    hr = _device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pso));
+
+    if (FAILED(hr))
+    {
+        AXLOGW("DXC unavailable: driver rejected DXIL, hr=0x{:08x}", static_cast<unsigned>(hr));
+        return false;
+    }
+
+    AXLOGI("DXC is available and DXIL is accepted by driver.");
+    return true;
 }
 
 }  // namespace ax::rhi::d3d12

--- a/axmol/rhi/d3d12/Driver12.cpp
+++ b/axmol/rhi/d3d12/Driver12.cpp
@@ -217,7 +217,7 @@ static bool detectDXCAvailability(ID3D12Device* device,
     }
 
     // --- 1. Minimal VS shader ---
-    static const char* kVS = R"(
+    static constexpr std::string_view kVS = R"(
         struct VSIn { float3 pos : POSITION; };
         struct VSOut { float4 pos : SV_Position; };
         VSOut main(VSIn input)
@@ -226,19 +226,19 @@ static bool detectDXCAvailability(ID3D12Device* device,
             o.pos = float4(input.pos, 1.0);
             return o;
         }
-    )";
+    )"sv;
 
     // --- 2. Minimal PS shader ---
-    static const char* kPS = R"(
+    static constexpr std::string_view kPS = R"(
         float4 main() : SV_Target
         {
             return float4(1, 0, 0, 1);
         }
-    )";
+    )"sv;
 
-    auto compileShader = [&](const char* src, LPCWSTR entry, LPCWSTR profile, ComPtr<IDxcBlob>& outBlob) -> bool {
+    auto compileShader = [&](std::string_view src, LPCWSTR entry, LPCWSTR profile, ComPtr<IDxcBlob>& outBlob) -> bool {
         ComPtr<IDxcBlobEncoding> srcBlob;
-        HRESULT hr = lib->CreateBlobWithEncodingOnHeapCopy(src, (UINT)strlen(src), CP_UTF8, &srcBlob);
+        HRESULT hr = lib->CreateBlobWithEncodingOnHeapCopy(src.data(), (UINT)src.size(), CP_UTF8, &srcBlob);
         if (FAILED(hr))
             return false;
 

--- a/axmol/rhi/d3d12/Driver12.cpp
+++ b/axmol/rhi/d3d12/Driver12.cpp
@@ -40,20 +40,15 @@
 
 #include "ntcvt/ntcvt.hpp"
 
-#include <algorithm>
+#include <d3dcompiler.h>
 
-// Note: d3dcompiler_47.dll also works well in HLSL shader model 5.1
-// DXC requires shader model 6.0
-#define _AX_USE_DXC 1
+#include <algorithm>
 
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3d12.lib")
 
-#if _AX_USE_DXC
-#    pragma comment(lib, "dxcompiler.lib")
-#else
-#    pragma comment(lib, "d3dcompiler.lib")
-#endif
+#pragma comment(lib, "dxcompiler.lib")
+#pragma comment(lib, "d3dcompiler.lib")
 
 namespace ax::rhi
 {
@@ -140,7 +135,7 @@ void main(uint3 tid : SV_DispatchThreadID)
 }
 )";
 
-static inline bool CheckHR(HRESULT hr, const char* msg = nullptr)
+static inline bool checkHR(HRESULT hr, const char* msg = nullptr)
 {
     if (FAILED(hr))
     {
@@ -175,8 +170,7 @@ static int evalulateMaxMsaaSamples(ID3D12Device* device, DXGI_FORMAT format)
     return static_cast<int>(best);
 }
 
-#if _AX_USE_DXC
-static inline std::wstring_view stageToProfile(ShaderStage s)
+static inline std::wstring_view stageToProfileDXC(ShaderStage s)
 {
     switch (s)
     {
@@ -190,8 +184,8 @@ static inline std::wstring_view stageToProfile(ShaderStage s)
         return L"vs_6_0"sv;
     }
 }
-#else
-static inline const char* stageToProfile(ShaderStage s)
+
+static inline const char* stageToProfileFXC(ShaderStage s)
 {
     switch (s)
     {
@@ -205,7 +199,138 @@ static inline const char* stageToProfile(ShaderStage s)
         return "vs_5_1";
     }
 }
-#endif
+
+// ------------------------------------------------------------
+// Detect whether DXC is usable on this machine.
+// 1. DXC must compile a minimal shader
+// 2. Driver must accept the DXIL (PSO creation test)
+// ------------------------------------------------------------
+static bool detectDXCAvailability(ID3D12Device* device,
+                                  IDxcLibrary* lib,
+                                  IDxcCompiler* compiler,
+                                  std::span<LPCWSTR> args)
+{
+    if (!device || !lib || !compiler)
+    {
+        AXLOGW("DXC unavailable: missing compiler or library.");
+        return false;
+    }
+
+    // --- 1. Minimal VS shader ---
+    static const char* kVS = R"(
+        struct VSIn { float3 pos : POSITION; };
+        struct VSOut { float4 pos : SV_Position; };
+        VSOut main(VSIn input)
+        {
+            VSOut o;
+            o.pos = float4(input.pos, 1.0);
+            return o;
+        }
+    )";
+
+    // --- 2. Minimal PS shader ---
+    static const char* kPS = R"(
+        float4 main() : SV_Target
+        {
+            return float4(1, 0, 0, 1);
+        }
+    )";
+
+    auto compileShader = [&](const char* src, LPCWSTR entry, LPCWSTR profile, ComPtr<IDxcBlob>& outBlob) -> bool {
+        ComPtr<IDxcBlobEncoding> srcBlob;
+        HRESULT hr = lib->CreateBlobWithEncodingOnHeapCopy(src, (UINT)strlen(src), CP_UTF8, &srcBlob);
+        if (FAILED(hr))
+            return false;
+
+        ComPtr<IDxcOperationResult> result;
+        hr = compiler->Compile(srcBlob.Get(), nullptr, entry, profile, args.data(), (UINT)args.size(), nullptr, 0,
+                               nullptr, &result);
+        if (FAILED(hr))
+            return false;
+
+        HRESULT status;
+        result->GetStatus(&status);
+        if (FAILED(status))
+            return false;
+
+        result->GetResult(&outBlob);
+        return outBlob != nullptr;
+    };
+
+    // Compile VS
+    ComPtr<IDxcBlob> vsBlob;
+    if (!compileShader(kVS, L"main", L"vs_6_0", vsBlob))
+    {
+        AXLOGW("DXC unavailable: VS compile failed.");
+        return false;
+    }
+
+    // Compile PS
+    ComPtr<IDxcBlob> psBlob;
+    if (!compileShader(kPS, L"main", L"ps_6_0", psBlob))
+    {
+        AXLOGW("DXC unavailable: PS compile failed.");
+        return false;
+    }
+
+    // --- 3. Create minimal root signature ---
+    D3D12_ROOT_SIGNATURE_DESC rsDesc{};
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    ComPtr<ID3DBlob> sigBlob, errBlob;
+    HRESULT hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &sigBlob, &errBlob);
+    if (FAILED(hr))
+    {
+        AXLOGW("DXC unavailable: root signature serialization failed.");
+        return false;
+    }
+
+    ComPtr<ID3D12RootSignature> rootSig;
+    hr = device->CreateRootSignature(0, sigBlob->GetBufferPointer(), sigBlob->GetBufferSize(), IID_PPV_ARGS(&rootSig));
+    if (FAILED(hr))
+    {
+        AXLOGW("DXC unavailable: root signature creation failed.");
+        return false;
+    }
+
+    // --- 4. Build minimal PSO ---
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc{};
+    psoDesc.pRootSignature = rootSig.Get();
+
+    psoDesc.VS = {vsBlob->GetBufferPointer(), vsBlob->GetBufferSize()};
+    psoDesc.PS = {psBlob->GetBufferPointer(), psBlob->GetBufferSize()};
+
+    // Input layout for POSITION
+    D3D12_INPUT_ELEMENT_DESC layout[] = {
+        {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0}};
+    psoDesc.InputLayout = {layout, _countof(layout)};
+
+    // Rasterizer / Blend / Depth
+    psoDesc.RasterizerState   = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    psoDesc.BlendState        = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+
+    psoDesc.SampleMask            = UINT_MAX;
+    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+
+    psoDesc.NumRenderTargets = 1;
+    psoDesc.RTVFormats[0]    = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    psoDesc.SampleDesc.Count = 1;
+
+    // --- 5. Try creating PSO (this validates DXIL acceptance) ---
+    ComPtr<ID3D12PipelineState> pso;
+    hr = device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pso));
+
+    if (FAILED(hr))
+    {
+        AXLOGW("DXC unavailable: driver rejected DXIL, hr=0x{:08x}", static_cast<unsigned>(hr));
+        return false;
+    }
+
+    AXLOGI("DXC is available and DXIL is accepted by driver.");
+    return true;
+}
 
 static constexpr auto kUploadQueueType = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
@@ -291,6 +416,7 @@ DriverImpl::~DriverImpl()
 
     _dxcLibrary.Reset();
     _dxcCompiler.Reset();
+    _dxcArguments.clear();
 
     _isolateSubmission.release();
 
@@ -312,8 +438,6 @@ DriverImpl::~DriverImpl()
         CloseHandle(_idleEvent);
         _idleEvent = nullptr;
     }
-
-    _dxcArguments.clear();
 
     if (debugDevice)
         debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL);
@@ -372,19 +496,19 @@ void DriverImpl::init()
     _device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&_idleFence));
     AXASSERT(_idleEvent && _idleFence, "Create sync objects failed");
 
-#if _AX_USE_DXC
     // init DXC instances once
     DxcCreateInstance(CLSID_DxcLibrary, IID_PPV_ARGS(&_dxcLibrary));
     DxcCreateInstance(CLSID_DxcCompiler, IID_PPV_ARGS(&_dxcCompiler));
 
-#    if defined(NDEBUG)
+#if defined(NDEBUG)
     // Release build arguments
     _dxcArguments = {L"-O2", L"-Qstrip_debug"};
-#    else
+#else
     // Debug build arguments
     _dxcArguments = {L"-Zi", L"-Od"};
-#    endif
 #endif
+
+    _dxcAvailable = detectDXCAvailability(_device.Get(), _dxcLibrary.Get(), _dxcCompiler.Get(), _dxcArguments);
 }
 
 void DriverImpl::initializeDevice()
@@ -753,21 +877,18 @@ std::string DriverImpl::getVersion() const
 std::string DriverImpl::getRenderer() const
 {
     auto desc = ntcvt::from_chars(_adapterDesc.Description);
-
-#if _AX_USE_DXC
-    return fmt::format("{} D3D12 DXC SM6.0", desc);
-#else
-    return fmt::format("{} D3D12 vs_5_1 ps_5_1", desc);
-#endif
+    if (_dxcAvailable)
+        return fmt::format("{} D3D12 DXC SM6.0", desc);
+    else
+        return fmt::format("{} D3D12 vs_5_1 ps_5_1", desc);
 }
 
 std::string DriverImpl::getShaderVersion() const
 {
-#if _AX_USE_DXC
-    return "HLSL Shader Model 6.0 (DXC)"s;
-#else
-    return "D3D12 HLSL vs_5_1 ps_5_1"s;
-#endif
+    if (_dxcAvailable)
+        return "HLSL Shader Model 6.0 (DXC)"s;
+    else
+        return "D3D12 HLSL vs_5_1 ps_5_1"s;
 }
 
 IsolateSubmission& DriverImpl::startIsolateSubmission()
@@ -861,75 +982,78 @@ bool DriverImpl::compileShader(std::span<uint8_t> shaderCode, ShaderStage stage,
         _shaderCompileBuffer += shaderCode;
         shaderCode = _shaderCompileBuffer;
     }
-#if _AX_USE_DXC
-    ComPtr<IDxcBlobEncoding> sourceBlob;
-    _dxcLibrary->CreateBlobWithEncodingOnHeapCopy(shaderCode.data(), static_cast<UINT32>(shaderCode.size()), CP_UTF8,
-                                                  &sourceBlob);
-
-    std::wstring_view entryPoint = L"main";
-    std::wstring_view profile    = stageToProfile(stage);
-
-    ComPtr<IDxcOperationResult> result;
-    HRESULT hr = _dxcCompiler->Compile(sourceBlob.Get(),
-                                       nullptr,            // source file name
-                                       entryPoint.data(),  // entry point
-                                       profile.data(),     // target profile
-                                       _dxcArguments.data(), (UINT)_dxcArguments.size(), nullptr, 0,  // defines
-                                       nullptr,                                                       // include handler
-                                       &result);
-
-    if (FAILED(hr))
+    if (_dxcAvailable)
     {
-        AXLOGE("axmol:ERROR: DXC compile failed, hr:{}", hr);
-        AXASSERT(false, "Shader compile failed!");
-        return false;
-    }
+        ComPtr<IDxcBlobEncoding> sourceBlob;
+        _dxcLibrary->CreateBlobWithEncodingOnHeapCopy(shaderCode.data(), static_cast<UINT32>(shaderCode.size()),
+                                                      CP_UTF8, &sourceBlob);
 
-    HRESULT status;
-    result->GetStatus(&status);
-    if (FAILED(status))
-    {
-        ComPtr<IDxcBlobEncoding> errors;
-        result->GetErrorBuffer(&errors);
-        std::string_view errorDetail =
-            errors ? std::string_view((const char*)errors->GetBufferPointer(), errors->GetBufferSize())
-                   : "Unknown compile error"sv;
-        AXLOGE("axmol:ERROR: Failed to compile shader, hr:{},{}", status, errorDetail);
-        AXASSERT(false, "Shader compile failed!");
-        return false;
-    }
+        std::wstring_view entryPoint = L"main";
+        std::wstring_view profile    = stageToProfileDXC(stage);
 
-    ComPtr<IDxcBlob> blob;
-    result->GetResult(&blob);
+        ComPtr<IDxcOperationResult> result;
+        HRESULT hr = _dxcCompiler->Compile(sourceBlob.Get(),
+                                           nullptr,            // source file name
+                                           entryPoint.data(),  // entry point
+                                           profile.data(),     // target profile
+                                           _dxcArguments.data(), (UINT)_dxcArguments.size(), nullptr, 0,  // defines
+                                           nullptr,  // include handler
+                                           &result);
 
-    outHandle.blob = blob;
-    outHandle.view = std::span<uint8_t>((uint8_t*)blob->GetBufferPointer(), blob->GetBufferSize());
+        if (FAILED(hr))
+        {
+            AXLOGE("axmol:ERROR: DXC compile failed, hr:{}", hr);
+            AXASSERT(false, "Shader compile failed!");
+            return false;
+        }
 
-    return true;
-#else
-    ComPtr<ID3DBlob> blob;
-    ComPtr<ID3DBlob> errorBlob;
-    UINT flags = D3DCOMPILE_OPTIMIZATION_LEVEL2 | D3DCOMPILE_ENABLE_STRICTNESS;
-#    if !defined(NDEBUG)
-    flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
-#    endif
-    HRESULT hr = D3DCompile(shaderCode.data(), shaderCode.size(), nullptr, nullptr, nullptr, "main",
-                            stageToProfile(stage), flags, 0, &blob, &errorBlob);
-    if (SUCCEEDED(hr))
-    {
+        HRESULT status;
+        result->GetStatus(&status);
+        if (FAILED(status))
+        {
+            ComPtr<IDxcBlobEncoding> errors;
+            result->GetErrorBuffer(&errors);
+            std::string_view errorDetail =
+                errors ? std::string_view((const char*)errors->GetBufferPointer(), errors->GetBufferSize())
+                       : "Unknown compile error"sv;
+            AXLOGE("axmol:ERROR: Failed to compile shader, hr:{},{}", status, errorDetail);
+            AXASSERT(false, "Shader compile failed!");
+            return false;
+        }
+
+        ComPtr<IDxcBlob> blob;
+        result->GetResult(&blob);
+
         outHandle.blob = blob;
         outHandle.view = std::span<uint8_t>((uint8_t*)blob->GetBufferPointer(), blob->GetBufferSize());
+
         return true;
     }
-
-    std::string_view errorDetail =
-        errorBlob ? std::string_view((const char*)errorBlob->GetBufferPointer(), errorBlob->GetBufferSize())
-                  : "Unknown compile error"sv;
-    AXLOGE("axmol:ERROR: Failed to compile shader, hr:{},{}", hr, errorDetail);
-    AXASSERT(false, "Shader compile failed!");
-
-    return false;
+    else
+    {
+        ComPtr<ID3DBlob> blob;
+        ComPtr<ID3DBlob> errorBlob;
+        UINT flags = D3DCOMPILE_OPTIMIZATION_LEVEL2 | D3DCOMPILE_ENABLE_STRICTNESS;
+#if !defined(NDEBUG)
+        flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #endif
+        HRESULT hr = D3DCompile(shaderCode.data(), shaderCode.size(), nullptr, nullptr, nullptr, "main",
+                                stageToProfileFXC(stage), flags, 0, &blob, &errorBlob);
+        if (SUCCEEDED(hr))
+        {
+            outHandle.blob = blob;
+            outHandle.view = std::span<uint8_t>((uint8_t*)blob->GetBufferPointer(), blob->GetBufferSize());
+            return true;
+        }
+
+        std::string_view errorDetail =
+            errorBlob ? std::string_view((const char*)errorBlob->GetBufferPointer(), errorBlob->GetBufferSize())
+                      : "Unknown compile error"sv;
+        AXLOGE("axmol:ERROR: Failed to compile shader, hr:{},{}", hr, errorDetail);
+        AXASSERT(false, "Shader compile failed!");
+
+        return false;
+    }
 }
 
 bool DriverImpl::generateMipmaps(ID3D12GraphicsCommandList* cmd, ID3D12Resource* texture)
@@ -1055,7 +1179,7 @@ bool DriverImpl::generateMipmaps(ID3D12GraphicsCommandList* cmd, ID3D12Resource*
     {
         CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_UPLOAD);
         auto bufDesc = CD3DX12_RESOURCE_DESC::Buffer(totalConstSize);
-        if (!CheckHR(_device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &bufDesc,
+        if (!checkHR(_device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &bufDesc,
                                                       D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
                                                       IID_PPV_ARGS(&constUpload)),
                      "Create constant upload buffer"))
@@ -1186,8 +1310,8 @@ void DriverImpl::ensureMipmapPipeline(bool isArray)
         rsDesc.Init(_countof(params), params, 1, &staticSampler, D3D12_ROOT_SIGNATURE_FLAG_NONE);
 
         ComPtr<ID3DBlob> rsBlob, rsErr;
-        CheckHR(D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &rsBlob, &rsErr));
-        CheckHR(getDevice()->CreateRootSignature(0, rsBlob->GetBufferPointer(), rsBlob->GetBufferSize(),
+        checkHR(D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &rsBlob, &rsErr));
+        checkHR(getDevice()->CreateRootSignature(0, rsBlob->GetBufferPointer(), rsBlob->GetBufferSize(),
                                                  IID_PPV_ARGS(&_mipmapRootSig)));
     }
 
@@ -1199,7 +1323,7 @@ void DriverImpl::ensureMipmapPipeline(bool isArray)
         psoDesc.pRootSignature     = _mipmapRootSig.Get();
         psoDesc.CS.pShaderBytecode = csBlob.view.data();
         psoDesc.CS.BytecodeLength  = csBlob.view.size();
-        CheckHR(getDevice()->CreateComputePipelineState(&psoDesc, IID_PPV_ARGS(&targetPSO)));
+        checkHR(getDevice()->CreateComputePipelineState(&psoDesc, IID_PPV_ARGS(&targetPSO)));
     }
 
     // Create (or ensure) a shader-visible SRV/UAV heap that we can copy CPU-only descriptors into.

--- a/axmol/rhi/d3d12/Driver12.h
+++ b/axmol/rhi/d3d12/Driver12.h
@@ -189,8 +189,8 @@ private:
     void createDescriptorAllocators();
 
     bool checkFormatSupport(DXGI_FORMAT format);
+    bool detectDXCAvailability();
 
-private:
     RenderContextImpl* _currentRenderContext{nullptr};
 
     ComPtr<IDXGIFactory4> _dxgiFactory;

--- a/axmol/rhi/d3d12/Driver12.h
+++ b/axmol/rhi/d3d12/Driver12.h
@@ -38,6 +38,8 @@
 #include <functional>
 #include <array>
 
+// Note: d3dcompiler_47.dll also works well in HLSL shader model 5.1
+// DXC requires shader model 6.0
 #include <dxcapi.h>
 
 namespace ax::rhi
@@ -226,6 +228,8 @@ private:
     ComPtr<IDxcLibrary> _dxcLibrary;
     ComPtr<IDxcCompiler> _dxcCompiler;
     std::vector<LPCWSTR> _dxcArguments;
+
+    bool _dxcAvailable{false};
 
     tlx::byte_buffer _shaderCompileBuffer;
 

--- a/axmol/rhi/d3d12/RenderPipeline12.cpp
+++ b/axmol/rhi/d3d12/RenderPipeline12.cpp
@@ -329,7 +329,11 @@ void RenderPipelineImpl::updateGraphicsPipeline(const PipelineDesc& desc, Progra
 
     Microsoft::WRL::ComPtr<ID3D12PipelineState> pso;
     HRESULT hr = _driver->getDevice()->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pso));
-    AXASSERT(SUCCEEDED(hr), "Failed to create PSO");
+    if (FAILED(hr))
+    {
+        AXLOGE("Failed to create PSO, hr=0x{:08x}", static_cast<unsigned>(hr));
+        AXASSERT(false, "Failed to create PSO");
+    }
 
     _activePSO = pso;
     _psoCache.emplace(key, pso);


### PR DESCRIPTION
- Added DetectDXCAvailability() to validate DXC compiler and driver DXIL support
- DXC is now tested via minimal shader compilation + dummy PSO creation
- If DXC or DXIL validation fails, _dxcAvailable is disabled
- FXC fallback path is used automatically when DXC is unavailable
- Prevents PSO creation failures on OEM NVIDIA drivers (e.g. RTX 3050 series)
- Improves shader compilation robustness across Windows versions and GPU vendors

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
