### PR TITLE
Use binary search to find fitting font size for labels shrinking on overflow.

### DIFF
--- a/core/2d/Label.cpp
+++ b/core/2d/Label.cpp
@@ -1088,86 +1088,114 @@ void Label::updateLabelLetters()
     }
 }
 
-bool Label::alignText()
+void Label::alignText()
 {
     if (_fontAtlas == nullptr || _utf32Text.empty())
     {
         setContentSize(Vec2::ZERO);
-        return true;
+        return;
     }
 
-    bool ret = true;
-    do
+    _fontAtlas->prepareLetterDefinitions(_utf32Text);
+
+    float currentFontSize = getRenderingFontSize();
+
+    if (!tryTextPlacement(currentFontSize))
     {
-        _fontAtlas->prepareLetterDefinitions(_utf32Text);
-        auto& textures = _fontAtlas->getTextures();
-        auto size      = textures.size();
-        if (size > static_cast<size_t>(_batchNodes.size()))
+        int maxFontSize = currentFontSize - 1;
+        int minFontSize = 1;
+        int lastSuccessfulFontSize = minFontSize;
+
+        while (minFontSize <= maxFontSize)
         {
-            for (auto index = static_cast<unsigned int>(_batchNodes.size()); index < size; ++index)
+            currentFontSize = minFontSize + (maxFontSize - minFontSize) / 2;
+            scaleFontSize(currentFontSize);
+
+            _fontAtlas->prepareLetterDefinitions(_utf32Text);
+
+            if (tryTextPlacement(currentFontSize))
             {
-                auto batchNode = SpriteBatchNode::createWithTexture(textures.at(index));
-                if (batchNode)
-                {
-                    _isOpacityModifyRGB = batchNode->getTexture()->hasPremultipliedAlpha();
-                    _blendFunc          = batchNode->getBlendFunc();
-                    batchNode->setAnchorPoint(Vec2::ANCHOR_TOP_LEFT);
-                    batchNode->setPosition(Vec2::ZERO);
-                    _batchNodes.pushBack(batchNode);
-                }
+                lastSuccessfulFontSize = currentFontSize;
+                minFontSize = lastSuccessfulFontSize + 1;
             }
-        }
-        if (_batchNodes.empty())
-        {
-            return true;
-        }
-        // optimize for one-texture-only scenario
-        // if multiple textures, then we should count how many chars
-        // are per texture
-        if (_batchNodes.size() == 1)
-            _batchNodes.at(0)->reserveCapacity(_utf32Text.size());
-
-        _reusedLetter->setBatchNode(_batchNodes.at(0));
-
-        _lengthOfString    = 0;
-        _textDesiredHeight = 0.f;
-        _linesWidth.clear();
-
-        const auto currentFontSize = getRenderingFontSize();
-
-        const auto atMinimumFontSizeLimit = currentFontSize <= 1.f;
-
-        bool redoProcess;
-        if (_maxLineWidth > 0.f && !_lineBreakWithoutSpaces)
-        {
-            redoProcess = !multilineTextWrapByWord(atMinimumFontSizeLimit);
-        }
-        else
-        {
-            redoProcess = !multilineTextWrapByChar(atMinimumFontSizeLimit);
-        }
-
-        if (!redoProcess && _overflow == Overflow::SHRINK && !atMinimumFontSizeLimit)
-        {
-            if (isVerticalClamp() || isHorizontalClamp())
+            else
             {
-                redoProcess = true;
+                maxFontSize = currentFontSize - 1;
             }
         }
 
-        if (redoProcess)
+        if (currentFontSize != lastSuccessfulFontSize)
         {
-            auto newFontSize = currentFontSize - 1;
-            if (newFontSize >= 1)
+            scaleFontSize(lastSuccessfulFontSize);
+            _fontAtlas->prepareLetterDefinitions(_utf32Text);
+            tryTextPlacement(lastSuccessfulFontSize);
+        }
+    }
+
+    updateBatchNode();
+}
+
+bool Label::tryTextPlacement(float fontSize)
+{
+    _lengthOfString    = 0;
+    _textDesiredHeight = 0.f;
+    _linesWidth.clear();
+
+    const bool atMinimumFontSizeLimit = fontSize <= 1.f;
+
+    bool redoProcess;
+    if (_maxLineWidth > 0.f && !_lineBreakWithoutSpaces)
+    {
+        redoProcess = !multilineTextWrapByWord(atMinimumFontSizeLimit);
+    }
+    else
+    {
+        redoProcess = !multilineTextWrapByChar(atMinimumFontSizeLimit);
+    }
+
+    if ((!redoProcess && _overflow == Overflow::SHRINK && !atMinimumFontSizeLimit)
+        && (isVerticalClamp() || isHorizontalClamp()))
+    {
+        redoProcess = true;
+    }
+
+    return !redoProcess;
+}
+
+void Label::updateBatchNode()
+{
+    const std::unordered_map<unsigned int, Texture2D*>& textures = _fontAtlas->getTextures();
+    const size_t textureCount = textures.size();
+    const size_t nodeCount = _batchNodes.size();
+
+    if (textureCount > nodeCount)
+    {
+        _batchNodes.reserve(textureCount);
+
+        for (size_t index = nodeCount; index < textureCount; ++index)
+        {
+            SpriteBatchNode* const batchNode = SpriteBatchNode::createWithTexture(textures.at(index));
+            if (batchNode)
             {
-                scaleFontSize(newFontSize);
-                continue;
+                _isOpacityModifyRGB = batchNode->getTexture()->hasPremultipliedAlpha();
+                _blendFunc          = batchNode->getBlendFunc();
+                batchNode->setAnchorPoint(Vec2::ANCHOR_TOP_LEFT);
+                batchNode->setPosition(Vec2::ZERO);
+                _batchNodes.pushBack(batchNode);
             }
         }
+    }
+    if (_batchNodes.empty())
+    {
+        return;
+    }
 
-        break;
+    // optimize for one-texture-only scenario if multiple textures, then we
+    // should count how many chars are per texture
+    if (textureCount == 1)
+        _batchNodes.at(0)->reserveCapacity(_utf32Text.size());
 
-    } while (true);
+    _reusedLetter->setBatchNode(_batchNodes.at(0));
 
     computeAlignmentOffset();
 
@@ -1176,8 +1204,6 @@ bool Label::alignText()
     updateLabelLetters();
 
     updateColor();
-
-    return ret;
 }
 
 bool Label::computeHorizontalKernings(const std::u32string& stringToRender)
@@ -1327,7 +1353,7 @@ bool Label::updateTTFConfigInternal(unsigned int mods)
             updateShaderProgram();
         }
     }
-    
+
     if (_fontConfig.italics)
         this->enableItalics();
     if (_fontConfig.bold)
@@ -1769,11 +1795,10 @@ void Label::clearTextures()
 void Label::updateContent()
 {
     clearTextures();
-    bool updateFinished = true;
 
     if (_fontAtlas)
     {
-        updateFinished = alignText();
+        alignText();
     }
     else
     {
@@ -1874,10 +1899,7 @@ void Label::updateContent()
         }
     }
 
-    if (updateFinished)
-    {
-        _contentDirty = false;
-    }
+    _contentDirty = false;
 
 #if AX_LABEL_DEBUG_DRAW
     _debugDrawNode->clear();

--- a/core/2d/Label.h
+++ b/core/2d/Label.h
@@ -761,7 +761,7 @@ protected:
         std::array<CustomCommand*, 3> getCommandArray();
 
         CustomCommand textCommand;
-        CustomCommand effectCommand; // effect: outline or glow 
+        CustomCommand effectCommand; // effect: outline or glow
         CustomCommand shadowCommand;
     };
 
@@ -782,7 +782,9 @@ protected:
     void rescaleWithOriginalFontSize();
 
     void updateLabelLetters();
-    virtual bool alignText();
+    void alignText();
+    bool tryTextPlacement(float fontSize);
+    void updateBatchNode();
     void computeAlignmentOffset();
     bool computeHorizontalKernings(const std::u32string& stringToRender);
 

--- a/core/renderer/Texture2D.cpp
+++ b/core/renderer/Texture2D.cpp
@@ -165,7 +165,9 @@ bool Texture2D::initWithData(const void* data,
                              int pixelsHigh,
                              bool preMultipliedAlpha)
 {
-    AXASSERT(dataLen > 0 && pixelsWide > 0 && pixelsHigh > 0, "Invalid size");
+    AXASSERT(dataLen > 0, "Invalid size");
+    AXASSERT(pixelsWide > 0, "Invalid size");
+    AXASSERT(pixelsHigh > 0, "Invalid size");
 
     // if data has no mipmaps, we will consider it has only one mipmap
     MipmapInfo mipmap;


### PR DESCRIPTION
Solves #2927.

I could not find flags for `FT_Load_Glyph` that would make it significantly faster, so I have just changed the way the font size is computed. Previously `ax::Label::alignText` would decrease the font size until it found one that fit the text in the label's size. Now it will use a binary search to find this size.

On my app, at launch, the original version spent an accumulated 1.73 s. in `ax::Label::alignText`, with this patch it spends 0.82 s. Both averaged on 10 runs, release builds running on a Pixel 3a.

I've checked this patch in all tests of the `Label` entry in cpp-tests.