### PR TITLE
Replace stringstream with fmt::format for serialization

### DIFF
--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -1015,9 +1015,7 @@ TMXTileAnimTask::TMXTileAnimTask(FastTMXLayer* layer, TMXTileAnimInfo* animation
     _frameCount   = static_cast<uint32_t>(_animation->_frames.size());
     _tilePosition = tilePos;
     _flag         = flag;
-    std::stringstream ss;
-    ss << "TickAnimOnTilePos(" << _tilePosition.x << "," << _tilePosition.y << ")";
-    _key = ss.str();
+    _key          = fmt::format("TickAnimOnTilePos({},{})", _tilePosition.x, _tilePosition.y);
 }
 
 void TMXTileAnimTask::tickAndScheduleNext(float dt)

--- a/axmol/3d/ObjLoader.cpp
+++ b/axmol/3d/ObjLoader.cpp
@@ -460,7 +460,7 @@ static std::string& replacePathSeperator(std::string& path)
 
 std::string LoadMtl(tlx::string_map<int>& material_map, std::vector<material_t>& materials, std::istream& inStream)
 {
-    std::stringstream err;
+    std::string err;
 
     // Create a default material anyway.
     material_t material;
@@ -676,7 +676,7 @@ std::string LoadMtl(tlx::string_map<int>& material_map, std::vector<material_t>&
     material_map.insert(std::pair<std::string, int>(material.name, static_cast<int>(materials.size())));
     materials.emplace_back(material);
 
-    return err.str();
+    return err;
 }
 
 std::string MaterialFileReader::operator()(std::string_view matId,
@@ -694,14 +694,13 @@ std::string MaterialFileReader::operator()(std::string_view matId,
         filepath = matId;
     }
 
-    std::string err = "";
+    std::string err;
 
     std::istringstream matIStream(ax::FileUtils::getInstance()->getStringFromFile(filepath));
     if (!matIStream)
     {
-        std::stringstream ss;
-        ss << "WARN: Material file [ " << filepath << " ] not found. Created a default material.";
-        err += ss.str();
+        fmt::format_to(std::back_inserter(err), "WARN: Material file [ {} ] not found. Created a default material.\n",
+                       filepath);
     }
     err += LoadMtl(matMap, materials, matIStream);
 
@@ -716,13 +715,10 @@ std::string LoadObj(std::vector<shape_t>& shapes,
 
     shapes.clear();
 
-    std::stringstream err;
-
     std::istringstream ifs(ax::FileUtils::getInstance()->getStringFromFile(filename));
     if (!ifs)
     {
-        err << "Cannot open file [" << filename << "]" << std::endl;
-        return err.str();
+        return fmt::format("Cannot open file [ {} ]\n", filename);
     }
 
     std::string basePath;
@@ -740,7 +736,7 @@ std::string LoadObj(std::vector<shape_t>& shapes,
                     std::istream& inStream,
                     MaterialReader& readMatFn)
 {
-    std::stringstream err;
+    std::string err;
 
     std::vector<float> v;
     std::vector<float> vn;
@@ -966,6 +962,6 @@ std::string LoadObj(std::vector<shape_t>& shapes,
     }
     faceGroup.clear();  // for safety
 
-    return err.str();
+    return err;
 }
 }  // namespace tinyobj

--- a/axmol/base/UserDefault.cpp
+++ b/axmol/base/UserDefault.cpp
@@ -514,9 +514,7 @@ void UserDefault::flush()
     for (auto&& kv : _values)
         r.append_child(kv.first.c_str()).append_child(pugi::xml_node_type::node_pcdata).set_value(kv.second.c_str());
 
-    std::stringstream ss;
-    doc.save(ss, "  ");
-    FileUtils::getInstance()->writeStringToFile(ss.str(), _filePath);
+    FileUtils::getInstance()->writeXmlDocToFile(doc, _filePath);
 #endif
 }
 

--- a/axmol/base/Value.cpp
+++ b/axmol/base/Value.cpp
@@ -820,49 +820,58 @@ static std::string visit(const Value& v, int depth);
 
 static std::string visitVector(const ValueVector& v, int depth)
 {
-    std::stringstream ret;
+    std::string ret;
 
     if (depth > 0)
-        ret << "\n";
+        ret += '\n';
 
-    ret << getTabs(depth) << "[\n";
+    ret += getTabs(depth);
+    ret += "[\n"sv;
 
     int i = 0;
     for (const auto& child : v)
     {
-        ret << getTabs(depth + 1) << i << ": " << visit(child, depth + 1);
+        ret += getTabs(depth + 1);
+        fmt::format_to(std::back_inserter(ret), "{}", i);
+        ret += ": ";
+        ret += visit(child, depth + 1);
         ++i;
     }
 
-    ret << getTabs(depth) << "]\n";
+    ret += getTabs(depth);
+    ret += "]\n"sv;
 
-    return ret.str();
+    return ret;
 }
 
 template <class T>
 static std::string visitMap(const T& v, int depth)
 {
-    std::stringstream ret;
+    std::string ret;
 
     if (depth > 0)
-        ret << "\n";
+        ret += '\n';
 
-    ret << getTabs(depth) << "{\n";
+    ret += getTabs(depth);
+    ret += "{\n"sv;
 
     for (auto&& iter : v)
     {
-        ret << getTabs(depth + 1) << iter.first << ": ";
-        ret << visit(iter.second, depth + 1);
+        ret += getTabs(depth + 1);
+        fmt::format_to(std::back_inserter(ret), "{}", iter.first);
+        ret += ": "sv;
+        ret += visit(iter.second, depth + 1);
     }
 
-    ret << getTabs(depth) << "}\n";
+    ret += getTabs(depth);
+    ret += "}\n"sv;
 
-    return ret.str();
+    return ret;
 }
 
 static std::string visit(const Value& v, int depth)
 {
-    std::stringstream ret;
+    std::string ret;
 
     switch (v.getTypeFamily())
     {
@@ -872,23 +881,24 @@ static std::string visit(const Value& v, int depth)
     case Value::Type::DOUBLE:
     case Value::Type::BOOLEAN:
     case Value::Type::STRING:
-        ret << v.asString() << "\n";
+        ret += v.asString();
+        ret += '\n';
         break;
     case Value::Type::VECTOR:
-        ret << visitVector(v.asValueVector(), depth);
+        ret += visitVector(v.asValueVector(), depth);
         break;
     case Value::Type::MAP:
-        ret << visitMap(v.asValueMap(), depth);
+        ret += visitMap(v.asValueMap(), depth);
         break;
     case Value::Type::INT_KEY_MAP:
-        ret << visitMap(v.asIntKeyMap(), depth);
+        ret += visitMap(v.asIntKeyMap(), depth);
         break;
     default:
         AXASSERT(false, "Invalid type!");
         break;
     }
 
-    return ret.str();
+    return ret;
 }
 
 std::string Value::getDescription() const

--- a/axmol/network/Uri.cpp
+++ b/axmol/network/Uri.cpp
@@ -44,9 +44,7 @@ namespace
 template <typename T>
 std::string toString(T arg)
 {
-    std::stringstream ss;
-    ss << arg;
-    return ss.str();
+    return fmt::to_string(arg);
 }
 
 std::string submatch(const std::smatch& m, int idx)
@@ -372,38 +370,44 @@ const std::vector<std::pair<std::string, std::string>>& Uri::getQueryParams()
 
 std::string Uri::toString() const
 {
-    std::stringstream ss;
+    std::string ret;
+    ret.reserve(_scheme.size() + _username.size() + _password.size() + _host.size() + _path.size() + _query.size() +
+                _fragment.size() + 32);
+
     if (_hasAuthority)
     {
-        ss << _scheme << "://";
+        fmt::format_to(std::back_inserter(ret), "{}://", _scheme);
+
         if (!_password.empty())
         {
-            ss << _username << ":" << _password << "@";
+            fmt::format_to(std::back_inserter(ret), "{}:{}@", _username, _password);
         }
         else if (!_username.empty())
         {
-            ss << _username << "@";
+            fmt::format_to(std::back_inserter(ret), "{}@", _username);
         }
-        ss << _host;
+        fmt::format_to(std::back_inserter(ret), "{}", _host);
+
         if (_isCustomPort)
         {
-            ss << ":" << _port;
+            fmt::format_to(std::back_inserter(ret), ":{}", _port);
         }
     }
     else
     {
-        ss << _scheme << ":";
+        fmt::format_to(std::back_inserter(ret), "{}:", _scheme);
     }
-    ss << _path;
+    fmt::format_to(std::back_inserter(ret), "{}", _path);
+
     if (!_query.empty())
     {
-        ss << "?" << _query;
+        fmt::format_to(std::back_inserter(ret), "?{}", _query);
     }
     if (!_fragment.empty())
     {
-        ss << "#" << _fragment;
+        fmt::format_to(std::back_inserter(ret), "#{}", _fragment);
     }
-    return ss.str();
+    return ret;
 }
 
 }  // namespace network

--- a/axmol/platform/FileUtils.cpp
+++ b/axmol/platform/FileUtils.cpp
@@ -386,9 +386,8 @@ bool FileUtils::writeValueMapToFile(const ValueMap& dict, std::string_view fullP
     auto rootEle = doc.document_element();
 
     generateElementForDict(dict, rootEle);
-    std::stringstream ss;
-    doc.save(ss, "  ");
-    return writeStringToFile(ss.str(), fullPath);
+
+    return writeXmlDocToFile(doc, fullPath);
 }
 
 bool FileUtils::writeValueVectorToFile(const ValueVector& vecData, std::string_view fullPath) const
@@ -401,9 +400,8 @@ bool FileUtils::writeValueVectorToFile(const ValueVector& vecData, std::string_v
 
     auto rootEle = doc.document_element();
     generateElementForArray(vecData, rootEle);
-    std::stringstream ss;
-    doc.save(ss, "  ");
-    return writeStringToFile(ss.str(), fullPath);
+
+    return writeXmlDocToFile(doc, fullPath);
 }
 
 static void generateElementForObject(const Value& value, pugi::xml_node& parent)
@@ -492,6 +490,14 @@ bool FileUtils::writeStringToFile(std::string_view dataStr, std::string_view ful
 bool FileUtils::writeDataToFile(const Data& data, std::string_view fullPath) const
 {
     return FileUtils::writeBinaryToFile(data.getBytes(), data.getSize(), fullPath);
+}
+
+bool FileUtils::writeXmlDocToFile(const pugi::xml_document& xmlDoc, std::string_view fullPath)
+{
+    std::stringstream ss;
+    xmlDoc.save(ss, "  ");
+    auto ssview = ss.view();
+    return writeBinaryToFile(ssview.data(), ssview.size(), fullPath);
 }
 
 bool FileUtils::writeBinaryToFile(const void* data, size_t dataSize, std::string_view fullPath)

--- a/axmol/platform/FileUtils.h
+++ b/axmol/platform/FileUtils.h
@@ -46,6 +46,11 @@ THE SOFTWARE.
 #define AX_CONTENT_DIR     "Content/"
 #define AX_CONTENT_DIR_LEN (sizeof("Content/") - 1)
 
+namespace pugi
+{
+class xml_document;
+}
+
 namespace ax
 {
 
@@ -412,6 +417,16 @@ public:
      *@return bool
      */
     virtual bool writeDataToFile(const Data& data, std::string_view fullPath) const;
+
+    /**
+     * save xml document to file
+     *
+     *@param xmlDoc the xmlDoc want to save
+     *@param fullPath The full path to the file you want to save a string
+     *@return bool
+     *@since axmol-3.0
+     */
+    static bool writeXmlDocToFile(const pugi::xml_document& xmlDoc, std::string_view fullPath);
 
     /**
      * save data to file

--- a/tools/tolua/ax_base.ini
+++ b/tools/tolua/ax_base.ini
@@ -94,7 +94,7 @@ skip = Node::[setGLServerState description _setLocalZOrder getUserObject .*UserD
         TextureCache::[addPVRTCImage addImageAsync],
         Timer::[getSelector createWithScriptHandler],
         *::[copyWith.* onEnter.* onExit.* ^description$ getObjectType (g|s)etDelegate onTouch.* onAcc.* onKey.* onRegisterTouchListener],
-        FileUtils::[getFileData getDataFromFile writeDataToFile getFullPathCache getContents openFileStream],
+        FileUtils::[getFileData getDataFromFile writeDataToFile writeXmlDocToFile getFullPathCache getContents openFileStream],
         Application::[^application.* ^run$],
         Camera::[getEyeXYZ getCenterXYZ getUpXYZ],
         ccFontDefinition::[*],


### PR DESCRIPTION
- Removed std::stringstream usage in Uri::toString and Value::visit
- Adopted fmt::format / fmt::format_to for string building
- Reduced unnecessary copies from ss.str()
- Improved performance and code clarity by using fmt's efficient formatting API

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
