### PR TITLE
Fix sprite sheet creation logic

### DIFF
--- a/axmol/2d/PlistSpriteSheetLoader.cpp
+++ b/axmol/2d/PlistSpriteSheetLoader.cpp
@@ -190,9 +190,16 @@ void PlistSpriteSheetLoader::addSpriteFramesWithDictionary(ValueMap& dictionary,
     if (dictionary["frames"].getType() != ax::Value::Type::MAP)
         return;
 
-    auto spriteSheet    = std::make_shared<SpriteSheet>();
-    spriteSheet->format = getFormat();
-    spriteSheet->path   = plist;
+    auto spriteSheet    = cache.getSpriteSheet(plist);
+
+    if (spriteSheet == nullptr)
+    {
+        // create a new sprite sheet
+        spriteSheet =  std::make_shared<SpriteSheet>();
+        spriteSheet->format = getFormat();
+        spriteSheet->path   = plist;
+    }
+
 
     auto& framesDict = dictionary["frames"].asValueMap();
     int format       = 0;

--- a/axmol/2d/PlistSpriteSheetLoader.cpp
+++ b/axmol/2d/PlistSpriteSheetLoader.cpp
@@ -190,16 +190,15 @@ void PlistSpriteSheetLoader::addSpriteFramesWithDictionary(ValueMap& dictionary,
     if (dictionary["frames"].getType() != ax::Value::Type::MAP)
         return;
 
-    auto spriteSheet    = cache.getSpriteSheet(plist);
+    auto spriteSheet = cache.getSpriteSheet(plist);
 
     if (spriteSheet == nullptr)
     {
         // create a new sprite sheet
-        spriteSheet =  std::make_shared<SpriteSheet>();
+        spriteSheet         = std::make_shared<SpriteSheet>();
         spriteSheet->format = getFormat();
         spriteSheet->path   = plist;
     }
-
 
     auto& framesDict = dictionary["frames"].asValueMap();
     int format       = 0;

--- a/axmol/2d/SpriteFrameCache.cpp
+++ b/axmol/2d/SpriteFrameCache.cpp
@@ -459,4 +459,15 @@ ISpriteSheetLoader* SpriteFrameCache::getSpriteSheetLoader(uint32_t spriteSheetF
     return nullptr;
 }
 
+std::shared_ptr<SpriteSheet> SpriteFrameCache::getSpriteSheet(std::string_view filePath)
+{
+    auto it = _spriteSheets.find(computeHash(filePath));
+    if (it != _spriteSheets.end())
+    {
+        return it->second;
+    }
+    
+    return nullptr;
+}
+
 }  // namespace ax

--- a/axmol/2d/SpriteFrameCache.cpp
+++ b/axmol/2d/SpriteFrameCache.cpp
@@ -466,7 +466,7 @@ std::shared_ptr<SpriteSheet> SpriteFrameCache::getSpriteSheet(std::string_view f
     {
         return it->second;
     }
-    
+
     return nullptr;
 }
 

--- a/axmol/2d/SpriteFrameCache.h
+++ b/axmol/2d/SpriteFrameCache.h
@@ -255,7 +255,7 @@ public:
     ISpriteSheetLoader* getSpriteSheetLoader(uint32_t spriteSheetFormat);
 
     std::shared_ptr<SpriteSheet> getSpriteSheet(std::string_view spriteSheetFileName);
-    
+
 protected:
     // MARMALADE: Made this protected not private, as deriving from this class is pretty useful
     SpriteFrameCache() {}

--- a/axmol/2d/SpriteFrameCache.h
+++ b/axmol/2d/SpriteFrameCache.h
@@ -254,6 +254,8 @@ public:
 
     ISpriteSheetLoader* getSpriteSheetLoader(uint32_t spriteSheetFormat);
 
+    std::shared_ptr<SpriteSheet> getSpriteSheet(std::string_view spriteSheetFileName);
+    
 protected:
     // MARMALADE: Made this protected not private, as deriving from this class is pretty useful
     SpriteFrameCache() {}


### PR DESCRIPTION
## Describe your changes
Instead of creating new SpriteSheet on loading, Now it'll check if that SpriteSheet already exists, if it does use and fill it otherwise create new.

Let me know if needs more details or other issues in the PR.


## Issue ticket number and link
Currently if SpriteSheet is partially deleted by android/ios partial memory cleanup. Reloading it again loads only missing sprites to a new SpriteSheet and marks it as `full` but it's not full. So If the cleanup happens again some sprites will be missed an not loaded again even after multiple tries.

```
Example.
Assume `p.plist` contains {`a.png`, `b.png`}

on first fresh load.
SpriteSheet{P}
  full: true
  _spriteFrames: {a.png, b.png}


first cleanup, let's assume a.png is removed
SpriteSheet{P}
  full: false
  _spriteFrames: {b.png}

If we load it again, current SpriteSheet will gets replaced, and it only loads missing png and marks it full.
SpriteSheet{P}
  full: true
  _spriteFrames: {a.png}


`b.png` will still be usable as SpriteFrameCache stores name to sprite.
but after second cleanup, let's assume `b.png` gets cleaned up. 
`p.plist` will not get loaded again as it's already full and `b.png` will not be found as as `SpriteSheet{P}` and cache doesn't contains it anymore.
```


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [x] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
