### PR TITLE
PhysicsDemoJoints: Remove the wrong joints to the "box".

### DIFF
--- a/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.cpp
@@ -887,8 +887,6 @@ void PhysicsDemoJoints::onEnter()
                 auto sp2PhysicsBody = sp2->getPhysicsBody();
                 sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
 
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp1PhysicsBody, box, sp1->getPosition()));
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp2PhysicsBody, box, sp2->getPosition()));
                 PhysicsJointRotarySpring* joint =
                     PhysicsJointRotarySpring::instantiate(sp1PhysicsBody, sp2PhysicsBody, 3000.0f, 60.0f);
                 getPhysicsWorld()->addJoint(joint);
@@ -907,8 +905,6 @@ void PhysicsDemoJoints::onEnter()
                 auto sp2PhysicsBody = sp2->getPhysicsBody();
                 sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
 
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp1PhysicsBody, box, sp1->getPosition()));
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp2PhysicsBody, box, sp2->getPosition()));
                 PhysicsJointRotaryLimit* joint =
                     PhysicsJointRotaryLimit::instantiate(sp1PhysicsBody, sp2PhysicsBody, 0.0f, (float)M_PI_2);
                 getPhysicsWorld()->addJoint(joint);
@@ -927,8 +923,6 @@ void PhysicsDemoJoints::onEnter()
                 auto sp2PhysicsBody = sp2->getPhysicsBody();
                 sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
 
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp1PhysicsBody, box, sp1->getPosition()));
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp2PhysicsBody, box, sp2->getPosition()));
                 PhysicsJointRatchet* joint =
                     PhysicsJointRatchet::instantiate(sp1PhysicsBody, sp2PhysicsBody, 0.0f, (float)M_PI_2);
                 getPhysicsWorld()->addJoint(joint);
@@ -947,8 +941,6 @@ void PhysicsDemoJoints::onEnter()
                 auto sp2PhysicsBody = sp2->getPhysicsBody();
                 sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
 
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp1PhysicsBody, box, sp1->getPosition()));
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp2PhysicsBody, box, sp2->getPosition()));
                 PhysicsJointGear* joint = PhysicsJointGear::instantiate(sp1PhysicsBody, sp2PhysicsBody, 0.0f, 2.0f);
                 getPhysicsWorld()->addJoint(joint);
 
@@ -966,8 +958,6 @@ void PhysicsDemoJoints::onEnter()
                 auto sp2PhysicsBody = sp2->getPhysicsBody();
                 sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
 
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp1PhysicsBody, box, sp1->getPosition()));
-                getPhysicsWorld()->addJoint(PhysicsJointPin::instantiate(sp2PhysicsBody, box, sp2->getPosition()));
                 PhysicsJointMotor* joint =
                     PhysicsJointMotor::instantiate(sp1PhysicsBody, sp2PhysicsBody, (float)M_PI_2);
                 getPhysicsWorld()->addJoint(joint);


### PR DESCRIPTION
## Describe your changes
see diff

Remove the wrong joints to the "box".
<img width="400" height="428" alt="image" src="https://github.com/user-attachments/assets/48cf6cbc-216d-4211-b58c-07f930bffa86" />

fix:
<img width="673" height="604" alt="image" src="https://github.com/user-attachments/assets/99d2557f-03eb-4a66-9452-2f5c1d7372fa" />

## Issue ticket number and link

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
