### PR TITLE
Optimize FileUtils Lua string/data return

### DIFF
--- a/3rdparty/lua/plainlua/lspec.c
+++ b/3rdparty/lua/plainlua/lspec.c
@@ -1,0 +1,21 @@
+/*
+** axmol spec lua APIs, DO NOT DELETE
+*/
+#define lspec_c
+#define LUA_LIB
+#include "lspec.h"
+#include "lstring.h"
+#include "lapi.h"
+
+LUA_API char* (lua_pushistring) (lua_State *L, size_t l)
+{
+    TString* ts;
+
+    lua_lock(L);
+    ts = luaS_createlngstrobj(L, l);
+    setsvalue2s(L, L->top.p, ts);
+    api_incr_top(L);
+    luaC_checkGC(L);
+    lua_unlock(L);
+    return getlngstr(ts);
+}

--- a/3rdparty/lua/plainlua/lspec.h
+++ b/3rdparty/lua/plainlua/lspec.h
@@ -1,0 +1,38 @@
+/*
+** axmol spec lua APIs, DO NOT DELETE
+*/
+#pragma once
+
+#include "lua.h"
+
+/*
+** lua_pushistring
+**
+** Create and push a new Lua long string object of length `l` directly
+** using luaS_createlngstrobj(), returning a writable buffer pointer.
+**
+** Unlike lua_pushstring/lua_pushlstring, this API is designed for
+** in-place string construction: the caller can fill the returned buffer
+** with native data (e.g. file contents, I/O streams) without incurring
+** an extra memory copy.
+**
+** This makes it especially useful for scenarios such as:
+**   - Reading large files or binary blobs directly into Lua strings
+**   - Integrating with native libraries that produce data buffers
+**   - Avoiding redundant allocations when bridging external data sources
+**
+** The string is managed by Lua's GC once pushed, and does not require
+** manual freeing by the caller.
+**
+** Note: This API is only applicable to standard Lua (non-LuaJIT),
+** as LuaJIT has its own internal string representation and memory model.
+*/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+LUA_API char*(lua_pushistring)(lua_State * L, size_t l);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/axmol/platform/FileUtils.h
+++ b/axmol/platform/FileUtils.h
@@ -318,12 +318,6 @@ public:
     }
 
     /**
-     * @brief update
-     * since axmol-3.0
-     */
-    virtual void updateSearchPaths();
-
-    /**
      * Get default resource root path.
      */
     const std::string& getDefaultResourceRootPath() const;
@@ -621,6 +615,12 @@ public:
     virtual std::unique_ptr<IFileStream> openFileStream(std::string_view filePath, IFileStream::Mode mode) const;
 
 protected:
+    /**
+     * @brief update
+     * since axmol-3.0
+     */
+    virtual void updateSearchPaths();
+
     /**
      *  The default constructor.
      */


### PR DESCRIPTION
## Describe your changes

- In non-LuaJIT builds, FileUtils::getStringFromFile and FileUtils::getDataFromFile now return Lua strings directly.
- This avoids extra memory copies by using LuaStringBufferAdapter for string/data content.



## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
