### PR TITLE
Assign cmakeVer before it is used

### DIFF
--- a/axmol/platform/android/dsl/axmol.gradle
+++ b/axmol/platform/android/dsl/axmol.gradle
@@ -367,6 +367,12 @@ class AxmolUtils {
             ++index
         }
 
+        if(verifiedVer == null) {
+            throw new Exception("No suitable cmake found, required $cmakeVer")
+        }
+
+        buildProfiles['cmakeVer'] = verifiedVer
+ 
         // Create symlink at sdk cmake when using fallback cmake in axmol engine
         // Only present for compatibility purpose, may remove in future axmol releases
         if (index == (cmakeBinDirs.size() - 1)) {
@@ -385,12 +391,6 @@ class AxmolUtils {
                 println "The symlinkd ${symlinkDir} ==> ${fallbackCMakeDir} exist"
             }
         }
-
-        if(verifiedVer == null) {
-            throw new Exception("No suitable cmake found, required $cmakeVer")
-        }
-
-        buildProfiles['cmakeVer'] = verifiedVer
     }
 
     private static String joinPath(String first, String... more) {


### PR DESCRIPTION
## Describe your changes
Android build failed for me because buildProfiles['cmakeVer'] was used before it was actually assigned.

## Issue ticket number and link
Did not create a ticket

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
