### PR TITLE
PhysicsDebugNode:  Faster/smoother circle rendering

### DIFF
--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -80,9 +80,9 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
     auto color4f = PhysicsHelper::toColor(color);
 
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-                radius * dn->getPTMRatio(), Color);
+                radius * dn->getPTMRatio(), color4f);
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-                radius * dn->getPTMRatio() - 0.5f, ax::Color(Color.r / 4, Color.g / 4, Color.b / 4, Color.a));
+                radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a));
     
     // Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -82,7 +82,7 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
                 radius * dn->getPTMRatio(), Color);
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-                radius * dn->getPTMRatio() - 1, ax::Color(Color.r / 4, Color.g / 4, Color.b / 4, Color.a));
+                radius * dn->getPTMRatio() - 0.5f, ax::Color(Color.r / 4, Color.g / 4, Color.b / 4, Color.a));
     
     // Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -67,9 +67,8 @@ static void b2DrawSolidPolygon(b2Transform t,
 // void (*DrawCircle)(b2Vec2 center, float radius, b2HexColor color, void* context);
 static void b2DrawCircle(b2Vec2 center, float radius, b2HexColor color, PhysicsDebugNode* dn)
 {
-    dn->drawCircle(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-                   radius * dn->getPTMRatio(), AX_DEGREES_TO_RADIANS(0), 30, true, 1.0f, 1.0f,
-                   PhysicsHelper::toColor(color));
+    dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
+                radius * dn->getPTMRatio(), PhysicsHelper::toColor(color));
 }
 
 /// Draw a solid circle.
@@ -80,8 +79,11 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
     Vec2 c       = {Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset()};
     auto color4f = PhysicsHelper::toColor(color);
 
-    dn->drawSolidCircle(c, radius * dn->getPTMRatio(), AX_DEGREES_TO_RADIANS(0), 20, 1.0f, 1.0f,
-                        ax::Color(color4f.r / 2, color4f.g / 2, color4f.b / 2, color4f.a), 0.4f, color4f);
+    dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
+                radius * dn->getPTMRatio(), Color);
+    dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
+                radius * dn->getPTMRatio() - 1, ax::Color(Color.r / 4, Color.g / 4, Color.b / 4, Color.a));
+    
     // Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};
     Vec2 cp   = {Vec2(pp.x * dn->getPTMRatio(), pp.y * dn->getPTMRatio()) + dn->getWorldOffset()};

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -83,7 +83,7 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
                 radius * dn->getPTMRatio(), color4f);
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
                 radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a));
-    
+
     // Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};
     Vec2 cp   = {Vec2(pp.x * dn->getPTMRatio(), pp.y * dn->getPTMRatio()) + dn->getWorldOffset()};


### PR DESCRIPTION
## Describe your changes

`drawDot` is faster as `drawCircle`

Values from cpp-tests:   9:Box2D - Basic

drawCircle:
<img width="228" height="95" alt="image" src="https://github.com/user-attachments/assets/38cade67-61fb-4235-914a-793753dad9ba" />

drawDot:
<img width="255" height="83" alt="image" src="https://github.com/user-attachments/assets/36ffec03-f87f-41ba-92c0-17846d8cab89" />

And smoother:
<img width="397" height="325" alt="image" src="https://github.com/user-attachments/assets/b43eec91-7cae-4482-9f6d-3c3dc5163088" />


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
