### PR TITLE
Improve cmake

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -111,9 +111,7 @@ function(ax_add_3rd source_dir)
       add_dependencies(3rdparty ${tgt})
     endif()
 
-    get_target_property(_is_imported_lib ${tgt} IMPORTED)
-    
-    if(NOT _is_imported_lib AND NOT (tgt_type STREQUAL "INTERFACE_LIBRARY"))
+    if(NOT (tgt_type STREQUAL "INTERFACE_LIBRARY"))
       set_target_properties(${tgt} PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" # Windows/Linux/macOS, .a, .lib
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" # Windows .dll, .exe
@@ -250,6 +248,10 @@ if(AX_ENABLE_AUDIO)
       "ALSOFT_UTILS OFF"
       "ALSOFT_EXAMPLES OFF"
       "ALSOFT_INSTALL OFF"
+      "ALSOFT_INSTALL_CONFIG OFF"
+      "ALSOFT_INSTALL_HRTF_DATA OFF"
+      "ALSOFT_INSTALL_AMBDEC_PRESETS OFF"
+      "ALSOFT_INSTALL_UTILS OFF"
       "ALSOFT_ENABLE_MODULES OFF"
     )
 

--- a/3rdparty/openal/CMakeLists.txt
+++ b/3rdparty/openal/CMakeLists.txt
@@ -1742,11 +1742,12 @@ else()
             set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
         endif()
 
+        set(_alsoft_bundle_id "org.openal-soft.openal")
         set_target_properties(${IMPL_TARGET} PROPERTIES
             FRAMEWORK TRUE
             FRAMEWORK_VERSION C
             MACOSX_FRAMEWORK_NAME "${IMPL_TARGET}"
-            MACOSX_FRAMEWORK_IDENTIFIER "org.openal-soft.openal"
+            MACOSX_FRAMEWORK_IDENTIFIER "${_alsoft_bundle_id}"
             MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${OpenAL_VERSION}"
             MACOSX_FRAMEWORK_BUNDLE_VERSION "${BUNDLE_VERSION}"
             XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
@@ -1757,6 +1758,7 @@ else()
             XCODE_ATTRIBUTE_GCC_GENERATE_DEBUGGING_SYMBOLS "YES"
             XCODE_ATTRIBUTE_ENABLE_STDEBUG_INFORMATION_FORMAT "dwarf-with-dsym"
             XCODE_ATTRIBUTE_CONFIGURATION_BUILD_DIR "$(inherited)"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${_alsoft_bundle_id}"
             PUBLIC_HEADER "${TARGET_PUBLIC_HEADERS}"
             MACOSX_RPATH TRUE)
     endif()


### PR DESCRIPTION
1. avoid copy xcfraemwork .a to bin dir
2. avoid macos openal bundle id mismatch warning

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
