### PR TITLE
Fix AxmolViewController lifecycle methods are not invoked on iOS

### DIFF
--- a/axmol/platform/RenderView.cpp
+++ b/axmol/platform/RenderView.cpp
@@ -498,10 +498,10 @@ float RenderView::getScaleY() const
 
 void RenderView::onSurfaceResized()
 {
-    AXLOGD("RenderView::onSurfaceResized");
-
     int screenWidth  = static_cast<uint32_t>(_renderSize.width);
     int screenHeight = static_cast<uint32_t>(_renderSize.height);
+    
+    AXLOGD("RenderView::onSurfaceResized: ({}x{})", screenWidth, screenHeight);
 
     auto renderer = Director::getInstance()->getRenderer();
     if (renderer)

--- a/axmol/platform/RenderView.cpp
+++ b/axmol/platform/RenderView.cpp
@@ -500,7 +500,7 @@ void RenderView::onSurfaceResized()
 {
     int screenWidth  = static_cast<uint32_t>(_renderSize.width);
     int screenHeight = static_cast<uint32_t>(_renderSize.height);
-    
+
     AXLOGD("RenderView::onSurfaceResized: ({}x{})", screenWidth, screenHeight);
 
     auto renderer = Director::getInstance()->getRenderer();

--- a/axmol/platform/ios/AxmolAppController.mm
+++ b/axmol/platform/ios/AxmolAppController.mm
@@ -37,7 +37,7 @@ using namespace ax;
 
 - (UIViewController*)createRootViewController
 {
-    return [[AxmolViewController alloc] initWithNibName:nil bundle:nil];
+    return [[AxmolViewController alloc] init];
 }
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
@@ -54,7 +54,7 @@ using namespace ax;
     _viewController = [self createRootViewController];
 
     renderView->showWindow(_viewController);
-
+    
     // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
     Director::getInstance()->setRenderView(renderView);
 

--- a/axmol/platform/ios/AxmolAppController.mm
+++ b/axmol/platform/ios/AxmolAppController.mm
@@ -54,7 +54,7 @@ using namespace ax;
     _viewController = [self createRootViewController];
 
     renderView->showWindow(_viewController);
-    
+
     // IMPORTANT: Setting the RenderView should be done after creating the RootViewController
     Director::getInstance()->setRenderView(renderView);
 

--- a/axmol/platform/ios/AxmolViewController.h
+++ b/axmol/platform/ios/AxmolViewController.h
@@ -29,6 +29,6 @@
 }
 - (BOOL)prefersStatusBarHidden;
 
-@property (nonatomic, strong) UIView *renderHostView;
+@property(nonatomic, strong) UIView* renderHostView;
 
 @end

--- a/axmol/platform/ios/AxmolViewController.h
+++ b/axmol/platform/ios/AxmolViewController.h
@@ -29,4 +29,6 @@
 }
 - (BOOL)prefersStatusBarHidden;
 
+@property (nonatomic, strong) UIView *renderHostView;
+
 @end

--- a/axmol/platform/ios/AxmolViewController.mm
+++ b/axmol/platform/ios/AxmolViewController.mm
@@ -48,7 +48,7 @@ customization that is not appropriate for viewDidLoad.
 - (void)loadView
 {
     // create platform render view
-    auto r = [[UIScreen mainScreen] bounds];
+    auto r                   = [[UIScreen mainScreen] bounds];
     RenderHostView* hostView = [RenderHostView viewWithFrame:r
                                                  pixelFormat:(int)RenderViewImpl::_pixelFormat
                                                  depthFormat:(int)RenderViewImpl::_depthFormat

--- a/axmol/platform/ios/AxmolViewController.mm
+++ b/axmol/platform/ios/AxmolViewController.mm
@@ -24,6 +24,7 @@
 
 #import "axmol/platform/ios/AxmolViewController.h"
 #import "axmol/platform/ios/RenderHostView-ios.h"
+#import "axmol/platform/ios/RenderViewImpl-ios.h"
 #include "axmol/platform/Device.h"
 #include "axmol/platform/Application.h"
 #include "axmol/base/Director.h"
@@ -46,7 +47,21 @@ customization that is not appropriate for viewDidLoad.
 // Implement loadView to create a view hierarchy programmatically, without using a nib.
 - (void)loadView
 {
-    self.view = self.renderHostView;
+    // create platform render view
+    auto r = [[UIScreen mainScreen] bounds];
+    RenderHostView* hostView = [RenderHostView viewWithFrame:r
+                                                 pixelFormat:(int)RenderViewImpl::_pixelFormat
+                                                 depthFormat:(int)RenderViewImpl::_depthFormat
+                                          preserveBackbuffer:NO
+                                                  sharegroup:nil
+                                               multiSampling:RenderViewImpl::_multisamplingCount > 0 ? YES : NO
+                                             numberOfSamples:RenderViewImpl::_multisamplingCount];
+
+    // Not available on tvOS
+#if !defined(AX_TARGET_OS_TVOS)
+    [hostView setMultipleTouchEnabled:YES];
+#endif
+    self.view = hostView;
 }
 
 // Implement viewDidLoad to do additional setup after loading the view, typically from a nib.

--- a/axmol/platform/ios/AxmolViewController.mm
+++ b/axmol/platform/ios/AxmolViewController.mm
@@ -44,9 +44,10 @@ customization that is not appropriate for viewDidLoad.
 */
 
 // Implement loadView to create a view hierarchy programmatically, without using a nib.
-// - (void)loadView
-// {
-// }
+- (void)loadView
+{
+    self.view = self.renderHostView;
+}
 
 // Implement viewDidLoad to do additional setup after loading the view, typically from a nib.
 - (void)viewDidLoad

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -151,9 +151,7 @@ void RenderViewImpl::choosePixelFormats()
 
 RenderViewImpl::RenderViewImpl() {}
 
-RenderViewImpl::~RenderViewImpl()
-{
-}
+RenderViewImpl::~RenderViewImpl() {}
 
 bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
                                   const Rect& rect,
@@ -214,11 +212,11 @@ void RenderViewImpl::showWindow(void* viewController)
     // Calling makeKeyAndVisible triggers the AxmolViewController lifecycle:
     // loadView -> viewDidLoad -> viewWillAppear
     [window makeKeyAndVisible];
-    
+
     // After lifecycle completes, controller.view is initialized with RenderHostView
-    auto hostView = controller.view;
+    auto hostView   = controller.view;
     _hostViewHandle = controller.view;
-    
+
     const auto size               = resolveViewSizeToOrientation([hostView bounds].size);
     const auto backingScaleFactor = [hostView contentScaleFactor];
 

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -29,6 +29,7 @@
 #include "axmol/platform/ios/RenderHostView-ios.h"
 #include "axmol/platform/ios/DirectorCaller-ios.h"
 #include "axmol/platform/ios/RenderViewImpl-ios.h"
+#include "axmol/platform/ios/AxmolViewController.h"
 #include "axmol/platform/Application.h"
 #include "axmol/platform/Device.h"
 #include "axmol/base/Touch.h"
@@ -216,13 +217,12 @@ void RenderViewImpl::setMultipleTouchEnabled(bool enabled)
 void RenderViewImpl::showWindow(void* viewController)
 {
     auto window     = (__bridge UIWindow*)_hostWindowHandle;
-    auto controller = (__bridge UIViewController*)viewController;
+    auto controller = (__bridge AxmolViewController*)viewController;
 
 #if !defined(AX_TARGET_OS_TVOS)
     controller.extendedLayoutIncludesOpaqueBars = YES;
 #endif
-    auto view       = (__bridge RenderHostView*)_hostViewHandle;
-    controller.view = view;
+    controller.renderHostView = (__bridge RenderHostView*)_hostViewHandle;
 
     // Set RootViewController to window
     if ([[UIDevice currentDevice].systemVersion floatValue] < 6.0)

--- a/axmol/platform/ios/RenderViewImpl-ios.mm
+++ b/axmol/platform/ios/RenderViewImpl-ios.mm
@@ -153,8 +153,6 @@ RenderViewImpl::RenderViewImpl() {}
 
 RenderViewImpl::~RenderViewImpl()
 {
-    // auto hostView = (__bridge RenderHostView*) _hostViewHandle;
-    //[hostView release];
 }
 
 bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
@@ -167,28 +165,6 @@ bool RenderViewImpl::initWithRect(std::string_view /*viewName*/,
 
     // create platform window
     _hostWindowHandle = [[UIWindow alloc] initWithFrame:r];
-
-    // create platform render view
-    RenderHostView* hostView = [RenderHostView viewWithFrame:r
-                                                 pixelFormat:(int)_pixelFormat
-                                                 depthFormat:(int)_depthFormat
-                                          preserveBackbuffer:NO
-                                                  sharegroup:nil
-                                               multiSampling:_multisamplingCount > 0 ? YES : NO
-                                             numberOfSamples:_multisamplingCount];
-
-    // Not available on tvOS
-#if !defined(AX_TARGET_OS_TVOS)
-    [hostView setMultipleTouchEnabled:YES];
-#endif
-    const auto size               = resolveViewSizeToOrientation([hostView bounds].size);
-    const auto backingScaleFactor = [hostView contentScaleFactor];
-
-    // simply set renderSize, renderSize to framebufferSize with renderScale=1.0
-    updateRenderSurface(size.width * backingScaleFactor, size.height * backingScaleFactor,
-                        SurfaceUpdateFlag::AllUpdatesSilently);
-
-    _hostViewHandle = hostView;
 
     return true;
 }
@@ -222,7 +198,6 @@ void RenderViewImpl::showWindow(void* viewController)
 #if !defined(AX_TARGET_OS_TVOS)
     controller.extendedLayoutIncludesOpaqueBars = YES;
 #endif
-    controller.renderHostView = (__bridge RenderHostView*)_hostViewHandle;
 
     // Set RootViewController to window
     if ([[UIDevice currentDevice].systemVersion floatValue] < 6.0)
@@ -236,7 +211,20 @@ void RenderViewImpl::showWindow(void* viewController)
         [window setRootViewController:controller];
     }
 
+    // Calling makeKeyAndVisible triggers the AxmolViewController lifecycle:
+    // loadView -> viewDidLoad -> viewWillAppear
     [window makeKeyAndVisible];
+    
+    // After lifecycle completes, controller.view is initialized with RenderHostView
+    auto hostView = controller.view;
+    _hostViewHandle = controller.view;
+    
+    const auto size               = resolveViewSizeToOrientation([hostView bounds].size);
+    const auto backingScaleFactor = [hostView contentScaleFactor];
+
+    // simply set renderSize, renderSize to framebufferSize with renderScale=1.0
+    updateRenderSurface(size.width * backingScaleFactor, size.height * backingScaleFactor,
+                        SurfaceUpdateFlag::AllUpdatesSilently);
 
 #if !defined(AX_TARGET_OS_TVOS)
     [controller prefersStatusBarHidden];

--- a/templates/common/proj.ios_mac/ios/GameViewController.mm
+++ b/templates/common/proj.ios_mac/ios/GameViewController.mm
@@ -30,5 +30,9 @@
 @implementation GameViewController
 
 // Override to allow custom control the app behavior.
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+}
 
 @end


### PR DESCRIPTION
- Add renderHostView property to AxmolViewController
- Use loadView to assign self.view = renderHostView
- Update RenderViewImpl::showWindow to set renderHostView instead of controller.view
- Minor logging improvement in RenderView::onSurfaceResized

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
