### PR TITLE
RHI: Add Vulkan minimal Android API level restriction

### DIFF
--- a/axmol/rhi/DriverContext.cpp
+++ b/axmol/rhi/DriverContext.cpp
@@ -22,6 +22,10 @@
 #    include "axmol/rhi/opengl/DriverGL.h"
 #endif
 
+#if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
+#    include <android/api-level.h>
+#endif
+
 namespace ax::rhi
 {
 
@@ -29,6 +33,7 @@ std::unique_ptr<DriverBase> DriverContext::_currentDriver;
 DriverType DriverContext::_currentDriverType = DriverType::Auto;
 int DriverContext::_currentShaderLang        = axslc::SHADER_LANG_NONE;
 int DriverContext::_currentShaderProfile     = 0;
+int DriverContext::_vulkanMinAndroidApiLevel = 31;  // Android 12
 
 static int _driverPriorities[(int)rhi::DriverType::Count] = {
     rhi::DefaultDriverPriority::OpenGL, rhi::DefaultDriverPriority::D3D11, rhi::DefaultDriverPriority::D3D12,
@@ -38,6 +43,11 @@ static int _driverPriorities[(int)rhi::DriverType::Count] = {
 static uint32_t make_msl_version(uint32_t major, uint32_t minor = 0, uint32_t patch = 0)
 {
     return (major * 10000) + (minor * 100) + patch;
+}
+
+void DriverContext::setVulkanMinAndroidApiLevel(int apiLevel)
+{
+    _vulkanMinAndroidApiLevel = apiLevel;
 }
 
 void DriverContext::setDriverPriority(DriverType driverType, int prio)
@@ -62,7 +72,15 @@ void DriverContext::makeCurrentDriver()
 #endif
 
 #if AX_ENABLE_VK
+#    if AX_TARGET_PLATFORM == AX_PLATFORM_ANDROID
+    int apiLevel = android_get_device_api_level();
+    if (apiLevel >= _vulkanMinAndroidApiLevel)
+        factories.push_back(std::make_unique<VulkanDriverFactory>(_driverPriorities[(int)DriverType::Vulkan]));
+    else
+        AXLOGI("Vulkan skipped: device API level {} < required {}", apiLevel, _vulkanMinAndroidApiLevel);
+#    else
     factories.push_back(std::make_unique<VulkanDriverFactory>(_driverPriorities[(int)DriverType::Vulkan]));
+#    endif
 #endif
 
 #if AX_ENABLE_D3D11

--- a/axmol/rhi/DriverContext.h
+++ b/axmol/rhi/DriverContext.h
@@ -42,6 +42,31 @@ class AX_DLL DriverContext
 {
 public:
     /**
+     * @brief Sets the minimum Android API level required to enable Vulkan.
+     *
+     * This function allows applications to restrict Vulkan usage based on
+     * the device's Android OS version. If the current device reports Vulkan
+     * support but its API level is lower than the configured minimum, Vulkan
+     * will be skipped during driver selection and the engine will fall back
+     * to the next available backend (e.g. OpenGL ES).
+     *
+     * @note This call is optional. If not invoked, Vulkan will be considered
+     *       on all devices that report support, regardless of OS version.
+     *
+     * @warning To ensure the restriction takes effect, this function should
+     *          be invoked as early as possible (e.g. in the application
+     *          delegate's constructor/initContextAttrs), before any rendering context or
+     *          driver initialization occurs.
+     *
+     * @param apiLevel The minimum Android API level (Default is 31 for Android 12)
+     *                 required to allow Vulkan usage.
+     *                 refers:
+     *                   - https://apilevels.com/
+     *                   - https://developer.android.com/tools/releases/platforms
+     */
+    static void setVulkanMinAndroidApiLevel(int apiLevel);
+
+    /**
      * @brief Sets the priority value for a specific driver type.
      *
      * This function allows advanced users to override the default driver
@@ -55,7 +80,7 @@ public:
      *
      * @warning To ensure the priority takes effect, this function should be
      *          invoked as early as possible, typically in the application
-     *          delegate's constructor, before any rendering context or window
+     *          delegate's constructor/initContextAttrs, before any rendering context or window
      *          is created. Late changes may not apply if the driver has already
      *          been initialized.
      *
@@ -121,6 +146,7 @@ private:
     static DriverType _currentDriverType;
     static int _currentShaderLang;
     static int _currentShaderProfile;
+    static int _vulkanMinAndroidApiLevel;
 };
 
 }  // namespace ax::rhi

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -2,6 +2,7 @@
  Copyright (c) 2013      cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -27,11 +28,10 @@
 #include <string>
 #include "AppDelegate.h"
 
-#include "axmol/axmol.h"
 #include "controller.h"
 #include "BaseTest.h"
 #include "extensions/axmol-ext.h"
-
+#include "axmol/rhi/DriverContext.h"
 #include "axmol/tlx/charconv.hpp"
 #include <system_error>
 
@@ -41,17 +41,17 @@ AppDelegate::AppDelegate() : _testController(nullptr) {}
 
 AppDelegate::~AppDelegate()
 {
-
     AXLOGI("AppDelegate::~AppDelegate");
-    // SimpleAudioEngine::end();
-    // TODO: minggo
-    //  cocostudio::ArmatureDataManager::destroyInstance();
 }
 
 // if you want a different context, modify the value of contextAttrs
 // it will affect all platforms
 void AppDelegate::initContextAttrs()
 {
+    // set vulkan min android api level, 31 for Android 12
+    // refer: https://developer.android.com/tools/releases/platforms
+    rhi::DriverContext::setVulkanMinAndroidApiLevel(31);
+
     // set app context attributes: red,green,blue,alpha,depth,stencil,multisamplesCount
     // powerPreference only affect when RHI backend is D3D11, D3D12, Vulkan
     ContextAttrs contextAttrs = {.debugLayerEnabled = false, .powerPreference = PowerPreference::HighPerformance};

--- a/tests/cpp-tests/Source/AppDelegate.h
+++ b/tests/cpp-tests/Source/AppDelegate.h
@@ -2,6 +2,7 @@
  Copyright (c) 2013      cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 
@@ -27,7 +28,7 @@
 #ifndef _APP_DELEGATE_H_
 #define _APP_DELEGATE_H_
 
-#include "axmol/axmol.h"
+#include "axmol/platform/Application.h"
 
 class TestController;
 /**


### PR DESCRIPTION
- Introduced DriverContext::setVulkanMinAndroidApiLevel(int apiLevel)
- Default minimal requirement set to Android 12 (API Level 31)
- Vulkan will be skipped on devices below this API level, falling back to OpenGL ES
- Helps avoid performance regressions on older Android versions and GPUs

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
