### PR TITLE
[WASM] Fix Downloader storage issue, new options for wasm

### DIFF
--- a/CMakeOptions.md
+++ b/CMakeOptions.md
@@ -52,6 +52,8 @@ default is: `navigator.hardwareConcurrency`
 - AX_WASM_INITIAL_MEMORY: set the wasm initial memory size, default `1024MB`
 - AX_WASM_ISA_SIMD: specify the wasm simd intrinsics type, default `none`, supports `sse`, `neon`, note the `wasm-simd` not support by axmol yet
 - AX_WASM_TIMING_USE_TIMEOUT: force the wasm emscripten loop timing to use `Timeout` with FPS value of `Application::setAnimationInterval` (app still run on focus lost), default is `FALSE` with timing `requestAnimationFrame` (no run on focus lost). See https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_set_main_loop_timing
+- AX_WASM_ASSETS_PRELOAD_FILE: Whether enable to bundle the assets to a .data file and preload them into an IndexedDB cache at first launch (`--preload-file`), otherwise bundle them into the wasm file itself and don't use the IndexedDB at all (`--embed-file`)", default `TRUE`
+- AX_WASM_GENERATE_SYMBOL_FILE: Generate a symbol file for the built wasm file, default `FALSE`
 
 ## The options for axmol apps
 

--- a/cmake/Modules/AXBuildHelpers.cmake
+++ b/cmake/Modules/AXBuildHelpers.cmake
@@ -591,9 +591,16 @@ function(ax_setup_app_config app_name)
       if(WINRT)
         ax_target_embed_compiled_shaders(${app_name} ${rt_output} FILES ${app_all_shaders})
       else()
-        # --preload-file
-        # refer to: https://emscripten.org/docs/porting/files/packaging_files.html
-        target_link_options(${app_name} PRIVATE "--preload-file" ${AXSLCC_OUT_DIR}@axslc/)
+
+        set(_WASM_ASSETS_LINKER_FILE "--embed-file")
+
+        if(AX_WASM_ASSETS_PRELOAD_FILE)
+          # --preload-file
+          # refer to: https://emscripten.org/docs/porting/files/packaging_files.html
+          set(_WASM_ASSETS_LINKER_FILE "--preload-file")
+        endif()
+
+        target_link_options(${app_name} PRIVATE ${_WASM_ASSETS_LINKER_FILE} ${AXSLCC_OUT_DIR}@axslc/)
       endif()
     endif()
   endif()
@@ -610,6 +617,10 @@ if(AX_WASM_ENABLE_DEVTOOLS)
 endif()
 
 set(AX_WASM_EXPORTS "${_AX_WASM_EXPORTS}" CACHE STRING "" FORCE)
+
+option(AX_WASM_ASSETS_PRELOAD_FILE "Assets are preloaded into IndexedDB from .data file" ON)
+
+option(AX_WASM_GENERATE_SYMBOL_FILE "Symbols file for WASM is generated" OFF)
 
 # stupid & pitfall: function not emcc not output .html
 macro(ax_setup_app_props app_name)
@@ -641,12 +652,23 @@ macro(ax_setup_app_props app_name)
     # string(APPEND EMSCRIPTEN_LINK_FLAGS " -s SEPARATE_DWARF_URL=http://127.0.0.1:6931/${app_name}.debug.wasm")
     # string(APPEND EMSCRIPTEN_LINK_FLAGS " -gseparate-dwarf=${CMAKE_BINARY_DIR}/bin/${app_name}/${app_name}.debug.wasm")
     # string(APPEND EMSCRIPTEN_LINK_FLAGS " -gsplit-dwarf")
+
+    if(AX_WASM_GENERATE_SYMBOL_FILE)
+      string(APPEND EMSCRIPTEN_LINK_FLAGS "-g --emit-symbol-map")
+    endif()
+
     if(NOT DEFINED _APP_RES_FOLDER)
       set(_APP_RES_FOLDER "${_APP_SOURCE_DIR}/Content")
     endif()
 
+    set(_WASM_ASSETS_LINKER_FILE "--embed-file")
+
+    if(AX_WASM_ASSETS_PRELOAD_FILE)
+      set(_WASM_ASSETS_LINKER_FILE "--preload-file")
+    endif()
+
     foreach(FOLDER IN LISTS _APP_RES_FOLDER)
-      string(APPEND EMSCRIPTEN_LINK_FLAGS " --preload-file ${FOLDER}/@/")
+      string(APPEND EMSCRIPTEN_LINK_FLAGS " ${_WASM_ASSETS_LINKER_FILE} ${FOLDER}/@/")
     endforeach()
 
     set_target_properties(${app_name} PROPERTIES LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS}")

--- a/core/network/Downloader-wasm.cpp
+++ b/core/network/Downloader-wasm.cpp
@@ -72,7 +72,7 @@ namespace ax { namespace network {
             emscripten_fetch_attr_t attr;
             emscripten_fetch_attr_init(&attr);
             strcpy(attr.requestMethod, "GET");
-            attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY | EMSCRIPTEN_FETCH_PERSIST_FILE;
+            attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
             if(task->storagePath.length() == 0) {
                 attr.onsuccess = DownloaderEmscripten::onDataLoad;
             }else{


### PR DESCRIPTION
## Describe your changes

Fix the wasm storage issue described in #3040 by removing `EMSCRIPTEN_FETCH_PERSIST_FILE` and only use memory.

Add 2 new options for WASM:
`AX_WASM_ASSETS_PRELOAD_FILE`: Whether enable to bundle the assets to a .data file and preload them into an IndexedDB cache at first launch (`--preload-file`), otherwise bundle them into the wasm file itself and don't use the IndexedDB at all (`--embed-file`)", default `TRUE`
`AX_WASM_GENERATE_SYMBOL_FILE`: Generate a symbol file for the built wasm file, default `FALSE`
