### PR TITLE
Fix chipmunk2D debug draw issues, resize designSize, removed DrawInfo

### DIFF
--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNodeChipmunk2D.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNodeChipmunk2D.cpp
@@ -95,7 +95,7 @@ static void DrawShape(cpShape* shape, DrawNode* renderer)
     case CP_SEGMENT_SHAPE:
     {
         cpSegmentShape* seg = (cpSegmentShape*)shape;
-        renderer->drawSegment(cpVert2Point(seg->ta), cpVert2Point(seg->tb), cpfmax(seg->r, 1.0), color);
+        renderer->drawSegment(cpVert2Point(seg->ta), cpVert2Point(seg->tb), cpfmax(seg->r*4, 1.0), color);
     }
     break;
     case CP_POLY_SHAPE:
@@ -109,7 +109,7 @@ static void DrawShape(cpShape* shape, DrawNode* renderer)
             pPoints[i] = cpVert2Point(poly->planes[i].v0);
         if (cpfmax(poly->r, 1.0) > 1.0)
         {
-            renderer->drawPolygon(pPoints, num, Color4F{}, poly->r, color);
+            renderer->drawPolygon(pPoints, num, Color4F{}, poly->r*2, color);
         }
         else
         {

--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
@@ -91,7 +91,7 @@ cpBool ChipmunkDemoRightDown  = cpFalse;
 cpBool ChipmunkDemoLeftDown   = cpFalse;
 double ChipmunkDemoTime;
 
-cpBody* mouse_body        = cpBodyNewKinematic();
+cpBody* mouse_body               = cpBodyNewKinematic();
 static cpConstraint* mouse_joint = nullptr;
 
 char const* ChipmunkDemoMessageString = nullptr;
@@ -102,7 +102,7 @@ cpShapeFilter NOT_GRABBABLE_FILTER = {CP_NO_GROUP, ~GRABBABLE_MASK_BIT, ~GRABBAB
 
 ax::DrawNode* drawCP = nullptr;
 
-void ChipmunkDemoDefaultDrawImpl(cpSpace* space){};
+void ChipmunkDemoDefaultDrawImpl(cpSpace* space) {};
 
 void ChipmunkDebugDrawDot(cpFloat size, cpVect pos, cpSpaceDebugColor fillColor)
 {
@@ -207,8 +207,9 @@ void ChipmunkTestBed::DrawInfo()
         ke += body->m * cpvdot(body->v, body->v) + body->i * body->w * body->w;
     }
 
-    auto msg = fmt::format_to_z(buffer, format, arbiters, max_arbiters, points, max_points, _space->constraints->num, _space->iterations,
-            constraints, max_constraints, ChipmunkDemoTime, (ke < 1e-10f ? 0.0f : ke));
+    auto msg =
+        fmt::format_to_z(buffer, format, arbiters, max_arbiters, points, max_points, _space->constraints->num,
+                         _space->iterations, constraints, max_constraints, ChipmunkDemoTime, (ke < 1e-10f ? 0.0f : ke));
 
     drawInfo->setString(msg);
 }
@@ -308,9 +309,9 @@ ChipmunkTestBed::ChipmunkTestBed()
 {
     // halx99: since axmol init scene default camera at 'initWithXXX' function, only change design size at scene
     // construct is ok see also: https://github.com/axmolengine/axmol/commit/581a7921554c09746616759d5a5ca6ce9d3eaa22
-    auto director = Director::getInstance();
-    auto renderView   = director->getRenderView();
-    Size designSize(g_designSize.width * 0.85, g_designSize.height * 0.85);
+    auto director   = Director::getInstance();
+    auto renderView = director->getRenderView();
+    Size designSize(g_designSize.width * 1.5, g_designSize.height * 1.5);
     renderView->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::SHOW_ALL);
 
     // creating a keyboard event listener
@@ -395,11 +396,11 @@ void ChipmunkTestBed::initPhysics()
 
 void ChipmunkTestBed::update(float delta)
 {
-    //#if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
-    //    cpSpaceStep(_space, delta);
-    //#else
-    //    cpHastySpaceStep(_space, delta);
-    //#endif
+    // #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
+    //     cpSpaceStep(_space, delta);
+    // #else
+    //     cpHastySpaceStep(_space, delta);
+    // #endif
 }
 
 void ChipmunkTestBed::createResetButton()
@@ -484,8 +485,8 @@ bool ChipmunkTestBed::onMouseUp(Event* event)
 
 bool ChipmunkTestBed::onMouseMove(Event* event)
 {
-    EventMouse* e = (EventMouse*)event;
-    auto pt = e->getLocation();
+    EventMouse* e       = (EventMouse*)event;
+    auto pt             = e->getLocation();
     ChipmunkDemoMouse.x = pt.x - physicsDebugNodeOffset.x;
     ChipmunkDemoMouse.y = pt.y - physicsDebugNodeOffset.y;
 

--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.cpp
@@ -174,45 +174,6 @@ static int max_arbiters    = 0;
 static int max_points      = 0;
 static int max_constraints = 0;
 
-void ChipmunkTestBed::DrawInfo()
-{
-    int arbiters = _space->arbiters->num;
-    int points   = 0;
-
-    for (int i = 0; i < arbiters; i++)
-        points += ((cpArbiter*)(_space->arbiters->arr[i]))->count;
-
-    int constraints = (_space->constraints->num + points) * _space->iterations;
-
-    max_arbiters    = arbiters > max_arbiters ? arbiters : max_arbiters;
-    max_points      = points > max_points ? points : max_points;
-    max_constraints = constraints > max_constraints ? constraints : max_constraints;
-
-    char buffer[1024];
-    constexpr auto format =
-        "Arbiters: {} ({}) - "
-        "Contact Points: {} ({})\n"
-        "Other Constraints: {}, Iterations: {}\n"
-        "Constraints x Iterations: {} ({})\n"
-        "Time:{:5.2f}s, KE:{:5.2e}"sv;
-
-    cpArray* bodies = _space->dynamicBodies;
-    cpFloat ke      = 0.0f;
-    for (int i = 0; i < bodies->num; i++)
-    {
-        cpBody* body = (cpBody*)bodies->arr[i];
-        if (body->m == INFINITY || body->i == INFINITY)
-            continue;
-
-        ke += body->m * cpvdot(body->v, body->v) + body->i * body->w * body->w;
-    }
-
-    auto msg =
-        fmt::format_to_z(buffer, format, arbiters, max_arbiters, points, max_points, _space->constraints->num,
-                         _space->iterations, constraints, max_constraints, ChipmunkDemoTime, (ke < 1e-10f ? 0.0f : ke));
-
-    drawInfo->setString(msg);
-}
 
 static char PrintStringBuffer[1024 * 8];
 static char* PrintStringCursor;
@@ -503,7 +464,6 @@ void ChipmunkTestBed::updateInit(ChipmunkDemo tt)
     drawCP->clear();
     updateMouseBody();
     ChipmunkDemoTime += tt.timestep;
-    ChipmunkTestBed::DrawInfo();
     tt.updateFunc(_space, tt.timestep);
 }
 

--- a/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.h
+++ b/tests/cpp-tests/Source/ChipmunkTestBed/ChipmunkTestBed.h
@@ -51,7 +51,6 @@ public:
     bool onMouseDown(ax::Event* event);
     bool onMouseUp(ax::Event* event);
     bool onMouseMove(ax::Event* event);
-    void DrawInfo();
     void updateInit(ChipmunkDemo tt);
 
     cpSpace* _space;                                              // strong ref


### PR DESCRIPTION
## Describe your changes

- see diff
- Improve the Chipmunk2D-Testbed test

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
