### PR TITLE
Removed hardcoded thickness clamp in DrawNode

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -66,5 +66,6 @@ Due to Axmol Engine is a fork of Cocos2d-x-4.0, so the [Cocos2d-x AUTHORS](https
     tkzcfc
     theunwisewolf (TheUnwiseWolf)
     Tosik86
+    w1257
     weiwest
     Yehsam23

--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -1064,9 +1064,6 @@ void DrawNode::_drawSegment(const Vec2& from,
                             DrawNode::EndType etStart,
                             DrawNode::EndType etEnd)
 {
-    if (thickness < 1.0f)
-        thickness = 1.0f;
-
     if (thickness == 1.0f && !properties.drawOrder)
     {
         _drawLine(from, to, color);  // fastest way to draw a line

--- a/axmol/2d/DrawNode.h
+++ b/axmol/2d/DrawNode.h
@@ -127,10 +127,12 @@ public:
                     DrawNode::PointType pointType = DrawNode::PointType::Rect);
 
     /** Draw an line from origin to destination with color.
+     * If thickness is 1.0f and drawOrder is false, always quickly draws 1px wide lines regardless of scale.
      *
      * @param origin The line origin.
      * @param destination The line destination.
      * @param color The line color.
+     * @param thickness The width of the line.
      */
     void drawLine(const Vec2& origin,
                   const Vec2& destination,


### PR DESCRIPTION
## Describe your changes
- Removed the thickness clamp in DrawNode::_drawSegment to allow greater control. Useful when DrawNode scale>1.0f and line 1px<thickness<1.0f.
- Updated drawLine to clarify thickness behavior and relation to the drawOrder.
- Added myself to the AUTHORS.md .
- Tested on Windows 11 with DrawNode::DrawLine.

## Issue ticket number and link

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [x] Check the '#include "axmol.h"' and replace it with the needed headers.
