### PR TITLE
Fix assertion failure when converting empty subrange to std::string_view

### DIFF
--- a/axmol/tlx/utility.hpp
+++ b/axmol/tlx/utility.hpp
@@ -106,9 +106,8 @@ inline void resize_and_overrite(_SeqCont& cont, size_t size, _Operation op)
 template <typename _Subrgn>
 inline std::string_view to_string_view(_Subrgn&& subrgn)
 {
-    return std::string_view{&*subrgn.begin(), static_cast<size_t>(std::ranges::distance(subrgn))};
+    return std::string_view{std::ranges::data(subrgn), static_cast<size_t>(std::ranges::size(subrgn))};
 }
-
 
 /**
  * @brief Safely copy a string into a fixed-size C-style buffer.


### PR DESCRIPTION
## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
