### PR TITLE
Add D3D11 10.1 compatibility and optimize swapchain creation

### DIFF
--- a/axmol/rhi/d3d11/Driver11.cpp
+++ b/axmol/rhi/d3d11/Driver11.cpp
@@ -35,7 +35,6 @@
 #include "axmol/base/Logging.h"
 #include "axmol/platform/Application.h"
 #include "ntcvt/ntcvt.hpp"
-#include <dxgi1_2.h>
 
 #pragma comment(lib, "D3D11.lib")
 #pragma comment(lib, "DXGI.lib")
@@ -101,11 +100,7 @@ bool DriverImpl::init()
         ComPtr<IDXGIDevice> dxgiDevice;
         _AXASSERT_HR(
             hr = _device->QueryInterface(__uuidof(IDXGIDevice), reinterpret_cast<void**>(dxgiDevice.GetAddressOf())));
-
         _AXASSERT_HR(hr = dxgiDevice->GetAdapter(&_dxgiAdapter));
-
-        _AXASSERT_HR(
-            hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.ReleaseAndGetAddressOf()));
     }
 
     LARGE_INTEGER version;
@@ -142,6 +137,7 @@ DriverImpl::~DriverImpl()
     SafeRelease(_device);
 
     _dxgiAdapter.Reset();
+    _dxgiFactory2.Reset();
     _dxgiFactory.Reset();
 
     if (debug)
@@ -153,17 +149,15 @@ void DriverImpl::initializeDevice()
     constexpr UINT releaseFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
     constexpr UINT debugFlags   = releaseFlags | D3D11_CREATE_DEVICE_DEBUG;
 
-    HRESULT hr              = E_FAIL;
     const bool isDebugLayer = Application::getContextAttrs().debugLayerEnabled;
 
-    ComPtr<IDXGIFactory2> factory2;
-    hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&factory2));
+    HRESULT hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&_dxgiFactory2));
 
     constexpr D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
                                                             D3D_FEATURE_LEVEL_10_1};
     std::span<const D3D_FEATURE_LEVEL> featureLevels(DEFAULT_FEATURE_LEVELS);
 
-    if (!factory2)
+    if (!_dxgiFactory2)
     {
         // On Windows 7 RTM or Windows 7 SP1 without the Platform Update (KB2670838),
         // D3D_FEATURE_LEVEL_11_1 is not supported. Passing 11_1 to D3D11CreateDevice
@@ -378,15 +372,19 @@ IUnknown* DriverImpl::compileShader(std::span<uint8_t> shaderCode, ShaderStage s
     IUnknown* shader{nullptr};
     if (stage == ShaderStage::VERTEX)
     {
-        ID3D11VertexShader* vs = nullptr;
-        hr     = _device->CreateVertexShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr, &vs);
-        shader = vs;
+        ComPtr<ID3D11VertexShader> vs;
+        hr = _device->CreateVertexShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr,
+                                         vs.GetAddressOf());
+        if (SUCCEEDED(hr))
+            shader = vs.Detach();
     }
     else
     {
-        ID3D11PixelShader* ps = nullptr;
-        hr     = _device->CreatePixelShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr, &ps);
-        shader = ps;
+        ComPtr<ID3D11PixelShader> ps;
+        hr = _device->CreatePixelShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr,
+                                        ps.GetAddressOf());
+        if (SUCCEEDED(hr))
+            shader = ps.Detach();
     }
 
     if (!shader)

--- a/axmol/rhi/d3d11/Driver11.cpp
+++ b/axmol/rhi/d3d11/Driver11.cpp
@@ -35,6 +35,7 @@
 #include "axmol/base/Logging.h"
 #include "axmol/platform/Application.h"
 #include "ntcvt/ntcvt.hpp"
+#include <dxgi1_2.h>
 
 #pragma comment(lib, "D3D11.lib")
 #pragma comment(lib, "DXGI.lib")
@@ -86,6 +87,8 @@ static uint32_t FindMaxMsaaSamples(ID3D11Device* device, DXGI_FORMAT format)
     return best;
 }
 }  // namespace
+
+static D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0};
 
 DriverImpl::DriverImpl() {}
 
@@ -155,6 +158,19 @@ void DriverImpl::initializeDevice()
     HRESULT hr              = E_FAIL;
     const bool isDebugLayer = Application::getContextAttrs().debugLayerEnabled;
 
+    ComPtr<IDXGIFactory2> factory2;
+    hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&factory2));
+    if (!factory2)
+    {
+        // On Windows 7 RTM or Windows 7 SP1 without the Platform Update (KB2670838),
+        // D3D_FEATURE_LEVEL_11_1 is not supported. Passing 11_1 to D3D11CreateDevice
+        // will result in E_INVALIDARG. To maintain compatibility, we must fall back
+        // to 11_0 as the highest feature level and include 10_1 in the list to ensure
+        // device creation succeeds on these systems.
+        DEFAULT_FEATURE_LEVELS[0] = D3D_FEATURE_LEVEL_11_0;
+        DEFAULT_FEATURE_LEVELS[1] = D3D_FEATURE_LEVEL_10_1;
+    }
+
     if (isDebugLayer) [[unlikely]]
     {
         hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, debugFlags);
@@ -185,7 +201,9 @@ L_ReleaseRuntime:
         hr = createD3DDevice(D3D_DRIVER_TYPE_WARP, releaseFlags);
     }
 
-    if (FAILED(hr)) [[unlikely]]
+    if (SUCCEEDED(hr))
+        AXLOGI("D3D11 Feature level: 0x{:04x}", static_cast<int>(_featureLevel));
+    else
         dxutils::fatalError("initializeDevice"sv, hr);
 }
 
@@ -259,8 +277,8 @@ HRESULT DriverImpl::createD3DDevice(int requestDriverType, int createFlags)
                                (D3D_DRIVER_TYPE)requestDriverType,  // Driver Type
                                nullptr,                             // Software
                                createFlags,                         // Flags
-                               DEFAULT_REATURE_LEVELS,              // Feature Levels
-                               ARRAYSIZE(DEFAULT_REATURE_LEVELS),   // Num Feature Levels
+                               DEFAULT_FEATURE_LEVELS,              // Feature Levels
+                               ARRAYSIZE(DEFAULT_FEATURE_LEVELS),   // Num Feature Levels
                                D3D11_SDK_VERSION,                   // SDK Version
                                &_device,                            // Device
                                &_featureLevel,                      // Feature Level
@@ -320,7 +338,54 @@ Program* DriverImpl::createProgram(Data vsData, Data fsData)
 
 ShaderModule* DriverImpl::createShaderModule(ShaderStage stage, Data& chunk)
 {
-    return new ShaderModuleImpl(_device, stage, chunk);
+    return new ShaderModuleImpl(this, stage, chunk);
+}
+
+IUnknown* DriverImpl::compileShader(std::span<uint8_t> shaderCode, ShaderStage stage, ID3DBlob*& outBlob)
+{
+    ComPtr<ID3DBlob> errorBlob;
+    UINT flags = D3DCOMPILE_OPTIMIZATION_LEVEL2 | D3DCOMPILE_ENABLE_STRICTNESS;
+#if !defined(NDEBUG)
+    flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+#endif
+
+    const char* stageProfile{nullptr};
+    if (_featureLevel >= D3D_FEATURE_LEVEL_11_0)
+    {
+        stageProfile = (stage == ShaderStage::VERTEX) ? "vs_5_0" : "ps_5_0";
+    }
+    else
+    {
+        stageProfile = (stage == ShaderStage::VERTEX) ? "vs_4_1" : "ps_4_1";
+    }
+
+    HRESULT hr = D3DCompile(shaderCode.data(), shaderCode.size(), nullptr, nullptr, nullptr, "main", stageProfile,
+                            flags, 0, &outBlob, &errorBlob);
+    if (FAILED(hr))
+    {
+        std::string_view errorDetail =
+            errorBlob ? std::string_view((const char*)errorBlob->GetBufferPointer(), errorBlob->GetBufferSize())
+                      : "Unknown compile error"sv;
+        AXLOGE("axmol:ERROR: Failed to compile shader, hr:{},{}", hr, errorDetail);
+        AXASSERT(false, "Shader compile failed!");
+        return nullptr;
+    }
+
+    IUnknown* shader{nullptr};
+    if (stage == ShaderStage::VERTEX)
+        hr = _device->CreateVertexShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr,
+                                         (ID3D11VertexShader**)&shader);
+    else
+        hr = _device->CreatePixelShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr,
+                                        (ID3D11PixelShader**)&shader);
+
+    if (!shader)
+    {
+        AXLOGE("axmol:ERROR: Failed to create shader, hr:{}", hr);
+        AXASSERT(false, "Shader compile failed!");
+    }
+
+    return shader;
 }
 
 SamplerHandle DriverImpl::createSampler(const SamplerDesc& desc)
@@ -410,7 +475,8 @@ std::string DriverImpl::getVendor() const
 std::string DriverImpl::getRenderer() const
 {
     auto desc = ntcvt::from_chars(_adapterDesc.Description);
-    return fmt::format("{} D3D11 vs_5_0 ps_5_0", desc);
+    return _featureLevel >= D3D_FEATURE_LEVEL_11_0 ? fmt::format("{} D3D11 vs_5_0 ps_5_0", desc)
+                                                   : fmt::format("{} D3D11 vs_4_1 ps_4_1", desc);
 }
 
 /**
@@ -435,7 +501,7 @@ std::string DriverImpl::getVersion() const
 
 std::string DriverImpl::getShaderVersion() const
 {
-    return "D3D11 HLSL vs_5_0 ps_5_0"s;
+    return _featureLevel >= D3D_FEATURE_LEVEL_11_0 ? "D3D11 HLSL vs_5_0 ps_5_0"s : "D3D10 HLSL vs_4_1 ps_4_1"s;
 }
 
 /**

--- a/axmol/rhi/d3d11/Driver11.cpp
+++ b/axmol/rhi/d3d11/Driver11.cpp
@@ -98,10 +98,89 @@ bool DriverImpl::init()
 
     if (powerPreferrence != PowerPreference::Auto)
         selectAdapter(powerPreferrence);
-    initializeDevice();
+    initializeDevice(contextAttrs.debugLayerEnabled);
 
-    HRESULT hr{E_FAIL};
-    if (!_dxgiAdapter)
+    return true;
+}
+
+DriverImpl::~DriverImpl()
+{
+    SafeRelease(_context);
+
+    ComPtr<ID3D11Debug> debug;
+    _device->QueryInterface(IID_PPV_ARGS(&debug));
+
+    SafeRelease(_device);
+
+    _dxgiAdapter.Reset();
+    _dxgiFactory2.Reset();
+    _dxgiFactory.Reset();
+
+    if (debug)
+        debug->ReportLiveDeviceObjects(D3D11_RLDO_DETAIL);
+}
+
+void DriverImpl::initializeDevice(bool requestDebugLayer)
+{
+    constexpr UINT releaseFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+    constexpr UINT debugFlags   = releaseFlags | D3D11_CREATE_DEVICE_DEBUG;
+
+    constexpr D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
+                                                            D3D_FEATURE_LEVEL_10_1};
+    std::span<const D3D_FEATURE_LEVEL> featureLevels(DEFAULT_FEATURE_LEVELS);
+
+    // It's ok to check whether DXGI 1.2 is supported at here
+    HRESULT hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&_dxgiFactory2));
+    if (!_dxgiFactory2)
+    {
+        // On Windows 7 RTM or Windows 7 SP1 without the Platform Update (KB2670838),
+        // D3D_FEATURE_LEVEL_11_1 is not supported. Passing 11_1 to D3D11CreateDevice
+        // will result in E_INVALIDARG. To maintain compatibility, we must fall back
+        // to 11_0 as the highest feature level and include 10_1 in the list to ensure
+        // device creation succeeds on these systems.
+        featureLevels = featureLevels.subspan(1);  // Skip D3D_FEATURE_LEVEL_11_1
+    }
+
+    if (requestDebugLayer) [[unlikely]]
+    {
+        hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, debugFlags, featureLevels);
+        if (SUCCEEDED(hr))
+            goto L_DeviceCreated;
+
+        if (hr != DXGI_ERROR_UNSUPPORTED)
+        {
+            AXLOGI("Failed creating Debug D3D11 device - falling back to release runtime.");
+            goto L_ReleaseRuntime;
+        }
+        else
+        {
+            goto L_WarpRuntime;
+        }
+    }
+
+L_ReleaseRuntime:
+    hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, releaseFlags, featureLevels);
+    if (hr == DXGI_ERROR_UNSUPPORTED) [[unlikely]]
+    {
+    L_WarpRuntime:
+        AXLOGI("Failed creating hardware D3D11 device - falling back to software runtime.");
+        // Reset adapter to null before using D3D_DRIVER_TYPE_WARP,
+        // otherwise D3D11CreateDevice will return E_INVALIDARG when both
+        // a non-null adapter and a non-matching driver type are specified.
+        _dxgiAdapter.Reset();
+        hr = createD3DDevice(D3D_DRIVER_TYPE_WARP, releaseFlags, featureLevels);
+    }
+
+    if (FAILED(hr))
+    {
+        dxutils::fatalError("initializeDevice"sv, hr);
+        return;
+    }
+
+L_DeviceCreated:
+    AXLOGI("D3D11 Feature level: 0x{:04x}", static_cast<int>(_featureLevel));
+
+    if (!_dxgiAdapter)  // adapter not selected or was reset to null, query from device
     {
         ComPtr<IDXGIDevice> dxgiDevice;
         _AXASSERT_HR(
@@ -132,91 +211,11 @@ bool DriverImpl::init()
     }
     _dxgiAdapter->GetDesc(&_adapterDesc);
 
-    _caps.maxAttributes = D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT;  // 16
-
-    _caps.maxTextureUnits = D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT;  // 128
-
-    _caps.maxTextureSize = EstimateMaxTexSize(_device->GetFeatureLevel());
-
+    // Device caps
+    _caps.maxAttributes     = D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT;     // 16
+    _caps.maxTextureUnits   = D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT;  // 128
+    _caps.maxTextureSize    = EstimateMaxTexSize(_device->GetFeatureLevel());
     _caps.maxSamplesAllowed = static_cast<int32_t>(FindMaxMsaaSamples(_device, DXGI_FORMAT_R8G8B8A8_UNORM));
-
-    return true;
-}
-
-DriverImpl::~DriverImpl()
-{
-    SafeRelease(_context);
-
-    ComPtr<ID3D11Debug> debug;
-    _device->QueryInterface(IID_PPV_ARGS(&debug));
-
-    SafeRelease(_device);
-
-    _dxgiAdapter.Reset();
-    _dxgiFactory2.Reset();
-    _dxgiFactory.Reset();
-
-    if (debug)
-        debug->ReportLiveDeviceObjects(D3D11_RLDO_DETAIL);
-}
-
-void DriverImpl::initializeDevice()
-{
-    constexpr UINT releaseFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    constexpr UINT debugFlags   = releaseFlags | D3D11_CREATE_DEVICE_DEBUG;
-
-    const bool isDebugLayer = Application::getContextAttrs().debugLayerEnabled;
-
-    constexpr D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
-                                                            D3D_FEATURE_LEVEL_10_1};
-    std::span<const D3D_FEATURE_LEVEL> featureLevels(DEFAULT_FEATURE_LEVELS);
-
-    // It's ok to check whether DXGI 1.2 is supported at here
-    HRESULT hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&_dxgiFactory2));
-    if (!_dxgiFactory2)
-    {
-        // On Windows 7 RTM or Windows 7 SP1 without the Platform Update (KB2670838),
-        // D3D_FEATURE_LEVEL_11_1 is not supported. Passing 11_1 to D3D11CreateDevice
-        // will result in E_INVALIDARG. To maintain compatibility, we must fall back
-        // to 11_0 as the highest feature level and include 10_1 in the list to ensure
-        // device creation succeeds on these systems.
-        featureLevels = featureLevels.subspan(1);  // Skip D3D_FEATURE_LEVEL_11_1
-    }
-
-    if (isDebugLayer) [[unlikely]]
-    {
-        hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, debugFlags, featureLevels);
-        if (SUCCEEDED(hr))
-            return;
-
-        if (hr != DXGI_ERROR_UNSUPPORTED)
-        {
-            AXLOGI("Failed creating Debug D3D11 device - falling back to release runtime.");
-            goto L_ReleaseRuntime;
-        }
-        else
-        {
-            goto L_WarpRuntime;
-        }
-    }
-
-L_ReleaseRuntime:
-    hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, releaseFlags, featureLevels);
-    if (hr == DXGI_ERROR_UNSUPPORTED) [[unlikely]]
-    {
-    L_WarpRuntime:
-        AXLOGI("Failed creating hardware D3D11 device - falling back to software runtime.");
-        // Reset adapter to null before using D3D_DRIVER_TYPE_WARP,
-        // otherwise D3D11CreateDevice will return E_INVALIDARG when both
-        // a non-null adapter and a non-matching driver type are specified.
-        _dxgiAdapter.Reset();
-        hr = createD3DDevice(D3D_DRIVER_TYPE_WARP, releaseFlags, featureLevels);
-    }
-
-    if (SUCCEEDED(hr))
-        AXLOGI("D3D11 Feature level: 0x{:04x}", static_cast<int>(_featureLevel));
-    else
-        dxutils::fatalError("initializeDevice"sv, hr);
 }
 
 void DriverImpl::selectAdapter(PowerPreference powerPreference)

--- a/axmol/rhi/d3d11/Driver11.cpp
+++ b/axmol/rhi/d3d11/Driver11.cpp
@@ -88,8 +88,6 @@ static uint32_t FindMaxMsaaSamples(ID3D11Device* device, DXGI_FORMAT format)
 }
 }  // namespace
 
-static D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0};
-
 DriverImpl::DriverImpl() {}
 
 bool DriverImpl::init()
@@ -160,6 +158,11 @@ void DriverImpl::initializeDevice()
 
     ComPtr<IDXGIFactory2> factory2;
     hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&factory2));
+
+    constexpr D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
+                                                            D3D_FEATURE_LEVEL_10_1};
+    std::span<const D3D_FEATURE_LEVEL> featureLevels(DEFAULT_FEATURE_LEVELS);
+
     if (!factory2)
     {
         // On Windows 7 RTM or Windows 7 SP1 without the Platform Update (KB2670838),
@@ -167,13 +170,12 @@ void DriverImpl::initializeDevice()
         // will result in E_INVALIDARG. To maintain compatibility, we must fall back
         // to 11_0 as the highest feature level and include 10_1 in the list to ensure
         // device creation succeeds on these systems.
-        DEFAULT_FEATURE_LEVELS[0] = D3D_FEATURE_LEVEL_11_0;
-        DEFAULT_FEATURE_LEVELS[1] = D3D_FEATURE_LEVEL_10_1;
+        featureLevels = featureLevels.subspan(1);  // Skip D3D_FEATURE_LEVEL_11_1
     }
 
     if (isDebugLayer) [[unlikely]]
     {
-        hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, debugFlags);
+        hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, debugFlags, featureLevels);
         if (SUCCEEDED(hr))
             return;
 
@@ -189,7 +191,7 @@ void DriverImpl::initializeDevice()
     }
 
 L_ReleaseRuntime:
-    hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, releaseFlags);
+    hr = createD3DDevice(D3D_DRIVER_TYPE_HARDWARE, releaseFlags, featureLevels);
     if (hr == DXGI_ERROR_UNSUPPORTED) [[unlikely]]
     {
     L_WarpRuntime:
@@ -198,7 +200,7 @@ L_ReleaseRuntime:
         // otherwise D3D11CreateDevice will return E_INVALIDARG when both
         // a non-null adapter and a non-matching driver type are specified.
         _dxgiAdapter.Reset();
-        hr = createD3DDevice(D3D_DRIVER_TYPE_WARP, releaseFlags);
+        hr = createD3DDevice(D3D_DRIVER_TYPE_WARP, releaseFlags, featureLevels);
     }
 
     if (SUCCEEDED(hr))
@@ -269,19 +271,21 @@ void DriverImpl::initializeAdapter()
     _dxgiAdapter = std::move(bestAdapter);
 }
 
-HRESULT DriverImpl::createD3DDevice(int requestDriverType, int createFlags)
+HRESULT DriverImpl::createD3DDevice(int requestDriverType,
+                                    int createFlags,
+                                    std::span<const D3D_FEATURE_LEVEL> featureLevels)
 {
     if (_dxgiAdapter)
         requestDriverType = D3D_DRIVER_TYPE_UNKNOWN;
-    return ::D3D11CreateDevice(_dxgiAdapter.Get(),                  // Adapter
-                               (D3D_DRIVER_TYPE)requestDriverType,  // Driver Type
-                               nullptr,                             // Software
-                               createFlags,                         // Flags
-                               DEFAULT_FEATURE_LEVELS,              // Feature Levels
-                               ARRAYSIZE(DEFAULT_FEATURE_LEVELS),   // Num Feature Levels
-                               D3D11_SDK_VERSION,                   // SDK Version
-                               &_device,                            // Device
-                               &_featureLevel,                      // Feature Level
+    return ::D3D11CreateDevice(_dxgiAdapter.Get(),                       // Adapter
+                               (D3D_DRIVER_TYPE)requestDriverType,       // Driver Type
+                               nullptr,                                  // Software
+                               createFlags,                              // Flags
+                               featureLevels.data(),                     // Feature Levels
+                               static_cast<UINT>(featureLevels.size()),  // Num Feature Levels
+                               D3D11_SDK_VERSION,                        // SDK Version
+                               &_device,                                 // Device
+                               &_featureLevel,                           // Feature Level
                                &_context);
 }
 
@@ -373,11 +377,17 @@ IUnknown* DriverImpl::compileShader(std::span<uint8_t> shaderCode, ShaderStage s
 
     IUnknown* shader{nullptr};
     if (stage == ShaderStage::VERTEX)
-        hr = _device->CreateVertexShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr,
-                                         (ID3D11VertexShader**)&shader);
+    {
+        ID3D11VertexShader* vs = nullptr;
+        hr     = _device->CreateVertexShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr, &vs);
+        shader = vs;
+    }
     else
-        hr = _device->CreatePixelShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr,
-                                        (ID3D11PixelShader**)&shader);
+    {
+        ID3D11PixelShader* ps = nullptr;
+        hr     = _device->CreatePixelShader(outBlob->GetBufferPointer(), outBlob->GetBufferSize(), nullptr, &ps);
+        shader = ps;
+    }
 
     if (!shader)
     {

--- a/axmol/rhi/d3d11/Driver11.cpp
+++ b/axmol/rhi/d3d11/Driver11.cpp
@@ -91,7 +91,13 @@ DriverImpl::DriverImpl() {}
 
 bool DriverImpl::init()
 {
-    initializeAdapter();
+    _AXASSERT_HR(CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&_dxgiFactory));
+
+    auto& contextAttrs          = Application::getContextAttrs();
+    const auto powerPreferrence = contextAttrs.powerPreference;
+
+    if (powerPreferrence != PowerPreference::Auto)
+        selectAdapter(powerPreferrence);
     initializeDevice();
 
     HRESULT hr{E_FAIL};
@@ -213,17 +219,8 @@ L_ReleaseRuntime:
         dxutils::fatalError("initializeDevice"sv, hr);
 }
 
-void DriverImpl::initializeAdapter()
+void DriverImpl::selectAdapter(PowerPreference powerPreference)
 {
-    auto& contextAttrs          = Application::getContextAttrs();
-    const auto powerPreferrence = contextAttrs.powerPreference;
-
-    if (powerPreferrence == PowerPreference::Auto)
-        return;
-
-    if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&_dxgiFactory)))
-        return;
-
     ComPtr<IDXGIAdapter> bestAdapter;
     int bestScore = std::numeric_limits<int>::min();
 
@@ -251,15 +248,15 @@ void DriverImpl::initializeAdapter()
             score += 500;  // Lower base score for integrated GPU
 
         // 2. Adjust score based on PowerPreference
-        if (powerPreferrence == PowerPreference::HighPerformance && isDiscrete)
+        if (powerPreference == PowerPreference::HighPerformance && isDiscrete)
             score += 500;
-        else if (powerPreferrence == PowerPreference::LowPower && !isDiscrete)
+        else if (powerPreference == PowerPreference::LowPower && !isDiscrete)
             score += 500;
 
         // 3. Adjust score based on VRAM size
-        if (powerPreferrence == PowerPreference::HighPerformance)
+        if (powerPreference == PowerPreference::HighPerformance)
             score += static_cast<int>(desc.DedicatedVideoMemory / (1024 * 1024));  // More VRAM = higher score
-        else if (powerPreferrence == PowerPreference::LowPower)
+        else if (powerPreference == PowerPreference::LowPower)
             score -= static_cast<int>(desc.DedicatedVideoMemory / (1024 * 1024));  // Less VRAM = higher score
 
         // Keep the adapter with the highest score

--- a/axmol/rhi/d3d11/Driver11.cpp
+++ b/axmol/rhi/d3d11/Driver11.cpp
@@ -101,6 +101,16 @@ bool DriverImpl::init()
         _AXASSERT_HR(
             hr = _device->QueryInterface(__uuidof(IDXGIDevice), reinterpret_cast<void**>(dxgiDevice.GetAddressOf())));
         _AXASSERT_HR(hr = dxgiDevice->GetAdapter(&_dxgiAdapter));
+
+        // Refresh factory pointer from adapter to ensure consistency.
+        // Using the factory obtained via GetParent guarantees it matches the adapter
+        // bound to the device. Without this, creating a swapchain may fail with
+        // DXGI_ERROR_INVALID_CALL(0x887A0001) if the factory and adapter come from different DXGI instances.
+        _AXASSERT_HR(
+            hr = _dxgiAdapter->GetParent(__uuidof(IDXGIFactory1), (void**)_dxgiFactory.ReleaseAndGetAddressOf()));
+
+        // Optionally query for DXGI 1.2+ factory (IDXGIFactory2) to enable modern features
+        _dxgiFactory->QueryInterface(IID_PPV_ARGS(_dxgiFactory2.ReleaseAndGetAddressOf()));
     }
 
     LARGE_INTEGER version;
@@ -151,12 +161,12 @@ void DriverImpl::initializeDevice()
 
     const bool isDebugLayer = Application::getContextAttrs().debugLayerEnabled;
 
-    HRESULT hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&_dxgiFactory2));
-
     constexpr D3D_FEATURE_LEVEL DEFAULT_FEATURE_LEVELS[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
                                                             D3D_FEATURE_LEVEL_10_1};
     std::span<const D3D_FEATURE_LEVEL> featureLevels(DEFAULT_FEATURE_LEVELS);
 
+    // It's ok to check whether DXGI 1.2 is supported at here
+    HRESULT hr = _dxgiFactory->QueryInterface(IID_PPV_ARGS(&_dxgiFactory2));
     if (!_dxgiFactory2)
     {
         // On Windows 7 RTM or Windows 7 SP1 without the Platform Update (KB2670838),

--- a/axmol/rhi/d3d11/Driver11.h
+++ b/axmol/rhi/d3d11/Driver11.h
@@ -27,6 +27,7 @@
 #include "axmol/rhi/DXUtils.h"
 #include "axmol/rhi/DriverFactory.h"
 #include <d3d11.h>
+#include <dxgi1_2.h>
 #include <optional>
 
 namespace ax::rhi::d3d11
@@ -136,6 +137,7 @@ public:
     inline ID3D11DeviceContext* getContext() const { return _context; }
 
     const ComPtr<IDXGIFactory>& getDXGIFactory() const { return _dxgiFactory; }
+    const ComPtr<IDXGIFactory2>& getDXGIFactory2() const { return _dxgiFactory2; }
     const ComPtr<IDXGIAdapter>& getDXGIAdapter() const { return _dxgiAdapter; }
 
     IUnknown* compileShader(std::span<uint8_t> shaderCode, ShaderStage stage, ID3DBlob*& outBlob);
@@ -162,6 +164,8 @@ private:
     ID3D11DeviceContext* _context = nullptr;
 
     ComPtr<IDXGIFactory> _dxgiFactory;
+    ComPtr<IDXGIFactory2> _dxgiFactory2;  // DXGI 1.2 factory, used for creating swapchain on Windows 8 and above, may
+                                          // be null on Windows 7
     ComPtr<IDXGIAdapter> _dxgiAdapter;
 
     DXGI_ADAPTER_DESC _adapterDesc{};

--- a/axmol/rhi/d3d11/Driver11.h
+++ b/axmol/rhi/d3d11/Driver11.h
@@ -44,11 +44,6 @@ namespace ax::rhi::d3d11
 class DriverImpl : public DriverBase
 {
 public:
-    static constexpr D3D_FEATURE_LEVEL DEFAULT_REATURE_LEVELS[2] = {
-        D3D_FEATURE_LEVEL_11_1,
-        D3D_FEATURE_LEVEL_11_0,
-    };
-
     /// @name Constructor, Destructor and Initializers
     DriverImpl();
     ~DriverImpl();
@@ -142,6 +137,8 @@ public:
 
     const ComPtr<IDXGIFactory>& getDXGIFactory() const { return _dxgiFactory; }
     const ComPtr<IDXGIAdapter>& getDXGIAdapter() const { return _dxgiAdapter; }
+
+    IUnknown* compileShader(std::span<uint8_t> shaderCode, ShaderStage stage, ID3DBlob*& outBlob);
 
 protected:
     /**

--- a/axmol/rhi/d3d11/Driver11.h
+++ b/axmol/rhi/d3d11/Driver11.h
@@ -154,7 +154,7 @@ protected:
     void destroySampler(SamplerHandle& h) override;
 
 private:
-    void initializeAdapter();
+    void selectAdapter(PowerPreference powerPreference);
     void initializeDevice();
     HRESULT createD3DDevice(int requestDriverType, int createFlags, std::span<const D3D_FEATURE_LEVEL> featureLevels);
 

--- a/axmol/rhi/d3d11/Driver11.h
+++ b/axmol/rhi/d3d11/Driver11.h
@@ -155,7 +155,7 @@ protected:
 
 private:
     void selectAdapter(PowerPreference powerPreference);
-    void initializeDevice();
+    void initializeDevice(bool requestDebugLayer);
     HRESULT createD3DDevice(int requestDriverType, int createFlags, std::span<const D3D_FEATURE_LEVEL> featureLevels);
 
     bool checkFormatSupport(DXGI_FORMAT format);

--- a/axmol/rhi/d3d11/Driver11.h
+++ b/axmol/rhi/d3d11/Driver11.h
@@ -154,7 +154,7 @@ protected:
 private:
     void initializeAdapter();
     void initializeDevice();
-    HRESULT createD3DDevice(int requestDriverType, int createFlags);
+    HRESULT createD3DDevice(int requestDriverType, int createFlags, std::span<const D3D_FEATURE_LEVEL> featureLevels);
 
     bool checkFormatSupport(DXGI_FORMAT format);
 
@@ -165,7 +165,6 @@ private:
     ComPtr<IDXGIAdapter> _dxgiAdapter;
 
     DXGI_ADAPTER_DESC _adapterDesc{};
-
     D3D_FEATURE_LEVEL _featureLevel{};
 
     // FeatureSet _featureSet = FeatureSet::Unknown;

--- a/axmol/rhi/d3d11/RenderContext11.cpp
+++ b/axmol/rhi/d3d11/RenderContext11.cpp
@@ -206,8 +206,9 @@ RenderContextImpl::RenderContextImpl(DriverImpl* driver, SurfaceHandle surface)
     auto context         = driver->getContext();
     ID3D11Device* device = driver->getDevice();
 
-    auto& factory = driver->getDXGIFactory();
-    auto& adapter = driver->getDXGIAdapter();
+    auto& factory  = driver->getDXGIFactory();
+    auto& factory2 = driver->getDXGIFactory2();
+    auto& adapter  = driver->getDXGIAdapter();
 
     ComPtr<IDXGISwapChain> swapChain;
     HRESULT hr = 0;
@@ -222,8 +223,6 @@ RenderContextImpl::RenderContextImpl(DriverImpl* driver, SurfaceHandle surface)
     // Try create swapchain, we prefer DXGI 1.2 but support fallback to DXGI 1.1 for win32 apps
     do
     {
-        ComPtr<IDXGIFactory2> factory2;
-        hr = factory->QueryInterface(IID_PPV_ARGS(&factory2));
         AX_BREAK_IF(!factory2);
 
         // Check allow tearing feature support and set swapchain flags

--- a/axmol/rhi/d3d11/RenderContext11.cpp
+++ b/axmol/rhi/d3d11/RenderContext11.cpp
@@ -85,9 +85,9 @@ static DXGI_FORMAT toDXGIFormat(IndexFormat format)
 typedef LONG(WINAPI* PFN_RtlVerifyVersionInfo)(OSVERSIONINFOEXW*, ULONG, ULONGLONG);
 
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
-static BOOL _axmolIsWindows10BuildOrGreaterWin32(WORD build)
+static BOOL _axmolIsWindowsVersionOrGreaterWin32(WORD major, WORD minor, WORD build)
 {
-    OSVERSIONINFOEXW osvi = {sizeof(osvi), 10, 0, build};
+    OSVERSIONINFOEXW osvi = {sizeof(osvi), major, minor, build};
     DWORD mask            = VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER;
     ULONGLONG cond        = VerSetConditionMask(0, VER_MAJORVERSION, VER_GREATER_EQUAL);
     cond                  = VerSetConditionMask(cond, VER_MINORVERSION, VER_GREATER_EQUAL);
@@ -100,6 +100,9 @@ static BOOL _axmolIsWindows10BuildOrGreaterWin32(WORD build)
         (PFN_RtlVerifyVersionInfo)GetProcAddress(GetModuleHandleW(L"ntdll"), "RtlVerifyVersionInfo");
     return RtlVerifyVersionInfo(&osvi, mask, cond) == 0;
 }
+
+#    define axmolIsWindows10OrGreater() \
+        _axmolIsWindowsVersionOrGreaterWin32(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 0)
 #elif AX_TARGET_PLATFORM == AX_PLATFORM_WINRT
 
 using ICoreDispatcher    = ABI::Windows::UI::Core::ICoreDispatcher;
@@ -206,11 +209,163 @@ RenderContextImpl::RenderContextImpl(DriverImpl* driver, SurfaceHandle surface)
     auto& factory = driver->getDXGIFactory();
     auto& adapter = driver->getDXGIAdapter();
 
-    // Check allow tearing feature support and set swapchain flags
-    ComPtr<IDXGIFactory5> factory5;
-    if (SUCCEEDED(factory.As(&factory5)))
-        factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &_allowTearing, sizeof(_allowTearing));
-    _swapChainFlags = _allowTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+    ComPtr<IDXGISwapChain> swapChain;
+    HRESULT hr = 0;
+#if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
+    RECT clientRect;
+    auto hwnd = static_cast<HWND>(surface);
+    GetClientRect(hwnd, &clientRect);
+    _screenWidth  = clientRect.right - clientRect.left;
+    _screenHeight = clientRect.bottom - clientRect.top;
+#endif
+
+    // Try create swapchain, we prefer DXGI 1.2 but support fallback to DXGI 1.1 for win32 apps
+    do
+    {
+        ComPtr<IDXGIFactory2> factory2;
+        hr = factory->QueryInterface(IID_PPV_ARGS(&factory2));
+        AX_BREAK_IF(!factory2);
+
+        // Check allow tearing feature support and set swapchain flags
+        ComPtr<IDXGIFactory5> factory5;
+        if (SUCCEEDED(factory.As(&factory5)))
+            factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &_allowTearing, sizeof(_allowTearing));
+        _swapChainFlags = _allowTearing && !contextAttrs.vsync ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+
+#if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
+        DXGI_SWAP_CHAIN_DESC1 desc1 = {};
+        desc1.Width                 = _screenWidth;
+        desc1.Height                = _screenHeight;
+        desc1.Format                = DEFAULT_SWAPCHAIN_FORMAT;
+        desc1.SampleDesc.Count      = 1;  // Flip not support MSAA
+        desc1.BufferUsage           = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        desc1.BufferCount           = 2;
+        desc1.Flags                 = _swapChainFlags;
+
+        // Choose swapchain effect by OS version
+        // DXGI_SWAP_EFFECT_FLIP_DISCARD:
+        //   Best performance, recommended on Windows 10 and later.
+        //   Officially supported starting with Windows 10.
+        // DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL:
+        //   Official documentation states this is supported beginning with Windows 8.
+        //   However, Windows 7 SP1 with the Platform Update (KB2670838) silently
+        //   upgrades DXGI to version 1.2. This update is not explicitly mentioned
+        //   in the API docs, but it brings hidden support for Flip Sequential.
+        //   Evidence: dxgi.dll version changes from 6.1.x (Win7 base) to 6.2.x,
+        //   and IDXGIFactory2 becomes available. Without the Platform Update,
+        //   attempting to create a Flip Sequential swapchain on Win7 will fail
+        //   with DXGI_ERROR_INVALID_CALL.
+        // DXGI_SWAP_EFFECT_SEQUENTIAL / DISCARD (Blt model):
+        //   The only swap effects available on vanilla Windows 7 (no Platform Update).
+        //   Use these as a fallback when Flip modes are not supported.
+        // refer to: https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect
+        desc1.SwapEffect =
+            axmolIsWindows10OrGreater() ? DXGI_SWAP_EFFECT_FLIP_DISCARD : DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        DXGI_SWAP_CHAIN_FULLSCREEN_DESC fsDesc = {};
+        fsDesc.Windowed                        = TRUE;
+
+        ComPtr<IDXGISwapChain1> swapChain1;
+        hr = factory2->CreateSwapChainForHwnd(device, hwnd, &desc1, &fsDesc, nullptr, &swapChain1);
+        if (SUCCEEDED(hr))
+        {
+            factory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER);
+            swapChain1.As(&swapChain);
+        }
+#elif AX_TARGET_PLATFORM == AX_PLATFORM_WINUWP
+        // ISwapChainPanel
+        ComPtr<IUnknown> surfaceHold{static_cast<IUnknown*>(surface)};
+        ComPtr<ISwapChainPanel> swapChainPanel;
+        hr = surfaceHold.As(&swapChainPanel);
+        AX_BREAK_IF(FAILED(hr));
+
+        // dispatcher
+        ComPtr<IDependencyObject> swapChainPanelDependencyObject;
+        hr = swapChainPanel.As(&swapChainPanelDependencyObject);
+        AX_BREAK_IF(FAILED(hr));
+
+        ComPtr<ICoreDispatcher> dispatcher;
+        hr = swapChainPanelDependencyObject->get_Dispatcher(dispatcher.GetAddressOf());
+        AX_BREAK_IF(FAILED(hr));
+
+        // ISwapChainPanelNative
+        ComPtr<ISwapChainPanelNative> swapChainPanelNative;
+        hr = swapChainPanel.As(&swapChainPanelNative);
+        AX_BREAK_IF(FAILED(hr));
+
+        ABI::Windows::Foundation::Size panelSize;
+        ComPtr<IUIElement> uiElement;
+        hr = swapChainPanel.As(&uiElement);
+        AX_BREAK_IF(FAILED(hr));
+        Vec2 renderScale;
+        hr = runOnUIThread(dispatcher, [&panelSize, &renderScale, uiElement, swapChainPanel] {
+            HRESULT hr1 = uiElement->get_RenderSize(&panelSize);
+            if (FAILED(hr1))
+                return hr1;
+            hr1 = swapChainPanel->get_CompositionScaleX(&renderScale.x);
+            if (FAILED(hr1))
+                return hr1;
+            hr1 = swapChainPanel->get_CompositionScaleY(&renderScale.y);
+            return hr1;
+        });
+        AX_BREAK_IF(FAILED(hr));
+
+        // create swapchain
+        // The swapchain size can't be zero for WinRT, maybe SwapChainPanel::ActualWidth/Height * DPI
+        DXGI_SWAP_CHAIN_DESC1 desc1 = {};
+        if (_renderScaleMode == RenderScaleMode::Physical)
+        {
+            desc1.Width  = static_cast<UINT>(panelSize.Width * renderScale.x);
+            desc1.Height = static_cast<UINT>(panelSize.Height * renderScale.y);
+        }
+        else
+        {
+            desc1.Width  = static_cast<UINT>(panelSize.Width);
+            desc1.Height = static_cast<UINT>(panelSize.Height);
+        }
+        desc1.Format           = DEFAULT_SWAPCHAIN_FORMAT;
+        desc1.SampleDesc.Count = 1;  // Flip not support MSAA
+        desc1.BufferUsage      = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        desc1.BufferCount      = 2;
+
+        desc1.Scaling    = DXGI_SCALING_STRETCH;
+        desc1.AlphaMode  = DXGI_ALPHA_MODE_IGNORE;
+        desc1.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+        desc1.Flags      = _swapChainFlags;
+
+        ComPtr<IDXGISwapChain1> swapChain1;
+        hr = factory2->CreateSwapChainForComposition(device, &desc1, nullptr, &swapChain1);
+        AX_BREAK_IF(FAILED(hr));
+        swapChain1.As(&swapChain);
+
+        hr = runOnUIThread(dispatcher, [swapChainPanelNative, swapChain1] {
+            return swapChainPanelNative->SetSwapChain(swapChain1.Get());
+        });
+
+        AX_BREAK_IF(FAILED(hr));
+
+        DXGI_SWAP_CHAIN_DESC1 actualDesc = {};
+        swapChain1->GetDesc1(&actualDesc);
+
+        if (_renderScaleMode == RenderScaleMode::Physical)
+        {
+            // Setup a scale matrix for the swap chain
+            DXGI_MATRIX_3X2_F scaleMatrix = {};
+            scaleMatrix._11               = 1 / renderScale.x;
+            scaleMatrix._22               = 1 / renderScale.y;
+
+            ComPtr<IDXGISwapChain2> swapChain2;
+            hr = swapChain1.As(&swapChain2);
+            AX_BREAK_IF(FAILED(hr));
+
+            hr = swapChain2->SetMatrixTransform(&scaleMatrix);
+            AX_BREAK_IF(FAILED(hr));
+        }
+
+        _screenWidth  = actualDesc.Width;
+        _screenHeight = actualDesc.Height;
+#endif
+    } while (false);
 
     // control vsync
     if (contextAttrs.vsync)
@@ -226,60 +381,23 @@ RenderContextImpl::RenderContextImpl(DriverImpl* driver, SurfaceHandle surface)
             _presentFlags |= DXGI_PRESENT_ALLOW_TEARING;
     }
 
-    // Try create swapchain, we prefer DXGI 1.2 but support fallback to DXGI 1.1
-    ComPtr<IDXGISwapChain> swapChain;
-    ComPtr<IDXGIFactory2> factory2;
-    HRESULT hr = factory->QueryInterface(IID_PPV_ARGS(&factory2));
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32
-    RECT clientRect;
-    auto hwnd = static_cast<HWND>(surface);
-    GetClientRect(hwnd, &clientRect);
-    _screenWidth  = clientRect.right - clientRect.left;
-    _screenHeight = clientRect.bottom - clientRect.top;
-
-    if (factory2)
-    {
-        // DXGI 1.2+ support Flip mode
-        DXGI_SWAP_CHAIN_DESC1 desc1 = {};
-        desc1.Width                 = _screenWidth;
-        desc1.Height                = _screenHeight;
-        desc1.Format                = DEFAULT_SWAPCHAIN_FORMAT;
-        desc1.SampleDesc.Count      = 1;  // Flip not support MSAA
-        desc1.BufferUsage           = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-        desc1.BufferCount           = 2;
-        desc1.Flags                 = _swapChainFlags;
-
-        // choolse swapchain by OS version
-        if (_axmolIsWindows10BuildOrGreaterWin32(0))
-        {  // Win10+
-            desc1.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-        }
-        else
-        {  // Win8 / Win7+PlatformUpdate
-            desc1.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-        }
-
-        DXGI_SWAP_CHAIN_FULLSCREEN_DESC fsDesc = {};
-        fsDesc.Windowed                        = TRUE;
-
-        ComPtr<IDXGISwapChain1> swapChain1;
-        hr = factory2->CreateSwapChainForHwnd(device, hwnd, &desc1, &fsDesc, nullptr, &swapChain1);
-        if (SUCCEEDED(hr))
-        {
-            factory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER);
-            swapChain1.As(&swapChain);
-        }
-    }
-
-    // Fallback to blt mode if flip mode fail
+    // Fallback to DXGI 1.1 blt mode if flip mode fail
     if (!swapChain)
     {
+        // Note: Windows 7 RTM/SP1 without Platform Update doesn't support Flip mode, but it does support blt mode. So
+        // we can fallback to blt mode for better compatibility.
+        AXLOGW("CreateSwapChain: Fallback to DXGI 1.1 blt mode (vsync disabled to avoid frame stall)");
+
+        // Force disable vsync on DXGI 1.1 (Win7 RTM/SP1) to avoid severe frame stall
+        _syncInterval = 0;
+
         DXGI_SWAP_CHAIN_DESC scDesc               = {};
-        scDesc.BufferCount                        = 1;
+        scDesc.BufferCount                        = 2;
         scDesc.BufferDesc.Width                   = _screenWidth;
         scDesc.BufferDesc.Height                  = _screenHeight;
         scDesc.BufferDesc.Format                  = DEFAULT_SWAPCHAIN_FORMAT;
-        scDesc.BufferDesc.RefreshRate.Numerator   = 60;
+        scDesc.BufferDesc.RefreshRate.Numerator   = 0;
         scDesc.BufferDesc.RefreshRate.Denominator = 1;
         scDesc.BufferUsage                        = DXGI_USAGE_RENDER_TARGET_OUTPUT;
         scDesc.OutputWindow                       = hwnd;
@@ -287,119 +405,19 @@ RenderContextImpl::RenderContextImpl(DriverImpl* driver, SurfaceHandle surface)
         scDesc.SampleDesc.Quality                 = 0;
         scDesc.Windowed                           = TRUE;
         scDesc.SwapEffect                         = DXGI_SWAP_EFFECT_DISCARD;
-        scDesc.Flags                              = _swapChainFlags;
+        scDesc.Flags                              = 0;
 
         hr = factory->CreateSwapChain(device, &scDesc, &swapChain);
-    }
-#elif AX_TARGET_PLATFORM == AX_PLATFORM_WINUWP
-    if (factory2)
-    {
-        do
-        {
-            // ISwapChainPanel
-            ComPtr<IUnknown> surfaceHold{static_cast<IUnknown*>(surface)};
-            ComPtr<ISwapChainPanel> swapChainPanel;
-            hr = surfaceHold.As(&swapChainPanel);
-            AX_BREAK_IF(FAILED(hr));
-
-            // dispatcher
-            ComPtr<IDependencyObject> swapChainPanelDependencyObject;
-            hr = swapChainPanel.As(&swapChainPanelDependencyObject);
-            AX_BREAK_IF(FAILED(hr));
-
-            ComPtr<ICoreDispatcher> dispatcher;
-            hr = swapChainPanelDependencyObject->get_Dispatcher(dispatcher.GetAddressOf());
-            AX_BREAK_IF(FAILED(hr));
-
-            // ISwapChainPanelNative
-            ComPtr<ISwapChainPanelNative> swapChainPanelNative;
-            hr = swapChainPanel.As(&swapChainPanelNative);
-            AX_BREAK_IF(FAILED(hr));
-
-            ABI::Windows::Foundation::Size panelSize;
-            ComPtr<IUIElement> uiElement;
-            hr = swapChainPanel.As(&uiElement);
-            AX_BREAK_IF(FAILED(hr));
-            Vec2 renderScale;
-            hr = runOnUIThread(dispatcher, [&panelSize, &renderScale, uiElement, swapChainPanel] {
-                HRESULT hr1 = uiElement->get_RenderSize(&panelSize);
-                if (FAILED(hr1))
-                    return hr1;
-                hr1 = swapChainPanel->get_CompositionScaleX(&renderScale.x);
-                if (FAILED(hr1))
-                    return hr1;
-                hr1 = swapChainPanel->get_CompositionScaleY(&renderScale.y);
-                return hr1;
-            });
-            AX_BREAK_IF(FAILED(hr));
-
-            // create swapchain
-            // The swapchain size can't be zero for WinRT, maybe SwapChainPanel::ActualWidth/Height * DPI
-            DXGI_SWAP_CHAIN_DESC1 desc1 = {};
-            if (_renderScaleMode == RenderScaleMode::Physical)
-            {
-                desc1.Width  = static_cast<UINT>(panelSize.Width * renderScale.x);
-                desc1.Height = static_cast<UINT>(panelSize.Height * renderScale.y);
-            }
-            else
-            {
-                desc1.Width  = static_cast<UINT>(panelSize.Width);
-                desc1.Height = static_cast<UINT>(panelSize.Height);
-            }
-            desc1.Format           = DEFAULT_SWAPCHAIN_FORMAT;
-            desc1.SampleDesc.Count = 1;  // Flip not support MSAA
-            desc1.BufferUsage      = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-            desc1.BufferCount      = 2;
-
-            desc1.Scaling    = DXGI_SCALING_STRETCH;
-            desc1.AlphaMode  = DXGI_ALPHA_MODE_IGNORE;
-            desc1.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-            desc1.Flags      = _swapChainFlags;
-
-            ComPtr<IDXGISwapChain1> swapChain1;
-            hr = factory2->CreateSwapChainForComposition(device, &desc1, nullptr, &swapChain1);
-            AX_BREAK_IF(FAILED(hr));
-            swapChain1.As(&swapChain);
-
-            hr = runOnUIThread(dispatcher, [swapChainPanelNative, swapChain1] {
-                return swapChainPanelNative->SetSwapChain(swapChain1.Get());
-            });
-
-            AX_BREAK_IF(FAILED(hr));
-
-            DXGI_SWAP_CHAIN_DESC1 actualDesc = {};
-            swapChain1->GetDesc1(&actualDesc);
-
-            if (_renderScaleMode == RenderScaleMode::Physical)
-            {
-                // Setup a scale matrix for the swap chain
-                DXGI_MATRIX_3X2_F scaleMatrix = {};
-                scaleMatrix._11               = 1 / renderScale.x;
-                scaleMatrix._22               = 1 / renderScale.y;
-
-                ComPtr<IDXGISwapChain2> swapChain2;
-                hr = swapChain1.As(&swapChain2);
-                AX_BREAK_IF(FAILED(hr));
-
-                hr = swapChain2->SetMatrixTransform(&scaleMatrix);
-                AX_BREAK_IF(FAILED(hr));
-            }
-
-            _screenWidth  = actualDesc.Width;
-            _screenHeight = actualDesc.Height;
-        } while (false);
     }
 #endif
 
     if (FAILED(hr))
         dxutils::fatalError("CreateSwapChain", hr);
 
+    // Final swapchain setup
     _swapChain = swapChain.Detach();
-
-    _screenRT = new RenderTargetImpl(_driver, true);
-
+    _screenRT  = new RenderTargetImpl(_driver, true);
     _screenRT->rebuildSwapchainBuffers(_swapChain, _screenWidth, _screenHeight);
-
     _nullSRVs.reserve(8);
 }
 

--- a/axmol/rhi/d3d11/RenderContext11.cpp
+++ b/axmol/rhi/d3d11/RenderContext11.cpp
@@ -229,6 +229,8 @@ RenderContextImpl::RenderContextImpl(DriverImpl* driver, SurfaceHandle surface)
         ComPtr<IDXGIFactory5> factory5;
         if (SUCCEEDED(factory.As(&factory5)))
             factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &_allowTearing, sizeof(_allowTearing));
+
+        // Axmol-v3 D3D11 doesn't support change vsync runtime, so don't enable tearing if vsync is on.
         _swapChainFlags = _allowTearing && !contextAttrs.vsync ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WIN32

--- a/axmol/rhi/d3d11/RenderContext11.h
+++ b/axmol/rhi/d3d11/RenderContext11.h
@@ -160,7 +160,7 @@ protected:
     UINT _textureBounds{0};
 
     UINT _swapChainFlags{0};
-    UINT _syncInterval{1};
+    UINT _syncInterval{0};
     UINT _presentFlags{0};
     BOOL _allowTearing{FALSE};
 

--- a/axmol/rhi/d3d11/ShaderModule11.cpp
+++ b/axmol/rhi/d3d11/ShaderModule11.cpp
@@ -23,6 +23,7 @@
  ****************************************************************************/
 // refer: https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics
 #include "axmol/rhi/d3d11/ShaderModule11.h"
+#include "axmol/rhi/d3d11/Driver11.h"
 #include "axmol/platform/win32/ComPtr.h"
 #include "axmol/base/Logging.h"
 
@@ -30,60 +31,15 @@
 
 namespace ax::rhi::d3d11
 {
-
-namespace
+ShaderModuleImpl::ShaderModuleImpl(DriverImpl* driver, ShaderStage stage, Data& data) : ShaderModule(stage, data)
 {
-// ShaderStage -> profile
-inline const char* stageToProfile(ShaderStage s)
-{
-    switch (s)
-    {
-    case ShaderStage::VERTEX:
-        return "vs_5_0";
-    case ShaderStage::FRAGMENT:
-        return "ps_5_0";
-    default:
-        return "vs_5_0";
-    }
-}
-}  // namespace
-
-ShaderModuleImpl::ShaderModuleImpl(ID3D11Device* device, ShaderStage stage, Data& data) : ShaderModule(stage, data)
-{
-    compileShader(device);
+    _shader = driver->compileShader(_codeSpan, stage, _blob);
 }
 
 ShaderModuleImpl::~ShaderModuleImpl()
 {
     SafeRelease(_shader);
     SafeRelease(_blob);
-}
-
-void ShaderModuleImpl::compileShader(ID3D11Device* device)
-{
-    ComPtr<ID3DBlob> errorBlob;
-    UINT flags = D3DCOMPILE_OPTIMIZATION_LEVEL2 | D3DCOMPILE_ENABLE_STRICTNESS;
-#if !defined(NDEBUG)
-    flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
-#endif
-    HRESULT hr = D3DCompile(_codeSpan.data(), _codeSpan.size(), nullptr, nullptr, nullptr, "main",
-                            stageToProfile(_stage), flags, 0, &_blob, &errorBlob);
-    if (FAILED(hr))
-    {
-        std::string_view errorDetail =
-            errorBlob ? std::string_view((const char*)errorBlob->GetBufferPointer(), errorBlob->GetBufferSize())
-                      : "Unknown compile error"sv;
-        AXLOGE("axmol:ERROR: Failed to compile shader, hr:{},{}", hr, errorDetail);
-        AXASSERT(false, "Shader compile failed!");
-        return;
-    }
-
-    if (_stage == ShaderStage::VERTEX)
-        device->CreateVertexShader(_blob->GetBufferPointer(), _blob->GetBufferSize(), nullptr,
-                                   (ID3D11VertexShader**)&_shader);
-    else
-        device->CreatePixelShader(_blob->GetBufferPointer(), _blob->GetBufferSize(), nullptr,
-                                  (ID3D11PixelShader**)&_shader);
 }
 
 }  // namespace ax::rhi::d3d11

--- a/axmol/rhi/d3d11/ShaderModule11.h
+++ b/axmol/rhi/d3d11/ShaderModule11.h
@@ -33,7 +33,7 @@ namespace ax::rhi::d3d11
  * @{
  */
 
-struct SLCReflectContext;
+class DriverImpl;
 
 /**
  * @brief A D3D11-based ShaderModule implementation
@@ -42,15 +42,13 @@ struct SLCReflectContext;
 class ShaderModuleImpl : public ShaderModule
 {
 public:
-    ShaderModuleImpl(ID3D11Device* device, ShaderStage stage, Data& data);
+    ShaderModuleImpl(DriverImpl* driver, ShaderStage stage, Data& data);
     ~ShaderModuleImpl();
 
     IUnknown* internalHandle() const { return _shader; }
     ID3DBlob* getShaderBlob() const { return _blob; }
 
 private:
-    void compileShader(ID3D11Device* device);
-
     IUnknown* _shader = nullptr;
     ID3DBlob* _blob   = nullptr;
 };


### PR DESCRIPTION
- Updated device creation logic to gracefully fall back to D3D_FEATURE_LEVEL_10_1 when D3D_FEATURE_LEVEL_11_1 is not available (e.g. Windows 7 RTM/SP1 without Platform Update KB2670838).
- Adjusted default feature level array to include 10.1 as a valid lowest target.
- Modified shader compilation pipeline to set minimum compatibility to Shader Model 4.1 (vs_4_1, ps_4_1), ensuring shaders can compile and run on hardware limited to D3D10.1.
- Optimized swapchain creation logic for better compatibility across Windows versions, improving fallback handling and ensuring consistent initialization on legacy systems.
- Improved comments and documentation to clarify fallback behavior and supported feature levels across Windows versions.

This change ensures Axmol can initialize correctly on older systems, compile shaders with the appropriate minimum shader model, and create swapchains more robustly, while maintaining full support for higher feature levels when available

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
