### PR TITLE
fix: prevent crash when textInput is nil

### DIFF
--- a/axmol/ui/UIEditBox/Mac/UIEditBoxMac.mm
+++ b/axmol/ui/UIEditBox/Mac/UIEditBoxMac.mm
@@ -77,7 +77,7 @@
 
 - (void)setTextInput:(NSView<AXUITextInput>*)textInput
 {
-    if (_textInput == textInput)
+    if (textInput && _textInput == textInput)
     {
         return;
     }


### PR DESCRIPTION
## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
