### PR TITLE
RHI: Refactor OpenGL texture allocation for array mipmap levels

### DIFF
--- a/axmol/rhi/RHIUtils.cpp
+++ b/axmol/rhi/RHIUtils.cpp
@@ -118,6 +118,19 @@ uint32_t computeRowPitch(PixelFormat format, uint32_t width)
     return 0;
 }
 
+uint32_t computeDataSize(PixelFormat format, int width, int height)
+{
+    const auto& desc = s_pixelFormatDescriptors[(uint32_t)format];
+
+    uint32_t numBlocksX = (width + desc.blockWidth - 1) / desc.blockWidth;
+    numBlocksX          = (std::max)(numBlocksX, (uint32_t)desc.minBlockX);
+
+    uint32_t numBlocksY = (height + desc.blockHeight - 1) / desc.blockHeight;
+    numBlocksY          = (std::max)(numBlocksY, (uint32_t)desc.minBlockY);
+
+    return numBlocksX * numBlocksY * desc.blockSize;
+}
+
 //////////////////////////////////////////////////////////////////////////
 // convertor function
 

--- a/axmol/rhi/RHIUtils.cpp
+++ b/axmol/rhi/RHIUtils.cpp
@@ -118,8 +118,10 @@ uint32_t computeRowPitch(PixelFormat format, uint32_t width)
     return 0;
 }
 
-uint32_t computeDataSize(PixelFormat format, int width, int height)
+uint32_t computeDataSize(PixelFormat format, uint32_t width, uint32_t height)
 {
+    if (AX_UNLIKELY(format >= PixelFormat::COUNT))
+        return 0;
     const auto& desc = s_pixelFormatDescriptors[(uint32_t)format];
 
     uint32_t numBlocksX = (width + desc.blockWidth - 1) / desc.blockWidth;

--- a/axmol/rhi/RHIUtils.h
+++ b/axmol/rhi/RHIUtils.h
@@ -51,6 +51,7 @@ struct PixelFormatDesc
 
 const PixelFormatDesc& getFormatDesc(PixelFormat format);
 uint32_t computeRowPitch(PixelFormat format, uint32_t width);
+uint32_t computeDataSize(PixelFormat format, int width, int height);
 inline uint8_t getBitsPerPixel(PixelFormat format)
 {
     return getFormatDesc(format).bpp;

--- a/axmol/rhi/RHIUtils.h
+++ b/axmol/rhi/RHIUtils.h
@@ -51,7 +51,7 @@ struct PixelFormatDesc
 
 const PixelFormatDesc& getFormatDesc(PixelFormat format);
 uint32_t computeRowPitch(PixelFormat format, uint32_t width);
-uint32_t computeDataSize(PixelFormat format, int width, int height);
+uint32_t computeDataSize(PixelFormat format, uint32_t width, uint32_t height);
 inline uint8_t getBitsPerPixel(PixelFormat format)
 {
     return getFormatDesc(format).bpp;

--- a/axmol/rhi/opengl/TextureGL.cpp
+++ b/axmol/rhi/opengl/TextureGL.cpp
@@ -84,50 +84,9 @@ void TextureImpl::updateSamplerDesc(const SamplerDesc& desc)
     this->_nativeSampler = static_cast<GLuint>(SamplerCache::getInstance()->getSampler(desc));
 }
 
-void TextureImpl::ensureNativeTexture(size_t imageSize)
-{
-    bool initial = !_nativeTexture;
-
-    if (initial)
-        glGenTextures(1, &_nativeTexture);
-
-    __state->bindTexture(_nativeDesc.target, _nativeTexture);
-
-    if (initial)
-    {  // allocate texture storage for we can use glTexSubImageXXX later
-
-        updateSamplerDesc(_desc.samplerDesc);
-
-        // we must allocate texture storage for GL_TEXTURE_2D_ARRAY
-        if (_desc.arraySize > 1)
-        {
-            if (_nativeDesc.type != 0)
-                glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
-                             _desc.arraySize, 0, _nativeDesc.format, _nativeDesc.type, nullptr);
-            else
-                glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, _nativeDesc.internalFormat, _desc.width, _desc.height,
-                                       _desc.arraySize, 0, imageSize * _desc.arraySize, nullptr);
-        }
-        else if (_desc.arraySize == 1)
-        {
-            // if (_nativeDesc.type != 0)
-            //     glTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
-            //                  _nativeDesc.format, _nativeDesc.type, nullptr);
-            // else
-            //     glCompressedTexImage2D(GL_TEXTURE_2D, 0, _nativeDesc.internalFormat, _desc.width, _desc.height, 0,
-            //                            imageSize, nullptr);
-        }
-        else
-        {
-            AXLOGE("TextureDesc arraySize can't be 0");
-        }
-        CHECK_GL_ERROR_DEBUG();
-    }
-}
-
 void TextureImpl::updateData(const void* data, int width, int height, int level, int layerIndex)
 {
-    if (!_nativeTexture && _desc.arraySize == 1)
+    if (_desc.arraySize == 1)
     {
         ensureNativeTexture();
 
@@ -155,9 +114,9 @@ void TextureImpl::updateCompressedData(const void* data,
                                        int level,
                                        int layerIndex)
 {
-    if (!_nativeTexture && _desc.arraySize == 1)
+    if (_desc.arraySize == 1)
     {
-        ensureNativeTexture(dataSize);
+        ensureNativeTexture();
 
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
@@ -194,8 +153,11 @@ void TextureImpl::updateSubData(int xoffset,
         glTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.format, _nativeDesc.type,
                         data);
     else
-        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,
-                        _nativeDesc.internalFormat, _nativeDesc.type, data);
+    {
+        ensureLevelStorage(level);
+        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1, _nativeDesc.format,
+                        _nativeDesc.type, data);
+    }
 
     CHECK_GL_ERROR_DEBUG();
 }
@@ -210,7 +172,7 @@ void TextureImpl::updateCompressedSubData(int xoffset,
                                           int layerIndex)
 {
     assert(_desc.textureType == TextureType::TEXTURE_2D);
-    ensureNativeTexture(dataSize);
+    ensureNativeTexture();
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
@@ -218,8 +180,11 @@ void TextureImpl::updateCompressedSubData(int xoffset,
         glCompressedTexSubImage2D(GL_TEXTURE_2D, level, xoffset, yoffset, width, height, _nativeDesc.internalFormat,
                                   static_cast<GLsizei>(dataSize), data);
     else
+    {
+        ensureLevelStorage(level);
         glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, level, xoffset, yoffset, layerIndex, width, height, 1,
                                   _nativeDesc.internalFormat, static_cast<GLsizei>(dataSize), data);
+    }
     CHECK_GL_ERROR_DEBUG();
 }
 
@@ -239,6 +204,50 @@ void TextureImpl::updateFaceData(TextureCubeFace side, const void* data)
 
     if (shouldGenMipmaps())
         generateMipmaps();
+}
+
+void TextureImpl::ensureNativeTexture()
+{
+    bool initial = !_nativeTexture;
+
+    if (initial)
+        glGenTextures(1, &_nativeTexture);
+
+    __state->bindTexture(_nativeDesc.target, _nativeTexture);
+
+    if (initial)
+    {
+        updateSamplerDesc(_desc.samplerDesc);
+        _allocatedLevelsBits = 0;
+    }
+}
+
+void TextureImpl::ensureLevelStorage(int level)
+{
+    // 32: max supported mipmap levels
+    assert(level >= 0 && level < 32);
+    if ((_allocatedLevelsBits & (1u << level)))
+        return;
+
+    int width  = static_cast<int>((std::max)(1u, static_cast<uint32_t>(_desc.width) >> level));
+    int height = static_cast<int>((std::max)(1u, static_cast<uint32_t>(_desc.height) >> level));
+
+    if (_nativeDesc.type != 0)  // Uncompressed
+    {
+        glTexImage3D(GL_TEXTURE_2D_ARRAY, level, _nativeDesc.internalFormat, width, height, _desc.arraySize, 0,
+                     _nativeDesc.format, _nativeDesc.type, nullptr);
+    }
+    else  // Compressed
+    {
+        auto imageSize = RHIUtils::computeDataSize(_desc.pixelFormat, width, height);
+        glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, level, _nativeDesc.internalFormat, width, height, _desc.arraySize,
+                               0, static_cast<GLsizei>(imageSize * _desc.arraySize), nullptr);
+    }
+
+    // 4. Mark this level as allocated in the bitmask
+    _allocatedLevelsBits |= (1u << level);
+
+    CHECK_GL_ERROR_DEBUG();
 }
 
 void TextureImpl::apply(int slot) const

--- a/axmol/rhi/opengl/TextureGL.h
+++ b/axmol/rhi/opengl/TextureGL.h
@@ -152,14 +152,32 @@ public:
      */
     void apply(int slot) const;
 
-    void ensureNativeTexture(size_t imageSize = 0);
+    void ensureNativeTexture();
+
+    /**
+     * @brief Allocate GPU storage for a specific mipmap level of a texture array.
+     *
+     * Ensures that the given mipmap level has valid storage before updating
+     * with glTexSubImage3D, preventing GL_INVALID_OPERATION (0x502).
+     *
+     * @note For GL_TEXTURE_ARRAY (arraySize > 1):
+     *       - Updating array elements must use glSubXXX with the `zoffset` parameter.
+     *       - glSubXXX requires that storage for the target mipmap level
+     *         be allocated in advance.
+     *
+     * @param level          Mipmap level index to allocate.
+     */
+    void ensureLevelStorage(int level);
 
 private:
     void configureUnpackAlignment(unsigned int width);
 
     NativeTextureDesc _nativeDesc{};
     GLuint _nativeTexture{0};
-    GLuint _nativeSampler{0};  // weak ref
+    GLuint _nativeSampler{0};  // weak
+
+    // Bitmask to track allocated mipmap levels for texture array (up to 32 levels)
+    uint32_t _allocatedLevelsBits{0};
 };
 
 // end of _opengl group


### PR DESCRIPTION
- Split ensureNativeTexture into a simpler version without imageSize.
- Introduced ensureLevelStorage(level) to explicitly allocate GPU storage for a specific mipmap level of GL_TEXTURE_2D_ARRAY.
- Added bitmask tracking (_allocatedLevelsBits) to avoid redundant allocations.
- Ensure glTexSubImage3D and glCompressedTexSubImage3D calls no longer trigger GL_INVALID_OPERATION (0x502) on uninitialized mip levels.
- Clarified handling of compressed vs. uncompressed textures

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
