### PR TITLE
RHI: Fix D3D12 scissor coords and unify viewport/scissor handling

### DIFF
--- a/axmol/2d/FontAtlas.cpp
+++ b/axmol/2d/FontAtlas.cpp
@@ -398,7 +398,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
             // Calculate occupied area using actual bitmap size
             const int glyphWidth  = glyphSize.width + letterExtend;
             const int glyphHeight = glyphSize.height + letterExtend;
-            // Not enough width in current line → wrap to next line
+            // Not enough width in current line -> wrap to next line
             if (_currentPageOrigX + glyphWidth > _width)
             {
                 _currentPageOrigY += _currLineHeight;
@@ -406,7 +406,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
                 _currentPageOrigX = 0;
             }
 
-            // Not enough height → upload current page and start a new page
+            // Not enough height -> upload current page and start a new page
             if (_currentPageOrigY + glyphHeight > _height)
             {
                 // Upload the written region of the current page (startY..pageUploadEndY)

--- a/axmol/base/Utils.h
+++ b/axmol/base/Utils.h
@@ -477,7 +477,7 @@ AX_DLL uint32_t fourccValue(std::string_view str);
  * Parses a 2D vector from a string representation.
  *
  * @param str  String in the form "{x,y}" where x and y are numeric values.
- *             Example: "{3,4}" → Vec2(3, 4)
+ *             Example: "{3,4}" -> Vec2(3, 4)
  * @return     A Vec2 initialized with the parsed coordinates.
  */
 AX_DLL Vec2 parseVec2(std::string_view str);
@@ -487,7 +487,7 @@ AX_DLL Vec2 parseVec2(std::string_view str);
  *
  * @param str  String in the form "{{x,y},{w,h}}" where (x,y) is the rectangle origin
  *             and (w,h) is its size. All values are numeric.
- *             Example: "{{4,3},{5,6}}" → Rect(origin=(4, 3), size=(5, 6))
+ *             Example: "{{4,3},{5,6}}" -> Rect(origin=(4, 3), size=(5, 6))
  * @return     A Rect initialized with the parsed origin and size.
  */
 AX_DLL Rect parseRect(std::string_view str);

--- a/axmol/math/MathUtil.h
+++ b/axmol/math/MathUtil.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include "axmol/math/MathBase.h"
 
 namespace ax
@@ -101,6 +102,8 @@ public:
     {
         return radians * 57.29577951f;  // PI * 180
     }
+
+    static inline bool fuzzyEquals(float a, float b, float eps = 1e-5) { return std::abs(a - b) <= eps; }
 
 private:
     // Indicates that if neon is enabled

--- a/axmol/math/MathUtil.h
+++ b/axmol/math/MathUtil.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <cstdlib>
+#include <cmath>
 #include "axmol/math/MathBase.h"
 
 namespace ax

--- a/axmol/renderer/Renderer.cpp
+++ b/axmol/renderer/Renderer.cpp
@@ -872,7 +872,7 @@ void Renderer::beginRenderPass()
     _context->setViewport(_viewport.x, _viewport.y, _viewport.width, _viewport.height);
     _context->setCullMode(_cullMode);
     _context->setWinding(_winding);
-    _context->setScissorRect(_scissorState.isEnabled, _scissorState.rect.x, _scissorState.rect.y,
+    _context->setScissorRect(_scissorState.enabled, _scissorState.rect.x, _scissorState.rect.y,
                              _scissorState.rect.width, _scissorState.rect.height);
 }
 
@@ -954,12 +954,12 @@ ClearFlag Renderer::getClearFlag() const
 
 void Renderer::setScissorTest(bool enabled)
 {
-    _scissorState.isEnabled = enabled;
+    _scissorState.enabled = enabled;
 }
 
 bool Renderer::getScissorTest() const
 {
-    return _scissorState.isEnabled;
+    return _scissorState.enabled;
 }
 
 const ScissorRect& Renderer::getScissorRect() const

--- a/axmol/renderer/Renderer.h
+++ b/axmol/renderer/Renderer.h
@@ -579,7 +579,7 @@ protected:
     struct ScissorState
     {
         ScissorRect rect;
-        bool isEnabled = false;
+        bool enabled{false};
     };
     ScissorState _scissorState;
 

--- a/axmol/rhi/DXUtils.h
+++ b/axmol/rhi/DXUtils.h
@@ -1,4 +1,28 @@
+/****************************************************************************
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
+
+ https://axmol.dev/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
 #pragma once
+#include "axmol/math/MathUtil.h"
 #include "axmol/rhi/RHITypes.h"
 #include <dxgi.h>
 #include <d3dcommon.h>
@@ -27,6 +51,14 @@ int evalulateMaxTexSize(D3D_FEATURE_LEVEL fl);
 DXGI_FORMAT getUAVCompatibleFormat(DXGI_FORMAT format);
 
 void fatalError(std::string_view op, HRESULT hr);
+
+template <typename _Viewport>
+inline bool viewportsDiffer(const _Viewport& a, const _Viewport& b)
+{  // we don't compare minDepth and maxDepth because they are always 0.0f and 1.0f in axmol, and comparing them may
+   // cause redundant state changes due to precision loss
+    return !MathUtil::fuzzyEquals(a.TopLeftX, b.TopLeftX) || !MathUtil::fuzzyEquals(a.TopLeftY, b.TopLeftY) ||
+           !MathUtil::fuzzyEquals(a.Width, b.Width) || !MathUtil::fuzzyEquals(a.Height, b.Height);
+}
 
 }  // namespace ax::rhi::dxutils
 /** @} */

--- a/axmol/rhi/DXUtils.h
+++ b/axmol/rhi/DXUtils.h
@@ -53,11 +53,17 @@ DXGI_FORMAT getUAVCompatibleFormat(DXGI_FORMAT format);
 void fatalError(std::string_view op, HRESULT hr);
 
 template <typename _Viewport>
-inline bool viewportsDiffer(const _Viewport& a, const _Viewport& b)
+inline bool viewportsEqual(const _Viewport& a, const _Viewport& b)
 {  // we don't compare minDepth and maxDepth because they are always 0.0f and 1.0f in axmol, and comparing them may
    // cause redundant state changes due to precision loss
-    return !MathUtil::fuzzyEquals(a.TopLeftX, b.TopLeftX) || !MathUtil::fuzzyEquals(a.TopLeftY, b.TopLeftY) ||
-           !MathUtil::fuzzyEquals(a.Width, b.Width) || !MathUtil::fuzzyEquals(a.Height, b.Height);
+    return MathUtil::fuzzyEquals(a.TopLeftX, b.TopLeftX) && MathUtil::fuzzyEquals(a.TopLeftY, b.TopLeftY) &&
+           MathUtil::fuzzyEquals(a.Width, b.Width) && MathUtil::fuzzyEquals(a.Height, b.Height);
+}
+
+template <typename _Rect>
+inline bool rectsEqual(const _Rect& a, const _Rect& b)
+{
+    return a.left == b.left && a.top == b.top && a.right == b.right && a.bottom == b.bottom;
 }
 
 }  // namespace ax::rhi::dxutils

--- a/axmol/rhi/RenderContext.h
+++ b/axmol/rhi/RenderContext.h
@@ -220,7 +220,7 @@ public:
      * @param wdith Specifies the width of the scissor box
      * @param height Specifies the height of the scissor box
      */
-    virtual void setScissorRect(bool isEnabled, float x, float y, float width, float height) = 0;
+    virtual void setScissorRect(bool enabled, float x, float y, float width, float height) = 0;
 
     /**
      * Read pixels from the specified render target.

--- a/axmol/rhi/d3d11/RenderContext11.cpp
+++ b/axmol/rhi/d3d11/RenderContext11.cpp
@@ -429,7 +429,7 @@ void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h
     vp.TopLeftY       = static_cast<FLOAT>(y);
     vp.Width          = static_cast<FLOAT>(w);
     vp.Height         = static_cast<FLOAT>(h);
-    if (dxutils::viewportsDiffer(_viewport, vp))
+    if (!dxutils::viewportsEqual(_viewport, vp))
     {
         _viewport = vp;
         _dirtyStateFlags |= RenderStateFlag::Viewport;
@@ -475,7 +475,7 @@ void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float wid
         _dirtyStateFlags |= RenderStateFlag::RasterDesc;
     }
 
-    if (_scissorRect != rect)
+    if (!dxutils::rectsEqual(_scissorRect, rect))
     {
         _scissorRect = rect;
         _dirtyStateFlags |= RenderStateFlag::ScissorRect;

--- a/axmol/rhi/d3d11/RenderContext11.cpp
+++ b/axmol/rhi/d3d11/RenderContext11.cpp
@@ -404,25 +404,12 @@ void RenderContextImpl::updatePipelineState(const RenderTarget* rt,
     _d3d11Context->IASetPrimitiveTopology(toD3DPrimitiveTopology(primitiveType));
 }
 
-void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h)
-{
-    D3D11_VIEWPORT viewport = {};
-    viewport.TopLeftX       = static_cast<FLOAT>(x);
-    viewport.TopLeftY       = static_cast<FLOAT>(y);
-    viewport.Width          = static_cast<FLOAT>(w);
-    viewport.Height         = static_cast<FLOAT>(h);
-    viewport.MinDepth       = 0.0f;
-    viewport.MaxDepth       = 1.0f;
-
-    _driver->getContext()->RSSetViewports(1, &viewport);
-}
-
 void RenderContextImpl::setCullMode(CullMode mode)
 {
     if (_rasterDesc.cullMode != mode)
     {
         _rasterDesc.cullMode = mode;
-        _rasterDesc.dirtyFlags |= RF_CULL_MODE;
+        _dirtyStateFlags |= RenderStateFlag::RasterDesc;
     }
 }
 
@@ -431,15 +418,29 @@ void RenderContextImpl::setWinding(Winding winding)
     if (_rasterDesc.winding != winding)
     {
         _rasterDesc.winding = winding;
-        _rasterDesc.dirtyFlags |= RF_WINDING;
+        _dirtyStateFlags |= RenderStateFlag::RasterDesc;
     }
 }
 
-void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float width, float height)
+void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h)
+{
+    D3D11_VIEWPORT vp = {.MinDepth = 0.0f, .MaxDepth = 1.0f};
+    vp.TopLeftX       = static_cast<FLOAT>(x);
+    vp.TopLeftY       = static_cast<FLOAT>(y);
+    vp.Width          = static_cast<FLOAT>(w);
+    vp.Height         = static_cast<FLOAT>(h);
+    if (dxutils::viewportsDiffer(_viewport, vp))
+    {
+        _viewport = vp;
+        _dirtyStateFlags |= RenderStateFlag::Viewport;
+    }
+}
+
+void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float width, float height)
 {
     D3D11_RECT rect{};
 
-    if (isEnabled)
+    if (enabled)
     {
         const float rtW = static_cast<float>(_renderTargetWidth);
         const float rtH = static_cast<float>(_renderTargetHeight);
@@ -468,43 +469,60 @@ void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float w
         rect.bottom = _renderTargetHeight;
     }
 
-    if (_rasterDesc.scissorEnable != isEnabled)
+    if (_rasterDesc.scissorEnable != enabled)
     {
-        _rasterDesc.scissorEnable = isEnabled;
-        _rasterDesc.dirtyFlags |= RF_SCISSOR;
+        _rasterDesc.scissorEnable = enabled;
+        _dirtyStateFlags |= RenderStateFlag::RasterDesc;
     }
 
-    _d3d11Context->RSSetScissorRects(1, &rect);
+    if (_scissorRect != rect)
+    {
+        _scissorRect = rect;
+        _dirtyStateFlags |= RenderStateFlag::ScissorRect;
+    }
 }
 
-void RenderContextImpl::updateRasterizerState()
+void RenderContextImpl::applyRenderStates()
 {
-    if (!_rasterDesc.dirtyFlags && _rasterState)
-        return;
-    D3D11_RASTERIZER_DESC desc = {};
-    desc.FillMode              = D3D11_FILL_SOLID;
-
-    switch (_rasterDesc.cullMode)
+    if (bitmask::any(RenderStateFlag::Viewport, _dirtyStateFlags))
     {
-    case CullMode::NONE:
-        desc.CullMode = D3D11_CULL_NONE;
-        break;
-    case CullMode::BACK:
-        desc.CullMode = D3D11_CULL_BACK;
-        break;
-    case CullMode::FRONT:
-        desc.CullMode = D3D11_CULL_FRONT;
-        break;
+        _d3d11Context->RSSetViewports(1, &_viewport);
+        _dirtyStateFlags &= ~RenderStateFlag::Viewport;
     }
 
-    desc.FrontCounterClockwise = (_rasterDesc.winding == Winding::COUNTER_CLOCK_WISE);
+    if (bitmask::any(RenderStateFlag::ScissorRect, _dirtyStateFlags))
+    {
+        _d3d11Context->RSSetScissorRects(1, &_scissorRect);
+        _dirtyStateFlags &= ~RenderStateFlag::ScissorRect;
+    }
 
-    desc.DepthClipEnable = TRUE;
-    desc.ScissorEnable   = _rasterDesc.scissorEnable ? TRUE : FALSE;
+    if (bitmask::any(RenderStateFlag::RasterDesc, _dirtyStateFlags))
+    {
+        D3D11_RASTERIZER_DESC desc = {};
+        desc.FillMode              = D3D11_FILL_SOLID;
 
-    _AXASSERT_HR(_driver->getDevice()->CreateRasterizerState(&desc, _rasterState.ReleaseAndGetAddressOf()));
-    _d3d11Context->RSSetState(_rasterState.Get());
-    _rasterDesc.dirtyFlags = 0;
+        switch (_rasterDesc.cullMode)
+        {
+        case CullMode::NONE:
+            desc.CullMode = D3D11_CULL_NONE;
+            break;
+        case CullMode::BACK:
+            desc.CullMode = D3D11_CULL_BACK;
+            break;
+        case CullMode::FRONT:
+            desc.CullMode = D3D11_CULL_FRONT;
+            break;
+        }
+
+        desc.FrontCounterClockwise = (_rasterDesc.winding == Winding::COUNTER_CLOCK_WISE);
+
+        desc.DepthClipEnable = TRUE;
+        desc.ScissorEnable   = _rasterDesc.scissorEnable ? TRUE : FALSE;
+
+        _AXASSERT_HR(_driver->getDevice()->CreateRasterizerState(&desc, _rasterState.ReleaseAndGetAddressOf()));
+        _d3d11Context->RSSetState(_rasterState.Get());
+        _dirtyStateFlags &= ~RenderStateFlag::RasterDesc;
+    }
 }
 
 void RenderContextImpl::setVertexBuffer(Buffer* buffer)
@@ -610,7 +628,7 @@ void RenderContextImpl::endRenderPass()
 void RenderContextImpl::prepareDrawing()
 {
     assert(_programState);
-    updateRasterizerState();
+    applyRenderStates();
 
     auto context = _driver->getContext();
 

--- a/axmol/rhi/d3d11/RenderContext11.h
+++ b/axmol/rhi/d3d11/RenderContext11.h
@@ -39,19 +39,20 @@ class DepthStencilStateImpl;
 class RenderPipelineImpl;
 class RenderTargetImpl;
 
-enum RasterFlag
+enum class RenderStateFlag : uint32_t
 {
-    RF_CULL_MODE = 1,
-    RF_WINDING   = 1 << 1,
-    RF_SCISSOR   = 1 << 2
+    None        = 0,
+    RasterDesc  = 1,
+    Viewport    = 1 << 1,
+    ScissorRect = 1 << 2,
 };
+AX_ENABLE_BITMASK_OPS(RenderStateFlag);
 
 struct RasterStateDesc
 {
     CullMode cullMode{CullMode::BACK};
     Winding winding{Winding::CLOCK_WISE};
     bool scissorEnable{FALSE};
-    unsigned int dirtyFlags{0};
 };
 
 /**
@@ -124,7 +125,7 @@ public:
 
     void endFrame() override;
 
-    void setScissorRect(bool isEnabled, float x, float y, float width, float height) override;
+    void setScissorRect(bool enabled, float x, float y, float width, float height) override;
 
     void readPixels(RenderTarget* rt,
                     bool preserveAxisHint,
@@ -133,7 +134,7 @@ public:
 protected:
     void readPixels(RenderTarget* rt, UINT x, UINT y, UINT width, UINT height, PixelBufferDesc& pbd);
 
-    void updateRasterizerState();
+    void applyRenderStates();
 
     void prepareDrawing();
 
@@ -145,6 +146,8 @@ protected:
     ID3D11Texture2D* _depthStencilTexture{nullptr};
     ComPtr<ID3D11RasterizerState> _rasterState{nullptr};
     RasterStateDesc _rasterDesc{};
+    D3D11_RECT _scissorRect{};
+    D3D11_VIEWPORT _viewport{.MinDepth = 0.0f, .MaxDepth = 1.0f};
     BufferImpl* _vertexBuffer{nullptr};
     BufferImpl* _indexBuffer{nullptr};
     BufferImpl* _instanceBuffer{nullptr};
@@ -163,6 +166,10 @@ protected:
     UINT _syncInterval{0};
     UINT _presentFlags{0};
     BOOL _allowTearing{FALSE};
+
+    // Initialize with RenderStateFlag::RasterDesc to ensure a rasterizer state is created and bound at
+    // least once before the first draw.
+    RenderStateFlag _dirtyStateFlags{RenderStateFlag::RasterDesc};
 
     RenderScaleMode _renderScaleMode{};
 };

--- a/axmol/rhi/d3d12/RenderContext12.cpp
+++ b/axmol/rhi/d3d12/RenderContext12.cpp
@@ -84,11 +84,6 @@ static DXGI_FORMAT toDxgiIndexFormat(IndexFormat fmt)
     }
 }
 
-inline bool operator!=(const D3D12_RECT& a, const D3D12_RECT& b)
-{
-    return a.left != b.left || a.top != b.top || a.right != b.right || a.bottom != b.bottom;
-}
-
 uint64_t GPUFence::wait() const
 {
     const auto completeFenceValue = this->handle->GetCompletedValue();
@@ -485,7 +480,7 @@ void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h
     vp.Height   = static_cast<float>(h);
 
     // Avoid redundant state if equal
-    if (dxutils::viewportsDiffer(_cachedViewport, vp))
+    if (!dxutils::viewportsEqual(_cachedViewport, vp))
     {
         _cachedViewport = vp;
         markDynamicStateDirty(DynamicStateBits::Viewport);
@@ -516,7 +511,7 @@ void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float wid
         rect.bottom = static_cast<LONG>(_renderTargetHeight);
     }
 
-    if (_cachedScissor != rect)
+    if (!dxutils::rectsEqual(_cachedScissor, rect))
     {
         _cachedScissor = rect;
         markDynamicStateDirty(DynamicStateBits::Scissor);

--- a/axmol/rhi/d3d12/RenderContext12.cpp
+++ b/axmol/rhi/d3d12/RenderContext12.cpp
@@ -31,6 +31,7 @@
 #include "axmol/rhi/d3d12/Buffer12.h"
 #include "axmol/rhi/d3d12/Texture12.h"
 #include "axmol/base/Logging.h"
+#include "axmol/math/MathUtil.h"
 
 #if AX_TARGET_PLATFORM == AX_PLATFORM_WINRT
 #    include "axmol/platform/winrt/SwapChainPanelUtil.h"
@@ -81,6 +82,11 @@ static DXGI_FORMAT toDxgiIndexFormat(IndexFormat fmt)
     default:
         return DXGI_FORMAT_R32_UINT;
     }
+}
+
+inline bool operator!=(const D3D12_RECT& a, const D3D12_RECT& b)
+{
+    return a.left != b.left || a.top != b.top || a.right != b.right || a.bottom != b.bottom;
 }
 
 uint64_t GPUFence::wait() const
@@ -472,40 +478,35 @@ void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h
     if (w == 0 || h == 0)
         return;
 
-    D3D12_VIEWPORT vp{};
+    D3D12_VIEWPORT vp{.MinDepth = 0.0f, .MaxDepth = 1.0f};
     vp.TopLeftX = static_cast<float>(x);
     vp.TopLeftY = static_cast<float>(y);
     vp.Width    = static_cast<float>(w);
     vp.Height   = static_cast<float>(h);
-    vp.MinDepth = 0.0f;
-    vp.MaxDepth = 1.0f;
 
     // Avoid redundant state if equal
-    const bool same = vp.TopLeftX == _cachedViewport.TopLeftX && vp.TopLeftY == _cachedViewport.TopLeftY &&
-                      vp.Width == _cachedViewport.Width && vp.Height == _cachedViewport.Height &&
-                      vp.MinDepth == _cachedViewport.MinDepth && vp.MaxDepth == _cachedViewport.MaxDepth;
-
-    if (!same)
+    if (dxutils::viewportsDiffer(_cachedViewport, vp))
     {
         _cachedViewport = vp;
         markDynamicStateDirty(DynamicStateBits::Viewport);
     }
 }
 
-void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float width, float height)
+void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float width, float height)
 {
     D3D12_RECT rect{};
-    if (isEnabled)
+    if (enabled)
     {
-        const LONG minX = static_cast<LONG>(std::max(0.f, x));
-        const LONG minY = static_cast<LONG>(std::max(0.f, y));
-        const LONG maxX = static_cast<LONG>(std::min<float>(x + width, static_cast<float>(_renderTargetWidth)));
-        const LONG maxY = static_cast<LONG>(std::min<float>(y + height, static_cast<float>(_renderTargetHeight)));
-
-        rect.left   = minX;
-        rect.top    = minY;
-        rect.right  = std::max<LONG>(minX, maxX);
-        rect.bottom = std::max<LONG>(minY, maxY);
+        const float rtW = static_cast<float>(_renderTargetWidth);
+        const float rtH = static_cast<float>(_renderTargetHeight);
+        const LONG l    = static_cast<LONG>(std::clamp(x, 0.f, rtW));
+        const LONG r    = static_cast<LONG>(std::clamp(x + width, 0.f, rtW));
+        const LONG t    = static_cast<LONG>(std::clamp(rtH - (y + height), 0.f, rtH));
+        const LONG b    = static_cast<LONG>(std::clamp(rtH - y, 0.f, rtH));
+        rect.left       = (std::min)(l, r);
+        rect.top        = (std::min)(t, b);
+        rect.right      = (std::max)(l, r);
+        rect.bottom     = (std::max)(t, b);
     }
     else
     {
@@ -515,13 +516,9 @@ void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float w
         rect.bottom = static_cast<LONG>(_renderTargetHeight);
     }
 
-    const bool changed = rect.left != _cachedScissor.left || rect.top != _cachedScissor.top ||
-                         rect.right != _cachedScissor.right || rect.bottom != _cachedScissor.bottom;
-
-    if (changed)
+    if (_cachedScissor != rect)
     {
         _cachedScissor = rect;
-
         markDynamicStateDirty(DynamicStateBits::Scissor);
     }
 }

--- a/axmol/rhi/d3d12/RenderContext12.h
+++ b/axmol/rhi/d3d12/RenderContext12.h
@@ -105,7 +105,7 @@ public:
     void setViewport(int x, int y, unsigned int w, unsigned int h) override;
     void setCullMode(CullMode mode) override;
     void setWinding(Winding winding) override;
-    void setScissorRect(bool isEnabled, float x, float y, float width, float height) override;
+    void setScissorRect(bool enabled, float x, float y, float width, float height) override;
 
     void setVertexBuffer(Buffer* buffer) override;
     void setIndexBuffer(Buffer* buffer) override;
@@ -236,7 +236,7 @@ private:
 
     std::vector<std::function<void(uint64_t)>> _frameCompletionOps;
 
-    D3D12_VIEWPORT _cachedViewport{};
+    D3D12_VIEWPORT _cachedViewport{.MinDepth = 0.0f, .MaxDepth = 1.0f};
     D3D12_RECT _cachedScissor{};
     D3D12_CULL_MODE _cachedCullMode{D3D12_CULL_MODE_NONE};
     BOOL _cachedFrontCounterClockwise{FALSE};

--- a/axmol/rhi/metal/RenderContextMTL.h
+++ b/axmol/rhi/metal/RenderContextMTL.h
@@ -181,7 +181,7 @@ public:
      * @param wdith Specifies the width of the scissor box
      * @param height Specifies the height of the scissor box
      */
-    void setScissorRect(bool isEnabled, float x, float y, float width, float height) override;
+    void setScissorRect(bool enabled, float x, float y, float width, float height) override;
 
     void readPixels(RenderTarget* rt,
                     bool preserveAxisHint,

--- a/axmol/rhi/metal/RenderContextMTL.mm
+++ b/axmol/rhi/metal/RenderContextMTL.mm
@@ -549,10 +549,10 @@ void RenderContextImpl::setUniformBuffer() const
     }
 }
 
-void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float width, float height)
+void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float width, float height)
 {
     MTLScissorRect scissorRect;
-    if (isEnabled)
+    if (enabled)
     {
         y                  = _renderTargetHeight - height - y;
         int minX           = std::clamp((int)x, 0, (int)_renderTargetWidth);

--- a/axmol/rhi/opengl/OpenGLState.h
+++ b/axmol/rhi/opengl/OpenGLState.h
@@ -205,11 +205,8 @@ struct AX_DLL OpenGLState
     void disableDepthTest() { try_disable(GL_DEPTH_TEST, _depthTest); }
     void enableBlend() { try_enable(GL_BLEND, _blend); }
     void disableBlend() { try_disable(GL_BLEND, _blend); }
-    void enableScissor(GLint x, GLint y, GLsizei width, GLsizei height)
-    {
-        try_enable(GL_SCISSOR_TEST, _scissor);
-        glScissor(x, y, width, height);
-    }
+    void enableScissor() { try_enable(GL_SCISSOR_TEST, _scissor); }
+    void setScissor(GLint x, GLint y, GLsizei width, GLsizei height) { glScissor(x, y, width, height); }
     void disableScissor() { try_disable(GL_SCISSOR_TEST, _scissor); }
     void lineWidth(float v) { try_call(glLineWidth, _lineWidth, v); }
     void bindFrameBuffer(GLuint v) { try_callu(glBindFramebuffer, GL_FRAMEBUFFER, _frameBufferBind, v); }

--- a/axmol/rhi/opengl/RenderContextGL.cpp
+++ b/axmol/rhi/opengl/RenderContextGL.cpp
@@ -78,6 +78,15 @@ void RenderContextImpl::beginRenderPass(RenderTarget* rt, const RenderPassDesc& 
 
     auto clearFlags = descriptor.flags.clear;
 
+    // Disable scissor test before clearing in OpenGL.
+    // In OpenGL, glClear is affected by the current scissor state, unlike other RHIs
+    // (D3D, Metal, Vulkan) where clears always apply to the full render target.
+    // To ensure consistent cross-platform behavior, we temporarily disable scissor
+    // here so that beginRenderPass clears the entire framebuffer regardless of any
+    // previously set scissor rect.
+    // @see also: issue #1627, #3123
+    __state->disableScissor();
+
     // set clear color, depth and stencil
     GLbitfield mask = 0;
     if (bitmask::any(clearFlags, TargetBufferFlags::COLOR))
@@ -386,12 +395,17 @@ void RenderContextImpl::cleanResources()
     _vertexLayout = nullptr;
 }
 
-void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float width, float height)
+void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float width, float height)
 {
-    if (isEnabled)
-        __state->enableScissor(x, y, width, height);
+    if (enabled)
+    {
+        __state->setScissor(x, y, width, height);
+        __state->enableScissor();
+    }
     else
+    {
         __state->disableScissor();
+    }
 }
 
 void RenderContextImpl::readPixels(RenderTarget* rt,

--- a/axmol/rhi/opengl/RenderContextGL.h
+++ b/axmol/rhi/opengl/RenderContextGL.h
@@ -160,13 +160,7 @@ public:
      */
     void endFrame() override;
 
-    /**
-     * Fixed-function state
-     * @param x, y Specifies the lower left corner of the scissor box
-     * @param wdith Specifies the width of the scissor box
-     * @param height Specifies the height of the scissor box
-     */
-    void setScissorRect(bool isEnabled, float x, float y, float width, float height) override;
+    void setScissorRect(bool enabled, float x, float y, float width, float height) override;
 
     void readPixels(RenderTarget* rt,
                     bool preserveAxisHint,

--- a/axmol/rhi/vulkan/RenderContextVK.cpp
+++ b/axmol/rhi/vulkan/RenderContextVK.cpp
@@ -97,8 +97,7 @@ static VkIndexType toVkIndexType(IndexFormat fmt)
 inline bool operator==(const VkViewport& a, const VkViewport& b)
 {
     return MathUtil::fuzzyEquals(a.x, b.x) && MathUtil::fuzzyEquals(a.y, b.y) &&
-           MathUtil::fuzzyEquals(a.width, b.width) && MathUtil::fuzzyEquals(a.height, b.height) &&
-           MathUtil::fuzzyEquals(a.minDepth, b.minDepth) && MathUtil::fuzzyEquals(a.maxDepth, b.maxDepth);
+           MathUtil::fuzzyEquals(a.width, b.width) && MathUtil::fuzzyEquals(a.height, b.height);
 }
 
 inline bool operator==(const VkRect2D& a, const VkRect2D& b)
@@ -758,14 +757,12 @@ void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h
     if (w == 0 || h == 0)
         return;
 
-    VkViewport vp{};
+    VkViewport vp{.minDepth = 0.0f, .maxDepth = 1.0f};
 
-    vp.x        = static_cast<float>(x);
-    vp.y        = static_cast<float>(y + h);
-    vp.width    = static_cast<float>(w);
-    vp.height   = -static_cast<float>(h);
-    vp.minDepth = 0.0f;
-    vp.maxDepth = 1.0f;
+    vp.x      = static_cast<float>(x);
+    vp.y      = static_cast<float>(y + h);
+    vp.width  = static_cast<float>(w);
+    vp.height = -static_cast<float>(h);
 
     if (vp != _cachedViewport)
     {

--- a/axmol/rhi/vulkan/RenderContextVK.cpp
+++ b/axmol/rhi/vulkan/RenderContextVK.cpp
@@ -34,6 +34,7 @@
 #include "axmol/rhi/vulkan/SemaphorePoolVK.h"
 #include "axmol/rhi/DriverContext.h"
 #include "axmol/base/Logging.h"
+#include "axmol/math/MathUtil.h"
 
 #include <glad/vulkan.h>
 #include <cassert>
@@ -93,16 +94,11 @@ static VkIndexType toVkIndexType(IndexFormat fmt)
     }
 }
 
-inline bool nearlyEqual(float a, float b, float eps = 1e-6f)
-{
-    return std::fabs(a - b) < eps;
-}
-
 inline bool operator==(const VkViewport& a, const VkViewport& b)
 {
-    return nearlyEqual(a.x, b.x) && nearlyEqual(a.y, b.y) && nearlyEqual(a.width, b.width) &&
-           nearlyEqual(a.height, b.height) && nearlyEqual(a.minDepth, b.minDepth) &&
-           nearlyEqual(a.maxDepth, b.maxDepth);
+    return MathUtil::fuzzyEquals(a.x, b.x) && MathUtil::fuzzyEquals(a.y, b.y) &&
+           MathUtil::fuzzyEquals(a.width, b.width) && MathUtil::fuzzyEquals(a.height, b.height) &&
+           MathUtil::fuzzyEquals(a.minDepth, b.minDepth) && MathUtil::fuzzyEquals(a.maxDepth, b.maxDepth);
 }
 
 inline bool operator==(const VkRect2D& a, const VkRect2D& b)
@@ -778,10 +774,10 @@ void RenderContextImpl::setViewport(int x, int y, unsigned int w, unsigned int h
     }
 }
 
-void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float width, float height)
+void RenderContextImpl::setScissorRect(bool enabled, float x, float y, float width, float height)
 {
     VkRect2D rect{};
-    if (isEnabled)
+    if (enabled)
     {
         const float rtW = static_cast<float>(_renderTargetWidth);
         const float rtH = static_cast<float>(_renderTargetHeight);
@@ -794,8 +790,8 @@ void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float w
 
         rect.offset.x      = minX;
         rect.offset.y      = static_cast<int32_t>(rtH) - maxY;  // filp Y
-        rect.extent.width  = static_cast<uint32_t>(std::max(0, maxX - minX));
-        rect.extent.height = static_cast<uint32_t>(std::max(0, maxY - minY));
+        rect.extent.width  = static_cast<uint32_t>((std::max)(0, maxX - minX));
+        rect.extent.height = static_cast<uint32_t>((std::max)(0, maxY - minY));
     }
     else
     {
@@ -803,10 +799,9 @@ void RenderContextImpl::setScissorRect(bool isEnabled, float x, float y, float w
         rect.extent = {_renderTargetWidth, _renderTargetHeight};
     }
 
-    if (_scissorEnabled != isEnabled || _cachedScissor != rect)
+    if (_cachedScissor != rect)
     {
-        _scissorEnabled = isEnabled;
-        _cachedScissor  = rect;
+        _cachedScissor = rect;
         markDynamicStateDirty(DynamicStateBits::Scissor);
     }
 }

--- a/axmol/rhi/vulkan/RenderContextVK.h
+++ b/axmol/rhi/vulkan/RenderContextVK.h
@@ -249,7 +249,7 @@ private:
     uint32_t _screenWidth{0};
     uint32_t _screenHeight{0};
 
-    VkViewport _cachedViewport{};
+    VkViewport _cachedViewport{.minDepth = 0.0f, .maxDepth = 1.0f};
     VkRect2D _cachedScissor{};
 
     ExtendedDynamicState _extendedDynamicState{};

--- a/axmol/rhi/vulkan/RenderContextVK.h
+++ b/axmol/rhi/vulkan/RenderContextVK.h
@@ -107,7 +107,7 @@ public:
     void setViewport(int x, int y, unsigned int w, unsigned int h) override;
     void setCullMode(CullMode mode) override;
     void setWinding(Winding winding) override;
-    void setScissorRect(bool isEnabled, float x, float y, float width, float height) override;
+    void setScissorRect(bool enabled, float x, float y, float width, float height) override;
 
     void setVertexBuffer(Buffer* buffer) override;
     void setIndexBuffer(Buffer* buffer) override;
@@ -255,8 +255,6 @@ private:
     ExtendedDynamicState _extendedDynamicState{};
 
     tlx::inlined_vector<VkDescriptorBufferInfo, 2> _descriptorBufferInfos;
-
-    bool _scissorEnabled{false};
 
     bool _swapchainDirty{false};
     bool _inFrame{false};

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -131,7 +131,7 @@ struct ImGui_ImplAxmol_Data
 
     ImGuiImplAxmolRebuildFontsFn RebuildFontsFunc = nullptr;
     void* RebuildFontsFuncUserData                = nullptr;
-    bool FontsDirty                             = false;
+    bool FontsDirty                               = false;
 
     ProgramInfoData ProgramInfo{};
     Mat4 Projection;
@@ -409,12 +409,8 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_RenderDrawData(ImDrawData* draw_data)
                 {
                     // Apply scissor/clipping rectangle
                     ImGui_ImplAxmol_PostCommand([=]() {
-                        if (rhi::DriverContext::isD3D12())
-                            renderer->setScissorRect(clip_rect.x, clip_rect.y, clip_rect.z - clip_rect.x,
-                                                     clip_rect.w - clip_rect.y);
-                        else
-                            renderer->setScissorRect(clip_rect.x, fb_height - clip_rect.w, clip_rect.z - clip_rect.x,
-                                                     clip_rect.w - clip_rect.y);
+                        renderer->setScissorRect(clip_rect.x, fb_height - clip_rect.w, clip_rect.z - clip_rect.x,
+                                                 clip_rect.w - clip_rect.y);
                     });
 
                     auto bd = ImGui_ImplAxmol_GetBackendData();
@@ -599,7 +595,7 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_DestroyDeviceObjects()
 
 IMGUI_IMPL_API void ImGui_ImplAxmol_SetRebuildFontsFunc(ImGuiImplAxmolRebuildFontsFn func, void* userdata)
 {
-    auto bd                     = ImGui_ImplAxmol_GetBackendData();
+    auto bd                      = ImGui_ImplAxmol_GetBackendData();
     bd->RebuildFontsFunc         = func;
     bd->RebuildFontsFuncUserData = userdata;
 }


### PR DESCRIPTION
- Fixed incorrect scissor coordinate calculation in D3D12 backend (top/bottom inversion and clamping)
- OpenGL: disable scissor before `glClear` in `beginRenderPass` to match cross‑RHI clear semantics: see also https://github.com/axmolengine/axmol/issues/1627, https://github.com/axmolengine/axmol/issues/3123
- Unified `setScissorRect` API across all RHIs (`enabled` instead of `isEnabled`)
- Added `RenderStateFlag` bitmask to track dirty render states (RasterDesc, Viewport, ScissorRect)
- Renamed `updateRasterizerState` => `applyRenderStates` for clarity and extensibility
- Introduced `viewportsEqual` helper with fuzzy float comparison to avoid redundant state changes
- Ensured `_dirtyStateFlags` initialized with `RasterDesc` so rasterizer state is created at least once
- Minor cleanups: comments, naming consistency (`enabled`), formatting fixes in Renderer and Utils

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
