### PR TITLE
Clarify minimum supported MSVC version 14.39+

### DIFF
--- a/1k/1kiss.ps1
+++ b/1k/1kiss.ps1
@@ -1623,7 +1623,11 @@ function preprocess_win() {
             elseif ($TOOLCHAIN_VER -match '^\d+\.\d+$') {
                 $toolsetInfo = Get-VsToolsetFromMsvcVersion $TOOLCHAIN_VER
                 $outputOptions += '-T', "$($toolsetInfo.toolset),version=$TOOLCHAIN_VER"
-                $Script:cmake_generator = "Visual Studio $($toolsetInfo.vsVer) $($toolsetInfo.vsYear)"
+                # Specifying a CMake generator requires multiple Visual Studio versions 
+                # (e.g., "Visual Studio $($toolsetInfo.vsVer) $($toolsetInfo.vsYear)").
+                # If no generator is specified, CMake will automatically select the latest 
+                # available version, so only the newest Visual Studio (e.g., VS2026) needs to be installed.
+                # $Script:cmake_generator = "Visual Studio $($toolsetInfo.vsVer) $($toolsetInfo.vsYear)"
             }
             # refer: https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_PLATFORM.html
             if ($options.sdk) {

--- a/1k/build.profiles
+++ b/1k/build.profiles
@@ -24,7 +24,7 @@ ninja=1.10.0~1.13.2+
 nuget=5.5.1.*
 
 # The visual studio version, @axmol-cmdline @verify
-vs=17.0+
+vs=17.9+
 
 # as stable and latest as possible, @axmol-cmdline @genbindings.ps1
 llvm=21.1.8

--- a/3rdparty/openal/alc/panning.cpp
+++ b/3rdparty/openal/alc/panning.cpp
@@ -388,9 +388,9 @@ auto MakeDecoderView(al::Device const *const device, AmbDecConf const *const con
 {
     auto ret = DecoderView{};
 
-    decoder.mOrder = (conf->ChanMask > Ambi3OrderMask) ? 4_u8 :
-        (conf->ChanMask > Ambi2OrderMask) ? 3_u8 :
-        (conf->ChanMask > Ambi1OrderMask) ? 2_u8 : 1_u8;
+    decoder.mOrder = (conf->ChanMask > Ambi3OrderMask) ? u8::make_from(4) : (conf->ChanMask > Ambi2OrderMask)
+            ? u8::make_from(3) : (conf->ChanMask > Ambi1OrderMask)
+            ? u8::make_from(2) : u8::make_from(1);
     decoder.m3DMode = (conf->ChanMask&AmbiPeriphonicMask) ? Periphonic : Pantaphonic;
 
     switch(conf->CoeffScale)

--- a/3rdparty/yasio/yasio/tlx/vector.hpp
+++ b/3rdparty/yasio/yasio/tlx/vector.hpp
@@ -1676,16 +1676,16 @@ namespace std
 template <class _Myvec>
 struct pointer_traits<_TLX sequence_const_iterator<_Myvec>> {
   using pointer         = _TLX sequence_const_iterator<_Myvec>;
-  using element_type    = const pointer::value_type;
-  using difference_type = pointer::difference_type;
+  using element_type    = const typename pointer::value_type;
+  using difference_type = typename pointer::difference_type;
 
   static constexpr element_type* to_address(const pointer _Iter) noexcept { return std::to_address(_Iter._Ptr); }
 };
 template <class _Myvec>
 struct pointer_traits<_TLX sequence_iterator<_Myvec>> {
   using pointer         = _TLX sequence_iterator<_Myvec>;
-  using element_type    = pointer::value_type;
-  using difference_type = pointer::difference_type;
+  using element_type    = typename pointer::value_type;
+  using difference_type = typename pointer::difference_type;
 
   static constexpr element_type* to_address(const pointer _Iter) noexcept { return std::to_address(_Iter._Ptr); }
 };

--- a/docs/DevSetup.md
+++ b/docs/DevSetup.md
@@ -23,8 +23,11 @@
 
 ### 2. **Install Compiler Toolchain**
 
-- **Windows**: Install **Visual Studio 2022 or 2026** with the **`Desktop development with C++`** workload.  
-  - For UWP development, also enable the **`WinUI application development tools`** workload and include the optional component **`C++ Universal Windows Platform tools`**.
+- **Windows**  
+  - Install **Visual Studio 2022 (version 17.9 or higher)** or **Visual Studio 2026**.  
+  - Enable the **`Desktop development with C++`** workload.  
+  - For UWP development, also enable the **`WinUI application development tools`** workload and include the optional component **`C++ Universal Windows Platform tools`**.  
+  - **MSVC Toolset Requirement**: Must install **MSVC v14.39 or higher**.  
 
 - **macOS**:
   - For `axmol-v2`: Install **Xcode 14.2 or later** — note that Xcode 14.2 is only supported on **macOS 12.5 ~ macOS 13.x**.  


### PR DESCRIPTION
## Describe your changes

- Explicitly mark MSVC v14.39 as the minimum supported compiler
- Improve documentation for Visual Studio 2022 (≥17.9) and 2026 setup
- Clarify installer instructions for selecting MSVC toolset

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
