### PR TITLE
Render tileoffset in tmx map

### DIFF
--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -915,8 +915,9 @@ void FastTMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, uint32_t gid
 
     // fix issue #1283 too;  put the anchor in the middle for ease of rotation.
     sprite->setAnchorPoint(Vec2(0.5f, 0.5f));
-    const float spriteTileOffsetX = _tileSet->_tileOffset.x / AX_CONTENT_SCALE_FACTOR();
-    const float spriteTileOffsetY = -_tileSet->_tileOffset.y / AX_CONTENT_SCALE_FACTOR();
+    const float csf = AX_CONTENT_SCALE_FACTOR();
+    const float spriteTileOffsetX = _tileSet->_tileOffset.x / csf;
+    const float spriteTileOffsetY = -_tileSet->_tileOffset.y / csf;
     sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2) + spriteTileOffsetX,
                         tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2)  + spriteTileOffsetY);
 

--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -916,10 +916,9 @@ void FastTMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, uint32_t gid
     // fix issue #1283 too;  put the anchor in the middle for ease of rotation.
     sprite->setAnchorPoint(Vec2(0.5f, 0.5f));
     const float csf = AX_CONTENT_SCALE_FACTOR();
-    const float spriteTileOffsetX = _tileSet->_tileOffset.x / csf;
-    const float spriteTileOffsetY = -_tileSet->_tileOffset.y / csf;
-    sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2) + spriteTileOffsetX,
-                        tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2)  + spriteTileOffsetY);
+    const Vec2 tileOffset(_tileSet->_tileOffset.x / csf, -_tileSet->_tileOffset.y / csf);
+    sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2) + tileOffset.x,
+                        tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2)  + tileOffset.y);
 
     // issue 1264, flip can be undone as well
     sprite->setFlippedX(false);

--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -497,6 +497,9 @@ void FastTMXLayer::updateTotalQuads()
     {
         Vec2 tileSize = AX_SIZE_PIXELS_TO_POINTS(_tileSet->_tileSize);
         Vec2 texSize  = _tileSet->_imageSize;
+        // Tiled stores tileoffset in screen-space pixels (y-down); convert to Axmol node-space (y-up).
+        const float csf        = AX_CONTENT_SCALE_FACTOR();
+        const Vec2  tileOffset = Vec2(_tileSet->_tileOffset.x / csf, -_tileSet->_tileOffset.y / csf);
         _tileToQuadIndex.clear();
         _totalQuads.resize(int(_layerSize.width * _layerSize.height));
         _indices.resize(6 * int(_layerSize.width * _layerSize.height));
@@ -548,17 +551,17 @@ void FastTMXLayer::updateTotalQuads()
                 // vertices
                 if (tileGID & kTMXTileDiagonalFlag)
                 {
-                    left   = nodePos.x;
-                    right  = nodePos.x + tileSize.height;
-                    bottom = nodePos.y + tileSize.width;
-                    top    = nodePos.y;
+                    left   = nodePos.x + tileOffset.x;
+                    right  = nodePos.x + tileSize.height + tileOffset.x;
+                    bottom = nodePos.y + tileSize.width  + tileOffset.y;
+                    top    = nodePos.y + tileOffset.y;
                 }
                 else
                 {
-                    left   = nodePos.x;
-                    right  = nodePos.x + tileSize.width;
-                    bottom = nodePos.y + tileSize.height;
-                    top    = nodePos.y;
+                    left   = nodePos.x + tileOffset.x;
+                    right  = nodePos.x + tileSize.width  + tileOffset.x;
+                    bottom = nodePos.y + tileSize.height + tileOffset.y;
+                    top    = nodePos.y + tileOffset.y;
                 }
 
                 if (tileGID & kTMXTileVerticalFlag)
@@ -912,8 +915,10 @@ void FastTMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, uint32_t gid
 
     // fix issue #1283 too;  put the anchor in the middle for ease of rotation.
     sprite->setAnchorPoint(Vec2(0.5f, 0.5f));
-    sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2),
-                        tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2));
+    const float spriteTileOffsetX = _tileSet->_tileOffset.x / AX_CONTENT_SCALE_FACTOR();
+    const float spriteTileOffsetY = -_tileSet->_tileOffset.y / AX_CONTENT_SCALE_FACTOR();
+    sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2) + spriteTileOffsetX,
+                        tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2)  + spriteTileOffsetY);
 
     // issue 1264, flip can be undone as well
     sprite->setFlippedX(false);

--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -498,8 +498,8 @@ void FastTMXLayer::updateTotalQuads()
         Vec2 tileSize = AX_SIZE_PIXELS_TO_POINTS(_tileSet->_tileSize);
         Vec2 texSize  = _tileSet->_imageSize;
         // Tiled stores tileoffset in screen-space pixels (y-down); convert to Axmol node-space (y-up).
-        const float csf        = AX_CONTENT_SCALE_FACTOR();
-        const Vec2  tileOffset = Vec2(_tileSet->_tileOffset.x / csf, -_tileSet->_tileOffset.y / csf);
+        const float csf       = AX_CONTENT_SCALE_FACTOR();
+        const Vec2 tileOffset = Vec2(_tileSet->_tileOffset.x / csf, -_tileSet->_tileOffset.y / csf);
         _tileToQuadIndex.clear();
         _totalQuads.resize(int(_layerSize.width * _layerSize.height));
         _indices.resize(6 * int(_layerSize.width * _layerSize.height));
@@ -553,13 +553,13 @@ void FastTMXLayer::updateTotalQuads()
                 {
                     left   = nodePos.x + tileOffset.x;
                     right  = nodePos.x + tileSize.height + tileOffset.x;
-                    bottom = nodePos.y + tileSize.width  + tileOffset.y;
+                    bottom = nodePos.y + tileSize.width + tileOffset.y;
                     top    = nodePos.y + tileOffset.y;
                 }
                 else
                 {
                     left   = nodePos.x + tileOffset.x;
-                    right  = nodePos.x + tileSize.width  + tileOffset.x;
+                    right  = nodePos.x + tileSize.width + tileOffset.x;
                     bottom = nodePos.y + tileSize.height + tileOffset.y;
                     top    = nodePos.y + tileOffset.y;
                 }
@@ -918,7 +918,7 @@ void FastTMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, uint32_t gid
     const float csf = AX_CONTENT_SCALE_FACTOR();
     const Vec2 tileOffset(_tileSet->_tileOffset.x / csf, -_tileSet->_tileOffset.y / csf);
     sprite->setPosition(tempPosAt.x + std::roundf(tempSpriteContentSize.height / 2) + tileOffset.x,
-                        tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2)  + tileOffset.y);
+                        tempPosAt.y + std::roundf(tempSpriteContentSize.width / 2) + tileOffset.y);
 
     // issue 1264, flip can be undone as well
     sprite->setFlippedX(false);


### PR DESCRIPTION
## Describe your changes
In Tiled Map Editor, tilesets can have "tileoffset" value. This value is currently parsed, but not applied to the renderer.

## Issue ticket number and link
none

## Checklist before requesting a review
### For each PR
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
