### PR TITLE
Fix setTileGID corrupting existing tiles.

### DIFF
--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -387,14 +387,15 @@ void FastTMXLayer::updateIndexBuffers()
         if (batch.indices.empty())
             continue;
         const auto size = sizeof(decltype(batch.indices)::value_type) * batch.indices.size();
-        // Recreate the buffer if the tile count grew beyond its allocated capacity.
-        if (batch.indexBuffer && size > batch.indexBuffer->getCapacity())
-        {
-            AX_SAFE_RELEASE(batch.indexBuffer);
-            batch.indexBuffer = nullptr;
-        }
         if (!batch.indexBuffer)
-            batch.indexBuffer = axdrv->createBuffer(size, rhi::BufferType::INDEX, rhi::BufferUsage::DYNAMIC);
+        {
+            // Pre-allocate at maximum possible size so the buffer never needs to be
+            // recreated when setTileGID adds tiles. Recreating would invalidate existing
+            // CustomCommand references (same reasoning as the vertex buffer).
+            const auto maxSize = sizeof(decltype(batch.indices)::value_type) * 6 *
+                                 static_cast<size_t>(_layerSize.width * _layerSize.height);
+            batch.indexBuffer = axdrv->createBuffer(maxSize, rhi::BufferType::INDEX, rhi::BufferUsage::DYNAMIC);
+        }
         batch.indexBuffer->updateData(batch.indices.data(), size);
     }
 }

--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -392,8 +392,8 @@ void FastTMXLayer::updateIndexBuffers()
             // Pre-allocate at maximum possible size so the buffer never needs to be
             // recreated when setTileGID adds tiles. Recreating would invalidate existing
             // CustomCommand references (same reasoning as the vertex buffer).
-            const auto maxSize = sizeof(decltype(batch.indices)::value_type) * 6 *
-                                 static_cast<size_t>(_layerSize.width * _layerSize.height);
+            const auto maxSize = sizeof(decltype(batch.indices)::value_type) * 6 /* 6 indices per quad */ *
+                                 static_cast<size_t>(_layerSize.width) * static_cast<size_t>(_layerSize.height);
             batch.indexBuffer = axdrv->createBuffer(maxSize, rhi::BufferType::INDEX, rhi::BufferUsage::DYNAMIC);
         }
         batch.indexBuffer->updateData(batch.indices.data(), size);


### PR DESCRIPTION
## Describe your changes
updateIndexBuffers() would recreate the index buffer when its capacity was exceeded (e.g., after setTileGID adds tiles to initially-empty cells). But CustomCommand::setIndexBuffer() retains the buffer and is only called once per command at creation time. After the buffer was replaced, all existing draw commands kept a retained reference to the old buffer — so the GPU was drawing with stale (pre-change) index data, causing tile corruption and disappearing tiles.

You can see this behavior in Test 14 (Tiles randomly disappear):

https://github.com/user-attachments/assets/89bb938f-96bd-46a6-8f62-022a9af47835

With Bugfix:

https://github.com/user-attachments/assets/47751a2b-c904-49cb-8b5a-a72357edd52a

