### PR TITLE
fix: correct char_as_u8 return type in alstring.h for C++23 compatibility

### DIFF
--- a/3rdparty/openal/common/alstring.h
+++ b/3rdparty/openal/common/alstring.h
@@ -44,7 +44,7 @@ inline auto char_as_u8(const std::string_view str LIFETIMEBOUND) -> std::string_
 inline auto u8_as_char(const std::string_view str LIFETIMEBOUND) -> std::string_view
 { return str; }
 #else
-inline auto char_as_u8(const std::string_view str LIFETIMEBOUND) -> std::string_view
+inline auto char_as_u8(const std::string_view str LIFETIMEBOUND) -> std::u8string_view
 { return std::u8string_view{reinterpret_cast<const char8_t*>(str.data()), str.size()}; }
 
 inline auto u8_as_char(const std::u8string_view str LIFETIMEBOUND) -> std::string_view


### PR DESCRIPTION
## Describe your changes
Fix C++23 build failure in vendored OpenAL caused by a mismatched return type in 3rdparty/openal/common/alstring.h.
The char_as_u8 function was declared to return std::string_view but returned std::u8string_view. This implicit conversion was valid in C++20 but is a hard error in C++23 where char8_t is a distinct type.
Changed the return type from std::string_view to std::u8string_view to match the function body, consistent with the fix already applied in upstream [openal-soft](https://github.com/kcat/openal-soft).
Tested and confirmed working on Windows 11 with MSVC and CLion.

## Issue ticket number and link
[#3156 https://github.com/axmolengine/axmol/issues/3156](https://github.com/axmolengine/axmol/issues/3156)

- [x] I have performed a self-review of my code.
