### PR TITLE
Fix UI Mistakes in Release/2.10.0

### DIFF
--- a/core/ui/UITextFieldEx.cpp
+++ b/core/ui/UITextFieldEx.cpp
@@ -367,8 +367,9 @@ void TextFieldEx::enableIME(Node* control)
     }
     _touchListener = EventListenerTouchOneByOne::create();
 
-    if (control == nullptr)
-        control = this;
+    // this->getContentSize() == Vec2::ZERO, so we need to use the size of _renderLabel;
+    if(control == nullptr)
+        control = this->_renderLabel;
 
     _touchListener->onTouchBegan = [control,this](Touch* touch, Event*) {
         bool focus = (_checkVisibility(this) && _editable && this->_enabled &&

--- a/extensions/fairygui/src/fairygui/GRoot.cpp
+++ b/extensions/fairygui/src/fairygui/GRoot.cpp
@@ -564,9 +564,6 @@ bool GRoot::initWithScene(ax::Scene* scene, int zOrder)
     _windowSizeListener = Director::getInstance()->getEventDispatcher()->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_RESIZED, AX_CALLBACK_1(GRoot::onWindowSizeChanged, this));
 #endif
 
-    // Fixed by WUCJ638:
-    // Directly copy the code in onWindowSizeChanged(), would
-    // get rid of the cost of calling function.
     /*onWindowSizeChanged*/{
         const ax::Size& rs = Director::getInstance()->getRenderView()->getDesignResolutionSize();
         setSize(rs.width, rs.height);
@@ -580,14 +577,9 @@ bool GRoot::initWithScene(ax::Scene* scene, int zOrder)
     return true;
 }
 
-// Fixed by WUCJ638:
-// Window failed to resize because
-// > const ax::Size& rs =...
-// will return the old size of the window.
-// Parameter could receive the new size of the window.
 void GRoot::onWindowSizeChanged(ax::EventCustom* e)
 {
-    const ax::Size& rs = *static_cast<ax::Size*>(e->getUserData());
+    const ax::Size rs = *static_cast<ax::Size*>(e->getUserData());
     setSize(rs.width, rs.height);
 
     updateContentScaleLevel();

--- a/extensions/fairygui/src/fairygui/GRoot.cpp
+++ b/extensions/fairygui/src/fairygui/GRoot.cpp
@@ -561,18 +561,33 @@ bool GRoot::initWithScene(ax::Scene* scene, int zOrder)
     _inputProcessor->setCaptureCallback(AX_CALLBACK_1(GRoot::onTouchEvent, this));
 
 #if defined(AX_PLATFORM_PC) && AX_TARGET_PLATFORM != AX_PLATFORM_WINRT
-    _windowSizeListener = Director::getInstance()->getEventDispatcher()->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_RESIZED, AX_CALLBACK_0(GRoot::onWindowSizeChanged, this));
+    _windowSizeListener = Director::getInstance()->getEventDispatcher()->addCustomEventListener(RenderViewImpl::EVENT_WINDOW_RESIZED, AX_CALLBACK_1(GRoot::onWindowSizeChanged, this));
 #endif
-    onWindowSizeChanged();
+
+    // Fixed by WUCJ638:
+    // Directly copy the code in onWindowSizeChanged(), would
+    // get rid of the cost of calling function.
+    /*onWindowSizeChanged*/{
+        const ax::Size& rs = Director::getInstance()->getRenderView()->getDesignResolutionSize();
+        setSize(rs.width, rs.height);
+
+        // updateContentScaleLevel();
+    }
+
 
     scene->addChild(_displayObject, zOrder);
 
     return true;
 }
 
-void GRoot::onWindowSizeChanged()
+// Fixed by WUCJ638:
+// Window failed to resize because
+// > const ax::Size& rs =...
+// will return the old size of the window.
+// Parameter could receive the new size of the window.
+void GRoot::onWindowSizeChanged(ax::EventCustom* e)
 {
-    const ax::Size& rs = Director::getInstance()->getRenderView()->getDesignResolutionSize();
+    const ax::Size& rs = *static_cast<ax::Size*>(e->getUserData());
     setSize(rs.width, rs.height);
 
     updateContentScaleLevel();

--- a/extensions/fairygui/src/fairygui/GRoot.h
+++ b/extensions/fairygui/src/fairygui/GRoot.h
@@ -71,7 +71,7 @@ protected:
 
 private:
     bool initWithScene(ax::Scene* scene, int zOrder);
-    void onWindowSizeChanged();
+    void onWindowSizeChanged(ax::EventCustom* e);
     void createModalLayer();
     void adjustModalLayer();
     void closePopup(GObject* target);


### PR DESCRIPTION
# 2026.04.05 Fix UI Mistakes

-----

## Summary

This PR contains 2 fixes for **Axmol 2.10.0 (actuall these changed are still applicable to 2.11.3)**. All of them're related to:

- Fixing wrong default touching area for UITextFieldEx(Ex in short).
- *(For FairyGUI)* GRoot's wrong y-position after maximizing window.

### Fixes

1. **GRoot's wrong y-position after maximizing window**
    - Original implementation failed to adjust y-position after maximizing window.
    - Fixed by receiving window size changing callback.
    <img width="1584" height="1231" alt="image" src="https://github.com/user-attachments/assets/216c4f9c-80e7-4599-8d04-074588c50e79" />

2. **Invalid Default Touching Area for UITextFieldEx**
    - Original touching area is applied from Ex itself, whose content size is `0, 0`.
    - However, its member `renderLabel` contains size, which should be considered touching controller.

## Testing

- Verified on Windows 10 (22h2) with Visual Studio 2026 (MSVC 19.50, CMake 4.3.0).
- GRoot's y-position become correct, see the picture above.
- IME function could be invoked without attaching any controller node.

> Since I'm a student who is occupied with heavy academic tasks and preparing for final exam, delayed response may be unavoidable. Thanks for your understanding!
