### PR TITLE
Refactor physics APIs and fixed-step handling

### DIFF
--- a/3rdparty/openal/CMakeLists.txt
+++ b/3rdparty/openal/CMakeLists.txt
@@ -364,7 +364,8 @@ if(MSVC)
     # C4373 - virtual function overrides 'base_function', previous versions of
     #         the compiler did not override when parameters only differed by
     #         const/volatile qualifiers
-    list(APPEND C_FLAGS /W4 /wd4127 /wd4324 /wd4373 /utf-8 $<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
+    # Axmol spec: Remove /W4 to avoid produces excessive warnings outside Axmol's codebase.
+    list(APPEND C_FLAGS /wd4127 /wd4324 /wd4373 /utf-8 $<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
 
     if(NOT DXSDK_DIR)
         string(REGEX REPLACE "\\\\" "/" DXSDK_DIR "$ENV{DXSDK_DIR}")

--- a/axmol/base/Director.cpp
+++ b/axmol/base/Director.cpp
@@ -342,9 +342,8 @@ void Director::drawScene()
 
     if (_runningScene)
     {
-#if (defined(AX_ENABLE_PHYSICS_2D) || defined(AX_ENABLE_PHYSICS_3D) || defined(AX_ENABLE_NAVMESH))
-        _runningScene->stepPhysicsAndNavigation(_deltaTime);
-#endif
+        _runningScene->tick(_deltaTime);
+
         // clear draw stats
         _renderer->clearDrawStats();
 

--- a/axmol/physics/2d/PhysicsWorld2D.cpp
+++ b/axmol/physics/2d/PhysicsWorld2D.cpp
@@ -502,16 +502,18 @@ void PhysicsWorld2D::setSubsteps(int steps)
 
 void PhysicsWorld2D::stepSimulation(float delta)
 {
+    // Skip simulation if step is too small
+    if (delta < FLT_EPSILON)
+        return;
+
     // Call pre-update callback if registered
     if (_preUpdateCallback)
         _preUpdateCallback();
 
-    // Prepare simulation: transform from scene to world
-    beforeSimulation(_scene, Mat4::IDENTITY, 1.f /* scaleX */, 1.f /* scaleY */, 0.f /* rotation */);
+    auto& sceneTransform = _scene->getNodeToParentTransform();
 
-    // Skip simulation if step is too small
-    if (delta < FLT_EPSILON)
-        return;
+    // Prepare simulation: transform from scene to world
+    beforeSimulation(_scene, sceneTransform, 1.f /* scaleX */, 1.f /* scaleY */, 0.f /* rotation */);
 
     // Apply local speed factor
     float timeStep = delta * _speed;
@@ -524,7 +526,7 @@ void PhysicsWorld2D::stepSimulation(float delta)
 
     // Update physics position, should loop as the same sequence as node tree.
     // PhysicsWorld2D::afterSimulation() will depend on the sequence.
-    afterSimulation(_scene, Mat4::IDENTITY, 0.f /* rotation */);
+    afterSimulation(_scene, sceneTransform, 0.f /* rotation */);
 
     if (_postUpdateCallback)
         _postUpdateCallback();  // fix #11154

--- a/axmol/physics/2d/PhysicsWorld2D.cpp
+++ b/axmol/physics/2d/PhysicsWorld2D.cpp
@@ -133,7 +133,7 @@ struct PhysicsQueryCallbacks2D
 
         bool continues = info->func(*info->world, hitInfo, info->data);
 
-        return continues ? 1 : 0;
+        return continues ? 1.0f : 0.0f;
     }
 
     static bool handleBoxOverlap(b2ShapeId shape, void* context)
@@ -277,11 +277,7 @@ PhysicsWorld2D::PhysicsWorld2D()
     : _gravity(Vec2(0.0f, -9.8f))
     , _PTMRatio(10.0f)
     , _speed(1.0f)
-    , _updateRate(1)
-    , _updateRateCount(0)
-    , _updateTime(0.0f)
     , _substeps(1)
-    , _fixedUpdateRate(0)
     , _eventBits(ContactEventBits::None)
     , _worldId(b2_nullWorldId)
     , _updateBodyTransform(false)
@@ -501,61 +497,30 @@ void PhysicsWorld2D::setGravity(const Vec2& gravity)
 void PhysicsWorld2D::setSubsteps(int steps)
 {
     if (steps > 0)
-    {
         _substeps = steps;
-        if (steps > 1)
-        {
-            _updateRate = 1;
-        }
-    }
 }
 
-void PhysicsWorld2D::step(float delta)
+void PhysicsWorld2D::stepSimulation(float delta)
 {
-    if (_autoStep)
-    {
-        AXLOGD("Physics Warning: You need to close auto step( setAutoStep(false) ) first");
-    }
-    else
-    {
-        update(delta, true);
-    }
-}
-
-void PhysicsWorld2D::update(float delta, bool userCall /* = false*/)
-{
-
+    // Call pre-update callback if registered
     if (_preUpdateCallback)
-        _preUpdateCallback();  // fix #11154
+        _preUpdateCallback();
 
+    // Prepare simulation: transform from scene to world
     auto sceneToWorldTransform = _scene->getNodeToParentTransform();
     beforeSimulation(_scene, sceneToWorldTransform, 1.f, 1.f, 0.f);
 
-    if (delta < FLT_EPSILON)
-    {
-        return;
-    }
-
+    // Skip simulation if step is too small
     if (delta < FLT_EPSILON)
         return;
 
-    _updateTime += delta * _speed;
+    // Apply local speed factor
+    float timeStep = delta * _speed;
 
-    if (userCall || _fixedUpdateRate <= 0)
-    {
-        b2World_Step(_worldId, delta, _substeps);
-    }
-    else
-    {
-        const float fixedStep = 1.0f / _fixedUpdateRate;
-        while (_updateTime >= fixedStep)
-        {
-            _updateTime -= fixedStep;
-            _scene->fixedUpdate(fixedStep);
-            b2World_Step(_worldId, fixedStep, _substeps);
-        }
-    }
+    // Advance Box2D world by one fixed step
+    b2World_Step(_worldId, timeStep, _substeps);
 
+    // Dispatch contact events generated during this step
     dispatchContactEvents();
 
     // Update physics position, should loop as the same sequence as node tree.

--- a/axmol/physics/2d/PhysicsWorld2D.cpp
+++ b/axmol/physics/2d/PhysicsWorld2D.cpp
@@ -507,8 +507,7 @@ void PhysicsWorld2D::stepSimulation(float delta)
         _preUpdateCallback();
 
     // Prepare simulation: transform from scene to world
-    auto sceneToWorldTransform = _scene->getNodeToParentTransform();
-    beforeSimulation(_scene, sceneToWorldTransform, 1.f, 1.f, 0.f);
+    beforeSimulation(_scene, Mat4::IDENTITY, 1.f /* scaleX */, 1.f /* scaleY */, 0.f /* rotation */);
 
     // Skip simulation if step is too small
     if (delta < FLT_EPSILON)
@@ -525,7 +524,7 @@ void PhysicsWorld2D::stepSimulation(float delta)
 
     // Update physics position, should loop as the same sequence as node tree.
     // PhysicsWorld2D::afterSimulation() will depend on the sequence.
-    afterSimulation(_scene, sceneToWorldTransform, 0.f);
+    afterSimulation(_scene, Mat4::IDENTITY, 0.f /* rotation */);
 
     if (_postUpdateCallback)
         _postUpdateCallback();  // fix #11154

--- a/axmol/physics/2d/PhysicsWorld2D.h
+++ b/axmol/physics/2d/PhysicsWorld2D.h
@@ -307,9 +307,7 @@ public:
     void setSpeed(float speed)
     {
         if (speed >= 0.0f)
-        {
             _speed = speed;
-        }
     }
 
     /**
@@ -318,29 +316,6 @@ public:
      * @return A float number.
      */
     float getSpeed() { return _speed; }
-
-    /**
-     * Set the update rate of this physics world
-     *
-     * Update rate is the value of EngineUpdateTimes/PhysicsWorldUpdateTimes.
-     * Set it higher can improve performance, set it lower can improve accuracy of physics world simulation.
-     * @attention if you setAutoStep(false), this won't work.
-     * @param rate An integer number, default value is 1.0.
-     */
-    void setUpdateRate(int rate)
-    {
-        if (rate > 0)
-        {
-            _updateRate = rate;
-        }
-    }
-
-    /**
-     * Get the update rate of this physics world.
-     *
-     * @return An integer number.
-     */
-    int getUpdateRate() { return _updateRate; }
 
     /**
      * set the number of substeps in an update of the physics world.
@@ -356,21 +331,6 @@ public:
      * @return An integer number.
      */
     int getSubsteps() const { return _substeps; }
-
-    /**
-     * set the number of update of the physics world in a second.
-     * 0 - disable fixed step system
-     * default value is 0
-     */
-    void setFixedUpdateRate(int updatesPerSecond)
-    {
-        if (updatesPerSecond > 0)
-        {
-            _fixedUpdateRate = updatesPerSecond;
-        }
-    }
-    /** get the number of substeps */
-    int getFixedUpdateRate() const { return _fixedUpdateRate; }
 
     /**
      * set the callback which invoked before update of each object in physics world.
@@ -401,17 +361,19 @@ public:
     bool isAutoStep() { return _autoStep; }
 
     /**
-     * The step for physics world.
+     * Advances the physics simulation by one step.
      *
-     * The times passing for simulate the physics.
-     * @attention You need to setAutoStep(false) first before it can work.
-     * @param   delta   A float number.
+     * By default, the physics world runs with auto-step enabled,
+     * and this function is called automatically each frame.
+     * If you disable auto-step via setAutoStep(false),
+     * you must call this function manually to update the simulation.
+     *
+     * @param delta The time step (in seconds) to simulate.
      */
-    void step(float delta);
+    void stepSimulation(float delta);
+    AX_DEPRECATED(3.0) inline void step(float dt) { stepSimulation(dt); }
 
 protected:
-    virtual void update(float delta, bool userCall = false);
-
     static bool handlePreSolve(b2ShapeId shapeIdA,
                                b2ShapeId shapeIdB,
                                b2Vec2 point,
@@ -434,11 +396,7 @@ protected:
     Vec2 _gravity;
     float _PTMRatio;
     float _speed;
-    int _updateRate;
-    int _updateRateCount;
-    float _updateTime;
     int _substeps;
-    int _fixedUpdateRate;
     ContactEventBits _eventBits;
     b2WorldId _worldId;
     bool _isWorldLocked = false;

--- a/axmol/physics/2d/PhysicsWorld2D.h
+++ b/axmol/physics/2d/PhysicsWorld2D.h
@@ -347,7 +347,7 @@ public:
      *
      * If you want control it by yourself( fixed-timestep for example ), you can set this to false and call step by
      * yourself.
-     * @attention If you set auto step to false, setSpeed setSubsteps and setUpdateRate won't work, you need to control
+     * @attention If you set auto step to false, setSpeed setSubsteps won't works, you need to control
      * the time step by yourself.
      * @param autoStep A bool object, default value is true.
      */

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -100,11 +100,6 @@ static Collider3D* asSensorCollider(PhysicsActor* actor)
     return collider && collider->isSensor() ? collider : nullptr;
 }
 
-static Collider3D* asCollider(PhysicsActor* actor)
-{
-    return actor && actor->getActorType() == PhysicsActor::kCollider ? static_cast<Collider3D*>(actor) : nullptr;
-}
-
 static ContactInfo3D reorderSensorContactInfo(const ContactInfo3D& info)
 {
     if (asSensorCollider(info.actorA) || !asSensorCollider(info.actorB))
@@ -357,7 +352,7 @@ void PhysicsWorld3D::debugDraw(Renderer* renderer)
     }
 }
 
-void PhysicsWorld3D::stepSimulate(float dt)
+void PhysicsWorld3D::stepSimulation(float dt)
 {
 
     for (auto* actor : _physicsActors)

--- a/axmol/physics/3d/PhysicsWorld3D.h
+++ b/axmol/physics/3d/PhysicsWorld3D.h
@@ -184,7 +184,7 @@ public:
      *
      * If you want control it by yourself( fixed-timestep for example ), you can set this to false and call step by
      * yourself.
-     * @attention If you set auto step to false, setSpeed setSubsteps and setUpdateRate won't work, you need to control
+     * @attention If you set auto step to false, you need to control
      * the time step by yourself.
      * @param autoStep A bool object, default value is true.
      */

--- a/axmol/physics/3d/PhysicsWorld3D.h
+++ b/axmol/physics/3d/PhysicsWorld3D.h
@@ -180,10 +180,34 @@ public:
     Vec3 getGravity() const;
 
     /**
-     * @brief Advances the physics simulation by one step.
-     * @param dt Step duration in seconds.
+     * To control the step of physics.
+     *
+     * If you want control it by yourself( fixed-timestep for example ), you can set this to false and call step by
+     * yourself.
+     * @attention If you set auto step to false, setSpeed setSubsteps and setUpdateRate won't work, you need to control
+     * the time step by yourself.
+     * @param autoStep A bool object, default value is true.
      */
-    void stepSimulate(float dt);
+    void setAutoStep(bool autoStep) { _autoStep = autoStep; }
+
+    /**
+     * Get the auto step of this physics world.
+     *
+     * @return A bool object.
+     */
+    bool isAutoStep() { return _autoStep; }
+
+    /**
+     * Advances the physics simulation by one step.
+     *
+     * By default, the physics world runs with auto-step enabled,
+     * and this function is called automatically each frame.
+     * If you disable auto-step via setAutoStep(false),
+     * you must call this function manually to update the simulation.
+     *
+     * @param delta The time step (in seconds) to simulate.
+     */
+    void stepSimulation(float delta);
 
     /**
      * @brief Enables or disables debug drawing for this world.
@@ -320,6 +344,8 @@ protected:
     tlx::flat_set<PhysicsActor*> _physicsActors;
     ContactEventBits _eventBits{ContactEventBits::None};
     PhysicsDebugDraw3D* _debugDrawer;
+
+    bool _autoStep{true};
 };
 
 // end of 3d group

--- a/axmol/platform/RenderView.h
+++ b/axmol/platform/RenderView.h
@@ -362,14 +362,14 @@ public:
      *
      * @param filename A path to image file, e.g., "icons/cusom.png".
      */
-    virtual void setIcon(std::string_view filename) const {};
+    virtual void setIcon(std::string_view /*filename*/) const {};
 
     /** Set window icon (implemented for windows and linux).
      * Best icon (based on size) will be auto selected.
      *
      * @param filelist The array contains icons.
      */
-    virtual void setIcon(std::span<const std::string_view> filelist) const {};
+    virtual void setIcon(std::span<const std::string_view> /*filelist*/) const {};
 
     /** Set default window icon (implemented for windows and linux).
      * On windows it will use icon from .exe file (if included).

--- a/axmol/scene/Scene.cpp
+++ b/axmol/scene/Scene.cpp
@@ -59,8 +59,6 @@ Scene::Scene()
     _ignoreAnchorPointForPosition = true;
     setAnchorPoint(Vec2(0.5f, 0.5f));
 
-    _fixedAccumulator = _fixedStep + 1e-3f;
-
     Camera::_visitingCamera = nullptr;
 }
 
@@ -373,11 +371,11 @@ void Scene::setFixedDeltaTime(float fixedStep)
 
 void Scene::tick(float deltaTime)
 {
+    // apply time scale and clamp to avoid huge dt spikes
+    deltaTime = (std::min)(deltaTime * _timeScale, _maxDeltaTime);
+
     if (_fixedUpdateEnabled)
     {
-        // apply time scale and clamp to avoid huge dt spikes
-        deltaTime = (std::min)(deltaTime * _timeScale, _maxDeltaTime);
-
         // accumulate time
         _fixedAccumulator += deltaTime;
 

--- a/axmol/scene/Scene.cpp
+++ b/axmol/scene/Scene.cpp
@@ -59,6 +59,10 @@ Scene::Scene()
     _ignoreAnchorPointForPosition = true;
     setAnchorPoint(Vec2(0.5f, 0.5f));
 
+    // Set accumulator to fixedDeltaTime so the next tick will immediately run at least one fixedUpdate,
+    // avoiding a stall after changing step size.
+    _fixedAccumulator = _fixedDeltaTime;
+
     Camera::_visitingCamera = nullptr;
 }
 
@@ -365,8 +369,11 @@ void Scene::setFixedDeltaTime(float fixedStep)
 {
     fixedStep = std::clamp<float>(fixedStep, 0.0001F, 10.0F);
 
-    _fixedDeltaTime   = fixedStep;
-    _fixedAccumulator = fixedStep;
+    _fixedDeltaTime = fixedStep;
+
+    // Reset accumulator to fixedDeltaTime so the next tick will immediately run at least one fixedUpdate,
+    // avoiding a stall after changing step size.
+    _fixedAccumulator = _fixedDeltaTime;
 }
 
 void Scene::tick(float deltaTime)

--- a/axmol/scene/Scene.cpp
+++ b/axmol/scene/Scene.cpp
@@ -59,6 +59,8 @@ Scene::Scene()
     _ignoreAnchorPointForPosition = true;
     setAnchorPoint(Vec2(0.5f, 0.5f));
 
+    _fixedAccumulator = _fixedStep + 1e-3f;
+
     Camera::_visitingCamera = nullptr;
 }
 
@@ -361,19 +363,66 @@ bool Scene::initPhysicsWorld()
 
 #endif
 
+void Scene::setFixedDeltaTime(float fixedStep)
+{
+    fixedStep = std::clamp<float>(fixedStep, 0.0001F, 10.0F);
+
+    _fixedDeltaTime   = fixedStep;
+    _fixedAccumulator = fixedStep;
+}
+
+void Scene::tick(float deltaTime)
+{
+    if (_fixedUpdateEnabled)
+    {
+        // apply time scale and clamp to avoid huge dt spikes
+        deltaTime = (std::min)(deltaTime * _timeScale, _maxDeltaTime);
+
+        // accumulate time
+        _fixedAccumulator += deltaTime;
+
+        int steps = 0;
+        while (_fixedAccumulator >= _fixedDeltaTime && steps < _maxFixedStepsPerFrame)
+        {
+            fixedUpdate(_fixedDeltaTime);
+
+            _fixedAccumulator -= _fixedDeltaTime;
+            ++steps;
+        }
+
+        // spiral of death protection: if we hit max steps, drop remaining accumulator
+        if (steps == _maxFixedStepsPerFrame)
+            _fixedAccumulator = 0.0f;
+
+        // compute interpolation alpha for rendering (0..1)
+        _physicsInterpolationAlpha = static_cast<float>(_fixedAccumulator) / _fixedDeltaTime;
+    }
+    else
+    {
+#if (defined(AX_ENABLE_PHYSICS_2D) || defined(AX_ENABLE_PHYSICS_3D) || defined(AX_ENABLE_NAVMESH))
+        stepPhysicsAndNavigation(deltaTime);
+#endif
+    }
+}
+
+void Scene::fixedUpdate(float delta)
+{
+#if (defined(AX_ENABLE_PHYSICS_2D) || defined(AX_ENABLE_PHYSICS_3D) || defined(AX_ENABLE_NAVMESH))
+    stepPhysicsAndNavigation(delta);
+#endif
+}
+
 #if (defined(AX_ENABLE_PHYSICS_2D) || defined(AX_ENABLE_PHYSICS_3D) || defined(AX_ENABLE_NAVMESH))
 void Scene::stepPhysicsAndNavigation(float deltaTime)
 {
 #    if defined(AX_ENABLE_PHYSICS_2D)
     if (_physicsWorld2D && _physicsWorld2D->isAutoStep())
-        _physicsWorld2D->update(deltaTime);
+        _physicsWorld2D->stepSimulation(deltaTime);
 #    endif
 
 #    if defined(AX_ENABLE_PHYSICS_3D)
-    if (_physicsWorld3D)
-    {
-        _physicsWorld3D->stepSimulate(deltaTime);
-    }
+    if (_physicsWorld3D && _physicsWorld3D->isAutoStep())
+        _physicsWorld3D->stepSimulation(deltaTime);
 #    endif
 #    if defined(AX_ENABLE_NAVMESH)
     if (_navMesh)

--- a/axmol/scene/Scene.h
+++ b/axmol/scene/Scene.h
@@ -130,6 +130,49 @@ public:
      */
     void setDebugCamera(Camera* camera);
 
+    // fixedStep configuration
+    /**
+     * @brief Set the fixed time step used for physics and logic updates.
+     * @param fixedStep Duration of each fixed update step in seconds.
+     */
+    void setFixedDeltaTime(float fixedStep);
+
+    /**
+     * @brief Set the maximum delta time allowed per frame.
+     *        Prevents excessive accumulation when resuming from pause or lag.
+     * @param maxDt Maximum delta time in seconds.
+     */
+    void setMaxDeltaTime(float maxDt) { _maxDeltaTime = maxDt; }
+
+    /**
+     * @brief Set the maximum number of fixed update steps allowed per frame.
+     *        Acts as a safeguard against spiral-of-death scenarios.
+     * @param maxSteps Maximum fixed steps per frame.
+     */
+    void setMaxFixedStepsPerFrame(int maxSteps) { _maxFixedStepsPerFrame = maxSteps; }
+
+    /**
+     * @brief Set the global time scale multiplier.
+     *        Affects both dynamic and fixed time progression.
+     * @param scale Time scale factor (1.0 = normal speed).
+     */
+    void setTimeScale(float scale) { _timeScale = scale; }
+
+    /**
+     * @brief Enable or disable fixed update processing.
+     * @param enabled True to run fixed updates, false to disable.
+     */
+    void setFixedUpdateEnabled(bool enabled) { _fixedUpdateEnabled = enabled; }
+
+    /**
+     * @brief Check if fixed update is currently enabled.
+     * @return True if fixed update is enabled, false otherwise.
+     */
+    bool isFixedUpdateEnabled() const { return _fixedUpdateEnabled; }
+
+    // query interpolation alpha for rendering
+    float getPhysicsInterpolationAlpha() const { return _physicsInterpolationAlpha; }
+
 private:
     void initDefaultCamera();
     void onProjectionChanged(EventCustom* event);
@@ -156,9 +199,20 @@ protected:
 
     /* indicates if the order is dirty and if so then it needs sorting */
     bool _cameraOrderDirty{true};
+
+    bool _fixedUpdateEnabled{true};
+
     EventListenerCustom* _event;
 
     std::vector<BaseLight*> _lights;
+
+    // fixed-step state
+    double _fixedAccumulator         = 1.0f / 60.0f;
+    float _fixedDeltaTime            = 1.0f / 60.0f;  // default 60Hz
+    int _maxFixedStepsPerFrame       = 5;             // prevent spiral of death
+    float _timeScale                 = 1.0f;
+    float _maxDeltaTime              = 0.25f;  // clamp dt to avoid huge jumps
+    float _physicsInterpolationAlpha = 0.0f;   // 0..1 for render interpolation
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(Scene);
@@ -186,7 +240,9 @@ public:
 
     bool initWithPhysics();
     bool initPhysicsWorld();
-    virtual void fixedUpdate(float delta) {}
+
+    void tick(float delta);
+    virtual void fixedUpdate(float delta);
 
 protected:
 #    if defined(AX_ENABLE_PHYSICS_2D)

--- a/axmol/scene/Scene.h
+++ b/axmol/scene/Scene.h
@@ -207,12 +207,12 @@ protected:
     std::vector<BaseLight*> _lights;
 
     // fixed-step state
-    double _fixedAccumulator         = 1.0f / 60.0f;
-    float _fixedDeltaTime            = 1.0f / 60.0f;  // default 60Hz
-    int _maxFixedStepsPerFrame       = 5;             // prevent spiral of death
-    float _timeScale                 = 1.0f;
-    float _maxDeltaTime              = 0.25f;  // clamp dt to avoid huge jumps
-    float _physicsInterpolationAlpha = 0.0f;   // 0..1 for render interpolation
+    double _fixedAccumulator;
+    float _fixedDeltaTime{1.0f / 60.0f};  // default 60Hz
+    int _maxFixedStepsPerFrame{5};        // prevent spiral of death
+    float _timeScale{1.0f};
+    float _maxDeltaTime{0.25f};              // clamp dt to avoid huge jumps
+    float _physicsInterpolationAlpha{0.0f};  // 0..1 for render interpolation
 
 private:
     AX_DISALLOW_COPY_AND_ASSIGN(Scene);

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -22618,6 +22618,350 @@ int lua_ax_base_Scene_setDebugCamera(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_base_Scene_setFixedDeltaTime(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_setFixedDeltaTime'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        double arg0;
+
+        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.Scene:setFixedDeltaTime");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_setFixedDeltaTime'", nullptr);
+            return 0;
+        }
+        obj->setFixedDeltaTime(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:setFixedDeltaTime",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_setFixedDeltaTime'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_setMaxDeltaTime(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_setMaxDeltaTime'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        double arg0;
+
+        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.Scene:setMaxDeltaTime");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_setMaxDeltaTime'", nullptr);
+            return 0;
+        }
+        obj->setMaxDeltaTime(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:setMaxDeltaTime",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_setMaxDeltaTime'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_setMaxFixedStepsPerFrame(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_setMaxFixedStepsPerFrame'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        int arg0;
+
+        ok &= luaval_to_int(tolua_S, 2, &arg0, "ax.Scene:setMaxFixedStepsPerFrame");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_setMaxFixedStepsPerFrame'", nullptr);
+            return 0;
+        }
+        obj->setMaxFixedStepsPerFrame(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:setMaxFixedStepsPerFrame",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_setMaxFixedStepsPerFrame'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_setTimeScale(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_setTimeScale'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        double arg0;
+
+        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.Scene:setTimeScale");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_setTimeScale'", nullptr);
+            return 0;
+        }
+        obj->setTimeScale(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:setTimeScale",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_setTimeScale'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_setFixedUpdateEnabled(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_setFixedUpdateEnabled'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        bool arg0;
+
+        ok &= luaval_to_boolean(tolua_S, 2, &arg0, "ax.Scene:setFixedUpdateEnabled");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_setFixedUpdateEnabled'", nullptr);
+            return 0;
+        }
+        obj->setFixedUpdateEnabled(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:setFixedUpdateEnabled",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_setFixedUpdateEnabled'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_isFixedUpdateEnabled(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_isFixedUpdateEnabled'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_isFixedUpdateEnabled'", nullptr);
+            return 0;
+        }
+        auto&& ret = obj->isFixedUpdateEnabled();
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:isFixedUpdateEnabled",argc, 0);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_isFixedUpdateEnabled'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_getPhysicsInterpolationAlpha(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_getPhysicsInterpolationAlpha'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_getPhysicsInterpolationAlpha'", nullptr);
+            return 0;
+        }
+        auto&& ret = obj->getPhysicsInterpolationAlpha();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:getPhysicsInterpolationAlpha",argc, 0);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_getPhysicsInterpolationAlpha'.",&tolua_err);
+#endif
+
+    return 0;
+}
 int lua_ax_base_Scene_getPhysicsWorld2D(lua_State* tolua_S)
 {
     int argc = 0;
@@ -22755,6 +23099,56 @@ int lua_ax_base_Scene_initPhysicsWorld(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_initPhysicsWorld'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_base_Scene_tick(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Scene* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Scene",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Scene*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Scene_tick'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        double arg0;
+
+        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.Scene:tick");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Scene_tick'", nullptr);
+            return 0;
+        }
+        obj->tick(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Scene:tick",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Scene_tick'.",&tolua_err);
 #endif
 
     return 0;
@@ -23018,9 +23412,17 @@ int lua_register_ax_base_Scene(lua_State* tolua_S)
         tolua_function(tolua_S,"initWithSize",lua_ax_base_Scene_initWithSize);
         tolua_function(tolua_S,"setCameraOrderDirty",lua_ax_base_Scene_setCameraOrderDirty);
         tolua_function(tolua_S,"setDebugCamera",lua_ax_base_Scene_setDebugCamera);
+        tolua_function(tolua_S,"setFixedDeltaTime",lua_ax_base_Scene_setFixedDeltaTime);
+        tolua_function(tolua_S,"setMaxDeltaTime",lua_ax_base_Scene_setMaxDeltaTime);
+        tolua_function(tolua_S,"setMaxFixedStepsPerFrame",lua_ax_base_Scene_setMaxFixedStepsPerFrame);
+        tolua_function(tolua_S,"setTimeScale",lua_ax_base_Scene_setTimeScale);
+        tolua_function(tolua_S,"setFixedUpdateEnabled",lua_ax_base_Scene_setFixedUpdateEnabled);
+        tolua_function(tolua_S,"isFixedUpdateEnabled",lua_ax_base_Scene_isFixedUpdateEnabled);
+        tolua_function(tolua_S,"getPhysicsInterpolationAlpha",lua_ax_base_Scene_getPhysicsInterpolationAlpha);
         tolua_function(tolua_S,"getPhysicsWorld2D",lua_ax_base_Scene_getPhysicsWorld2D);
         tolua_function(tolua_S,"initWithPhysics",lua_ax_base_Scene_initWithPhysics);
         tolua_function(tolua_S,"initPhysicsWorld",lua_ax_base_Scene_initPhysicsWorld);
+        tolua_function(tolua_S,"tick",lua_ax_base_Scene_tick);
         tolua_function(tolua_S,"fixedUpdate",lua_ax_base_Scene_fixedUpdate);
         tolua_function(tolua_S,"stepPhysicsAndNavigation",lua_ax_base_Scene_stepPhysicsAndNavigation);
         tolua_function(tolua_S,"create", lua_ax_base_Scene_create);

--- a/extensions/scripting/lua-bindings/auto/axlua_physics2d_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_physics2d_auto.cpp
@@ -12758,103 +12758,6 @@ int lua_ax_physics2d_PhysicsWorld2D_getSpeed(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_physics2d_PhysicsWorld2D_setUpdateRate(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::PhysicsWorld2D* obj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.PhysicsWorld2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    obj = (ax::PhysicsWorld2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!obj)
-    {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics2d_PhysicsWorld2D_setUpdateRate'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        int arg0;
-
-        ok &= luaval_to_int(tolua_S, 2, &arg0, "ax.PhysicsWorld2D:setUpdateRate");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics2d_PhysicsWorld2D_setUpdateRate'", nullptr);
-            return 0;
-        }
-        obj->setUpdateRate(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld2D:setUpdateRate",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_setUpdateRate'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_physics2d_PhysicsWorld2D_getUpdateRate(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::PhysicsWorld2D* obj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.PhysicsWorld2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    obj = (ax::PhysicsWorld2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!obj)
-    {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics2d_PhysicsWorld2D_getUpdateRate'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics2d_PhysicsWorld2D_getUpdateRate'", nullptr);
-            return 0;
-        }
-        auto&& ret = obj->getUpdateRate();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld2D:getUpdateRate",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_getUpdateRate'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_physics2d_PhysicsWorld2D_setSubsteps(lua_State* tolua_S)
 {
     int argc = 0;
@@ -12948,103 +12851,6 @@ int lua_ax_physics2d_PhysicsWorld2D_getSubsteps(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     tolua_lerror:
     tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_getSubsteps'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_physics2d_PhysicsWorld2D_setFixedUpdateRate(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::PhysicsWorld2D* obj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.PhysicsWorld2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    obj = (ax::PhysicsWorld2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!obj)
-    {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics2d_PhysicsWorld2D_setFixedUpdateRate'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        int arg0;
-
-        ok &= luaval_to_int(tolua_S, 2, &arg0, "ax.PhysicsWorld2D:setFixedUpdateRate");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics2d_PhysicsWorld2D_setFixedUpdateRate'", nullptr);
-            return 0;
-        }
-        obj->setFixedUpdateRate(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld2D:setFixedUpdateRate",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_setFixedUpdateRate'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_ax_physics2d_PhysicsWorld2D_getFixedUpdateRate(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::PhysicsWorld2D* obj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.PhysicsWorld2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    obj = (ax::PhysicsWorld2D*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!obj)
-    {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics2d_PhysicsWorld2D_getFixedUpdateRate'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics2d_PhysicsWorld2D_getFixedUpdateRate'", nullptr);
-            return 0;
-        }
-        auto&& ret = obj->getFixedUpdateRate();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld2D:getFixedUpdateRate",argc, 0);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_getFixedUpdateRate'.",&tolua_err);
 #endif
 
     return 0;
@@ -13254,7 +13060,7 @@ int lua_ax_physics2d_PhysicsWorld2D_isAutoStep(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_physics2d_PhysicsWorld2D_step(lua_State* tolua_S)
+int lua_ax_physics2d_PhysicsWorld2D_stepSimulation(lua_State* tolua_S)
 {
     int argc = 0;
     ax::PhysicsWorld2D* obj = nullptr;
@@ -13274,7 +13080,7 @@ int lua_ax_physics2d_PhysicsWorld2D_step(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!obj)
     {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics2d_PhysicsWorld2D_step'", nullptr);
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics2d_PhysicsWorld2D_stepSimulation'", nullptr);
         return 0;
     }
 #endif
@@ -13284,22 +13090,22 @@ int lua_ax_physics2d_PhysicsWorld2D_step(lua_State* tolua_S)
     {
         double arg0;
 
-        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.PhysicsWorld2D:step");
+        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.PhysicsWorld2D:stepSimulation");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics2d_PhysicsWorld2D_step'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics2d_PhysicsWorld2D_stepSimulation'", nullptr);
             return 0;
         }
-        obj->step(arg0);
+        obj->stepSimulation(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld2D:step",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld2D:stepSimulation",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_step'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics2d_PhysicsWorld2D_stepSimulation'.",&tolua_err);
 #endif
 
     return 0;
@@ -13327,17 +13133,13 @@ int lua_register_ax_physics2d_PhysicsWorld2D(lua_State* tolua_S)
         tolua_function(tolua_S,"setGravity",lua_ax_physics2d_PhysicsWorld2D_setGravity);
         tolua_function(tolua_S,"setSpeed",lua_ax_physics2d_PhysicsWorld2D_setSpeed);
         tolua_function(tolua_S,"getSpeed",lua_ax_physics2d_PhysicsWorld2D_getSpeed);
-        tolua_function(tolua_S,"setUpdateRate",lua_ax_physics2d_PhysicsWorld2D_setUpdateRate);
-        tolua_function(tolua_S,"getUpdateRate",lua_ax_physics2d_PhysicsWorld2D_getUpdateRate);
         tolua_function(tolua_S,"setSubsteps",lua_ax_physics2d_PhysicsWorld2D_setSubsteps);
         tolua_function(tolua_S,"getSubsteps",lua_ax_physics2d_PhysicsWorld2D_getSubsteps);
-        tolua_function(tolua_S,"setFixedUpdateRate",lua_ax_physics2d_PhysicsWorld2D_setFixedUpdateRate);
-        tolua_function(tolua_S,"getFixedUpdateRate",lua_ax_physics2d_PhysicsWorld2D_getFixedUpdateRate);
         tolua_function(tolua_S,"setPreUpdateCallback",lua_ax_physics2d_PhysicsWorld2D_setPreUpdateCallback);
         tolua_function(tolua_S,"setPostUpdateCallback",lua_ax_physics2d_PhysicsWorld2D_setPostUpdateCallback);
         tolua_function(tolua_S,"setAutoStep",lua_ax_physics2d_PhysicsWorld2D_setAutoStep);
         tolua_function(tolua_S,"isAutoStep",lua_ax_physics2d_PhysicsWorld2D_isAutoStep);
-        tolua_function(tolua_S,"step",lua_ax_physics2d_PhysicsWorld2D_step);
+        tolua_function(tolua_S,"stepSimulation",lua_ax_physics2d_PhysicsWorld2D_stepSimulation);
     tolua_endmodule(tolua_S);
     auto typeName = typeid(ax::PhysicsWorld2D).name(); // rtti is literal storage
     g_luaType[reinterpret_cast<uintptr_t>(typeName)] = "ax.PhysicsWorld2D";

--- a/extensions/scripting/lua-bindings/auto/axlua_physics3d_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_physics3d_auto.cpp
@@ -8424,7 +8424,7 @@ int lua_ax_physics3d_PhysicsWorld3D_getGravity(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_physics3d_PhysicsWorld3D_stepSimulate(lua_State* tolua_S)
+int lua_ax_physics3d_PhysicsWorld3D_setAutoStep(lua_State* tolua_S)
 {
     int argc = 0;
     ax::PhysicsWorld3D* obj = nullptr;
@@ -8444,7 +8444,104 @@ int lua_ax_physics3d_PhysicsWorld3D_stepSimulate(lua_State* tolua_S)
 #if _AX_DEBUG >= 1
     if (!obj)
     {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics3d_PhysicsWorld3D_stepSimulate'", nullptr);
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics3d_PhysicsWorld3D_setAutoStep'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        bool arg0;
+
+        ok &= luaval_to_boolean(tolua_S, 2, &arg0, "ax.PhysicsWorld3D:setAutoStep");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics3d_PhysicsWorld3D_setAutoStep'", nullptr);
+            return 0;
+        }
+        obj->setAutoStep(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld3D:setAutoStep",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics3d_PhysicsWorld3D_setAutoStep'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_physics3d_PhysicsWorld3D_isAutoStep(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::PhysicsWorld3D* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.PhysicsWorld3D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::PhysicsWorld3D*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics3d_PhysicsWorld3D_isAutoStep'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics3d_PhysicsWorld3D_isAutoStep'", nullptr);
+            return 0;
+        }
+        auto&& ret = obj->isAutoStep();
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld3D:isAutoStep",argc, 0);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics3d_PhysicsWorld3D_isAutoStep'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_ax_physics3d_PhysicsWorld3D_stepSimulation(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::PhysicsWorld3D* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.PhysicsWorld3D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::PhysicsWorld3D*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_physics3d_PhysicsWorld3D_stepSimulation'", nullptr);
         return 0;
     }
 #endif
@@ -8454,22 +8551,22 @@ int lua_ax_physics3d_PhysicsWorld3D_stepSimulate(lua_State* tolua_S)
     {
         double arg0;
 
-        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.PhysicsWorld3D:stepSimulate");
+        ok &= luaval_to_number(tolua_S, 2, &arg0, "ax.PhysicsWorld3D:stepSimulation");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics3d_PhysicsWorld3D_stepSimulate'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_physics3d_PhysicsWorld3D_stepSimulation'", nullptr);
             return 0;
         }
-        obj->stepSimulate(arg0);
+        obj->stepSimulation(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld3D:stepSimulate",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.PhysicsWorld3D:stepSimulation",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics3d_PhysicsWorld3D_stepSimulate'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_physics3d_PhysicsWorld3D_stepSimulation'.",&tolua_err);
 #endif
 
     return 0;
@@ -8899,7 +8996,9 @@ int lua_register_ax_physics3d_PhysicsWorld3D(lua_State* tolua_S)
         tolua_function(tolua_S,"getScene",lua_ax_physics3d_PhysicsWorld3D_getScene);
         tolua_function(tolua_S,"setGravity",lua_ax_physics3d_PhysicsWorld3D_setGravity);
         tolua_function(tolua_S,"getGravity",lua_ax_physics3d_PhysicsWorld3D_getGravity);
-        tolua_function(tolua_S,"stepSimulate",lua_ax_physics3d_PhysicsWorld3D_stepSimulate);
+        tolua_function(tolua_S,"setAutoStep",lua_ax_physics3d_PhysicsWorld3D_setAutoStep);
+        tolua_function(tolua_S,"isAutoStep",lua_ax_physics3d_PhysicsWorld3D_isAutoStep);
+        tolua_function(tolua_S,"stepSimulation",lua_ax_physics3d_PhysicsWorld3D_stepSimulation);
         tolua_function(tolua_S,"setDebugDrawEnabled",lua_ax_physics3d_PhysicsWorld3D_setDebugDrawEnabled);
         tolua_function(tolua_S,"isDebugDrawEnabled",lua_ax_physics3d_PhysicsWorld3D_isDebugDrawEnabled);
         tolua_function(tolua_S,"setGlobalEventEnabled",lua_ax_physics3d_PhysicsWorld3D_setGlobalEventEnabled);

--- a/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.cpp
@@ -78,6 +78,7 @@ PhysicsDemo::PhysicsDemo() : _spriteTexture(nullptr), _ball(nullptr), _debugDraw
 bool PhysicsDemo::init()
 {
     TestCase::init();
+    setFixedUpdateEnabled(false);
     return initWithPhysics();
 }
 
@@ -348,7 +349,6 @@ void PhysicsDemoLogoSmash::onEnter()
                            Color32::GREEN, Color32(0, 178, 255), Color32(255, 174, 201)};
 
     _physicsWorld2D->setGravity(Vec2(0.0f, 0.0f));
-    _physicsWorld2D->setUpdateRate(1);
 
     _ball = SpriteBatchNode::create(
         "Images/ball.png", LOGO_WIDTH_COLORED * LOGO_HEIGHT_COLORED + LOGO_WIDTH_COLORED + LOGO_HEIGHT_COLORED);
@@ -1913,17 +1913,16 @@ void PhysicsFixedUpdate::updateStart(float /*delta*/)
 {
     addBall();
 
-    _physicsWorld2D->setFixedUpdateRate(180);
+    //_physicsWorld2D->setSpeed(2.0f);
 }
 
 void PhysicsFixedUpdate::update(float /*delta*/)
 {
-
     // use fixed time and calculate 3 times per frame makes physics simulate more precisely.
-    for (int i = 0; i < 3; ++i)
-    {
-        _physicsWorld2D->step(1 / 180.0f);
-    }
+    // for (int i = 0; i < 3; ++i)
+    // {
+    //     _physicsWorld2D->stepSimulation(1 / 180.0f);
+    // }
 }
 
 std::string PhysicsFixedUpdate::title() const
@@ -2075,6 +2074,8 @@ void PhysicsDemoPyramidStackFixedUpdate::onEnter()
 {
     PhysicsDemo::onEnter();
 
+    setFixedUpdateEnabled(true);
+
     auto touchListener          = EventListenerTouchOneByOne::create();
     touchListener->onTouchBegan = AX_CALLBACK_2(PhysicsDemoPyramidStackFixedUpdate::onTouchBegan, this);
     touchListener->onTouchMoved = AX_CALLBACK_2(PhysicsDemoPyramidStackFixedUpdate::onTouchMoved, this);
@@ -2097,7 +2098,6 @@ void PhysicsDemoPyramidStackFixedUpdate::onEnter()
 
     _delayTime = 0;
     _isAddBall = false;
-    _physicsWorld2D->setFixedUpdateRate(50);
 
     int count = 1;
     for (int i = 0; i < 14; i++)
@@ -2122,6 +2122,8 @@ std::string PhysicsDemoPyramidStackFixedUpdate::title() const
 
 void PhysicsDemoPyramidStackFixedUpdate::fixedUpdate(float delta)
 {
+    Scene::fixedUpdate(delta);
+
     _delayTime += delta;
     if (_delayTime >= 3.0f && !_isAddBall)
     {

--- a/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.cpp
@@ -1913,16 +1913,8 @@ void PhysicsFixedUpdate::updateStart(float /*delta*/)
 {
     addBall();
 
-    //_physicsWorld2D->setSpeed(2.0f);
-}
-
-void PhysicsFixedUpdate::update(float /*delta*/)
-{
-    // use fixed time and calculate 3 times per frame makes physics simulate more precisely.
-    // for (int i = 0; i < 3; ++i)
-    // {
-    //     _physicsWorld2D->stepSimulation(1 / 180.0f);
-    // }
+    setFixedUpdateEnabled(true);
+    setFixedDeltaTime(1 / 180.0f);
 }
 
 std::string PhysicsFixedUpdate::title() const

--- a/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.h
+++ b/tests/cpp-tests/Source/PhysicsTest/PhysicsTest.h
@@ -37,12 +37,12 @@ class PhysicsDemo : public TestCase
 {
 public:
     PhysicsDemo();
-    virtual ~PhysicsDemo();
+    ~PhysicsDemo() override;
 
-    virtual bool init() override;
-    virtual void onEnter() override;
+    bool init() override;
+    void onEnter() override;
 
-    virtual std::string title() const override;
+    std::string title() const override;
 
     void toggleDebugCallback(ax::Object* sender);
 
@@ -90,9 +90,9 @@ class PhysicsDemoClickAdd : public PhysicsDemo
 public:
     CREATE_FUNC(PhysicsDemoClickAdd);
 
-    virtual ~PhysicsDemoClickAdd();
+    ~PhysicsDemoClickAdd() override;
     void onEnter() override;
-    virtual std::string subtitle() const override;
+    std::string subtitle() const override;
 
     void onTouchesEnded(const std::vector<ax::Touch*>& touches, ax::Event* event);
     void onAcceleration(ax::Acceleration* acc, ax::Event* event);
@@ -105,7 +105,7 @@ public:
 
     void onEnter() override;
     void updateOnce(float delta);
-    virtual std::string title() const override;
+    std::string title() const override;
 };
 
 class PhysicsDemoRayCast : public PhysicsDemo
@@ -116,7 +116,7 @@ public:
     PhysicsDemoRayCast();
 
     void onEnter() override;
-    virtual std::string title() const override;
+    std::string title() const override;
     void update(float delta) override;
     void onTouchesEnded(const std::vector<ax::Touch*>& touches, ax::Event* event);
 
@@ -204,8 +204,8 @@ public:
     CREATE_FUNC(PhysicsDemoBug3988);
 
     void onEnter() override;
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 };
 
 class PhysicsContactTest : public PhysicsDemo
@@ -216,8 +216,8 @@ public:
     void onEnter() override;
     void resetTest();
     bool onPreSolve(const ax::ContactInfo2D& info);
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 
     void onDecrease(ax::Object* sender);
     void onIncrease(ax::Object* sender);
@@ -235,7 +235,7 @@ public:
     CREATE_FUNC(PhysicsPositionRotationTest);
 
     void onEnter() override;
-    virtual std::string title() const override;
+    std::string title() const override;
 };
 
 class PhysicsSetGravityEnableTest : public PhysicsDemo
@@ -245,8 +245,8 @@ public:
 
     void onEnter() override;
     void onScheduleOnce(float delta);
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 };
 
 class PhysicsDemoBug5482 : public PhysicsDemo
@@ -256,8 +256,8 @@ public:
 
     void onEnter() override;
     void onExit() override;
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 
     void changeBodyCallback(ax::Object* sender);
 
@@ -276,9 +276,8 @@ public:
     void onEnter() override;
     void updateStart(float delta);
     void addBall();
-    virtual void update(float delta) override;
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 };
 
 class PhysicsTransformTest : public PhysicsDemo
@@ -302,8 +301,8 @@ public:
     CREATE_FUNC(PhysicsIssue9959);
 
     void onEnter() override;
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 };
 
 class PhysicsIssue15932 : public PhysicsDemo
@@ -312,8 +311,8 @@ public:
     CREATE_FUNC(PhysicsIssue15932);
 
     void onEnter() override;
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
+    std::string title() const override;
+    std::string subtitle() const override;
 };
 
 class PhysicsDemoPyramidStackFixedUpdate : public PhysicsDemo
@@ -322,9 +321,9 @@ public:
     CREATE_FUNC(PhysicsDemoPyramidStackFixedUpdate);
 
     void onEnter() override;
-    virtual std::string title() const override;
+    std::string title() const override;
 
-    virtual void fixedUpdate(float delta) override;
+    void fixedUpdate(float delta) override;
 
 private:
     bool _isAddBall;


### PR DESCRIPTION
## Describe your changes

- Unify Scene tick/fixedUpdate loop with accumulator, timeScale, maxDeltaTime clamp, and maxFixedStepsPerFrame
- Replace PhysicsWorld2D/3D step/update with stepSimulation, remove fixedUpdateRate/updateRate APIs
- Add fixedUpdateEnabled flag and interpolation alpha support in Scene
- Adjust Physics tests to use new fixedUpdateEnabled and stepSimulation
- Clean up Director to call Scene::tick instead of stepPhysicsAndNavigation
- Minor fixes in RenderView and openal-soft CMake (remove /W4 warnings)


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
