### PR TITLE
Add AX_DRAWNODE_FAST_LINE2CENTER to PhysicsDebugNode

### DIFF
--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -1095,10 +1095,10 @@ void DrawNode::_drawSegment(const Vec2& from,
     }
 }
 
-void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& color, Vec2& vec)
+void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, Vec2& vec)
 {
-    Color fillColor = Color(1.0f - color.r, 1.0f - color.g, 1.0f - color.b, 1.0f);
-#ifdef AX_DRAWNODE_FAST_LINE2CENTER
+   // Color fillColor = Color(color.r*4, 1.0f - color.g, 1.0f - color.b, 1.0f);
+#if AX_DRAWNODE_FAST_LINE2CENTER
     auto triangles  = reinterpret_cast<V2F_T2F_C4F_Triangle*>(expandBufferAndGetPointer(_triangles, 9));
     _trianglesDirty = true;
 
@@ -1110,9 +1110,9 @@ void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& c
     triangles[0] = {a, b, c};
     triangles[1] = {a, c, d};
 
-    V2F_T2F_C4F e = {center - Vec2(1, 1), Vec2::ZERO, fillColor};
-    V2F_T2F_C4F f = {center + vec * radius, Vec2::ZERO, fillColor};
-    V2F_T2F_C4F g = {center + Vec2(1, 1), Vec2::ZERO, fillColor};
+    V2F_T2F_C4F e = {center - Vec2(1, 1), Vec2::ZERO, lineColor};
+    V2F_T2F_C4F f = {center + vec * radius, Vec2::ZERO, lineColor};
+    V2F_T2F_C4F g = {center + Vec2(1, 1), Vec2::ZERO, lineColor};
     triangles[2]  = {g, f, e};
 #else
     auto triangles  = reinterpret_cast<V2F_T2F_C4F_Triangle*>(expandBufferAndGetPointer(_triangles, 6));
@@ -1128,12 +1128,12 @@ void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& c
     auto line    = expandBufferAndGetPointer(_lines, 2);
     _linesDirty  = true;
 
-    line[0] = {center, Vec2::ZERO, fillColor};
-    line[1] = {center + vec * radius, Vec2::ZERO, fillColor};
+    line[0] = {center, Vec2::ZERO, lineColor};
+    line[1] = {center + vec * radius, Vec2::ZERO, lineColor};
 #endif  // AX_DRAWNODE_FAST_LINE2CENTER
 }
 
-void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, float angle)
+void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, float angle)
 {
     Vec2 vec = {-1, 0};
     if (angle != 0.0f)
@@ -1142,7 +1142,12 @@ void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& co
         Vec2 _angle = {cosf(aa), sinf(aa)};
         vec         = {_angle.x, _angle.y};
     }
-    _drawSolidCircle(center, radius, color, vec);
+    _drawSolidCircle(center, radius, color, lineColor, vec);
+}
+
+void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, Vec2& vec)
+{
+    _drawSolidCircle(center, radius, color, lineColor, vec);
 }
 
 void DrawNode::_drawSolidCircle(const Vec2& center,

--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -1095,7 +1095,11 @@ void DrawNode::_drawSegment(const Vec2& from,
     }
 }
 
-void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, const Vec2& vec)
+void DrawNode::_drawSolidCircle(const Vec2& center,
+                                float radius,
+                                const Color& color,
+                                const Color& lineColor,
+                                const Vec2& vec)
 {
 #if AX_DRAWNODE_FAST_LINE2CENTER
     auto triangles  = reinterpret_cast<V2F_T2F_C4F_Triangle*>(expandBufferAndGetPointer(_triangles, 9));
@@ -1132,7 +1136,11 @@ void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& c
 #endif  // AX_DRAWNODE_FAST_LINE2CENTER
 }
 
-void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, float angle)
+void DrawNode::drawSolidCircle(const Vec2& center,
+                               float radius,
+                               const Color& color,
+                               const Color& lineColor,
+                               float angle)
 {
     Vec2 vec = {-1, 0};
     if (angle != 0.0f)
@@ -1144,7 +1152,11 @@ void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& co
     _drawSolidCircle(center, radius, color, lineColor, vec);
 }
 
-void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, const Vec2& vec)
+void DrawNode::drawSolidCircle(const Vec2& center,
+                               float radius,
+                               const Color& color,
+                               const Color& lineColor,
+                               const Vec2& vec)
 {
     _drawSolidCircle(center, radius, color, lineColor, vec);
 }

--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -1095,9 +1095,8 @@ void DrawNode::_drawSegment(const Vec2& from,
     }
 }
 
-void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, Vec2& vec)
+void DrawNode::_drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, const Vec2& vec)
 {
-   // Color fillColor = Color(color.r*4, 1.0f - color.g, 1.0f - color.b, 1.0f);
 #if AX_DRAWNODE_FAST_LINE2CENTER
     auto triangles  = reinterpret_cast<V2F_T2F_C4F_Triangle*>(expandBufferAndGetPointer(_triangles, 9));
     _trianglesDirty = true;
@@ -1145,7 +1144,7 @@ void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& co
     _drawSolidCircle(center, radius, color, lineColor, vec);
 }
 
-void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, Vec2& vec)
+void DrawNode::drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, const Vec2& vec)
 {
     _drawSolidCircle(center, radius, color, lineColor, vec);
 }

--- a/axmol/2d/DrawNode.h
+++ b/axmol/2d/DrawNode.h
@@ -376,7 +376,11 @@ public:
                          bool drawLineToCenter = false);
 
     void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, float angle);
-    void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, const Vec2& vec);  
+    void drawSolidCircle(const Vec2& center,
+                         float radius,
+                         const Color& fillColor,
+                         const Color& lineColor,
+                         const Vec2& vec);
 
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
@@ -672,7 +676,11 @@ private:
                           float thickness);
 
     // Internal function _drawSolidCircle
-    void _drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, const Vec2& vec2);
+    void _drawSolidCircle(const Vec2& center,
+                          float radius,
+                          const Color& color,
+                          const Color& lineColor,
+                          const Vec2& vec2);
 
     // Internal function _drawPie
     void _drawPie(const Vec2& center,

--- a/axmol/2d/DrawNode.h
+++ b/axmol/2d/DrawNode.h
@@ -375,6 +375,9 @@ public:
                          const Color& borderColor,
                          bool drawLineToCenter = false);
 
+    void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, float angle);
+    void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, Vec2& vec);  
+
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
@@ -400,7 +403,6 @@ public:
      * @param color The solid circle color.
      */
     void drawSolidCircle(const Vec2& center, float radius, float angle, unsigned int segments, const Color& color);
-    void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, float angle);
     void drawSolidCircle(const Vec2& center, float radius, const Color& color);
 
     /** Draws a pie given the center, radius, angle, start angle, end angle  and number of segments.
@@ -670,7 +672,7 @@ private:
                           float thickness);
 
     // Internal function _drawSolidCircle
-    void _drawSolidCircle(const Vec2& center, float radius, const Color& color, Vec2& vec2);
+    void _drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, Vec2& vec2);
 
     // Internal function _drawPie
     void _drawPie(const Vec2& center,

--- a/axmol/2d/DrawNode.h
+++ b/axmol/2d/DrawNode.h
@@ -376,7 +376,7 @@ public:
                          bool drawLineToCenter = false);
 
     void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, float angle);
-    void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, Vec2& vec);  
+    void drawSolidCircle(const Vec2& center, float radius, const Color& fillColor, const Color& lineColor, const Vec2& vec);  
 
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
@@ -672,7 +672,7 @@ private:
                           float thickness);
 
     // Internal function _drawSolidCircle
-    void _drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, Vec2& vec2);
+    void _drawSolidCircle(const Vec2& center, float radius, const Color& color, const Color& lineColor, const Vec2& vec2);
 
     // Internal function _drawPie
     void _drawPie(const Vec2& center,

--- a/axmol/base/Config.h
+++ b/axmol/base/Config.h
@@ -319,7 +319,7 @@ THE SOFTWARE.
  * 0 = DrawNode 2.0 drawLine methode (slower)
  */
 #ifndef AX_DRAWNODE_FAST_LINE2CENTER
-#    define AX_DRAWNODE_FAST_LINE2CENTER 1
+#    define AX_DRAWNODE_FAST_LINE2CENTER 0
 #endif
 
 /// @name namespace ax

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -79,15 +79,22 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
     Vec2 c       = {Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset()};
     auto color4f = b2util::cast(color);
 
+#if AX_DRAWNODE_FAST_LINE2CENTER
+    dn->drawSolidCircle(c, radius * dn->getPTMRatio(), color4f,
+                    ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a),                          
+            AX_RADIANS_TO_DEGREES(b2Rot_GetAngle(t.q)));
+#else
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-                radius * dn->getPTMRatio(), color4f);
+            radius * dn->getPTMRatio(), color4f);
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-                radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a));
+            radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4,
+            color4f.a));
 
-    // Draw a line fixed in the circle to animate rotation.
+    //// Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};
     Vec2 cp   = {Vec2(pp.x * dn->getPTMRatio(), pp.y * dn->getPTMRatio()) + dn->getWorldOffset()};
     dn->drawLine(c, cp, color4f);
+#endif  // AX_DRAWNODE_FAST_LINE2CENTER
 }
 
 /// Draw a solid capsule.

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -81,14 +81,13 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
 
 #if AX_DRAWNODE_FAST_LINE2CENTER
     dn->drawSolidCircle(c, radius * dn->getPTMRatio(), color4f,
-                    ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a),                          
-            AX_RADIANS_TO_DEGREES(b2Rot_GetAngle(t.q)));
+                        ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a),
+                        AX_RADIANS_TO_DEGREES(b2Rot_GetAngle(t.q)));
 #else
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-            radius * dn->getPTMRatio(), color4f);
+                radius * dn->getPTMRatio(), color4f);
     dn->drawDot(Vec2(center.x * dn->getPTMRatio(), center.y * dn->getPTMRatio()) + dn->getWorldOffset(),
-            radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4,
-            color4f.a));
+                radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4, color4f.a));
 
     // Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -90,7 +90,7 @@ static void b2DrawSolidCircle(b2Transform t, float radius, b2HexColor color, Phy
             radius * dn->getPTMRatio() - 0.5f, ax::Color(color4f.r / 4, color4f.g / 4, color4f.b / 4,
             color4f.a));
 
-    //// Draw a line fixed in the circle to animate rotation.
+    // Draw a line fixed in the circle to animate rotation.
     b2Vec2 pp = {(center + radius * b2Rot_GetXAxis(t.q))};
     Vec2 cp   = {Vec2(pp.x * dn->getPTMRatio(), pp.y * dn->getPTMRatio()) + dn->getWorldOffset()};
     dn->drawLine(c, cp, color4f);

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -52717,7 +52717,7 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
 #endif
     argc = lua_gettop(tolua_S)-1;
     do {
-        if (argc == 7) {
+        if (argc == 5) {
             ax::Vec2 arg0;
             ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidCircle");
 
@@ -52726,27 +52726,19 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            double arg2;
-            ok &= luaval_to_number(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidCircle");
+            ax::Color arg2;
+            ok &=luaval_to_color(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            unsigned int arg3;
-            ok &= luaval_to_int(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidCircle");
+            ax::Color arg3;
+            ok &=luaval_to_color(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
             double arg4;
             ok &= luaval_to_number(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
-            double arg5;
-            ok &= luaval_to_number(tolua_S, 7, &arg5, "ax.DrawNode:drawSolidCircle");
-
-            if (!ok) { break; }
-            ax::Color arg6;
-            ok &=luaval_to_color(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
-
-            if (!ok) { break; }
-            obj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+            obj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4);
             lua_settop(tolua_S, 1);
             return 1;
         }
@@ -52854,6 +52846,70 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
             ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidCircle");
 
             if (!ok) { break; }
+            ax::Color arg2;
+            ok &=luaval_to_color(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            ax::Color arg3;
+            ok &=luaval_to_color(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            ax::Vec2 arg4;
+            ok &= luaval_to_vec2(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            obj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4);
+            lua_settop(tolua_S, 1);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do {
+        if (argc == 7) {
+            ax::Vec2 arg0;
+            ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            double arg1;
+            ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            unsigned int arg3;
+            ok &= luaval_to_int(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            double arg4;
+            ok &= luaval_to_number(tolua_S, 6, &arg4, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            double arg5;
+            ok &= luaval_to_number(tolua_S, 7, &arg5, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            ax::Color arg6;
+            ok &=luaval_to_color(tolua_S, 8, &arg6, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            obj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+            lua_settop(tolua_S, 1);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do {
+        if (argc == 5) {
+            ax::Vec2 arg0;
+            ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
+            double arg1;
+            ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidCircle");
+
+            if (!ok) { break; }
             double arg2;
             ok &= luaval_to_number(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidCircle");
 
@@ -52867,30 +52923,6 @@ int lua_ax_base_DrawNode_drawSolidCircle(lua_State* tolua_S)
 
             if (!ok) { break; }
             obj->drawSolidCircle(arg0, arg1, arg2, arg3, arg4);
-            lua_settop(tolua_S, 1);
-            return 1;
-        }
-    }while(0);
-    ok  = true;
-    do {
-        if (argc == 4) {
-            ax::Vec2 arg0;
-            ok &= luaval_to_vec2(tolua_S, 2, &arg0, "ax.DrawNode:drawSolidCircle");
-
-            if (!ok) { break; }
-            double arg1;
-            ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.DrawNode:drawSolidCircle");
-
-            if (!ok) { break; }
-            ax::Color arg2;
-            ok &=luaval_to_color(tolua_S, 4, &arg2, "ax.DrawNode:drawSolidCircle");
-
-            if (!ok) { break; }
-            double arg3;
-            ok &= luaval_to_number(tolua_S, 5, &arg3, "ax.DrawNode:drawSolidCircle");
-
-            if (!ok) { break; }
-            obj->drawSolidCircle(arg0, arg1, arg2, arg3);
             lua_settop(tolua_S, 1);
             return 1;
         }


### PR DESCRIPTION
## Describe your changes

Add AX_DRAWNODE_FAST_LINE2CENTER to PhysicsDebugNode
=>can be switched between the both DrawSolidCircle versions now.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
