### PR TITLE
Fix FontTest

### DIFF
--- a/tests/cpp-tests/Source/FontTest/FontTest.cpp
+++ b/tests/cpp-tests/Source/FontTest/FontTest.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/tests/cpp-tests/Source/FontTest/FontTest.cpp
+++ b/tests/cpp-tests/Source/FontTest/FontTest.cpp
@@ -97,13 +97,13 @@ void FontTest::showFont(std::string_view fontFile)
     removeChildByTag(kTagColor2, true);
     removeChildByTag(kTagColor3, true);
 
-    auto top    = Label::createWithSystemFont(fontFile, fontFile, 24);
-    auto left   = Label::createWithSystemFont("alignment left", fontFile, fontSize, blockSize, TextHAlignment::LEFT,
-                                              verticalAlignment[vAlignIdx]);
-    auto center = Label::createWithSystemFont("alignment center", fontFile, fontSize, blockSize, TextHAlignment::CENTER,
-                                              verticalAlignment[vAlignIdx]);
-    auto right  = Label::createWithSystemFont("alignment right", fontFile, fontSize, blockSize, TextHAlignment::RIGHT,
-                                              verticalAlignment[vAlignIdx]);
+    auto top    = Label::createWithTTF(fontFile, fontFile, 10);
+    auto left   = Label::createWithTTF("alignment left", fontFile, fontSize, blockSize, TextHAlignment::LEFT,
+                                       verticalAlignment[vAlignIdx]);
+    auto center = Label::createWithTTF("alignment center", fontFile, fontSize, blockSize, TextHAlignment::CENTER,
+                                       verticalAlignment[vAlignIdx]);
+    auto right  = Label::createWithTTF("alignment right", fontFile, fontSize, blockSize, TextHAlignment::RIGHT,
+                                       verticalAlignment[vAlignIdx]);
 
     auto leftColor   = LayerColor::create(Color32(100, 100, 100, 255), blockSize.width, blockSize.height);
     auto centerColor = LayerColor::create(Color32(200, 100, 100, 255), blockSize.width, blockSize.height);
@@ -121,7 +121,7 @@ void FontTest::showFont(std::string_view fontFile)
     right->setAnchorPoint(Vec2(0, 0.5));
     rightColor->setAnchorPoint(Vec2(0, 0.5));
 
-    top->setPosition(s.width / 2, s.height - 20);
+    top->setPosition(s.width / 2, s.height - 45);
     left->setPosition(0, s.height / 2);
     leftColor->setPosition(left->getPosition());
     center->setPosition(blockSize.width, s.height / 2);
@@ -192,7 +192,7 @@ void FontNoReplacementTest::onEnter()
     removeChildByTag(kTagColor2, true);
     removeChildByTag(kTagColor3, true);
 
-    auto top    = Label::createWithTTF("fonts/A Damn Mess.ttf" + suffix, "fonts/A Damn Mess.ttf", 24);
+    auto top    = Label::createWithTTF("fonts/A Damn Mess.ttf" + suffix, "fonts/A Damn Mess.ttf", 10);
     auto left   = Label::createWithTTF("fonts/Abberancy.ttf" + suffix, "fonts/Abberancy.ttf", fontSize, blockSize,
                                        TextHAlignment::LEFT, verticalAlignment[0]);
     auto center = Label::createWithTTF("fonts/Abduction.ttf" + suffix, "fonts/Abduction.ttf", fontSize, blockSize,
@@ -216,7 +216,7 @@ void FontNoReplacementTest::onEnter()
     right->setAnchorPoint(Vec2(0, 0.5));
     rightColor->setAnchorPoint(Vec2(0, 0.5));
 
-    top->setPosition(s.width / 2, s.height - 20);
+    top->setPosition(s.width / 2, s.height - 45);
     left->setPosition(0, s.height / 2);
     leftColor->setPosition(left->getPosition());
     center->setPosition(blockSize.width, s.height / 2);

--- a/tests/cpp-tests/Source/FontTest/FontTest.h
+++ b/tests/cpp-tests/Source/FontTest/FontTest.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md).
 
  https://axmol.dev/
 

--- a/tests/cpp-tests/Source/FontTest/FontTest.h
+++ b/tests/cpp-tests/Source/FontTest/FontTest.h
@@ -39,7 +39,6 @@ public:
         if (ret->init())
         {
             ret->showFont(fontFile);
-            ret->autorelease();
         }
         else
         {

--- a/tests/cpp-tests/Source/FontTest/FontTest.h
+++ b/tests/cpp-tests/Source/FontTest/FontTest.h
@@ -40,6 +40,7 @@ public:
         if (ret->init())
         {
             ret->showFont(fontFile);
+            ret->autorelease();
         }
         else
         {


### PR DESCRIPTION
## Describe your changes
fix FontTest  (fonts be shown now)

Internal info:
https://github.com/cocos2d/cocos2d-x/pull/16797 

With Cocos2dx 4.0/Axmol this method no longer existing:
`FileUtils::getInstance()->setFilenameLookupDictionary(ValueMap());`

- [ ] So its seems I can remove the corresponding comments too.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
