### PR TITLE
Add docstring to dm2x function

### DIFF
--- a/1k/dm/dm.c
+++ b/1k/dm/dm.c
@@ -1,3 +1,7 @@
+/* Converts a value from decimeters to a unit multiplied by 10.33.
+ * @param v The value in decimeters.
+ * @return The converted value.
+ */
 long double dm2x(long double v)
 {
     return v * 10.33;


### PR DESCRIPTION
### Problem Background
The public function `dm2x` in `1k/dm/dm.c` lacked documentation comments, which decreased code readability and maintainability. Proper documentation is essential for understanding function behavior and usage in open-source projects.

### Changes Made
Added a comprehensive docstring to the `dm2x` function, including:
- A clear description of its purpose: converting decimeters to a unit multiplied by 10.33.
- Documentation for the input parameter `v`.
- Documentation for the return value.

### Verification
The documentation can be verified by reviewing the code to ensure the docstring accurately reflects the function's implementation and intent. This change does not alter functionality, only improves clarity.