### PR TITLE
docs: Add ai-instructions.md context file for AI coding assistants

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -18,7 +18,7 @@ This document provides system-level rules and context for AI coding assistants, 
 ### release/2.x (stable)
 - **Standard:** Implement features using clean **C++17/C++20** standards. Leverage `auto`, `nullptr`, `override`, `constexpr`, and structured bindings where appropriate.
 
-### [v3] dev/v3
+### [v3] dev
 - **Standard:** The v3 branch targets **C++23**. Use C++23 features freely (e.g., `std::expected`, `if consteval`, deducing `this`).
 
 ### Two-Stage Initialization (both branches)

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -1,0 +1,74 @@
+# Axmol Engine AI Coding Instructions
+
+This document provides system-level rules and context for AI coding assistants, LLMs, and agentic workflows (e.g., Cursor, Copilot, Claude, Windsurf, Aider) interacting with the Axmol Engine codebase.
+
+> **Scope:** Unless stated otherwise, all instructions in this document apply to the stable **`release/2.x`** branch (current LTS branch).
+> Sections specific to the **`dev/v3`** development branch are explicitly marked with the **[v3]** tag.
+
+---
+
+## 1. Engine Identity & Namespaces (CRITICAL)
+- **Namespace:** Always use the `ax::` namespace for all core engine types (e.g., `ax::Node`, `ax::Sprite`, `ax::Vec2`, `ax::Scene`, `ax::Director`).
+- **Legacy Naming:** Do not use the legacy `cocos2d::` namespace or `CC_*` prefixes in new code. Axmol provides compatibility aliases (`namespace cocos2d = ax;`, `CC_*` macros), so existing code will compile, but all new code must use `ax::` and `AX_*` exclusively.
+
+---
+
+## 2. Modern C++ Standard & Architecture
+
+### release/2.x (stable)
+- **Standard:** Implement features using clean **C++17/C++20** standards. Leverage `auto`, `nullptr`, `override`, `constexpr`, and structured bindings where appropriate.
+
+### [v3] dev/v3
+- **Standard:** The v3 branch targets **C++23**. Use C++23 features freely (e.g., `std::expected`, `if consteval`, deducing `this`).
+
+### Two-Stage Initialization (both branches)
+- Implement a static `create()` method combined with the `CREATE_FUNC(ClassName)` macro.
+- Implement a virtual `bool init()` method that returns `true` on success and explicitly calls its parent's init method (e.g., `Node::init()`).
+- **No Smart Pointers for Nodes (CRITICAL):** NEVER wrap `ax::Ref` or scene graph nodes (e.g., `Sprite`, `Scene`) into `std::shared_ptr` or `std::unique_ptr`. Use `Class::create()` and let the engine's reference counting handle lifetime.
+
+### Callbacks (both branches)
+- Use `AX_CALLBACK_*` macros for lambda assignments, scheduling, and event handling.
+
+---
+
+## 3. Memory Management & Ownership
+- **Autorelease Pool:** Objects instantiated via `::create()` are automatically managed by Axmol's reference-counting autorelease pool. Do not call `delete` on them.
+- **Scene Graph & Delayed Attachment:** Adding a node via `addChild()` increments its reference count; removing it via `removeChild()` or `removeFromParent()` decrements it. If an autoreleased object is created but not immediately added to the scene graph, it will be destroyed when the autorelease pool is drained (typically at the end of the current frame). Always call `obj->retain()` when storing a node as a class member outside the scene graph, and balance it with `obj->release()` in the destructor.
+- **Raw Ownership:** For memory blocks outside the scene graph, prefer modern standard smart pointers (`std::unique_ptr`, `std::shared_ptr`) or Axmol-specific containers (`ax::Vector<T>`, `ax::Map<K, V>`). Use `AX_SAFE_DELETE` for raw pointers when manual cleanup is necessary.
+
+---
+
+## 4. Guarded and High-Risk Areas
+
+### Third-Party Code (both branches)
+- Do not modify anything inside the `3rdparty/` directory unless explicitly instructed.
+
+### Generated Templates (both branches)
+- Do not alter platform template structures or boilerplate files in `templates/` without explicit isolation.
+
+### Platform Glue (both branches)
+- Use `AX_TARGET_PLATFORM` preprocessor guards for platform-specific C++, Objective-C++ (`.mm`), or Android JNI implementations. Keep JNI signatures strictly synchronized.
+
+### Public APIs (both branches)
+- Maintain strict backward compatibility when modifying public headers in `extensions/` or `core/`.
+- **[v3]** The engine core directory is `axmol/` instead of `core/`. Update include paths accordingly.
+
+---
+
+## 5. Verification & Builds
+
+### Requirements
+- Use CMake out-of-tree builds for testing: `cmake -S . -B build`
+
+### Build Commands (Axmol CLI)
+If the Axmol CLI environment is active, use the following entry points:
+
+| Platform | Command |
+|----------|---------|
+| Linux Desktop | `axmol build -p linux` |
+| Windows | `axmol build -p win32` |
+| Android | `axmol build -p android` |
+
+### [v3] Additional Build Notes
+- The v3 branch introduces experimental **Direct3D 12** and **Vulkan** RHI backends. To test them, refer to the [About-RHI-in-axmol-v3](https://github.com/axmolengine/axmol/wiki/About-RHI-in-axmol-v3) wiki page.
+- arm64 builds for Linux and Windows are available starting from v3.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -70,5 +70,5 @@ If the Axmol CLI environment is active, use the following entry points:
 | Android | `axmol build -p android` |
 
 ### [v3] Additional Build Notes
-- The v3 branch introduces experimental **Direct3D 12** and **Vulkan** RHI backends. To test them, refer to the [About-RHI-in-axmol-v3](https://github.com/axmolengine/axmol/wiki/About-RHI-in-axmol-v3) wiki page.
+- The v3 branch introduces experimental **Direct3D 11**, **Direct3D 12** and **Vulkan** RHI backends. To test them, refer to the [About-RHI-in-axmol-v3](https://github.com/axmolengine/axmol/wiki/About-RHI-in-axmol-v3) wiki page.
 - arm64 builds for Linux and Windows are available starting from v3.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -3,7 +3,7 @@
 This document provides system-level rules and context for AI coding assistants, LLMs, and agentic workflows (e.g., Cursor, Copilot, Claude, Windsurf, Aider) interacting with the Axmol Engine codebase.
 
 > **Scope:** Unless stated otherwise, all instructions in this document apply to the stable **`release/2.x`** branch (current LTS branch).
-> Sections specific to the **`dev/v3`** development branch are explicitly marked with the **[v3]** tag.
+> Sections specific to the **`dev`** development branch are explicitly marked with the **[v3]** tag.
 
 ---
 


### PR DESCRIPTION
## Describe your changes
This is a documentation-only patch that introduces `docs/ai-instructions.md`.

Modern AI coding tools and agentic workflows (such as Cursor, Copilot, Claude, Windsurf, Aider) are heavily utilized by developers today. However, due to legacy training data, LLMs consistently hallucinate obsolete Cocos2d-x APIs, the `cocos2d::` namespace, old `CC` prefixes, and incorrect memory management paradigms (like wrapping nodes in `std::shared_ptr`).

This machine-readable instruction file strictly guides AI assistants to use modern Axmol idioms: the `ax::` namespace, clean C++17/20/23 standards, proper two-stage initialization (`CREATE_FUNC`), and correct reference-counting/autorelease mechanics.

It introduces **zero changes** to the engine source code, third-party libraries, platform templates, or build configurations, maintaining 100% backward compatibility.

## Issue ticket number and link
Ref: https://github.com/axmolengine/axmol/discussions/3182

## Checklist before requesting a review
### For each PR
- [x] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [x] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.