### PR TITLE
Fix for issue 3198

### DIFF
--- a/core/2d/ActionInterval.cpp
+++ b/core/2d/ActionInterval.cpp
@@ -472,9 +472,7 @@ void Repeat::stop()
 void Repeat::update(float dt)
 {
     if (isDone())
-    {
         return;
-    }
 
     if (dt >= _nextDt)
     {

--- a/core/2d/ActionInterval.cpp
+++ b/core/2d/ActionInterval.cpp
@@ -471,6 +471,11 @@ void Repeat::stop()
 // container action like Repeat, Sequence, Ease, etc..
 void Repeat::update(float dt)
 {
+    if (isDone())
+    {
+        return;
+    }
+
     if (dt >= _nextDt)
     {
         while (dt >= _nextDt && _total < _times)
@@ -506,15 +511,17 @@ void Repeat::update(float dt)
             else
             {
                 // issue #390 prevent jerk, use right update
-                if (!(sendUpdateEventToScript(dt - (_nextDt - _innerAction->getDuration() / _duration), _innerAction)))
-                    _innerAction->update(dt - (_nextDt - _innerAction->getDuration() / _duration));
+                const auto innerDt = dt - (_nextDt - _innerAction->getDuration() / _duration);
+                if (!(sendUpdateEventToScript(innerDt, _innerAction)))
+                    _innerAction->update(innerDt);
             }
         }
     }
     else
     {
-        if (!(sendUpdateEventToScript(fmodf(dt * _times, 1.0f), _innerAction)))
-            _innerAction->update(fmodf(dt * _times, 1.0f));
+        const auto innerDt = fmodf(dt * _times, 1.0f);
+        if (!(sendUpdateEventToScript(innerDt, _innerAction)))
+            _innerAction->update(innerDt);
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Fix for issue where `Repeat::update()` is called after it has already completed all loops.

Minor code improvements as well.

## Issue ticket number and link
#3198 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
