### PR TITLE
Fix VR controller ray hit-test and use-after-free in pollEvents

### DIFF
--- a/axmol/base/EventDispatcher.cpp
+++ b/axmol/base/EventDispatcher.cpp
@@ -115,6 +115,8 @@ static PointerEvent::CaptureBits makePointerCaptureBits(PointerEvent* event)
 
 static bool pointerHitTest(PointerEvent* event, const Camera* camera, PointerEventListener* listener, Node* target)
 {
+    event->setCamera(camera);
+
     if (camera && event->getPointerType() != PointerType::Controller)
         event->setRay(camera->screenToRay(event->getPoint()));
 
@@ -1875,6 +1877,49 @@ const Camera* EventDispatcher::findHitCameraForListener(PointerEvent* event,
     }
 
     return nullptr;
+}
+
+PointerHitResult EventDispatcher::hitTestPointerEvent(PointerEvent* event)
+{
+    if (!event)
+        return {};
+
+    event->clearHitResult();
+    event->setCamera(nullptr);
+
+    sortEventListeners(PointerEventListener::LISTENER_ID);
+
+    auto listeners = getListeners(PointerEventListener::LISTENER_ID);
+    auto scene     = Director::getInstance()->getRunningScene();
+    if (!listeners || !scene)
+        return {};
+
+    auto sceneGraphPriorityListeners = listeners->getSceneGraphPriorityListeners();
+    if (!sceneGraphPriorityListeners)
+        return {};
+
+    auto cameras = scene->getCameras();
+    for (auto&& listener : *sceneGraphPriorityListeners)
+    {
+        if (!listener || !listener->isEnabled() || listener->isPaused() || !listener->isAttached())
+            continue;
+
+        auto target = listener->getAssociatedNode();
+        if (!target || _nodePriorityMap.find(target) == _nodePriorityMap.end())
+            continue;
+
+        auto pointerListener = static_cast<PointerEventListener*>(listener);
+        if (!findHitCameraForListener(event, pointerListener, cameras))
+            continue;
+
+        auto result = event->getHitResult();
+        event->setCamera(nullptr);
+        return result;
+    }
+
+    event->clearHitResult();
+    event->setCamera(nullptr);
+    return {};
 }
 
 }  // namespace ax

--- a/axmol/base/EventDispatcher.h
+++ b/axmol/base/EventDispatcher.h
@@ -56,6 +56,7 @@ class CustomEvent;
 class CustomEventListener;
 class PointerEventListener;
 class Camera;
+class InputSystem;
 
 /** @class EventDispatcher
 * @brief This class manages event listener subscriptions
@@ -217,6 +218,7 @@ public:
 
 protected:
     friend class Node;
+    friend class InputSystem;
 
     /** Sets the dirty flag for a node. */
     void setDirtyForNode(Node* node);
@@ -285,6 +287,8 @@ protected:
     void updateListeners(Event* event);
 
     void dispatchPointerEvent(PointerEvent* event);
+
+    PointerHitResult hitTestPointerEvent(PointerEvent* event);
 
     /** Associates node with event listener */
     void associateNodeAndEventListener(Node* node, EventListener* listener);

--- a/axmol/base/InputSystem.cpp
+++ b/axmol/base/InputSystem.cpp
@@ -607,6 +607,19 @@ PointerHitResult InputSystem::handleVRPointerEvent(InputPhase phase,
     return dispatchVRPointerEvent(phase, point, ray, state);
 }
 
+PointerHitResult InputSystem::hitTestVRPointer(Vec2 point, const Ray& ray, const PointerInputState& state)
+{
+    if (!_interactive)
+        return {};
+
+    // Reticle refresh needs a pure "currently under the ray" hit-test.
+    // PointerMove hit-tests may intentionally return the previous hovered widget
+    // to emit hover-exit events, and that path can report no fresh hit point.
+    _isolatedMoveEvent.setPointerInfo(InputPhase::PointerScroll, nativeToScreen(point), state);
+    _isolatedMoveEvent.setRay(ray);
+    return _eventDispatcher->hitTestPointerEvent(&_isolatedMoveEvent);
+}
+
 PointerHitResult InputSystem::dispatchVRPointerEvent(InputPhase phase,
                                                      Vec2 point,
                                                      const Ray& ray,

--- a/axmol/base/InputSystem.h
+++ b/axmol/base/InputSystem.h
@@ -96,6 +96,7 @@ public:
 
     // VR controller input: PointerType::Controller with a 3D ray.
     PointerHitResult handleVRPointerEvent(InputPhase phase, Vec2 point, const Ray& ray, const PointerInputState& state);
+    PointerHitResult hitTestVRPointer(Vec2 point, const Ray& ray, const PointerInputState& state);
     PointerHitResult handleVRPointerScroll(Vec2 point,
                                            Vec2 scrollDelta,
                                            const Ray& ray,

--- a/axmol/vr/OpenXRDriver.cpp
+++ b/axmol/vr/OpenXRDriver.cpp
@@ -45,6 +45,7 @@
 #include "axmol/base/Logging.h"
 #include "axmol/base/InputSystem.h"
 #include "axmol/math/Quat.h"
+#include "axmol/scene/Camera.h"
 #include "axmol/scene/Scene.h"
 #include "axmol/platform/RenderView.h"
 #include "axmol/platform/Application.h"
@@ -262,6 +263,18 @@ Ray OpenXRDriver::xrPoseToRay(const XrPosef& pose)
 Vec2 OpenXRDriver::xrToVec2(const XrVector2f& v)
 {
     return Vec2(v.x, v.y);
+}
+
+void OpenXRDriver::setPointerRayTransform(const Mat4& transform)
+{
+    _pointerRayTransform      = transform;
+    _pointerRayTransformValid = true;
+}
+
+void OpenXRDriver::clearPointerRayTransform()
+{
+    _pointerRayTransform      = Mat4::identity;
+    _pointerRayTransformValid = false;
 }
 
 // ---------------------------------------------------------------------------
@@ -1419,7 +1432,11 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
         return;
     }
 
-    Mat4 controllerToWorld = _headViewTransformValid ? _headViewTransform.getInversed() : Mat4::identity;
+    // Controller poses are located in the same OpenXR local space as the eye poses.
+    // VRSceneCompositor owns the stable pointer-ray camera and pushes its world
+    // transform here before polling actions. Do not use the inverse HMD pose here;
+    // that converts the ray to head-relative space and makes scene hit testing miss.
+    const Mat4& controllerToWorld = _pointerRayTransformValid ? _pointerRayTransform : Mat4::identity;
 
     for (uint32_t hand = 0; hand < 2; ++hand)
     {
@@ -1635,6 +1652,11 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
                     ctrl.lastPointerEventRay      = eventRay;
                     ctrl.lastPointerEventRayValid = true;
                 }
+                else
+                {
+                    hitResult    = InputSystem::getInstance()->hitTestVRPointer(centerPoint, eventRay, inputState);
+                    hasHitResult = true;
+                }
 
                 constexpr float thumbstickScrollDeadzone = 0.0001f;
                 if (std::abs(ctrl.thumbstick.y) > thumbstickScrollDeadzone)
@@ -1659,6 +1681,12 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
                 if (hasHitResult && hitResult.hit)
                 {
                     Vec3 visualHitPoint = hitResult.worldPoint;
+
+                    if (_pointerRayTransformValid && hitResult.camera)
+                    {
+                        hitResult.camera->getWorldToNodeTransform().transformPoint(&visualHitPoint);
+                        _pointerRayTransform.transformPoint(&visualHitPoint);
+                    }
 
                     const float hitDistance =
                         std::max(0.0f, (visualHitPoint - ctrl.currentRay.origin).dot(ctrl.currentRay.direction));

--- a/axmol/vr/OpenXRDriver.h
+++ b/axmol/vr/OpenXRDriver.h
@@ -156,6 +156,11 @@ public:
     const ControllerState* getControllers() const { return _controllers; }
     Mat4 getPointerViewTransform() const { return _headViewTransform; }
     bool isPointerViewTransformValid() const { return _headViewTransformValid; }
+    void setPointerRayTransform(const Mat4& transform);
+    void clearPointerRayTransform();
+    void setCompositorAlive(bool alive) { _compositorAlive = alive; }
+    bool isCompositorAlive() const { return _compositorAlive; }
+
     void setXrToSceneScale(float scale) { _xrToSceneScale = scale > 0.0f ? scale : 1.0f; }
     float getXrToSceneScale() const { return _xrToSceneScale; }
 
@@ -241,10 +246,13 @@ private:
     std::unique_ptr<rhi::OpenXRVulkanInterop> _vulkanInterop;
 #endif
 
+    bool _compositorAlive{false};
     float _xrToSceneScale{1.0f};
 
     Mat4 _headViewTransform{Mat4::identity};
     bool _headViewTransformValid{false};
+    Mat4 _pointerRayTransform{Mat4::identity};
+    bool _pointerRayTransformValid{false};
 
     void* _graphicsBindingStorage{nullptr};
 

--- a/axmol/vr/VRSceneCompositor.cpp
+++ b/axmol/vr/VRSceneCompositor.cpp
@@ -94,6 +94,8 @@ VRSceneCompositor::VRSceneCompositor()
 
 VRSceneCompositor::~VRSceneCompositor()
 {
+    if (_xrDriver)
+        _xrDriver->setCompositorAlive(false);
     shutdownControllerRayResources();
 }
 
@@ -114,18 +116,24 @@ XrSession VRSceneCompositor::getXrSession() const
 
 void VRSceneCompositor::setXrDriver(OpenXRDriver* context)
 {
+    if (_xrDriver)
+        _xrDriver->setCompositorAlive(false);
     _xrDriver = context;
+    if (_xrDriver)
+        _xrDriver->setCompositorAlive(true);
 }
 
 void VRSceneCompositor::pollEvents()
 {
+    auto xrDriver = _xrDriver;
     SceneCompositor::pollEvents();
 
-    if (!_xrDriver)
+    if (!xrDriver || !xrDriver->isCompositorAlive())
         return;
 
-    _xrDriver->setXrToSceneScale(_xrToSceneScale);
-    _xrDriver->pollEvents();
+    xrDriver->setXrToSceneScale(_xrToSceneScale);
+    syncPointerRayCamera(_director->getRunningScene());
+    xrDriver->pollEvents();
 }
 
 bool VRSceneCompositor::isVRActive() const
@@ -152,6 +160,58 @@ void VRSceneCompositor::setXrToSceneScale(float scale)
     _xrToSceneScale = scale > 0.0f ? scale : 1.0f;
     if (_xrDriver)
         _xrDriver->setXrToSceneScale(_xrToSceneScale);
+}
+
+Camera* VRSceneCompositor::selectPointerRaySourceCamera(Scene* scene) const
+{
+    if (!scene)
+        return nullptr;
+
+    auto defaultCamera = scene->getDefaultCamera();
+    if (defaultCamera && defaultCamera->isVisible())
+        return defaultCamera;
+
+    for (auto camera : scene->getCameras())
+    {
+        if (camera && camera->isVisible())
+            return camera;
+    }
+
+    return defaultCamera;
+}
+
+Camera* VRSceneCompositor::ensurePointerRayCamera(Scene* scene)
+{
+    auto sourceCamera = selectPointerRaySourceCamera(scene);
+    if (!sourceCamera)
+        return nullptr;
+
+    if (!_pointerRayCamera)
+        _pointerRayCamera = RefPtr<Camera>(Camera::createPerspective(60.0f, 1.0f, _nearZ, _farZ));
+
+    const auto canvasSize = _director->getCanvasSize();
+    const float aspect    = canvasSize.height > 0.0f ? canvasSize.width / canvasSize.height : 1.0f;
+    _pointerRayCamera->initPerspective(60.0f, aspect, _nearZ, _farZ);
+    _pointerRayCamera->setNodeToParentTransform(sourceCamera->getNodeToWorldTransform());
+    _pointerRayCamera->setAdditionalTransform(Mat4::identity);
+    _pointerRayCamera->setCameraFlag(sourceCamera->getCameraFlag());
+
+    return _pointerRayCamera.get();
+}
+
+void VRSceneCompositor::syncPointerRayCamera(Scene* scene)
+{
+    if (!_xrDriver)
+        return;
+
+    auto camera = ensurePointerRayCamera(scene);
+    if (!camera)
+    {
+        _xrDriver->clearPointerRayTransform();
+        return;
+    }
+
+    _xrDriver->setPointerRayTransform(camera->getNodeToWorldTransform());
 }
 
 void VRSceneCompositor::ensureControllerRayResources()
@@ -361,7 +421,7 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
             camera->setAdditionalTransform(Mat4::identity);
         }
 
-        auto rayCamera = eyeCamera;
+        auto rayCamera = _pointerRayCamera ? _pointerRayCamera.get() : eyeCamera;
         if (rayCamera)
         {
             Camera::setVisitingCamera(rayCamera);

--- a/axmol/vr/VRSceneCompositor.h
+++ b/axmol/vr/VRSceneCompositor.h
@@ -88,6 +88,9 @@ protected:
 private:
     void ensureControllerRayResources();
     void shutdownControllerRayResources();
+    Camera* ensurePointerRayCamera(Scene* scene);
+    Camera* selectPointerRaySourceCamera(Scene* scene) const;
+    void syncPointerRayCamera(Scene* scene);
     void drawControllerRays(Renderer* renderer, uint32_t eyeIdx, const XrView& view);
     void onBeforeControllerRayDraw();
     void onAfterControllerRayDraw();
@@ -111,6 +114,7 @@ private:
     float _xrToSceneScale{1.0f};
 
     RefPtr<RenderTexturePass> _rtPass;
+    RefPtr<Camera> _pointerRayCamera;
 
     ScissorRect _sourceScissorRect;
     LinearStack<VRScissorTransform> _scissorTransformStack;


### PR DESCRIPTION
## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
