### PR TITLE
Fix warnings on implicit numeric conversions

### DIFF
--- a/axmol/3d/Bundle3D.cpp
+++ b/axmol/3d/Bundle3D.cpp
@@ -739,7 +739,7 @@ bool Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
         auto&& mesh_data_vertex_array = mesh_data[VERTICES].get_array();
         for (auto&& vertex_val : mesh_data_vertex_array)
         {
-            meshData->vertex.emplace_back(static_cast<double>(vertex_val));
+            meshData->vertex.emplace_back(static_cast<float>(vertex_val.get_double().value()));
         }
         meshData->vertexSizeInFloat = meshData->vertex.size();
         // mesh part

--- a/axmol/rhi/VertexLayout.cpp
+++ b/axmol/rhi/VertexLayout.cpp
@@ -158,7 +158,12 @@ void VertexLayoutDesc::addAttrib(const VertexInputDesc* desc,
     else
         _strides[1] += static_cast<uint32_t>(sizeInBytes);
 
-    _bindings.emplace_back(desc->semantic.name, desc->location, format, offset, needToBeNormallized, instanceStepRate);
+    _bindings.emplace_back(desc->semantic.name,
+                           desc->location,
+                           format,
+                           static_cast<unsigned int>(offset),
+                           needToBeNormallized,
+                           instanceStepRate);
 }
 
 }  // namespace ax::rhi

--- a/axmol/rhi/VertexLayout.cpp
+++ b/axmol/rhi/VertexLayout.cpp
@@ -158,12 +158,8 @@ void VertexLayoutDesc::addAttrib(const VertexInputDesc* desc,
     else
         _strides[1] += static_cast<uint32_t>(sizeInBytes);
 
-    _bindings.emplace_back(desc->semantic.name,
-                           desc->location,
-                           format,
-                           static_cast<unsigned int>(offset),
-                           needToBeNormallized,
-                           instanceStepRate);
+    _bindings.emplace_back(desc->semantic.name, desc->location, format, static_cast<unsigned int>(offset),
+                           needToBeNormallized, instanceStepRate);
 }
 
 }  // namespace ax::rhi


### PR DESCRIPTION
This PR fixes 2 MSVC warnings about numeric conversions, without the intent of changing any behavior.

The warnings show up even when you set the project to /W0 in the latest MSVC (18.8.1), assuming default build configuration.