### PR TITLE
Refactor scene rendering with explicit per-view state

### DIFF
--- a/axmol/2d/AtlasNode.cpp
+++ b/axmol/2d/AtlasNode.cpp
@@ -130,19 +130,19 @@ void AtlasNode::updateAtlasValues()
 }
 
 // AtlasNode - draw
-void AtlasNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void AtlasNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_textureAtlas->getTotalQuads() == 0)
         return;
 
     auto programState = _quadCommand.unsafePS();
 
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMat = state.getViewProjectionMatrix();
     programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));
 
     _quadCommand.init(_globalZOrder, _textureAtlas->getTexture(), _blendFunc, _textureAtlas->getQuads(), _quadsToDraw,
-                      transform, flags);
-    renderer->addCommand(&_quadCommand);
+                      transform, flags, state.getView());
+    state.getRenderer()->addCommand(&_quadCommand);
 }
 
 // AtlasNode - RGBA protocol

--- a/axmol/2d/AtlasNode.h
+++ b/axmol/2d/AtlasNode.h
@@ -67,7 +67,7 @@ public:
     virtual void updateAtlasValues();
 
     // Overrides
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     Texture2D* getTexture() const override;
     void setTexture(Texture2D* texture) override;
     bool isOpacityModifyRGB() const override;

--- a/axmol/2d/ClippingNode.cpp
+++ b/axmol/2d/ClippingNode.cpp
@@ -134,26 +134,26 @@ void ClippingNode::onExit()
     Node::onExit();
 }
 
-void ClippingNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void ClippingNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (!_visible || !hasContent())
         return;
 
     AXASSERT(_stencil, "No stencil set");
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     // Add group command
 
-    auto* groupCommandStencil = renderer->getNextGroupCommand();
+    auto* groupCommandStencil = state.getRenderer()->getNextGroupCommand();
     groupCommandStencil->init(_globalZOrder);
-    renderer->addCommand(groupCommandStencil);
+    state.getRenderer()->addCommand(groupCommandStencil);
 
-    renderer->pushGroup(groupCommandStencil->getRenderQueueID());
+    state.getRenderer()->pushGroup(groupCommandStencil->getRenderQueueID());
 
     // _beforeVisitCmd.init(_globalZOrder);
     // _beforeVisitCmd.func = AX_CALLBACK_0(StencilStateManager::onBeforeVisit, _stencilStateManager);
-    // renderer->addCommand(&_beforeVisitCmd);
+    // state.getRenderer()->addCommand(&_beforeVisitCmd);
     _stencilStateManager->onBeforeVisit(_globalZOrder);
 
     auto alphaThreshold = this->getAlphaThreshold();
@@ -167,23 +167,23 @@ void ClippingNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32
 
         AX_SAFE_RELEASE_NULL(programState);
     }
-    _stencil->visit(renderer, _modelViewTransform, flags);
+    _stencil->visit(state, _modelViewTransform, flags);
 
-    auto afterDrawStencilCmd = renderer->nextCallbackCommand();
+    auto afterDrawStencilCmd = state.getRenderer()->nextCallbackCommand();
     afterDrawStencilCmd->init(_globalZOrder);
     afterDrawStencilCmd->func = AX_CALLBACK_0(StencilStateManager::onAfterDrawStencil, _stencilStateManager);
-    renderer->addCommand(afterDrawStencilCmd);
+    state.getRenderer()->addCommand(afterDrawStencilCmd);
 
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
 
     // `_groupCommandChildren` is used as a barrier
     // to ensure commands above be executed before children nodes
-    auto* groupCommandChildren = renderer->getNextGroupCommand();
+    auto* groupCommandChildren = state.getRenderer()->getNextGroupCommand();
 
     groupCommandChildren->init(_globalZOrder);
-    renderer->addCommand(groupCommandChildren);
+    state.getRenderer()->addCommand(groupCommandChildren);
 
-    renderer->pushGroup(groupCommandChildren->getRenderQueueID());
+    state.getRenderer()->pushGroup(groupCommandChildren->getRenderQueueID());
 
     if (!_children.empty())
     {
@@ -195,30 +195,30 @@ void ClippingNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32
             auto node = _children.at(i);
 
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
         // self draw
         if (visibleByCamera)
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
 
         for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
+            (*it)->visit(state, _modelViewTransform, flags);
     }
     else if (visibleByCamera)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
     }
 
-    renderer->popGroup();
+    state.getRenderer()->popGroup();
 
-    auto _afterVisitCmd = renderer->nextCallbackCommand();
+    auto _afterVisitCmd = state.getRenderer()->nextCallbackCommand();
     _afterVisitCmd->init(_globalZOrder);
     _afterVisitCmd->func = AX_CALLBACK_0(StencilStateManager::onAfterVisit, _stencilStateManager);
-    renderer->addCommand(_afterVisitCmd);
+    state.getRenderer()->addCommand(_afterVisitCmd);
 
-    renderer->popGroup();
+    state.getRenderer()->popGroup();
 }
 
 void ClippingNode::setGlobalZOrder(float globalZOrder)

--- a/axmol/2d/ClippingNode.h
+++ b/axmol/2d/ClippingNode.h
@@ -135,7 +135,7 @@ public:
      * @lua NA
      */
     void onExit() override;
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     void setGlobalZOrder(float globalZOrder) override;
 

--- a/axmol/2d/ClippingRectangleNode.cpp
+++ b/axmol/2d/ClippingRectangleNode.cpp
@@ -91,19 +91,19 @@ void ClippingRectangleNode::onAfterVisitScissor()
         _director->getRenderer()->setScissorTest(_oldScissorTest);
 }
 
-void ClippingRectangleNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void ClippingRectangleNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
-    auto beforeVisitCmdScissor = renderer->nextCallbackCommand();
+    auto beforeVisitCmdScissor = state.getRenderer()->nextCallbackCommand();
     beforeVisitCmdScissor->init(_globalZOrder);
     beforeVisitCmdScissor->func = AX_CALLBACK_0(ClippingRectangleNode::onBeforeVisitScissor, this);
-    renderer->addCommand(beforeVisitCmdScissor);
+    state.getRenderer()->addCommand(beforeVisitCmdScissor);
 
-    Node::visit(renderer, parentTransform, parentFlags);
+    Node::visit(state, parentTransform, parentFlags);
 
-    auto afterVisitCmdScissor = renderer->nextCallbackCommand();
+    auto afterVisitCmdScissor = state.getRenderer()->nextCallbackCommand();
     afterVisitCmdScissor->init(_globalZOrder);
     afterVisitCmdScissor->func = AX_CALLBACK_0(ClippingRectangleNode::onAfterVisitScissor, this);
-    renderer->addCommand(afterVisitCmdScissor);
+    state.getRenderer()->addCommand(afterVisitCmdScissor);
 }
 
 }  // namespace ax

--- a/axmol/2d/ClippingRectangleNode.h
+++ b/axmol/2d/ClippingRectangleNode.h
@@ -82,7 +82,7 @@ public:
     void setClippingEnabled(bool enabled) { _clippingEnabled = enabled; }
 
     // virtual void draw(Renderer* renderer, const Mat4 &transform, uint32_t flags) override;
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
 protected:
     ClippingRectangleNode() = default;

--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -195,10 +195,10 @@ void DrawNode::updateBlendState(CustomCommand& cmd)
     }
 }
 
-void DrawNode::updateUniforms(const Mat4& transform, CustomCommand& cmd)
+void DrawNode::updateUniforms(const SceneRenderState& state, const Mat4& transform, CustomCommand& cmd)
 {
     auto pipelinePS     = cmd.unsafePS();
-    const auto& matrixP = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixP = state.getViewProjectionMatrix();
     Mat4 matrixMVP      = matrixP * transform;
     auto mvpLocation    = pipelinePS->getUniformLocation("u_MVPMatrix");
     pipelinePS->setUniform(mvpLocation, matrixMVP.m, sizeof(matrixMVP.m));
@@ -209,7 +209,7 @@ void DrawNode::updateUniforms(const Mat4& transform, CustomCommand& cmd)
     pipelinePS->setUniform(alphaUniformLocation, &alpha, sizeof(alpha));
 }
 
-void DrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void DrawNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_trianglesDirty || _pointsDirty || _linesDirty)
         updateBuffers();
@@ -217,25 +217,25 @@ void DrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
     if (_customCommandTriangle.getVertexDrawCount() > 0)
     {
         updateBlendState(_customCommandTriangle);
-        updateUniforms(transform, _customCommandTriangle);
+        updateUniforms(state, transform, _customCommandTriangle);
         _customCommandTriangle.init(_globalZOrder);
-        renderer->addCommand(&_customCommandTriangle);
+        state.getRenderer()->addCommand(&_customCommandTriangle);
     }
 
     if (_customCommandPoint.getVertexDrawCount() > 0)
     {
         updateBlendState(_customCommandPoint);
-        updateUniforms(transform, _customCommandPoint);
+        updateUniforms(state, transform, _customCommandPoint);
         _customCommandPoint.init(_globalZOrder);
-        renderer->addCommand(&_customCommandPoint);
+        state.getRenderer()->addCommand(&_customCommandPoint);
     }
 
     if (_customCommandLine.getVertexDrawCount() > 0)
     {
         updateBlendState(_customCommandLine);
-        updateUniforms(transform, _customCommandLine);
+        updateUniforms(state, transform, _customCommandLine);
         _customCommandLine.init(_globalZOrder);
-        renderer->addCommand(&_customCommandLine);
+        state.getRenderer()->addCommand(&_customCommandLine);
     }
 }
 
@@ -688,16 +688,16 @@ void DrawNode::setBlendFunc(const BlendFunc& blendFunc)
     _blendFunc = blendFunc;
 }
 
-void DrawNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void DrawNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (_isolated)
     {
         // ignore `parentTransform` from parent
-        Node::visit(renderer, Mat4::identity, parentFlags);
+        Node::visit(state, Mat4::identity, parentFlags);
     }
     else
     {
-        Node::visit(renderer, parentTransform, parentFlags);
+        Node::visit(state, parentTransform, parentFlags);
     }
 }
 

--- a/axmol/2d/DrawNode.h
+++ b/axmol/2d/DrawNode.h
@@ -538,9 +538,9 @@ public:
     void setBlendFunc(const BlendFunc& blendFunc) override;
 
     // Overrides
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     /**
      * When isolated is set, the position of the node is no longer affected by parent nodes.
@@ -564,7 +564,7 @@ protected:
     void freeShaderInternal(CustomCommand& cmd);
 
     void updateBlendState(CustomCommand& cmd);
-    void updateUniforms(const Mat4& transform, CustomCommand& cmd);
+    void updateUniforms(const SceneRenderState& state, const Mat4& transform, CustomCommand& cmd);
 
     bool _trianglesDirty : 1 = false;
     bool _pointsDirty : 1    = false;

--- a/axmol/2d/FastTMXLayer.cpp
+++ b/axmol/2d/FastTMXLayer.cpp
@@ -211,23 +211,24 @@ int FastTMXLayer::batchIndexForGID(uint32_t gid) const
     return -1;
 }
 
-void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void FastTMXLayer::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     updateTotalQuads();
 
     const float refTileX = _batches.empty() ? 1.0f : _batches[0].tilesetInfo->_tileSize.x;
-    auto cam             = Camera::getVisitingCamera();
+    auto cam             = state.getCamera();
     if (!cam)
         return;
-    if (flags != 0 || _dirty || _quadsDirty || !_cameraPositionDirty.fuzzyEquals(cam->getPosition(), refTileX) ||
+    const Vec2 cameraPosition(state.getView().position.x, state.getView().position.y);
+    if (flags != 0 || _dirty || _quadsDirty || !_cameraPositionDirty.fuzzyEquals(cameraPosition, refTileX) ||
         _cameraZoomDirty != cam->getZoom())
     {
-        _cameraPositionDirty = cam->getPosition();
+        _cameraPositionDirty = cameraPosition;
         auto zoom = _cameraZoomDirty = cam->getZoom();
         Vec2 s                       = _director->getVisibleSize();
         const Vec2& anchor           = getAnchorPoint();
-        auto rect                    = Rect(cam->getPositionX() - s.width * zoom * (anchor.x == 0.0f ? 0.5f : anchor.x),
-                                            cam->getPositionY() - s.height * zoom * (anchor.y == 0.0f ? 0.5f : anchor.y), s.width * zoom,
+        auto rect                    = Rect(cameraPosition.x - s.width * zoom * (anchor.x == 0.0f ? 0.5f : anchor.x),
+                                            cameraPosition.y - s.height * zoom * (anchor.y == 0.0f ? 0.5f : anchor.y), s.width * zoom,
                                             s.height * zoom);
 
         Mat4 inv = transform;
@@ -240,7 +241,7 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
         _dirty = false;
     }
 
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMat = state.getViewProjectionMatrix();
     Mat4 finalMat             = projectionMat * _modelViewTransform;
     // Submit batches lowest-firstGid first so base/terrain tiles (low GIDs) draw behind
     // overlay/object tiles (high GIDs) that share the same vertexZ.
@@ -252,7 +253,7 @@ void FastTMXLayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
             {
                 // All commands in a batch share the same program, so the cached location is valid.
                 cmd->unsafePS()->setUniform(it->mvpMatrixLocation, finalMat.m, sizeof(finalMat.m));
-                renderer->addCommand(cmd);
+                state.getRenderer()->addCommand(cmd);
             }
         }
     }

--- a/axmol/2d/FastTMXLayer.h
+++ b/axmol/2d/FastTMXLayer.h
@@ -306,7 +306,7 @@ public:
     // Override
     //
     std::string getDescription() const override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void removeChild(Node* child, bool cleanup = true) override;
 
     /** Map from gid of animated tile to its instance.

--- a/axmol/2d/Grid.cpp
+++ b/axmol/2d/Grid.cpp
@@ -222,7 +222,7 @@ void GridBase::beforeDraw()
     _renderTexturePass->clear(ClearFlag::COLOR, {.color = _clearColor, .depth = 1.0f, .stencil = 0});
 }
 
-void GridBase::afterDraw(ax::Node* /*target*/)
+void GridBase::afterDraw(ax::Node* /*target*/, const SceneRenderState& state)
 {
     auto renderer = Director::getInstance()->getRenderer();
 
@@ -231,7 +231,7 @@ void GridBase::afterDraw(ax::Node* /*target*/)
 
     renderer->addCallbackCommand([this]() -> void { beforeBlit(); });
 
-    blit();
+    blit(state);
 
     renderer->addCallbackCommand([this]() -> void { afterBlit(); });
 }
@@ -349,13 +349,12 @@ void Grid3D::afterBlit()
     }
 }
 
-void Grid3D::blit()
+void Grid3D::blit(const SceneRenderState& state)
 {
     updateVertexBuffer();
     _drawCommand.init(GRID_BLIT_ORDER, _blendFunc);
     Director::getInstance()->getRenderer()->addCommand(&_drawCommand);
-    auto camera            = Camera::getVisitingCamera();
-    ax::Mat4 projectionMat = camera ? camera->getVisitingViewProjectionMatrix() : Mat4::identity;
+    ax::Mat4 projectionMat = state.getViewProjectionMatrix();
     auto programState      = _drawCommand.unsafePS();
     programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));
     programState->setTexture(_textureLocation, 0, _texture->getRHITexture());
@@ -622,13 +621,12 @@ TiledGrid3D* TiledGrid3D::create(const Vec2& gridSize, Texture2D* texture, bool 
     return ret;
 }
 
-void TiledGrid3D::blit()
+void TiledGrid3D::blit(const SceneRenderState& state)
 {
     updateVertexBuffer();
     _drawCommand.init(GRID_BLIT_ORDER, _blendFunc);
     Director::getInstance()->getRenderer()->addCommand(&_drawCommand);
-    auto camera            = Camera::getVisitingCamera();
-    ax::Mat4 projectionMat = camera ? camera->getVisitingViewProjectionMatrix() : Mat4::identity;
+    ax::Mat4 projectionMat = state.getViewProjectionMatrix();
     auto programState      = _drawCommand.unsafePS();
     programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));
     programState->setTexture(_textureLocation, 0, _texture->getRHITexture());

--- a/axmol/2d/Grid.h
+++ b/axmol/2d/Grid.h
@@ -42,6 +42,7 @@ class Texture2D;
 class Node;
 class NodeGrid;
 class RenderTexturePass;
+struct SceneRenderState;
 
 namespace rhi
 {
@@ -72,7 +73,7 @@ public:
     /**@}*/
 
     /**Interface used to blit the texture with grid to screen.*/
-    virtual void blit() = 0;
+    virtual void blit(const SceneRenderState& state) = 0;
     /**Interface, Reuse the grid vertices.*/
     virtual void reuse() = 0;
     /**Interface, Calculate the vertices used for the blit.*/
@@ -122,7 +123,7 @@ public:
      Init and reset the status when render effects by using the grid.
      */
     void beforeDraw();
-    void afterDraw(Node* target);
+    void afterDraw(Node* target, const SceneRenderState& state);
     /**@}*/
 
     /**
@@ -220,7 +221,7 @@ public:
      */
     void beforeBlit() override;
     void afterBlit() override;
-    void blit() override;
+    void blit(const SceneRenderState& state) override;
     void reuse() override;
     void calculateVertexPoints() override;
     /**@}*/
@@ -264,7 +265,7 @@ public:
     /**@{
      Implementations for interfaces in base class.
      */
-    void blit() override;
+    void blit(const SceneRenderState& state) override;
     void reuse() override;
     void calculateVertexPoints() override;
     /**@}*/

--- a/axmol/2d/Label.cpp
+++ b/axmol/2d/Label.cpp
@@ -187,7 +187,7 @@ public:
     bool isVisible() const override { return _letterVisible; }
 
     // LabelLetter doesn't need to draw directly.
-    void draw(Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t /*flags*/) override {}
+    void draw(const SceneRenderState& /*state*/, const Mat4& /*transform*/, uint32_t /*flags*/) override {}
 
 private:
     bool _letterVisible;
@@ -1956,12 +1956,12 @@ void Label::updateBuffer(TextureAtlas* textureAtlas, CustomCommand& customComman
 
 void Label::updateEffectUniforms(BatchCommand& batch,
                                  TextureAtlas* textureAtlas,
-                                 Renderer* renderer,
+                                 const SceneRenderState& state,
                                  const Mat4& transform)
 {
     updateBuffer(textureAtlas, batch.textCommand);
 
-    const auto& matrixProjection = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixProjection = state.getViewProjectionMatrix();
 
     if (_shadowEnabled)
     {
@@ -1987,7 +1987,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                 shadowPS->setUniform(_effectColorLocation, &shadowColor, sizeof(Vec4));
                 shadowPS->setUniform(_passLocation, &pass, sizeof(pass));
                 batch.shadowCommand.init(_globalZOrder);
-                renderer->addCommand(&batch.shadowCommand);
+                state.getRenderer()->addCommand(&batch.shadowCommand);
             }
 
             if (_useDistanceField)
@@ -2004,7 +2004,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                     effectPS->setUniform(_effectWidthLocation, &effectWidth, sizeof(float));
                     effectPS->setUniform(_passLocation, &pass, sizeof(pass));
                     batch.effectCommand.init(_globalZOrder);
-                    renderer->addCommand(&batch.effectCommand);
+                    state.getRenderer()->addCommand(&batch.effectCommand);
                 }
 
                 // text pass
@@ -2026,7 +2026,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                     effectPS->setUniform(_effectColorLocation, &effectColor, sizeof(Vec4));
                     effectPS->setUniform(_passLocation, &pass, sizeof(pass));
                     batch.effectCommand.init(_globalZOrder);
-                    renderer->addCommand(&batch.effectCommand);
+                    state.getRenderer()->addCommand(&batch.effectCommand);
                 }
 
                 // text pass
@@ -2047,7 +2047,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                 auto shadowPS = batch.shadowCommand.unsafePS();
                 shadowPS->setUniform(_textColorLocation, &_shadowColor, sizeof(Vec4));
                 batch.shadowCommand.init(_globalZOrder);
-                renderer->addCommand(&batch.shadowCommand);
+                state.getRenderer()->addCommand(&batch.shadowCommand);
             }
         }
         break;
@@ -2063,7 +2063,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                 shadowPS->setUniform(_effectColorLocation, &_shadowColor, sizeof(Vec4));
                 shadowPS->setUniform(_passLocation, &pass, sizeof(pass));
                 batch.shadowCommand.init(_globalZOrder);
-                renderer->addCommand(&batch.shadowCommand);
+                state.getRenderer()->addCommand(&batch.shadowCommand);
             }
 
             // glow pass
@@ -2076,7 +2076,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
                 effectPS->setUniform(_effectWidthLocation, &effectWidth, sizeof(float));
                 effectPS->setUniform(_passLocation, &pass, sizeof(pass));
                 batch.effectCommand.init(_globalZOrder);
-                renderer->addCommand(&batch.effectCommand);
+                state.getRenderer()->addCommand(&batch.effectCommand);
             }
 
             // text pass
@@ -2101,7 +2101,7 @@ void Label::updateEffectUniforms(BatchCommand& batch,
             batch.shadowCommand.updateVertexBuffer(
                 textureAtlas->getQuads(), (unsigned int)(textureAtlas->getTotalQuads() * sizeof(V3F_T2F_C4B_Quad)));
             batch.shadowCommand.init(_globalZOrder);
-            renderer->addCommand(&batch.shadowCommand);
+            state.getRenderer()->addCommand(&batch.shadowCommand);
 
             _displayedColor.a = oldOPacity;
             setColor(oldColor);
@@ -2109,10 +2109,10 @@ void Label::updateEffectUniforms(BatchCommand& batch,
     }
 
     batch.textCommand.init(_globalZOrder);
-    renderer->addCommand(&batch.textCommand);
+    state.getRenderer()->addCommand(&batch.textCommand);
 }
 
-void Label::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void Label::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_batchNodes.empty() || _utf32Text.empty())
     {
@@ -2120,24 +2120,21 @@ void Label::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
     }
     // Don't do calculate the culling if the transform was not updated
 #if AX_USE_CULLING
-    auto visitingCamera = Camera::getVisitingCamera();
-    auto defaultCamera  = Camera::getDefaultCamera();
-    if (visitingCamera == defaultCamera)
+    auto visitingCamera = state.getCamera();
+    if (visitingCamera)
     {
-        const auto transformUpdated = flags & FLAGS_TRANSFORM_DIRTY;
-        _insideBounds               = (transformUpdated || visitingCamera->isViewProjectionUpdated())
-                                          ? renderer->checkVisibility(transform, _contentSize)
-                                          : _insideBounds;
+        _insideBounds = state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize)
+                                                              : _insideBounds;
     }
     else
     {
-        _insideBounds = renderer->checkVisibility(transform, _contentSize);
+        _insideBounds = state.checkVisibility(transform, _contentSize);
     }
 
     if (_insideBounds)
 #endif
     {
-        ax::Mat4 matrixProjection = Camera::getVisitingViewProjectionMatrix();
+        ax::Mat4 matrixProjection = state.getViewProjectionMatrix();
         if (!_shadowEnabled && (_currentLabelType == LabelType::BMFONT || _currentLabelType == LabelType::CHARMAP))
         {
             updateBlendState();
@@ -2155,8 +2152,8 @@ void Label::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
             pipelinePS->setUniform(_mvpMatrixLocation, matrixProjection.m, sizeof(matrixProjection.m));
             pipelinePS->setTexture(texture->getRHITexture());
             _quadCommand.init(_globalZOrder, texture, _blendFunc, textureAtlas->getQuads(),
-                              textureAtlas->getTotalQuads(), transform, flags);
-            renderer->addCommand(&_quadCommand);
+                              textureAtlas->getTotalQuads(), transform, flags, state.getView());
+            state.getRenderer()->addCommand(&_quadCommand);
         }
         else
         {
@@ -2191,7 +2188,7 @@ void Label::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
                 }
                 batch.textCommand.unsafePS()->setUniform(_mvpMatrixLocation, matrixMVP.m, sizeof(matrixMVP.m));
                 batch.effectCommand.unsafePS()->setUniform(_mvpMatrixLocation, matrixMVP.m, sizeof(matrixMVP.m));
-                updateEffectUniforms(batch, textureAtlas, renderer, transform);
+                updateEffectUniforms(batch, textureAtlas, state, transform);
             }
         }
     }
@@ -2211,7 +2208,7 @@ void Label::updateBlendState()
     updateBlend(_quadCommand.blendDesc(), _blendFunc);
 }
 
-void Label::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void Label::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (!_visible || (_utf8Text.empty() && _children.empty()))
     {
@@ -2227,7 +2224,7 @@ void Label::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t pare
         updateContent();
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     if (!_utf8Text.empty() && _shadowEnabled && (_shadowDirty || (flags & FLAGS_DIRTY_MASK)))
     {
@@ -2244,7 +2241,7 @@ void Label::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t pare
         _shadowDirty = false;
     }
 
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
     if (_children.empty() && !_textSprite && !visibleByCamera)
     {
         return;
@@ -2261,41 +2258,41 @@ void Label::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t pare
             auto node = _children.at(i);
 
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
 
-        this->drawSelf(visibleByCamera, renderer, flags);
+        this->drawSelf(visibleByCamera, state, flags);
 
         for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
         {
-            (*it)->visit(renderer, _modelViewTransform, flags);
+            (*it)->visit(state, _modelViewTransform, flags);
         }
     }
     else
     {
-        this->drawSelf(visibleByCamera, renderer, flags);
+        this->drawSelf(visibleByCamera, state, flags);
     }
 
 #if AX_LABEL_DEBUG_DRAW
-    _debugDrawNode->visit(renderer, _modelViewTransform, parentFlags | FLAGS_TRANSFORM_DIRTY);
+    _debugDrawNode->visit(state, _modelViewTransform, parentFlags | FLAGS_TRANSFORM_DIRTY);
 #endif
 }
 
-void Label::drawSelf(bool visibleByCamera, Renderer* renderer, uint32_t flags)
+void Label::drawSelf(bool visibleByCamera, const SceneRenderState& state, uint32_t flags)
 {
     if (_textSprite)
     {
         if (_shadowNode)
         {
-            _shadowNode->visit(renderer, _modelViewTransform, flags);
+            _shadowNode->visit(state, _modelViewTransform, flags);
         }
-        _textSprite->visit(renderer, _modelViewTransform, flags);
+        _textSprite->visit(state, _modelViewTransform, flags);
     }
     else if (visibleByCamera && !_utf8Text.empty())
     {
-        draw(renderer, _modelViewTransform, flags);
+        draw(state, _modelViewTransform, flags);
     }
 }
 

--- a/axmol/2d/Label.cpp
+++ b/axmol/2d/Label.cpp
@@ -2123,8 +2123,8 @@ void Label::draw(const SceneRenderState& state, const Mat4& transform, uint32_t 
     auto visitingCamera = state.getCamera();
     if (visitingCamera)
     {
-        _insideBounds = state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize)
-                                                              : _insideBounds;
+        _insideBounds =
+            state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize) : _insideBounds;
     }
     else
     {

--- a/axmol/2d/Label.h
+++ b/axmol/2d/Label.h
@@ -731,8 +731,8 @@ public:
     const Vec2& getContentSize() const override;
     Rect getBoundingBox() const override;
 
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     void setCameraMask(unsigned short mask, bool applyChildren = true) override;
 
@@ -802,7 +802,7 @@ protected:
 
     void computeStringNumLines();
 
-    void drawSelf(bool visibleByCamera, Renderer* renderer, uint32_t flags);
+    void drawSelf(bool visibleByCamera, const SceneRenderState& state, uint32_t flags);
 
     bool multilineTextWrapByChar(bool ignoreOverflow = false);
     bool multilineTextWrapByWord(bool ignoreOverflow = false);
@@ -855,7 +855,7 @@ protected:
     void updateBlendState();
     void updateEffectUniforms(BatchCommand& batch,
                               TextureAtlas* textureAtlas,
-                              Renderer* renderer,
+                              const SceneRenderState& state,
                               const Mat4& transform);
     void updateBuffer(TextureAtlas* textureAtlas, CustomCommand& customCommand);
 

--- a/axmol/2d/LabelAtlas.cpp
+++ b/axmol/2d/LabelAtlas.cpp
@@ -267,9 +267,9 @@ void LabelAtlas::updateColor()
 
 // CCLabelAtlas - draw
 #if AX_LABELATLAS_DEBUG_DRAW
-void LabelAtlas::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void LabelAtlas::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    AtlasNode::draw(renderer, transform, _transformUpdated);
+    AtlasNode::draw(state, transform, _transformUpdated);
 
     _debugDrawNode->clear();
     auto size        = getContentSize();

--- a/axmol/2d/LabelAtlas.h
+++ b/axmol/2d/LabelAtlas.h
@@ -107,7 +107,7 @@ public:
     std::string getDescription() const override;
 
 #if AX_LABELATLAS_DEBUG_DRAW
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 #endif
 
     LabelAtlas()

--- a/axmol/2d/Layer.cpp
+++ b/axmol/2d/Layer.cpp
@@ -421,12 +421,12 @@ bool LayerRadialGradient::initWithColor(const ax::Color32& startColor,
     return false;
 }
 
-void LayerRadialGradient::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void LayerRadialGradient::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder, _blendFunc);
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
 
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMat = state.getViewProjectionMatrix();
     auto ps                   = _customCommand.unsafePS();
     Mat4 finalMat             = projectionMat * transform;
     ps->setUniform(_mvpMatrixLocation, finalMat.m, sizeof(finalMat.m));

--- a/axmol/2d/Layer.h
+++ b/axmol/2d/Layer.h
@@ -273,7 +273,7 @@ public:
     //
     // overrides
     //
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void setContentSize(const Vec2& size) override;
 
     void setStartOpacity(uint8_t opacity);

--- a/axmol/2d/MotionStreak.cpp
+++ b/axmol/2d/MotionStreak.cpp
@@ -378,7 +378,7 @@ void MotionStreak::reset()
     _nuPoints = 0;
 }
 
-void MotionStreak::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void MotionStreak::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_nuPoints <= 1)
         return;
@@ -387,11 +387,11 @@ void MotionStreak::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
 
     _customCommand.init(_globalZOrder, _blendFunc);
     _customCommand.setVertexDrawInfo(0, drawCount);
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
 
     auto programState = _customCommand.unsafePS();
 
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMat = state.getViewProjectionMatrix();
     Mat4 finalMat             = projectionMat * transform;
     programState->setUniform(_mvpMatrixLocaiton, finalMat.m, sizeof(Mat4));
 

--- a/axmol/2d/MotionStreak.h
+++ b/axmol/2d/MotionStreak.h
@@ -91,7 +91,7 @@ public:
     /**
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     /**
      * @lua NA
      */

--- a/axmol/2d/NodeGrid.cpp
+++ b/axmol/2d/NodeGrid.cpp
@@ -177,9 +177,8 @@ void NodeGrid::visit(const SceneRenderState& state, const Mat4& parentTransform,
         // canvas ortho matrix. Projecting the uploaded grid vertices/UVs keeps
         // tile edges in the same camera space as the captured texture.
         const auto& screenProjection = state.getViewProjectionMatrix();
-        _nodeGrid->setScreenProjectionForBlit(
-            _projectGridBlitToVisitingCamera ? &screenProjection : nullptr,
-            _director->getCanvasSize());
+        _nodeGrid->setScreenProjectionForBlit(_projectGridBlitToVisitingCamera ? &screenProjection : nullptr,
+                                              _director->getCanvasSize());
     }
 
     // Blit with the grid camera's ortho VP matrix instead of the scene camera's

--- a/axmol/2d/NodeGrid.cpp
+++ b/axmol/2d/NodeGrid.cpp
@@ -80,7 +80,7 @@ NodeGrid::~NodeGrid()
     AX_SAFE_RELEASE(_gridTarget);
 }
 
-Camera* NodeGrid::getGridCamera()
+Camera* NodeGrid::getGridCamera(const Camera* currentCamera)
 {
     if (!_gridCamera)
     {
@@ -92,8 +92,7 @@ Camera* NodeGrid::getGridCamera()
         _gridCamera->configureOrthographicView(_director->getCanvasSize(), -1024, 1024);
     }
 
-    auto visitingCamera = Camera::getVisitingCamera();
-    _gridCamera->setCameraFlag(visitingCamera ? visitingCamera->getCameraFlag() : CameraFlag::DEFAULT);
+    _gridCamera->setCameraFlag(currentCamera ? currentCamera->getCameraFlag() : CameraFlag::DEFAULT);
 
     return _gridCamera;
 }
@@ -106,15 +105,15 @@ void NodeGrid::onGridBeginDraw()
     }
 }
 
-void NodeGrid::onGridEndDraw()
+void NodeGrid::onGridEndDraw(const SceneRenderState& state)
 {
     if (_nodeGrid && _nodeGrid->isActive())
     {
-        _nodeGrid->afterDraw(this);
+        _nodeGrid->afterDraw(this, state);
     }
 }
 
-void NodeGrid::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void NodeGrid::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -127,21 +126,19 @@ void NodeGrid::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t p
         _modelViewTransform = this->transform(parentTransform);
     _transformUpdated = false;
 
-    auto activeGrid     = _nodeGrid && _nodeGrid->isActive();
-    auto previousCamera = const_cast<Camera*>(Camera::getVisitingCamera());
-
-    auto gridCam        = activeGrid ? getGridCamera() : nullptr;
-    auto switchedCamera = gridCam != nullptr;
+    auto activeGrid    = _nodeGrid && _nodeGrid->isActive();
+    auto currentCamera = state.getCamera();
+    auto gridCam       = activeGrid ? getGridCamera(currentCamera) : nullptr;
 
     onGridBeginDraw();
 
     if (_gridTarget)
     {
-        _gridTarget->visit(renderer, _modelViewTransform, dirty);
+        _gridTarget->visit(state, _modelViewTransform, dirty);
     }
 
     int i                = 0;
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
 
     if (!_children.empty())
     {
@@ -152,22 +149,22 @@ void NodeGrid::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t p
             auto node = _children.at(i);
 
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, dirty);
+                node->visit(state, _modelViewTransform, dirty);
             else
                 break;
         }
         // self draw,currently we have nothing to draw on NodeGrid, so there is no need to add render command
         if (visibleByCamera)
-            this->draw(renderer, _modelViewTransform, dirty);
+            this->draw(state, _modelViewTransform, dirty);
 
         for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
         {
-            (*it)->visit(renderer, _modelViewTransform, dirty);
+            (*it)->visit(state, _modelViewTransform, dirty);
         }
     }
     else if (visibleByCamera)
     {
-        this->draw(renderer, _modelViewTransform, dirty);
+        this->draw(state, _modelViewTransform, dirty);
     }
 
     // FIX ME: Why need to set _orderOfArrival to 0??
@@ -179,26 +176,19 @@ void NodeGrid::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t p
         // Capture may use the scene/XR camera, while blit still uses gridCam's
         // canvas ortho matrix. Projecting the uploaded grid vertices/UVs keeps
         // tile edges in the same camera space as the captured texture.
-        const auto& screenProjection = previousCamera ? previousCamera->getViewProjectionMatrix() : Mat4::identity;
+        const auto& screenProjection = state.getViewProjectionMatrix();
         _nodeGrid->setScreenProjectionForBlit(
-            _projectGridBlitToVisitingCamera && previousCamera ? &screenProjection : nullptr,
+            _projectGridBlitToVisitingCamera ? &screenProjection : nullptr,
             _director->getCanvasSize());
     }
 
-    // Switch to grid camera before blit so that Grid3D::blit() /
-    // TiledGrid3D::blit() pick up the grid camera's ortho VP matrix
-    // via Camera::getVisitingViewProjectionMatrix(), instead of the
-    // scene camera's VR perspective VP which would warp the grid mesh.
-    if (gridCam)
-        Camera::setVisitingCamera(gridCam);
-
-    onGridEndDraw();
+    // Blit with the grid camera's ortho VP matrix instead of the scene camera's
+    // VR perspective VP, which would warp the grid mesh.
+    SceneRenderState gridRenderState = gridCam ? SceneRenderState(state.getRenderer(), gridCam) : state;
+    onGridEndDraw(gridRenderState);
 
     if (_nodeGrid)
         _nodeGrid->setScreenProjectionForBlit(nullptr, Vec2::zero);
-
-    if (gridCam || switchedCamera)
-        Camera::setVisitingCamera(previousCamera);
 }
 
 void NodeGrid::setGrid(GridBase* grid)

--- a/axmol/2d/NodeGrid.h
+++ b/axmol/2d/NodeGrid.h
@@ -88,7 +88,7 @@ public:
     const Rect& getGridRect() const { return _gridRect; }
 
     // overrides
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     NodeGrid();
     virtual ~NodeGrid();
@@ -102,8 +102,8 @@ protected:
     void setProjectGridBlitToVisitingCamera(bool enabled) { _projectGridBlitToVisitingCamera = enabled; }
 
     void onGridBeginDraw();
-    void onGridEndDraw();
-    Camera* getGridCamera();
+    void onGridEndDraw(const SceneRenderState& state);
+    Camera* getGridCamera(const Camera* currentCamera);
 
     Node* _gridTarget   = nullptr;
     GridBase* _nodeGrid = nullptr;

--- a/axmol/2d/ParallaxNode.cpp
+++ b/axmol/2d/ParallaxNode.cpp
@@ -140,7 +140,7 @@ The positions are updated at visit because:
 - using a timer is not guaranteed that it will called after all the positions were updated
 - overriding "draw" will only precise if the children have a z > 0
 */
-void ParallaxNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void ParallaxNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     //    Vec2 pos = position_;
     //    Vec2    pos = [self convertToWorldSpace:Vec2::zero];
@@ -156,7 +156,7 @@ void ParallaxNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32
         }
         _lastPosition = pos;
     }
-    Node::visit(renderer, parentTransform, parentFlags);
+    Node::visit(state, parentTransform, parentFlags);
 }
 
 }  // namespace ax

--- a/axmol/2d/ParallaxNode.h
+++ b/axmol/2d/ParallaxNode.h
@@ -84,7 +84,7 @@ public:
     void addChild(Node* child, int zOrder, std::string_view name) override;
     void removeChild(Node* child, bool cleanup) override;
     void removeAllChildrenWithCleanup(bool cleanup) override;
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     /** Adds a child to the container with a z-order, a parallax ratio and a position offset
      It returns self, so you can chain several addChilds.

--- a/axmol/2d/ParticleBatchNode.cpp
+++ b/axmol/2d/ParticleBatchNode.cpp
@@ -131,7 +131,7 @@ bool ParticleBatchNode::initWithFile(std::string_view fileImage, int capacity)
 
 // override visit.
 // Don't call visit on it's children
-void ParticleBatchNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void ParticleBatchNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // CAREFUL:
     // This visit is almost identical to Node#visit
@@ -145,11 +145,11 @@ void ParticleBatchNode::visit(Renderer* renderer, const Mat4& parentTransform, u
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
-    if (isVisitableByVisitingCamera())
+    if (isVisitableByCamera(state.cameraFlag))
     {
-        draw(renderer, _modelViewTransform, flags);
+        draw(state, _modelViewTransform, flags);
     }
 }
 
@@ -418,7 +418,7 @@ void ParticleBatchNode::removeAllChildrenWithCleanup(bool doCleanup)
     _textureAtlas->removeAllQuads();
 }
 
-void ParticleBatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void ParticleBatchNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     AX_PROFILER_START("CCParticleBatchNode - draw");
 
@@ -428,7 +428,7 @@ void ParticleBatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t
     _customCommand.init(_globalZOrder, _blendFunc);
 
     // Texture is set in TextureAtlas.
-    const ax::Mat4& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const ax::Mat4& projectionMat = state.getViewProjectionMatrix();
     Mat4 finalMat                 = projectionMat * transform;
     auto programState             = _customCommand.unsafePS();
     programState->setUniform(_mvpMatrixLocaiton, finalMat.m, sizeof(finalMat.m));
@@ -447,7 +447,7 @@ void ParticleBatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t
         _customCommand.updateIndexBuffer(indices, sizeof(indices[0]) * capacity * 6);
     }
 
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
 
     AX_PROFILER_STOP("CCParticleBatchNode - draw");
 }

--- a/axmol/2d/ParticleBatchNode.h
+++ b/axmol/2d/ParticleBatchNode.h
@@ -124,14 +124,14 @@ public:
     void setTextureAtlas(TextureAtlas* atlas) { _textureAtlas = atlas; }
 
     // Overrides
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     using Node::addChild;
     void addChild(Node* child, int zOrder, int tag) override;
     void addChild(Node* child, int zOrder, std::string_view name) override;
     void removeChild(Node* child, bool cleanup) override;
     void reorderChild(Node* child, int zOrder) override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     Texture2D* getTexture() const override;
     void setTexture(Texture2D* texture) override;
     /**

--- a/axmol/2d/ParticleSystemQuad.cpp
+++ b/axmol/2d/ParticleSystemQuad.cpp
@@ -665,7 +665,8 @@ void ParticleSystemQuad::draw(const SceneRenderState& state, const Mat4& transfo
         ax::Mat4 projectionMat = state.getViewProjectionMatrix();
         programState->setUniform(_mvpMatrixLocaiton, projectionMat.m, sizeof(projectionMat.m));
 
-        _quadCommand.init(_globalZOrder, _texture, _blendFunc, _quads, _particleCount, transform, flags, state.getView());
+        _quadCommand.init(_globalZOrder, _texture, _blendFunc, _quads, _particleCount, transform, flags,
+                          state.getView());
         state.getRenderer()->addCommand(&_quadCommand);
     }
 }

--- a/axmol/2d/ParticleSystemQuad.cpp
+++ b/axmol/2d/ParticleSystemQuad.cpp
@@ -655,18 +655,18 @@ void ParticleSystemQuad::updateParticleQuads()
 }
 
 // overriding draw method
-void ParticleSystemQuad::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void ParticleSystemQuad::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     // quad command
     if (_particleCount > 0)
     {
         auto programState = _quadCommand.unsafePS();
 
-        ax::Mat4 projectionMat = Camera::getVisitingViewProjectionMatrix();
+        ax::Mat4 projectionMat = state.getViewProjectionMatrix();
         programState->setUniform(_mvpMatrixLocaiton, projectionMat.m, sizeof(projectionMat.m));
 
-        _quadCommand.init(_globalZOrder, _texture, _blendFunc, _quads, _particleCount, transform, flags);
-        renderer->addCommand(&_quadCommand);
+        _quadCommand.init(_globalZOrder, _texture, _blendFunc, _quads, _particleCount, transform, flags, state.getView());
+        state.getRenderer()->addCommand(&_quadCommand);
     }
 }
 

--- a/axmol/2d/ParticleSystemQuad.h
+++ b/axmol/2d/ParticleSystemQuad.h
@@ -119,7 +119,7 @@ public:
     /**
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     /**
      * @lua NA

--- a/axmol/2d/ProgressTimer.cpp
+++ b/axmol/2d/ProgressTimer.cpp
@@ -636,12 +636,12 @@ Vec2 ProgressTimer::boundaryTexCoord(char index)
     return Vec2::zero;
 }
 
-void ProgressTimer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void ProgressTimer::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_vertexData.empty() || !_sprite)
         return;
 
-    const ax::Mat4& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const ax::Mat4& projectionMat = state.getViewProjectionMatrix();
     Mat4 finalMat                 = projectionMat * transform;
     _programState->setUniform(_locMVP1, finalMat.m, sizeof(finalMat.m));
     _programState->setTexture(_locTex1, 0, _sprite->getTexture()->getRHITexture());
@@ -651,23 +651,23 @@ void ProgressTimer::draw(Renderer* renderer, const Mat4& transform, uint32_t fla
         if (!_reverseDirection)
         {
             _customCommand.init(_globalZOrder, _sprite->getBlendFunc());
-            renderer->addCommand(&_customCommand);
+            state.getRenderer()->addCommand(&_customCommand);
         }
         else
         {
             _customCommand.init(_globalZOrder, _sprite->getBlendFunc());
-            renderer->addCommand(&_customCommand);
+            state.getRenderer()->addCommand(&_customCommand);
 
             _customCommand2.init(_globalZOrder, _sprite->getBlendFunc());
             _programState2->setUniform(_locMVP2, finalMat.m, sizeof(finalMat.m));
             _programState2->setTexture(_locTex2, 0, _sprite->getTexture()->getRHITexture());
-            renderer->addCommand(&_customCommand2);
+            state.getRenderer()->addCommand(&_customCommand2);
         }
     }
     else
     {
         _customCommand.init(_globalZOrder, _sprite->getBlendFunc());
-        renderer->addCommand(&_customCommand);
+        state.getRenderer()->addCommand(&_customCommand);
     }
 }
 

--- a/axmol/2d/ProgressTimer.h
+++ b/axmol/2d/ProgressTimer.h
@@ -151,7 +151,7 @@ public:
     Vec2 getBarChangeRate() const { return _barChangeRate; }
 
     // Overrides
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void setAnchorPoint(const Vec2& anchorPoint) override;
     void setColor(const Color32& color) override;
     const Color32& getColor() const override;

--- a/axmol/2d/ProtectedNode.cpp
+++ b/axmol/2d/ProtectedNode.cpp
@@ -271,7 +271,7 @@ void ProtectedNode::reorderProtectedChild(ax::Node* child, int localZOrder)
     child->setLocalZOrder(localZOrder);
 }
 
-void ProtectedNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void ProtectedNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -279,7 +279,7 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4& parentTransform, uint3
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     int i = 0;  // used by _children
     int j = 0;  // used by _protectedChildren
@@ -295,7 +295,7 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4& parentTransform, uint3
         auto node = _children.at(i);
 
         if (node && node->getLocalZOrder() < 0)
-            node->visit(renderer, _modelViewTransform, flags);
+            node->visit(state, _modelViewTransform, flags);
         else
             break;
     }
@@ -305,7 +305,7 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4& parentTransform, uint3
         auto node = _protectedChildren.at(j);
 
         if (node && node->getLocalZOrder() < 0)
-            node->visit(renderer, _modelViewTransform, flags);
+            node->visit(state, _modelViewTransform, flags);
         else
             break;
     }
@@ -313,17 +313,17 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4& parentTransform, uint3
     //
     // draw self
     //
-    if (isVisitableByVisitingCamera())
-        this->draw(renderer, _modelViewTransform, flags);
+    if (isVisitableByCamera(state.cameraFlag))
+        this->draw(state, _modelViewTransform, flags);
 
     //
     // draw children and protectedChildren zOrder >= 0
     //
     for (auto it = _protectedChildren.cbegin() + j, itCend = _protectedChildren.cend(); it != itCend; ++it)
-        (*it)->visit(renderer, _modelViewTransform, flags);
+        (*it)->visit(state, _modelViewTransform, flags);
 
     for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-        (*it)->visit(renderer, _modelViewTransform, flags);
+        (*it)->visit(state, _modelViewTransform, flags);
 
     // FIX ME: Why need to set _orderOfArrival to 0??
     // Please refer to https://github.com/cocos2d/cocos2d-x/pull/6920

--- a/axmol/2d/ProtectedNode.h
+++ b/axmol/2d/ProtectedNode.h
@@ -159,7 +159,7 @@ public:
 
     /**
      */
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     void cleanup() override;
 

--- a/axmol/2d/Sprite.cpp
+++ b/axmol/2d/Sprite.cpp
@@ -1068,7 +1068,7 @@ void Sprite::updateTransform()
 }
 
 // draw
-void Sprite::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void Sprite::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     AX_PROFILER_ZONE_SCOPED;
 
@@ -1076,27 +1076,22 @@ void Sprite::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
         return;
 
     // TODO: arnold: current camera can be a non-default one.
-    setMVPMatrixUniform();
+    setMVPMatrixUniform(state);
 
 #if AX_USE_CULLING
     // Don't calculate the culling if the transform was not updated
-    auto visitingCamera = Camera::getVisitingCamera();
-    auto defaultCamera  = Camera::getDefaultCamera();
+    auto visitingCamera = state.getCamera();
     if (visitingCamera == nullptr)
         _insideBounds = true;
-    else if (visitingCamera == defaultCamera)
-        _insideBounds = ((flags & FLAGS_TRANSFORM_DIRTY) || visitingCamera->isViewProjectionUpdated())
-                            ? renderer->checkVisibility(transform, _contentSize)
-                            : _insideBounds;
     else
-        // XXX: this always return true since
-        _insideBounds = renderer->checkVisibility(transform, _contentSize);
+        _insideBounds = state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize)
+                                                              : _insideBounds;
 
     if (_insideBounds)
 #endif
     {
-        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags);
-        renderer->addCommand(&_trianglesCommand);
+        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags, state.getView());
+        state.getRenderer()->addCommand(&_trianglesCommand);
 
 #if AX_SPRITE_DEBUG_DRAW
         _debugDrawNode->clear();
@@ -1719,9 +1714,9 @@ void Sprite::setPolygonInfo(const PolygonInfo& info)
     _renderMode = RenderMode::POLYGON;
 }
 
-void Sprite::setMVPMatrixUniform()
+void Sprite::setMVPMatrixUniform(const SceneRenderState& state)
 {
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMat = state.getViewProjectionMatrix();
     auto programState         = _trianglesCommand.unsafePS();
     if (programState && _mvpMatrixLocation)
         programState->setUniform(_mvpMatrixLocation, projectionMat.m, sizeof(projectionMat.m));

--- a/axmol/2d/Sprite.cpp
+++ b/axmol/2d/Sprite.cpp
@@ -1084,13 +1084,14 @@ void Sprite::draw(const SceneRenderState& state, const Mat4& transform, uint32_t
     if (visitingCamera == nullptr)
         _insideBounds = true;
     else
-        _insideBounds = state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize)
-                                                              : _insideBounds;
+        _insideBounds =
+            state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize) : _insideBounds;
 
     if (_insideBounds)
 #endif
     {
-        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags, state.getView());
+        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags,
+                               state.getView());
         state.getRenderer()->addCommand(&_trianglesCommand);
 
 #if AX_SPRITE_DEBUG_DRAW

--- a/axmol/2d/Sprite.h
+++ b/axmol/2d/Sprite.h
@@ -390,7 +390,7 @@ public:
     void setIgnoreAnchorPointForPosition(bool value) override;
 
     void setVisible(bool bVisible) override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void setOpacityModifyRGB(bool modify) override;
     bool isOpacityModifyRGB() const override;
     /// @}
@@ -666,7 +666,7 @@ protected:
     void updatePoly();
     void updateStretchFactor();
     void populateTriangle(int quadIndex, const V3F_T2F_C4B_Quad& quad);
-    void setMVPMatrixUniform();
+    void setMVPMatrixUniform(const SceneRenderState& state);
     //
     // Data used when the sprite is rendered using a SpriteSheet
     //

--- a/axmol/2d/SpriteBatchNode.cpp
+++ b/axmol/2d/SpriteBatchNode.cpp
@@ -166,7 +166,7 @@ SpriteBatchNode::~SpriteBatchNode()
 
 // override visit
 // don't call visit on it's children
-void SpriteBatchNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void SpriteBatchNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     AX_PROFILER_START_CATEGORY(kProfilerCategoryBatchSprite, "CCSpriteBatchNode - visit");
 
@@ -184,11 +184,11 @@ void SpriteBatchNode::visit(Renderer* renderer, const Mat4& parentTransform, uin
 
     sortAllChildren();
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
-    if (isVisitableByVisitingCamera())
+    if (isVisitableByCamera(state.cameraFlag))
     {
-        draw(renderer, _modelViewTransform, flags);
+        draw(state, _modelViewTransform, flags);
         // FIX ME: Why need to set _orderOfArrival to 0??
         // Please refer to https://github.com/cocos2d/cocos2d-x/pull/6920
         //    setOrderOfArrival(0);
@@ -405,7 +405,7 @@ void SpriteBatchNode::reorderBatch(bool reorder)
     _reorderChildDirty = reorder;
 }
 
-void SpriteBatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void SpriteBatchNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     // Optimization: Fast Dispatch
     if (_textureAtlas->getTotalQuads() == 0)
@@ -418,12 +418,12 @@ void SpriteBatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t f
         child->updateTransform();
     }
 
-    const auto& matrixProjection = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixProjection = state.getViewProjectionMatrix();
     auto programState            = _quadCommand.unsafePS();
     programState->setUniform(_mvpMatrixLocaiton, matrixProjection.m, sizeof(matrixProjection.m));
     _quadCommand.init(_globalZOrder, _textureAtlas->getTexture(), _blendFunc, _textureAtlas->getQuads(),
-                      _textureAtlas->getTotalQuads(), transform, flags);
-    renderer->addCommand(&_quadCommand);
+                      _textureAtlas->getTotalQuads(), transform, flags, state.getView());
+    state.getRenderer()->addCommand(&_quadCommand);
 }
 
 void SpriteBatchNode::increaseAtlasCapacity()

--- a/axmol/2d/SpriteBatchNode.h
+++ b/axmol/2d/SpriteBatchNode.h
@@ -192,7 +192,7 @@ public:
 
     /**
      */
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     using Node::addChild;
     void addChild(Node* child, int zOrder, int tag) override;
@@ -206,7 +206,7 @@ public:
     void sortAllChildren() override;
     /**
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     /**
      */
     std::string getDescription() const override;

--- a/axmol/2d/Transition.cpp
+++ b/axmol/2d/Transition.cpp
@@ -117,19 +117,19 @@ void TransitionScene::sceneOrder()
     _isInSceneOnTop = true;
 }
 
-void TransitionScene::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void TransitionScene::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    Scene::draw(renderer, transform, flags);
+    Scene::draw(state, transform, flags);
 
     if (_isInSceneOnTop)
     {
-        _outScene->visit(renderer, transform, flags);
-        _inScene->visit(renderer, transform, flags);
+        _outScene->visit(state, transform, flags);
+        _inScene->visit(state, transform, flags);
     }
     else
     {
-        _inScene->visit(renderer, transform, flags);
-        _outScene->visit(renderer, transform, flags);
+        _inScene->visit(state, transform, flags);
+        _outScene->visit(state, transform, flags);
     }
 }
 
@@ -1111,7 +1111,7 @@ TransitionCrossFade* TransitionCrossFade::create(float t, Scene* scene)
     return nullptr;
 }
 
-void TransitionCrossFade::draw(Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t /*flags*/)
+void TransitionCrossFade::draw(const SceneRenderState& /*state*/, const Mat4& /*transform*/, uint32_t /*flags*/)
 {
     // override draw since both scenes (textures) are rendered in 1 scene
 }
@@ -1136,7 +1136,8 @@ void TransitionCrossFade::onEnter()
 
     // render inScene to its texturebuffer
     pass->begin(camera);
-    _inScene->visit(_director->getRenderer(), _inScene->getNodeToParentTransform(), 0);
+    SceneRenderState renderState(_director->getRenderer(), camera);
+    _inScene->visit(renderState, _inScene->getNodeToParentTransform(), 0);
     pass->end();
 
     _director->getRenderer()->render();
@@ -1153,7 +1154,8 @@ void TransitionCrossFade::onEnter()
     pass->setTarget(outTexture);
 
     pass->begin(camera);
-    _outScene->visit(_director->getRenderer(), _outScene->getNodeToParentTransform(), 0);
+    renderState = SceneRenderState(_director->getRenderer(), camera);
+    _outScene->visit(renderState, _outScene->getNodeToParentTransform(), 0);
     pass->end();
 
     _director->getRenderer()->render();
@@ -1250,19 +1252,19 @@ void TransitionTurnOffTiles::onExit()
     TransitionScene::onExit();
 }
 
-void TransitionTurnOffTiles::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void TransitionTurnOffTiles::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    Scene::draw(renderer, transform, flags);
+    Scene::draw(state, transform, flags);
 
     if (_isInSceneOnTop)
     {
-        _outSceneProxy->visit(renderer, transform, flags);
-        _inScene->visit(renderer, transform, flags);
+        _outSceneProxy->visit(state, transform, flags);
+        _inScene->visit(state, transform, flags);
     }
     else
     {
-        _inScene->visit(renderer, transform, flags);
-        _outSceneProxy->visit(renderer, transform, flags);
+        _inScene->visit(state, transform, flags);
+        _outSceneProxy->visit(state, transform, flags);
     }
 }
 
@@ -1318,10 +1320,10 @@ void TransitionSplitCols::switchTargetToInscene()
     _gridProxy->setTarget(_inScene);
 }
 
-void TransitionSplitCols::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void TransitionSplitCols::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    Scene::draw(renderer, transform, flags);
-    _gridProxy->visit(renderer, transform, flags);
+    Scene::draw(state, transform, flags);
+    _gridProxy->visit(state, transform, flags);
 }
 
 void TransitionSplitCols::onExit()
@@ -1422,19 +1424,19 @@ void TransitionFadeTR::onExit()
     TransitionScene::onExit();
 }
 
-void TransitionFadeTR::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void TransitionFadeTR::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    Scene::draw(renderer, transform, flags);
+    Scene::draw(state, transform, flags);
 
     if (_isInSceneOnTop)
     {
-        _outSceneProxy->visit(renderer, transform, flags);
-        _inScene->visit(renderer, transform, flags);
+        _outSceneProxy->visit(state, transform, flags);
+        _inScene->visit(state, transform, flags);
     }
     else
     {
-        _inScene->visit(renderer, transform, flags);
-        _outSceneProxy->visit(renderer, transform, flags);
+        _inScene->visit(state, transform, flags);
+        _outSceneProxy->visit(state, transform, flags);
     }
 }
 

--- a/axmol/2d/Transition.h
+++ b/axmol/2d/Transition.h
@@ -108,7 +108,7 @@ public:
     //
     // Overrides
     //
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void onEnter() override;
     void onExit() override;
     void cleanup() override;
@@ -803,7 +803,7 @@ public:
     /**
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     /**
      * @lua NA
      */
@@ -848,7 +848,7 @@ public:
     ActionInterval* easeActionWithAction(ActionInterval* action) override;
     /**
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     TransitionTurnOffTiles();
     virtual ~TransitionTurnOffTiles();
@@ -891,7 +891,7 @@ public:
     void onEnter() override;
     ActionInterval* easeActionWithAction(ActionInterval* action) override;
     void onExit() override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     TransitionSplitCols();
     virtual ~TransitionSplitCols();
@@ -962,7 +962,7 @@ public:
     void onEnter() override;
     ActionInterval* easeActionWithAction(ActionInterval* action) override;
     void onExit() override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     TransitionFadeTR();
     virtual ~TransitionFadeTR();

--- a/axmol/2d/TransitionPageTurn.cpp
+++ b/axmol/2d/TransitionPageTurn.cpp
@@ -76,19 +76,19 @@ void TransitionPageTurn::sceneOrder()
     _isInSceneOnTop = _back;
 }
 
-void TransitionPageTurn::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void TransitionPageTurn::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    Scene::draw(renderer, transform, flags);
+    Scene::draw(state, transform, flags);
 
     if (_isInSceneOnTop)
     {
-        _outSceneProxy->visit(renderer, transform, flags);
-        _inSceneProxy->visit(renderer, transform, flags);
+        _outSceneProxy->visit(state, transform, flags);
+        _inSceneProxy->visit(state, transform, flags);
     }
     else
     {
-        _inSceneProxy->visit(renderer, transform, flags);
-        _outSceneProxy->visit(renderer, transform, flags);
+        _inSceneProxy->visit(state, transform, flags);
+        _outSceneProxy->visit(state, transform, flags);
     }
 }
 

--- a/axmol/2d/TransitionPageTurn.h
+++ b/axmol/2d/TransitionPageTurn.h
@@ -70,7 +70,7 @@ public:
     //
     // Overrides
     //
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     /**
      * Creates a base transition with duration and incoming scene.

--- a/axmol/2d/TransitionProgress.cpp
+++ b/axmol/2d/TransitionProgress.cpp
@@ -85,8 +85,9 @@ void TransitionProgress::onEnter()
     {
         RefPtr<RenderTexturePass> pass(RenderTexturePass::obtain(texture), tlx::adopt_object);
         pass->begin(camera);
+        SceneRenderState renderState(_director->getRenderer(), camera);
         pass->clear(ClearFlag::COLOR, {.color = Color(0, 0, 0, 1)});
-        _sceneToBeModified->visit(_director->getRenderer(), _sceneToBeModified->getNodeToParentTransform(), 0);
+        _sceneToBeModified->visit(renderState, _sceneToBeModified->getNodeToParentTransform(), 0);
         pass->end();
     }
     _director->getRenderer()->render();

--- a/axmol/3d/AttachNode.cpp
+++ b/axmol/3d/AttachNode.cpp
@@ -69,8 +69,8 @@ const Mat4& AttachNode::getNodeToParentTransform() const
     return _transformToParent;
 }
 
-void AttachNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t /*parentFlags*/)
+void AttachNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t /*parentFlags*/)
 {
-    Node::visit(renderer, parentTransform, Node::FLAGS_DIRTY_MASK);
+    Node::visit(state, parentTransform, Node::FLAGS_DIRTY_MASK);
 }
 }  // namespace ax

--- a/axmol/3d/AttachNode.h
+++ b/axmol/3d/AttachNode.h
@@ -57,7 +57,7 @@ public:
     Mat4 getWorldToNodeTransform() const override;
     Mat4 getNodeToWorldTransform() const override;
     const Mat4& getNodeToParentTransform() const override;
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     AttachNode();
     virtual ~AttachNode();

--- a/axmol/3d/BillBoard.cpp
+++ b/axmol/3d/BillBoard.cpp
@@ -93,27 +93,27 @@ BillBoard* BillBoard::create(Mode mode)
     return nullptr;
 }
 
-void BillBoard::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void BillBoard::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
     {
         return;
     }
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
     // quick return if not visible by camera and has no children.
     if (!visibleByCamera && _children.empty())
     {
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     // Add 3D flag so all the children will be rendered as 3D object
     flags |= FLAGS_RENDER_AS_3D;
 
     // Update Billboard transform
-    bool dirty = calculateBillboardTransform();
+    bool dirty = calculateBillboardTransform(state);
     if (dirty)
     {
         flags |= FLAGS_TRANSFORM_DIRTY;
@@ -130,28 +130,28 @@ void BillBoard::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t 
             auto node = _children.at(i);
 
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
         // self draw
         if (visibleByCamera)
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
 
         for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
+            (*it)->visit(state, _modelViewTransform, flags);
     }
     else if (visibleByCamera)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
     }
 }
 
-bool BillBoard::calculateBillboardTransform()
+bool BillBoard::calculateBillboardTransform(const SceneRenderState& state)
 {
-    // Get camera world position
-    auto camera             = Camera::getVisitingCamera();
-    const Mat4& camWorldMat = camera->getNodeToWorldTransform();
+    // Get current view world transform. In XR this includes the eye/head pose
+    // from the SceneRenderState snapshot, not just the persistent Camera node.
+    const Mat4 camWorldMat = state.getViewMatrix().getInversed();
 
     // TODO: use math lib to calculate math lib Make it easier to read and maintain
     if (memcmp(_camWorldMat.m, camWorldMat.m, sizeof(float) * 16) != 0 ||
@@ -229,13 +229,13 @@ bool BillBoard::calculateBillboardTransform()
     return false;
 }
 
-void BillBoard::draw(Renderer* renderer, const Mat4& /*transform*/, uint32_t flags)
+void BillBoard::draw(const SceneRenderState& state, const Mat4& /*transform*/, uint32_t flags)
 {
     // FIXME: frustum culling here
     flags |= Node::FLAGS_RENDER_AS_3D;
-    _trianglesCommand.init(0, _texture, _blendFunc, _polyInfo.triangles, _modelViewTransform, flags);
-    setMVPMatrixUniform();  // update uniform
-    renderer->addCommand(&_trianglesCommand);
+    _trianglesCommand.init(0, _texture, _blendFunc, _polyInfo.triangles, _modelViewTransform, flags, state.getView());
+    setMVPMatrixUniform(state);  // update uniform
+    state.getRenderer()->addCommand(&_trianglesCommand);
 }
 
 void BillBoard::setMode(Mode mode)

--- a/axmol/3d/BillBoard.h
+++ b/axmol/3d/BillBoard.h
@@ -94,14 +94,14 @@ public:
     // override
 
     /** update billboard's transform and turn it towards camera */
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     /**
      * draw BillBoard object.
      *
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     BillBoard();
     virtual ~BillBoard();
@@ -110,7 +110,7 @@ protected:
     /**
      * calculate a model matrix which keep original translate & scaling but always face to the camera
      */
-    bool calculateBillboardTransform();
+    bool calculateBillboardTransform(const SceneRenderState& state);
 
     Mat4 _camWorldMat;
     Mat4 _mvTransform;

--- a/axmol/3d/Mesh.cpp
+++ b/axmol/3d/Mesh.cpp
@@ -426,7 +426,7 @@ Material* Mesh::getMaterial() const
     return _material;
 }
 
-void Mesh::draw(Renderer* renderer,
+void Mesh::draw(const SceneRenderState& state,
                 float globalZOrder,
                 const Mat4& transform,
                 uint32_t flags,
@@ -519,7 +519,7 @@ void Mesh::draw(Renderer* renderer,
 
     for (auto&& command : commands)
     {
-        command.init(globalZ, transform);
+        command.init(globalZ, transform, state.getView());
         command.setSkipBatching(isTransparent);
         command.setTransparent(isTransparent);
         command.set3D(!_material->isForce2DQueue());

--- a/axmol/3d/Mesh.h
+++ b/axmol/3d/Mesh.h
@@ -53,6 +53,7 @@ class Material;
 class Renderer;
 class Scene;
 class Pass;
+struct SceneRenderState;
 
 namespace rhi
 {
@@ -220,7 +221,7 @@ public:
     /** Returns the Material being used by the Mesh */
     Material* getMaterial() const;
 
-    void draw(Renderer* renderer,
+    void draw(const SceneRenderState& state,
               float globalZ,
               const Mat4& transform,
               uint32_t flags,

--- a/axmol/3d/MeshRenderer.cpp
+++ b/axmol/3d/MeshRenderer.cpp
@@ -812,7 +812,7 @@ void MeshRenderer::removeAllAttachNode()
     _attachments.clear();
 }
 
-void MeshRenderer::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags)
+void MeshRenderer::visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -820,10 +820,10 @@ void MeshRenderer::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
     flags |= FLAGS_RENDER_AS_3D;
 
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
 
     int i = 0;
 
@@ -836,30 +836,30 @@ void MeshRenderer::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform
             auto node = _children.at(i);
 
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
         // self draw
         if (visibleByCamera)
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
 
         for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
+            (*it)->visit(state, _modelViewTransform, flags);
     }
     else if (visibleByCamera)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
     }
 }
 
-void MeshRenderer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void MeshRenderer::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
 #if AX_USE_CULLING
-    // TODO new-renderer: interface isVisibleInFrustum removal
+    // TODO new-state: interface isVisibleInFrustum removal
     //  camera clipping
-    // if(_children.empty() && Camera::getVisitingCamera() &&
-    // !Camera::getVisitingCamera()->isVisibleInFrustum(&getAABB()))
+    // if(_children.empty() && state.getCamera() &&
+    // !state.getCamera()->isVisibleInFrustum(&getAABB()))
     //     return;
 #endif
 
@@ -891,7 +891,7 @@ void MeshRenderer::draw(Renderer* renderer, const Mat4& transform, uint32_t flag
 
     for (auto&& mesh : _meshes)
     {
-        mesh->draw(renderer, _globalZOrder, transform, flags, _lightMask, Vec4(color.r, color.g, color.b, color.a),
+        mesh->draw(state, _globalZOrder, transform, flags, _lightMask, Vec4(color.r, color.g, color.b, color.a),
                    _forceDepthWrite, _wireframe);
     }
 }

--- a/axmol/3d/MeshRenderer.h
+++ b/axmol/3d/MeshRenderer.h
@@ -188,7 +188,7 @@ public:
     bool isWireframe() const { return _wireframe; }
 
     /** render all meshes within this mesh renderer */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     /** Adds a new material to this mesh renderer.
      The Material will be applied to all the meshes that belong to the mesh renderer.
@@ -247,7 +247,7 @@ public:
      * Note: all children will be rendered in 3D space with depth, this behaviour can be changed using
      * setForce2DQueue()
      */
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     /** generate default material. */
     void genMaterial(bool useLight = false);

--- a/axmol/3d/MotionStreak3D.cpp
+++ b/axmol/3d/MotionStreak3D.cpp
@@ -398,18 +398,18 @@ void MotionStreak3D::reset()
     _nuPoints = 0;
 }
 
-void MotionStreak3D::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void MotionStreak3D::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_nuPoints <= 1)
         return;
-    auto beforeCommand = renderer->nextCallbackCommand();
-    auto afterCommand  = renderer->nextCallbackCommand();
+    auto beforeCommand = state.getRenderer()->nextCallbackCommand();
+    auto afterCommand  = state.getRenderer()->nextCallbackCommand();
 
     beforeCommand->init(_globalZOrder);
     afterCommand->init(_globalZOrder);
-    _customCommand.init(_globalZOrder, transform, flags);
+    _customCommand.init(_globalZOrder, transform, flags, state.getView());
 
-    auto pmatrix   = Camera::getVisitingViewProjectionMatrix();
+    auto pmatrix   = state.getViewProjectionMatrix();
     auto mvpMatrix = pmatrix * transform;
 
     _programState->setUniform(_locMVP, mvpMatrix.m, sizeof(mvpMatrix.m));
@@ -421,9 +421,9 @@ void MotionStreak3D::draw(Renderer* renderer, const Mat4& transform, uint32_t fl
 
     _customCommand.setVertexDrawInfo(0, _nuPoints * 2);
 
-    renderer->addCommand(beforeCommand);
-    renderer->addCommand(&_customCommand);
-    renderer->addCommand(afterCommand);
+    state.getRenderer()->addCommand(beforeCommand);
+    state.getRenderer()->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(afterCommand);
     AX_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, _nuPoints * 2);
 }
 

--- a/axmol/3d/MotionStreak3D.h
+++ b/axmol/3d/MotionStreak3D.h
@@ -122,7 +122,7 @@ public:
     /**
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     /**
      * @lua NA
      */

--- a/axmol/3d/Skybox.cpp
+++ b/axmol/3d/Skybox.cpp
@@ -133,16 +133,14 @@ void Skybox::initBuffers()
     _customCommand.updateIndexBuffer(&idxBuf[0], sizeof(idxBuf));
 }
 
-void Skybox::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void Skybox::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder);
 
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
 
-    auto camera = Camera::getVisitingCamera();
-
-    Mat4 cameraModelMat = camera->getNodeToWorldTransform();
-    Mat4 projectionMat  = camera->getProjectionMatrix();
+    Mat4 cameraModelMat       = state.getViewMatrix().getInversed();
+    const Mat4& projectionMat = state.getProjectionMatrix();
     // Ignore the translation
     cameraModelMat.m[12] = cameraModelMat.m[13] = cameraModelMat.m[14] = 0;
     // prescale the matrix to account for the camera fov

--- a/axmol/3d/Skybox.h
+++ b/axmol/3d/Skybox.h
@@ -69,7 +69,7 @@ public:
     void setTexture(TextureCube*);
 
     /** draw Skybox object */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     /** reload sky box after GLESContext reconstructed.*/
     void reload();

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -79,7 +79,7 @@ bool isAABBOutOfViewProjection(const AABB& aabb, const Plane planes[6])
     Vec3 point;
     for (int i = 0; i < 6; ++i)
     {
-        const auto& plane   = planes[i];
+        const auto& plane  = planes[i];
         const Vec3& normal = plane.getNormal();
         point.x            = normal.x < 0 ? aabb._max.x : aabb._min.x;
         point.y            = normal.y < 0 ? aabb._max.y : aabb._min.y;
@@ -580,11 +580,11 @@ bool Terrain::getIntersectionPoint(const Ray& ray_, Vec3& intersectionPoint) con
     ray.transform(getWorldToNodeTransform());
 
     std::set<Chunk*> closeList;
-    Vec2 start = Vec2(ray.origin.x, ray.origin.z);
-    Vec2 dir   = Vec2(ray.direction.x, ray.direction.z);
+    Vec2 start              = Vec2(ray.origin.x, ray.origin.z);
+    Vec2 dir                = Vec2(ray.direction.x, ray.direction.z);
     const float invMapScale = _terrainData._mapScale != 0.0f ? 1.0f / _terrainData._mapScale : 0.0f;
-    start.x                  = (start.x + _terrainData._mapScale * _imageWidth * 0.5f) * invMapScale;
-    start.y                  = (start.y + _terrainData._mapScale * _imageHeight * 0.5f) * invMapScale;
+    start.x                 = (start.x + _terrainData._mapScale * _imageWidth * 0.5f) * invMapScale;
+    start.y                 = (start.y + _terrainData._mapScale * _imageHeight * 0.5f) * invMapScale;
     start.x /= (_terrainData._chunkSize.width + 1);
     start.y /= (_terrainData._chunkSize.height + 1);
     Vec2 delta             = dir.getNormalized();

--- a/axmol/3d/Terrain.cpp
+++ b/axmol/3d/Terrain.cpp
@@ -50,6 +50,49 @@ using namespace ax;
 
 namespace ax
 {
+namespace
+{
+void buildViewProjectionPlanes(const Mat4& viewProjection, Plane planes[6])
+{
+    planes[0].initPlane(-Vec3(viewProjection.m[3] + viewProjection.m[0], viewProjection.m[7] + viewProjection.m[4],
+                              viewProjection.m[11] + viewProjection.m[8]),
+                        viewProjection.m[15] + viewProjection.m[12]);
+    planes[1].initPlane(-Vec3(viewProjection.m[3] - viewProjection.m[0], viewProjection.m[7] - viewProjection.m[4],
+                              viewProjection.m[11] - viewProjection.m[8]),
+                        viewProjection.m[15] - viewProjection.m[12]);
+    planes[2].initPlane(-Vec3(viewProjection.m[3] + viewProjection.m[1], viewProjection.m[7] + viewProjection.m[5],
+                              viewProjection.m[11] + viewProjection.m[9]),
+                        viewProjection.m[15] + viewProjection.m[13]);
+    planes[3].initPlane(-Vec3(viewProjection.m[3] - viewProjection.m[1], viewProjection.m[7] - viewProjection.m[5],
+                              viewProjection.m[11] - viewProjection.m[9]),
+                        viewProjection.m[15] - viewProjection.m[13]);
+    planes[4].initPlane(-Vec3(viewProjection.m[3] + viewProjection.m[2], viewProjection.m[7] + viewProjection.m[6],
+                              viewProjection.m[11] + viewProjection.m[10]),
+                        viewProjection.m[15] + viewProjection.m[14]);
+    planes[5].initPlane(-Vec3(viewProjection.m[3] - viewProjection.m[2], viewProjection.m[7] - viewProjection.m[6],
+                              viewProjection.m[11] - viewProjection.m[10]),
+                        viewProjection.m[15] - viewProjection.m[14]);
+}
+
+bool isAABBOutOfViewProjection(const AABB& aabb, const Plane planes[6])
+{
+    Vec3 point;
+    for (int i = 0; i < 6; ++i)
+    {
+        const auto& plane   = planes[i];
+        const Vec3& normal = plane.getNormal();
+        point.x            = normal.x < 0 ? aabb._max.x : aabb._min.x;
+        point.y            = normal.y < 0 ? aabb._max.y : aabb._min.y;
+        point.z            = normal.z < 0 ? aabb._max.z : aabb._min.z;
+
+        if (plane.getSide(point) == PointSide::FRONT_PLANE)
+            return true;
+    }
+
+    return false;
+}
+}  // namespace
+
 Terrain* Terrain::create(TerrainData& parameter, CrackFixedType fixedType)
 {
     Terrain* terrain = new Terrain();
@@ -113,7 +156,7 @@ bool Terrain::initProperties()
     return true;
 }
 
-void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void Terrain::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
     auto modelMatrix = getNodeToWorldTransform();
     if (memcmp(&modelMatrix, &_terrainModelMatrix, sizeof(Mat4)) != 0)
@@ -122,7 +165,7 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
         _quadRoot->preCalculateAABB(_terrainModelMatrix);
     }
 
-    const auto& projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMatrix = state.getViewProjectionMatrix();
     auto finalMatrix             = projectionMatrix * transform;
     _programState->setUniform(_mvpMatrixLocation, &finalMatrix.m, sizeof(finalMatrix.m));
 
@@ -160,19 +203,17 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
         _programState->setUniform(_lightMapCheckLocation, &hasLightMap, sizeof(hasLightMap));
         _programState->setTexture(_lightMapLocation, BINDING_SLOT_LIGHT_MAP, _dummyTexture->getRHITexture());
     }
-    auto camera = Camera::getVisitingCamera();
-
-    if (memcmp(&_CameraMatrix, &camera->getViewMatrix(), sizeof(Mat4)) != 0)
+    const auto& viewMatrix = state.getViewMatrix();
+    if (memcmp(&_CameraMatrix, &viewMatrix, sizeof(Mat4)) != 0)
     {
         _isCameraViewChanged = true;
-        _CameraMatrix        = camera->getViewMatrix();
+        _CameraMatrix        = viewMatrix;
     }
 
     if (_isCameraViewChanged)
     {
-        auto m = camera->getNodeToWorldTransform();
         // set lod
-        setChunksLOD(Vec3(m.m[12], m.m[13], m.m[14]));
+        setChunksLOD(state.getView().position);
     }
 
     if (_isCameraViewChanged)
@@ -181,7 +222,9 @@ void Terrain::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t f
         // camera frustum culling
         if (_isEnableFrustumCull)
         {
-            _quadRoot->cullByCamera(camera, _terrainModelMatrix);
+            Plane viewProjectionPlanes[6];
+            buildViewProjectionPlanes(state.getViewProjectionMatrix(), viewProjectionPlanes);
+            _quadRoot->cullByCamera(viewProjectionPlanes, _terrainModelMatrix);
         }
     }
     _quadRoot->draw();
@@ -516,18 +559,6 @@ bool Terrain::onPointerHitTest(PointerEvent* event, Vec3* outHitPoint)
 
     Ray ray = event->getRay();
 
-    if (event->getPointerType() == PointerType::Controller)
-    {
-        // The current VR ray is generated in the default camera space; terrain hit testing runs in the hit camera
-        // space.
-        const auto sourceCamera = Camera::getDefaultCamera();
-        const auto hitCamera    = event->getCamera();
-        if (sourceCamera && hitCamera && sourceCamera != hitCamera)
-        {
-            ray.transform(sourceCamera->getWorldToNodeTransform());
-            ray.transform(hitCamera->getNodeToWorldTransform());
-        }
-    }
     Vec3 hitPoint;
 
     bool hitted = getIntersectionPoint(ray, hitPoint);
@@ -549,9 +580,11 @@ bool Terrain::getIntersectionPoint(const Ray& ray_, Vec3& intersectionPoint) con
     ray.transform(getWorldToNodeTransform());
 
     std::set<Chunk*> closeList;
-    Vec2 start = Vec2(ray_.origin.x, ray_.origin.z);
+    Vec2 start = Vec2(ray.origin.x, ray.origin.z);
     Vec2 dir   = Vec2(ray.direction.x, ray.direction.z);
-    start      = convertToTerrainSpace(start);
+    const float invMapScale = _terrainData._mapScale != 0.0f ? 1.0f / _terrainData._mapScale : 0.0f;
+    start.x                  = (start.x + _terrainData._mapScale * _imageWidth * 0.5f) * invMapScale;
+    start.y                  = (start.y + _terrainData._mapScale * _imageHeight * 0.5f) * invMapScale;
     start.x /= (_terrainData._chunkSize.width + 1);
     start.y /= (_terrainData._chunkSize.height + 1);
     Vec2 delta             = dir.getNormalized();
@@ -1613,18 +1646,18 @@ void Terrain::QuadTree::resetNeedDraw(bool value)
     }
 }
 
-void Terrain::QuadTree::cullByCamera(const Camera* camera, const Mat4& worldTransform)
+void Terrain::QuadTree::cullByCamera(const Plane viewProjectionPlanes[6], const Mat4& worldTransform)
 {
-    if (!camera->isVisibleInFrustum(&_worldSpaceAABB))
+    if (isAABBOutOfViewProjection(_worldSpaceAABB, viewProjectionPlanes))
     {
         this->resetNeedDraw(false);
     }
     else if (!_isTerminal)
     {
-        _tl->cullByCamera(camera, worldTransform);
-        _tr->cullByCamera(camera, worldTransform);
-        _bl->cullByCamera(camera, worldTransform);
-        _br->cullByCamera(camera, worldTransform);
+        _tl->cullByCamera(viewProjectionPlanes, worldTransform);
+        _tr->cullByCamera(viewProjectionPlanes, worldTransform);
+        _bl->cullByCamera(viewProjectionPlanes, worldTransform);
+        _br->cullByCamera(viewProjectionPlanes, worldTransform);
     }
 }
 

--- a/axmol/3d/Terrain.h
+++ b/axmol/3d/Terrain.h
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include "axmol/renderer/RenderState.h"
 #include "axmol/rhi/ProgramState.h"
 #include "axmol/math/AABB.h"
+#include "axmol/math/Plane.h"
 #include "axmol/math/Ray.h"
 #include "axmol/base/CustomEventListener.h"
 #include "axmol/base/EventDispatcher.h"
@@ -322,7 +323,7 @@ private:
         /**recursively set itself and its children is need to draw*/
         void resetNeedDraw(bool value);
         /**recursively potential visible culling*/
-        void cullByCamera(const Camera* camera, const Mat4& worldTransform);
+        void cullByCamera(const Plane viewProjectionPlanes[6], const Mat4& worldTransform);
         /**precalculate the AABB(In world space) of each quad*/
         void preCalculateAABB(const Mat4& worldTransform);
         QuadTree* _tl;
@@ -414,7 +415,7 @@ public:
     void setDetailMap(unsigned int index, DetailMap detailMap);
 
     // Overrides, internal use only
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
     bool onPointerHitTest(PointerEvent* event, Vec3* outHitPoint) override;
 
     /**

--- a/axmol/base/Director.cpp
+++ b/axmol/base/Director.cpp
@@ -490,7 +490,6 @@ static void getViewProjMatrix(Mat4* transformOut)
     auto scene  = director->getRunningScene();
     auto camera = scene ? scene->getDefaultCamera() : nullptr;
 
-    AXASSERT(camera, "Director screen/world conversion requires a running scene default camera");
     *transformOut = camera ? camera->getViewProjectionMatrix() : Mat4::identity;
 }
 
@@ -1062,11 +1061,9 @@ void Director::showStats()
             _frames  = 0;
         }
 
-        auto previousCamera = Camera::_visitingCamera;
         auto* overlayCamera = getOverlayCamera();
         if (overlayCamera)
         {
-            Camera::_visitingCamera = overlayCamera;
             overlayCamera->apply();
         }
 
@@ -1089,12 +1086,11 @@ void Director::showStats()
         const Mat4& identity = Mat4::identity;
         if (overlayCamera)
         {
-            _drawnVerticesLabel->visit(_renderer, identity, 0);
-            _drawnBatchesLabel->visit(_renderer, identity, 0);
-            _FPSLabel->visit(_renderer, identity, 0);
+            SceneRenderState overlayState(_renderer, overlayCamera);
+            _drawnVerticesLabel->visit(overlayState, identity, 0);
+            _drawnBatchesLabel->visit(overlayState, identity, 0);
+            _FPSLabel->visit(overlayState, identity, 0);
         }
-
-        Camera::_visitingCamera = previousCamera;
     }
 }
 
@@ -1116,15 +1112,13 @@ void Director::showVRModeIndicator()
         _VRModeLabel->enableOutline(Color32::black, 2);
     }
 
-    auto previousCamera = Camera::_visitingCamera;
     auto* overlayCamera = getOverlayCamera();
     if (overlayCamera)
     {
-        Camera::_visitingCamera = overlayCamera;
         overlayCamera->apply();
-        _VRModeLabel->visit(_renderer, Mat4::identity, 0);
+        SceneRenderState overlayState(_renderer, overlayCamera);
+        _VRModeLabel->visit(overlayState, Mat4::identity, 0);
     }
-    Camera::_visitingCamera = previousCamera;
 }
 
 void Director::calculateMPF()
@@ -1498,15 +1492,13 @@ void Director::renderFrame()
         // draw the notifications node
         if (_notificationNode)
         {
-            auto previousCamera = Camera::_visitingCamera;
             auto* overlayCamera = getOverlayCamera();
             if (overlayCamera)
             {
-                Camera::_visitingCamera = overlayCamera;
                 overlayCamera->apply();
-                _notificationNode->visit(_renderer, Mat4::identity, 0);
+                SceneRenderState overlayState(_renderer, overlayCamera);
+                _notificationNode->visit(overlayState, Mat4::identity, 0);
             }
-            Camera::_visitingCamera = previousCamera;
         }
 
         updateFrameRate();

--- a/axmol/base/EventDispatcher.cpp
+++ b/axmol/base/EventDispatcher.cpp
@@ -118,7 +118,7 @@ static bool pointerHitTest(PointerEvent* event, const Camera* camera, PointerEve
 {
     event->setCamera(camera);
 
-    if (camera && event->getPointerType() != PointerType::Controller)
+    if (!event->resolveRayForCamera(camera) && camera && event->getPointerType() != PointerType::Controller)
         event->setRay(camera->screenToRay(event->getPoint()));
 
     Vec3 hitPoint;
@@ -1279,7 +1279,7 @@ void EventDispatcher::dispatchUncapturedPointerEvent(PointerEvent* event, Pointe
             if (!hitCamera)
                 continue;
 
-            // Camera context for input callbacks. Do not use Camera::_visitingCamera.
+            // Camera context for input callbacks.
             event->setCamera(hitCamera);
 
             if (deliverUncapturedEvent(l))

--- a/axmol/base/InputSystem.cpp
+++ b/axmol/base/InputSystem.cpp
@@ -740,8 +740,8 @@ void InputSystem::onPlatformKeyboardWillShow(float rawX, float rawY, float rawWi
         keyboardPos  = nativeToScreen(keyboardPos);
 
         // Transform the relative screen size vector into World Space dimensions
-        auto scene           = director->getRunningScene();
-        auto camera          = scene ? scene->getDefaultCamera() : nullptr;
+        auto scene  = director->getRunningScene();
+        auto camera = scene ? scene->getDefaultCamera() : nullptr;
         if (!camera)
             return ax::Rect();
         Vec3 nearWorldSize   = camera->deprojectScreenToWorld(Vec3(keyboardSize.x, keyboardSize.y, 0.0f));

--- a/axmol/base/InputSystem.cpp
+++ b/axmol/base/InputSystem.cpp
@@ -90,10 +90,10 @@ InputSystem::~InputSystem()
 
 Rect InputSystem::getNodeNativeWindowRect(Node* node) const
 {
-    // 1. Fetch the currently active running camera
-    auto camera = Camera::getVisitingCamera();
+    auto scene  = Director::getInstance()->getRunningScene();
+    auto camera = scene ? scene->getDefaultCamera() : nullptr;
     if (!camera)
-        camera = Camera::getDefaultCamera();
+        return Rect();
 
     // 2. Transform local bounds of the node directly into 3D World Space coordinates
     auto worldLeftBottom = node->convertToWorldSpace(Vec2::zero);
@@ -465,12 +465,13 @@ void InputSystem::handlePointerScroll(Vec2 point, Vec2 scollDelat, const Pointer
 PointerHitResult InputSystem::handleVRPointerScroll(Vec2 point,
                                                     Vec2 scrollDelta,
                                                     const Ray& ray,
-                                                    const PointerInputState& state)
+                                                    const PointerInputState& state,
+                                                    const PointerRayContext* rayContext)
 {
     if (!_interactive)
         return {};
 
-    return dispatchVRPointerScroll(point, scrollDelta, ray, state);
+    return dispatchVRPointerScroll(point, scrollDelta, ray, state, rayContext);
 }
 
 void InputSystem::handleXRInput(const XRInputEvent::State& state)
@@ -599,15 +600,19 @@ void InputSystem::dispatchPointerEvent(InputPhase phase, Vec2 point, const Point
 PointerHitResult InputSystem::handleVRPointerEvent(InputPhase phase,
                                                    Vec2 point,
                                                    const Ray& ray,
-                                                   const PointerInputState& state)
+                                                   const PointerInputState& state,
+                                                   const PointerRayContext* rayContext)
 {
     if (!_interactive)
         return {};
 
-    return dispatchVRPointerEvent(phase, point, ray, state);
+    return dispatchVRPointerEvent(phase, point, ray, state, rayContext);
 }
 
-PointerHitResult InputSystem::hitTestVRPointer(Vec2 point, const Ray& ray, const PointerInputState& state)
+PointerHitResult InputSystem::hitTestVRPointer(Vec2 point,
+                                               const Ray& ray,
+                                               const PointerInputState& state,
+                                               const PointerRayContext* rayContext)
 {
     if (!_interactive)
         return {};
@@ -617,13 +622,15 @@ PointerHitResult InputSystem::hitTestVRPointer(Vec2 point, const Ray& ray, const
     // to emit hover-exit events, and that path can report no fresh hit point.
     _isolatedMoveEvent.setPointerInfo(InputPhase::PointerScroll, nativeToScreen(point), state);
     _isolatedMoveEvent.setRay(ray);
+    _isolatedMoveEvent.setRayContext(rayContext);
     return _eventDispatcher->hitTestPointerEvent(&_isolatedMoveEvent);
 }
 
 PointerHitResult InputSystem::dispatchVRPointerEvent(InputPhase phase,
                                                      Vec2 point,
                                                      const Ray& ray,
-                                                     const PointerInputState& state)
+                                                     const PointerInputState& state,
+                                                     const PointerRayContext* rayContext)
 {
     _lastPointerPosition = point;
 
@@ -654,6 +661,7 @@ PointerHitResult InputSystem::dispatchVRPointerEvent(InputPhase phase,
 
     event->setPointerInfo(phase, nativeToScreen(point), state);
     event->setRay(ray);
+    event->setRayContext(rayContext);
     dispatchEvent(event);
 
     auto result = event->getHitResult();
@@ -673,13 +681,15 @@ PointerHitResult InputSystem::dispatchVRPointerEvent(InputPhase phase,
 PointerHitResult InputSystem::dispatchVRPointerScroll(Vec2 point,
                                                       Vec2 scrollDelta,
                                                       const Ray& ray,
-                                                      const PointerInputState& state)
+                                                      const PointerInputState& state,
+                                                      const PointerRayContext* rayContext)
 {
     _lastPointerPosition = point;
 
     _scrollEvent.setPointerInfo(InputPhase::PointerScroll, nativeToScreen(point), state);
     _scrollEvent.setScrollData(scrollDelta);
     _scrollEvent.setRay(ray);
+    _scrollEvent.setRayContext(rayContext);
     dispatchEvent(&_scrollEvent);
 
     return _scrollEvent.getHitResult();
@@ -730,7 +740,10 @@ void InputSystem::onPlatformKeyboardWillShow(float rawX, float rawY, float rawWi
         keyboardPos  = nativeToScreen(keyboardPos);
 
         // Transform the relative screen size vector into World Space dimensions
-        auto camera          = Camera::getDefaultCamera();
+        auto scene           = director->getRunningScene();
+        auto camera          = scene ? scene->getDefaultCamera() : nullptr;
+        if (!camera)
+            return ax::Rect();
         Vec3 nearWorldSize   = camera->deprojectScreenToWorld(Vec3(keyboardSize.x, keyboardSize.y, 0.0f));
         Vec3 nearWorldOrigin = camera->deprojectScreenToWorld(Vec3(0.0f, 0.0f, 0.0f));
         float worldW         = std::abs(nearWorldSize.x - nearWorldOrigin.x);

--- a/axmol/base/InputSystem.h
+++ b/axmol/base/InputSystem.h
@@ -95,12 +95,20 @@ public:
     void handlePointerScroll(Vec2 point, Vec2 scrollDelat, const PointerInputState& state);
 
     // VR controller input: PointerType::Controller with a 3D ray.
-    PointerHitResult handleVRPointerEvent(InputPhase phase, Vec2 point, const Ray& ray, const PointerInputState& state);
-    PointerHitResult hitTestVRPointer(Vec2 point, const Ray& ray, const PointerInputState& state);
+    PointerHitResult handleVRPointerEvent(InputPhase phase,
+                                          Vec2 point,
+                                          const Ray& ray,
+                                          const PointerInputState& state,
+                                          const PointerRayContext* rayContext = nullptr);
+    PointerHitResult hitTestVRPointer(Vec2 point,
+                                      const Ray& ray,
+                                      const PointerInputState& state,
+                                      const PointerRayContext* rayContext = nullptr);
     PointerHitResult handleVRPointerScroll(Vec2 point,
                                            Vec2 scrollDelta,
                                            const Ray& ray,
-                                           const PointerInputState& state);
+                                           const PointerInputState& state,
+                                           const PointerRayContext* rayContext = nullptr);
 
     void handleXRInput(const XRInputEvent::State& state);
 
@@ -246,11 +254,13 @@ protected:
     PointerHitResult dispatchVRPointerEvent(InputPhase phase,
                                             Vec2 point,
                                             const Ray& ray,
-                                            const PointerInputState& state);
+                                            const PointerInputState& state,
+                                            const PointerRayContext* rayContext);
     PointerHitResult dispatchVRPointerScroll(Vec2 point,
                                              Vec2 scrollDelta,
                                              const Ray& ray,
-                                             const PointerInputState& state);
+                                             const PointerInputState& state,
+                                             const PointerRayContext* rayContext);
 
     // cached mouse position with inputScale applied
     Vec2 _lastPointerPosition;  // the original pointer position

--- a/axmol/base/PointerEvent.cpp
+++ b/axmol/base/PointerEvent.cpp
@@ -27,6 +27,8 @@
 
 #include <utility>
 
+#include "axmol/scene/Camera.h"
+
 namespace ax
 {
 
@@ -50,6 +52,7 @@ void PointerEvent::setPointerInfo(InputPhase phase, Vec2 point, const PointerInp
     _pressure         = state.pressure;
     _previousRay      = _ray;
     _ray              = Ray{};
+    clearRayContext();
     _previousHitPoint = _hitResult.hit ? std::optional<Vec3>(_hitResult.worldPoint) : std::nullopt;
     _hitResult        = {};
     if (!_startPointCaptured)
@@ -123,13 +126,56 @@ bool PointerEvent::isPrimaryPressed() const
 
 void PointerEvent::setHitResult(const Vec3& worldPoint, const Camera* camera, const Node* target)
 {
-    _hitResult.hit        = true;
-    _hitResult.worldPoint = worldPoint;
-    _hitResult.camera     = camera;
-    _hitResult.target     = target;
+    _hitResult.hit              = true;
+    _hitResult.worldPoint       = worldPoint;
+    _hitResult.camera           = camera;
+    _hitResult.target           = target;
+    _hitResult.visualPointValid = false;
+    if (_hasRayContext && camera)
+    {
+        const Mat4 worldToTracking = camera->getNodeToWorldTransform().getInversed();
+        Vec3 trackingPoint         = worldPoint;
+        worldToTracking.transformPoint(&trackingPoint);
+
+        _hitResult.visualPoint = trackingPoint;
+        _rayContext.primaryTrackingToWorld.transformPoint(&_hitResult.visualPoint);
+        _hitResult.visualPointValid = true;
+    }
 
     if (!_startHitPoint.has_value())
         _startHitPoint = worldPoint;
+}
+
+void PointerEvent::setRayContext(const PointerRayContext* context)
+{
+    if (!context)
+    {
+        clearRayContext();
+        return;
+    }
+
+    _rayContext    = *context;
+    _hasRayContext = true;
+    resolveRayForCamera(nullptr);
+}
+
+void PointerEvent::clearRayContext()
+{
+    _rayContext    = {};
+    _hasRayContext = false;
+}
+
+bool PointerEvent::resolveRayForCamera(const Camera* camera)
+{
+    if (!_hasRayContext)
+        return false;
+
+    const Mat4& trackingToWorld = camera ? camera->getNodeToWorldTransform() : _rayContext.primaryTrackingToWorld;
+    _ray                        = _rayContext.trackingRay;
+    _ray.origin *= _rayContext.trackingScale;
+    _ray.transform(trackingToWorld);
+    _ray.direction.normalize();
+    return true;
 }
 
 void PointerEvent::clearHitResult()

--- a/axmol/base/PointerEvent.cpp
+++ b/axmol/base/PointerEvent.cpp
@@ -48,10 +48,10 @@ void PointerEvent::setPointerInfo(InputPhase phase, Vec2 point, const PointerInp
     _pointerId      = state.id;
     _pressedButtons = state.pressedButtons;
 
-    _point            = point;
-    _pressure         = state.pressure;
-    _previousRay      = _ray;
-    _ray              = Ray{};
+    _point       = point;
+    _pressure    = state.pressure;
+    _previousRay = _ray;
+    _ray         = Ray{};
     clearRayContext();
     _previousHitPoint = _hitResult.hit ? std::optional<Vec3>(_hitResult.worldPoint) : std::nullopt;
     _hitResult        = {};

--- a/axmol/base/PointerEvent.h
+++ b/axmol/base/PointerEvent.h
@@ -49,8 +49,17 @@ struct AX_DLL PointerHitResult
 {
     bool hit{false};
     Vec3 worldPoint{Vec3::zero};
+    Vec3 visualPoint{Vec3::zero};
     const Camera* camera{nullptr};
     const Node* target{nullptr};
+    bool visualPointValid{false};
+};
+
+struct AX_DLL PointerRayContext
+{
+    Ray trackingRay;
+    Mat4 primaryTrackingToWorld{Mat4::identity};
+    float trackingScale{1.0f};
 };
 
 /** @class PointerEvent
@@ -257,6 +266,9 @@ public:
     [[internal]] void setRay(const Ray& ray) { _ray = ray; }
     const Ray& getRay() const { return _ray; }
     const Ray& getPreviousRay() const { return _previousRay; }
+    [[internal]] void setRayContext(const PointerRayContext* context);
+    [[internal]] void clearRayContext();
+    [[internal]] bool resolveRayForCamera(const Camera* camera);
 
     [[internal]] void setHitResult(const Vec3& worldPoint, const Camera* camera, const Node* target);
     [[internal]] void clearHitResult();
@@ -270,6 +282,8 @@ protected:
     const Camera* _camera{nullptr};
     Ray _ray;
     Ray _previousRay;
+    PointerRayContext _rayContext;
+    bool _hasRayContext{false};
     PointerHitResult _hitResult;
     std::optional<Vec3> _previousHitPoint;
     std::optional<Vec3> _startHitPoint;

--- a/axmol/base/Utils.cpp
+++ b/axmol/base/Utils.cpp
@@ -164,7 +164,8 @@ void captureNode(Node* startNode, std::function<void(RefPtr<Image>)> imageCallba
 
         rtxPass->begin(camera);
         rtxPass->clearAll();
-        startNode->visit();
+        SceneRenderState renderState(director->getRenderer(), camera);
+        startNode->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
         rtxPass->end();
 
         startNode->setPosition(savedPos);

--- a/axmol/navmesh/NavMesh.cpp
+++ b/axmol/navmesh/NavMesh.cpp
@@ -467,13 +467,13 @@ void NavMesh::setDebugDrawEnabled(bool enable)
     _isDebugDrawEnabled = enable;
 }
 
-void NavMesh::debugDraw(Renderer* renderer)
+void NavMesh::debugDraw(const SceneRenderState& state)
 {
     if (_isDebugDrawEnabled)
     {
         _debugDraw.clear();
         dtDraw();
-        _debugDraw.draw(renderer);
+        _debugDraw.draw(state);
     }
 }
 

--- a/axmol/navmesh/NavMesh.h
+++ b/axmol/navmesh/NavMesh.h
@@ -51,6 +51,7 @@ namespace ax
  * @{
  */
 class Renderer;
+struct SceneRenderState;
 /** @brief NavMesh: The NavMesh information container, include mesh, tileCache, and so on. */
 class AX_DLL NavMesh : public Object
 {
@@ -67,7 +68,7 @@ public:
     void update(float dt);
 
     /** Internal method, the updater of debug drawing, need called each frame. */
-    void debugDraw(Renderer* renderer);
+    void debugDraw(const SceneRenderState& state);
 
     /** Enable debug draw or disable. */
     void setDebugDrawEnabled(bool enable);

--- a/axmol/navmesh/NavMeshDebugDraw.cpp
+++ b/axmol/navmesh/NavMeshDebugDraw.cpp
@@ -47,11 +47,11 @@ NavMeshDebugDraw::NavMeshDebugDraw()
     _locMVP = _programState->getUniformLocation("u_MVPMatrix");
 }
 
-void NavMeshDebugDraw::initCustomCommand(CustomCommand& command)
+void NavMeshDebugDraw::initCustomCommand(CustomCommand& command, const SceneViewData& view)
 {
     command.set3D(true);
     command.setTransparent(true);
-    command.init(0, Mat4::identity, Node::FLAGS_RENDER_AS_3D);
+    command.init(0, Mat4::identity, Node::FLAGS_RENDER_AS_3D, view);
     command.setDrawType(CustomCommand::DrawType::ARRAY);
     command.setWeakPSVL(_programState, _vertexLayout);
 
@@ -150,14 +150,14 @@ rhi::PrimitiveType NavMeshDebugDraw::getPrimitiveType(duDebugDrawPrimitives prim
     }
 }
 
-void NavMeshDebugDraw::draw(Renderer* renderer)
+void NavMeshDebugDraw::draw(const SceneRenderState& state)
 {
-    const auto& transform = Camera::getVisitingViewProjectionMatrix();
-    auto beforeCommand    = renderer->nextCallbackCommand();
-    auto afterCommand     = renderer->nextCallbackCommand();
+    const auto& transform = state.getViewProjectionMatrix();
+    auto beforeCommand    = state.getRenderer()->nextCallbackCommand();
+    auto afterCommand     = state.getRenderer()->nextCallbackCommand();
 
-    beforeCommand->init(0, Mat4::identity, Node::FLAGS_RENDER_AS_3D);
-    afterCommand->init(0, Mat4::identity, Node::FLAGS_RENDER_AS_3D);
+    beforeCommand->init(0, Mat4::identity, Node::FLAGS_RENDER_AS_3D, state.getView());
+    afterCommand->init(0, Mat4::identity, Node::FLAGS_RENDER_AS_3D, state.getView());
 
     beforeCommand->func = AX_CALLBACK_0(NavMeshDebugDraw::onBeforeVisitCmd, this);
     afterCommand->func  = AX_CALLBACK_0(NavMeshDebugDraw::onAfterVisitCmd, this);
@@ -169,7 +169,7 @@ void NavMeshDebugDraw::draw(Renderer* renderer)
 
     _programState->setUniform(_locMVP, transform.m, sizeof(transform.m));
 
-    renderer->addCommand(beforeCommand);
+    state.getRenderer()->addCommand(beforeCommand);
 
     if (!_vertexBuffer || _vertexBuffer->getSize() < _vertices.size() * sizeof(_vertices[0]))
     {
@@ -197,20 +197,20 @@ void NavMeshDebugDraw::draw(Renderer* renderer)
 
         auto& command = _commands[idx];
 
-        initCustomCommand(command);
+        initCustomCommand(command, state.getView());
         command.setBeforeCallback(AX_CALLBACK_0(NavMeshDebugDraw::onBeforeEachCommand, this, iter->depthMask));
 
         command.setVertexBuffer(_vertexBuffer);
         command.setPrimitiveType(iter->type);
         command.setVertexDrawInfo(iter->start, iter->end - iter->start);
 
-        renderer->addCommand(&command);
+        state.getRenderer()->addCommand(&command);
 
         AX_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, iter->end - iter->start);
         idx++;
     }
 
-    renderer->addCommand(afterCommand);
+    state.getRenderer()->addCommand(afterCommand);
 }
 
 void NavMeshDebugDraw::onBeforeVisitCmd()

--- a/axmol/navmesh/NavMeshDebugDraw.h
+++ b/axmol/navmesh/NavMeshDebugDraw.h
@@ -48,6 +48,8 @@ namespace ax
  * @{
  */
 class Renderer;
+struct SceneViewData;
+struct SceneRenderState;
 class NavMeshDebugDraw : public duDebugDraw
 {
 public:
@@ -67,12 +69,12 @@ public:
 
     void end() override;
 
-    void draw(Renderer* renderer);
+    void draw(const SceneRenderState& state);
 
     void clear();
 
 private:
-    void initCustomCommand(CustomCommand& command);
+    void initCustomCommand(CustomCommand& command, const SceneViewData& view);
     rhi::PrimitiveType getPrimitiveType(duDebugDrawPrimitives prim);
     static Vec4 getColor(unsigned int col);
 

--- a/axmol/physics/2d/PhysicsWorld2D.h
+++ b/axmol/physics/2d/PhysicsWorld2D.h
@@ -42,7 +42,7 @@ class Rigidbody2D;
 class Joint2D;
 class Collider2D;
 class ContactEvent2D;
-class ContactInfo2D;
+struct ContactInfo2D;
 class Director;
 class Node;
 class Sprite;

--- a/axmol/physics/3d/PhysicsDebugDraw3D.cpp
+++ b/axmol/physics/3d/PhysicsDebugDraw3D.cpp
@@ -218,9 +218,9 @@ void PhysicsDebugDraw3D::DrawText3D(JPH::RVec3Arg inPosition,
     //        (float)inPosition.GetZ(), inString);
 }
 
-void PhysicsDebugDraw3D::draw(ax::Renderer* renderer)
+void PhysicsDebugDraw3D::draw(const ax::SceneRenderState& state)
 {
-    const auto& transform = Camera::getVisitingViewProjectionMatrix();
+    const auto& transform = state.getViewProjectionMatrix();
 
     auto& blend                  = _lineCommand.blendDesc();
     blend.blendEnabled           = true;
@@ -231,14 +231,14 @@ void PhysicsDebugDraw3D::draw(ax::Renderer* renderer)
     if (_dirtyLines && !_lineBuffer.empty())
     {
         _lineCommand.unsafePS()->setUniform(_locMVP, transform.m, sizeof(transform.m));
-        _lineCommand.init(0, Mat4::identity, 0);
+        _lineCommand.init(0, Mat4::identity, 0, state.getView());
 
         _lineCommand.setPrimitiveType(CustomCommand::PrimitiveType::LINE);
         _lineCommand.createVertexBuffer(sizeof(_lineBuffer[0]), _lineBuffer.size(),
                                         CustomCommand::BufferUsage::DYNAMIC);
         _lineCommand.updateVertexBuffer(_lineBuffer.data(), _lineBuffer.size() * sizeof(_lineBuffer[0]));
         _lineCommand.setVertexDrawInfo(0, _lineBuffer.size());
-        renderer->addCommand(&_lineCommand);
+        state.getRenderer()->addCommand(&_lineCommand);
         _dirtyLines = false;
     }
 
@@ -246,13 +246,13 @@ void PhysicsDebugDraw3D::draw(ax::Renderer* renderer)
     if (_dirtyTris && !_triBuffer.empty())
     {
         _triCommand.unsafePS()->setUniform(_locMVP, transform.m, sizeof(transform.m));
-        _triCommand.init(0, Mat4::identity, 0);
+        _triCommand.init(0, Mat4::identity, 0, state.getView());
 
         _triCommand.setPrimitiveType(CustomCommand::PrimitiveType::TRIANGLE);
         _triCommand.createVertexBuffer(sizeof(_triBuffer[0]), _triBuffer.size(), CustomCommand::BufferUsage::DYNAMIC);
         _triCommand.updateVertexBuffer(_triBuffer.data(), _triBuffer.size() * sizeof(_triBuffer[0]));
         _triCommand.setVertexDrawInfo(0, _triBuffer.size());
-        renderer->addCommand(&_triCommand);
+        state.getRenderer()->addCommand(&_triCommand);
         _dirtyTris = false;
     }
 

--- a/axmol/physics/3d/PhysicsDebugDraw3D.h
+++ b/axmol/physics/3d/PhysicsDebugDraw3D.h
@@ -46,6 +46,7 @@ namespace ax
  */
 
 class Renderer;
+struct SceneRenderState;
 
 /** @brief PhysicsDebugDraw3D: debug draw the physics object, used by PhysicsWorld3D */
 class PhysicsDebugDraw3D : public JPH::DebugRenderer
@@ -80,7 +81,7 @@ public:
                     float inHeight        = 0.5f) override;
 
     // Render entry point
-    void draw(ax::Renderer* renderer);
+    void draw(const ax::SceneRenderState& state);
     void clear();
 
 protected:

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -339,7 +339,7 @@ bool PhysicsWorld3D::isDebugDrawEnabled() const
     return !!_debugDrawer;
 }
 
-void PhysicsWorld3D::debugDraw(Renderer* renderer)
+void PhysicsWorld3D::debugDraw(const SceneRenderState& state)
 {
     if (_debugDrawer)
     {
@@ -349,7 +349,7 @@ void PhysicsWorld3D::debugDraw(Renderer* renderer)
         _physicsSystem.DrawBodies(drawSettings, JPH::DebugRenderer::sInstance);
         _physicsSystem.DrawConstraints(JPH::DebugRenderer::sInstance);
         _physicsSystem.DrawConstraintLimits(JPH::DebugRenderer::sInstance);
-        _debugDrawer->draw(renderer);
+        _debugDrawer->draw(state);
     }
 }
 

--- a/axmol/physics/3d/PhysicsWorld3D.h
+++ b/axmol/physics/3d/PhysicsWorld3D.h
@@ -81,6 +81,7 @@ class Collider3D;
 class Joint3D;
 class Component;
 class Renderer;
+struct SceneRenderState;
 class Scene;
 
 /**
@@ -226,7 +227,7 @@ public:
      * @param renderer Renderer used by the owning scene.
      * @note This is called automatically by Scene.
      */
-    [[internal]] void debugDraw(ax::Renderer* renderer);
+    [[internal]] void debugDraw(const ax::SceneRenderState& state);
 
     /**
      * @brief Casts a ray through the physics world.

--- a/axmol/renderer/CallbackCommand.cpp
+++ b/axmol/renderer/CallbackCommand.cpp
@@ -40,9 +40,9 @@ void CallbackCommand::init(float globalOrder)
     _globalOrder = globalOrder;
 }
 
-void CallbackCommand::init(float globalOrder, const Mat4& transform, unsigned int flags)
+void CallbackCommand::init(float globalOrder, const Mat4& transform, unsigned int flags, const SceneViewData& view)
 {
-    RenderCommand::init(globalOrder, transform, flags);
+    RenderCommand::init(globalOrder, transform, flags, view);
 }
 
 void CallbackCommand::reset()

--- a/axmol/renderer/CallbackCommand.h
+++ b/axmol/renderer/CallbackCommand.h
@@ -56,7 +56,7 @@ class AX_DLL CallbackCommand : public RenderCommand
 
 public:
     void init(float globalZOrder);
-    void init(float globalZorder, const Mat4& transform, unsigned int);
+    void init(float globalZorder, const Mat4& transform, unsigned int, const SceneViewData& view);
 
     /**
      * @brief Reset the command state for reuse

--- a/axmol/renderer/CustomCommand.cpp
+++ b/axmol/renderer/CustomCommand.cpp
@@ -117,9 +117,9 @@ void CustomCommand::assign(CustomCommand&& rhs)
 #    pragma GCC diagnostic pop
 #endif
 
-void CustomCommand::init(float depth, const ax::Mat4& modelViewTransform, unsigned int flags)
+void CustomCommand::init(float depth, const ax::Mat4& modelViewTransform, unsigned int flags, const SceneViewData& view)
 {
-    RenderCommand::init(depth, modelViewTransform, flags);
+    RenderCommand::init(depth, modelViewTransform, flags, view);
 }
 
 void CustomCommand::init(float globalZOrder)

--- a/axmol/renderer/CustomCommand.h
+++ b/axmol/renderer/CustomCommand.h
@@ -91,7 +91,7 @@ TODO: should remove it.
     @param modelViewTransform When in 3D mode, depth sorting needs modelViewTransform.
     @param flags Use to identify that the render command is 3D mode or not.
     */
-    void init(float globalZOrder, const Mat4& modelViewTransform, unsigned int flags);
+    void init(float globalZOrder, const Mat4& modelViewTransform, unsigned int flags, const SceneViewData& view);
 
     /**
     Init function. The render command will be in 2D mode.

--- a/axmol/renderer/MeshCommand.cpp
+++ b/axmol/renderer/MeshCommand.cpp
@@ -32,7 +32,7 @@
 #include "axmol/base/EventDispatcher.h"
 #include "axmol/base/EventType.h"
 #include "axmol/2d/Light.h"
-#include "axmol/scene/Camera.h"
+#include "axmol/scene/Node.h"
 #include "axmol/renderer/Renderer.h"
 #include "axmol/renderer/TextureAtlas.h"
 #include "axmol/renderer/Texture2D.h"
@@ -64,14 +64,9 @@ void MeshCommand::init(float globalZOrder)
     CustomCommand::init(globalZOrder);
 }
 
-void MeshCommand::init(float globalZOrder, const Mat4& transform)
+void MeshCommand::init(float globalZOrder, const Mat4& transform, const SceneViewData& view)
 {
-    CustomCommand::init(globalZOrder);
-    if (Camera::getVisitingCamera())
-    {
-        _depth = Camera::getVisitingCamera()->getDepthInView(transform);
-    }
-    _mv = transform;
+    RenderCommand::init(globalZOrder, transform, Node::FLAGS_RENDER_AS_3D, view);
 }
 
 MeshCommand::~MeshCommand()

--- a/axmol/renderer/MeshCommand.h
+++ b/axmol/renderer/MeshCommand.h
@@ -71,7 +71,7 @@ public:
     */
     void init(float globalZOrder);
 
-    void init(float globalZOrder, const Mat4& transform);
+    void init(float globalZOrder, const Mat4& transform, const SceneViewData& view);
 
 #if AX_ENABLE_CONTEXT_LOSS_RECOVERY
     void listenRendererRecreated(CustomEvent* event);

--- a/axmol/renderer/Pass.cpp
+++ b/axmol/renderer/Pass.cpp
@@ -189,10 +189,11 @@ void Pass::draw(MeshCommand* meshCommand,
                 unsigned int indexCount,
                 const Mat4& modelView)
 {
+    AX_UNUSED_PARAM(globalZOrder);
+    AX_UNUSED_PARAM(modelView);
 
     meshCommand->setBeforeCallback(AX_CALLBACK_0(Pass::onBeforeVisitCmd, this, meshCommand));
     meshCommand->setAfterCallback(AX_CALLBACK_0(Pass::onAfterVisitCmd, this, meshCommand));
-    meshCommand->init(globalZOrder, modelView);
     meshCommand->setPrimitiveType(primitive);
     meshCommand->setIndexBuffer(indexBuffer, indexFormat);
     meshCommand->setVertexBuffer(vertexBuffer);
@@ -204,9 +205,9 @@ void Pass::draw(MeshCommand* meshCommand,
     renderer->addCommand(meshCommand);
 }
 
-void Pass::updateMVPUniform(const Mat4& modelView)
+void Pass::updateMVPUniform(MeshCommand* command, const Mat4& modelView)
 {
-    const auto& matrixP = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixP = command->getViewProjectionMatrix();
     auto mvp            = matrixP * modelView;
     _programState->setUniform(_locMVPMatrix, mvp.m, sizeof(mvp.m));
     if (_locMVMatrix)
@@ -239,7 +240,7 @@ void Pass::onBeforeVisitCmd(MeshCommand* command)
     // apply state blocks
     _renderState.bindPass(this, command);
 
-    updateMVPUniform(command->getMV());
+    updateMVPUniform(command, command->getMV());
 }
 
 void Pass::onAfterVisitCmd(MeshCommand* command)

--- a/axmol/renderer/Pass.h
+++ b/axmol/renderer/Pass.h
@@ -106,7 +106,7 @@ public:
 
     void setTechnique(Technique* technique);
 
-    void updateMVPUniform(const Mat4& modelView);
+    void updateMVPUniform(MeshCommand* command, const Mat4& modelView);
 
     void setUniformTexture(uint32_t slot, rhi::Texture*);      // u_tex0
     void setUniformNormTexture(uint32_t slot, rhi::Texture*);  // u_normalTex

--- a/axmol/renderer/QuadCommand.cpp
+++ b/axmol/renderer/QuadCommand.cpp
@@ -95,7 +95,8 @@ void QuadCommand::init(float globalOrder,
                        V3F_T2F_C4B_Quad* quads,
                        ssize_t quadCount,
                        const Mat4& mv,
-                       uint32_t flags)
+                       uint32_t flags,
+                       const SceneViewData& view)
 {
     if (quadCount * 6 > _indexSize)
         reIndex((int)quadCount * 6);
@@ -105,7 +106,7 @@ void QuadCommand::init(float globalOrder,
     triangles.vertCount  = (int)quadCount * 4;
     triangles.indices    = __indices;
     triangles.indexCount = (int)quadCount * 6;
-    TrianglesCommand::init(globalOrder, texture, blendType, triangles, mv, flags);
+    TrianglesCommand::init(globalOrder, texture, blendType, triangles, mv, flags, view);
 }
 
 }  // namespace ax

--- a/axmol/renderer/QuadCommand.h
+++ b/axmol/renderer/QuadCommand.h
@@ -66,7 +66,8 @@ public:
               V3F_T2F_C4B_Quad* quads,
               ssize_t quadCount,
               const Mat4& mv,
-              uint32_t flags);
+              uint32_t flags,
+              const SceneViewData& view);
 
     static void destroyIsolatedIndices();
 

--- a/axmol/renderer/RenderCommand.cpp
+++ b/axmol/renderer/RenderCommand.cpp
@@ -24,7 +24,6 @@
  THE SOFTWARE.
  ****************************************************************************/
 #include "axmol/renderer/RenderCommand.h"
-#include "axmol/scene/Camera.h"
 #include "axmol/scene/Node.h"
 #include "axmol/renderer/VertexLayoutManager.h"
 
@@ -41,14 +40,14 @@ RenderCommand::~RenderCommand()
     }
 }
 
-void RenderCommand::init(float globalZOrder, const ax::Mat4& transform, unsigned int flags)
+void RenderCommand::init(float globalZOrder, const ax::Mat4& transform, unsigned int flags, const SceneViewData& view)
 {
-    _globalOrder = globalZOrder;
+    _globalOrder    = globalZOrder;
+    _mv             = transform;
+    _viewProjection = view.viewProjection;
     if (flags & Node::FLAGS_RENDER_AS_3D)
     {
-        if (Camera::getVisitingCamera())
-            _depth = Camera::getVisitingCamera()->getDepthInView(transform);
-
+        _depth = view.getDepthInView(transform);
         set3D(true);
     }
     else

--- a/axmol/renderer/RenderCommand.h
+++ b/axmol/renderer/RenderCommand.h
@@ -37,6 +37,8 @@
 namespace ax
 {
 
+struct SceneViewData;
+
 /** Base class of the `RenderCommand` hierarchy.
 *
  The `Renderer` knows how to render `RenderCommands` objects.
@@ -78,7 +80,7 @@ public:
      @param modelViewTransform Modelview matrix when submitting the render command.
      @param flags Flag used to indicate whether the command should be draw at 3D mode or not.
      */
-    void init(float globalZOrder, const Mat4& modelViewTransform, unsigned int flags);
+    void init(float globalZOrder, const Mat4& modelViewTransform, unsigned int flags, const SceneViewData& view);
 
     /** Get global Z order. */
     float getGlobalOrder() const { return _globalOrder; }
@@ -103,6 +105,8 @@ public:
     void set3D(bool value) { _is3D = value; }
     /**Get the depth by current model view matrix.*/
     float getDepth() const { return _depth; }
+    /**Get the view-projection matrix captured when the command was submitted.*/
+    const Mat4& getViewProjectionMatrix() const { return _viewProjection; }
     /**Whether the command should be rendered in wireframe mode.*/
     bool isWireframe() const { return _isWireframe; }
     /**Set wireframe render mode for this command.*/
@@ -153,6 +157,9 @@ protected:
 
     /** Depth from the model view matrix. */
     float _depth = 0.f;
+
+    /** View-projection matrix from the scene render state when this command was submitted. */
+    Mat4 _viewProjection = Mat4::identity;
 
     /** Polygon render mode set to LINE, which represents wireframe mode. */
     bool _isWireframe = false;

--- a/axmol/renderer/RenderTexturePass.cpp
+++ b/axmol/renderer/RenderTexturePass.cpp
@@ -118,24 +118,20 @@ void RenderTexturePass::begin(const Camera* camera)
 
     if (_cameraOverrideEnabled)
     {
-        // Fallback chain: explicit camera -> visiting camera -> default camera -> offscreen camera
+        // Fallback chain: explicit camera -> default camera -> offscreen camera
         if (!camera)
         {
-            camera = Camera::getVisitingCamera();
-            if (!camera)
-                camera = Camera::getDefaultCamera();
+            auto scene = Director::getInstance()->getRunningScene();
+            camera     = scene ? scene->getDefaultCamera() : nullptr;
             if (!camera)
                 camera = Director::getInstance()->getOffscreenCamera();
         }
-
-        // Save visiting camera
-        _savedCamera = Camera::getVisitingCamera();
-        Camera::setVisitingCamera(const_cast<Camera*>(camera));
+        _activeCamera = camera;
 
         // Save and flip visiting camera's projection on OpenGL to keep texture upright
         if (_autoFlipY && rhi::GraphicsCore::isOpenGL())
         {
-            auto cam = const_cast<Camera*>(Camera::getVisitingCamera());
+            auto cam = const_cast<Camera*>(_activeCamera);
             if (cam)
             {
                 _savedProjection = cam->getProjectionMatrix();
@@ -205,15 +201,12 @@ void RenderTexturePass::end()
     // Restore visiting camera's projection immediately
     if (_savedProjection.has_value())
     {
-        auto cam = const_cast<Camera*>(Camera::getVisitingCamera());
+        auto cam = const_cast<Camera*>(_activeCamera);
         if (cam)
             cam->setProjectionMatrix(*_savedProjection);
         _savedProjection.reset();
     }
-
-    // Restore visiting camera immediately
-    if (_savedCamera)
-        Camera::setVisitingCamera(const_cast<Camera*>(_savedCamera));
+    _activeCamera = nullptr;
 
     _active = false;
 }

--- a/axmol/renderer/RenderTexturePass.h
+++ b/axmol/renderer/RenderTexturePass.h
@@ -82,7 +82,7 @@ static constexpr float RT_PASS_END_ORDER   = 100000;
  *
  * On OpenGL, offscreen FBO textures have a bottom-left origin, while D3D, Metal,
  * and Vulkan use a top-left origin. When automatic Y flipping is enabled, this
- * pass can flip the visiting camera's projection matrix on OpenGL so that the
+ * pass can flip the selected camera's projection matrix on OpenGL so that the
  * rendered texture has a consistent orientation across backends.
  *
  * @note This guarantee applies only to rendering managed by RenderTexturePass.
@@ -158,14 +158,14 @@ public:
     /** @{ */
     /**
      * @brief Begin offscreen rendering.
-     * @param camera Optional visiting camera override.
+     * @param camera Optional camera used for backend-specific projection adjustment.
      * Saves current render target/viewport, pushes render group.
      */
     void begin(const Camera* camera = nullptr);
 
     /**
      * @brief End offscreen rendering.
-     * Restores previous render target/viewport and visiting camera.
+     * Restores previous render target/viewport and camera projection.
      */
     void end();
 
@@ -199,18 +199,17 @@ public:
 
     /** @} */
     /**
-     * @brief Enables or disables automatic visiting camera override for this pass.
+     * @brief Enables or disables automatic camera adjustment for this pass.
      *
-     * When enabled, begin() temporarily sets the selected camera as the visiting
-     * camera and applies backend-specific projection adjustments when needed.
-     * end() restores the previous visiting camera and projection state.
+     * When enabled, begin() applies backend-specific projection adjustments to
+     * the selected camera when needed. end() restores the projection state.
      *
      * Advanced renderers that manage their own camera loop, such as VR or custom
      * multi-view renderers, can disable this behavior and handle camera state
      * explicitly.
      *
-     * @param enabled True to let RenderTexturePass override the visiting camera;
-     *                false to leave camera state untouched.
+     * @param enabled True to let RenderTexturePass adjust the selected camera;
+     *                false to leave camera projection untouched.
      */
     void setCameraOverrideEnabled(bool enabled) { _cameraOverrideEnabled = enabled; }
 
@@ -237,15 +236,13 @@ private:
     bool _active{false};
     bool _autoFlipY{true};
 
-    // When enabled, begin() temporarily overrides the visiting camera and applies
-    // backend-specific projection adjustments when needed. end() restores the
-    // previous camera state. Advanced renderers can disable this and manage camera
-    // state explicitly.
+    // When enabled, begin() applies backend-specific projection adjustments when
+    // needed. Advanced renderers can disable this and manage camera state explicitly.
     bool _cameraOverrideEnabled{true};
 
     std::optional<Viewport> _viewport;
 
-    const Camera* _savedCamera{nullptr};
+    const Camera* _activeCamera{nullptr};
     std::optional<Mat4> _savedProjection;
     std::vector<SavedState> _savedStates;
 

--- a/axmol/renderer/Renderer.cpp
+++ b/axmol/renderer/Renderer.cpp
@@ -806,9 +806,9 @@ bool Renderer::checkVisibility(const Mat4& transform, const Vec2& size)
     auto director = Director::getInstance();
     auto scene    = director->getRunningScene();
 
-    // If draw to Rendertexture, return true directly.
-    //  only cull the default camera. The culling algorithm is valid for default camera.
-    if (!scene || (scene->_defaultCamera != Camera::getVisitingCamera()))
+    // Legacy Renderer API can only cull against the running scene default camera.
+    auto camera = scene ? scene->_defaultCamera : nullptr;
+    if (!camera)
         return true;
 
     Rect visibleRect(director->getVisibleOrigin(), director->getVisibleSize());
@@ -818,7 +818,7 @@ bool Renderer::checkVisibility(const Mat4& transform, const Vec2& size)
     float hSizeY = size.height / 2;
     Vec3 v3p(hSizeX, hSizeY, 0);
     transform.transformPoint(&v3p);
-    Vec2 v2p = Camera::getVisitingCamera()->projectWorldToCanvas(v3p);
+    Vec2 v2p = camera->projectWorldToCanvas(v3p);
 
     // convert content size to world coordinates
     float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]),

--- a/axmol/renderer/TrianglesCommand.cpp
+++ b/axmol/renderer/TrianglesCommand.cpp
@@ -42,9 +42,10 @@ void TrianglesCommand::init(float globalOrder,
                             const BlendFunc& blendType,
                             const Triangles& triangles,
                             const Mat4& mv,
-                            uint32_t flags)
+                            uint32_t flags,
+                            const SceneViewData& view)
 {
-    RenderCommand::init(globalOrder, mv, flags);
+    RenderCommand::init(globalOrder, mv, flags, view);
 
     _triangles = triangles;
     if (_triangles.indexCount % 3 != 0)

--- a/axmol/renderer/TrianglesCommand.h
+++ b/axmol/renderer/TrianglesCommand.h
@@ -87,7 +87,8 @@ public:
               const BlendFunc& blendType,
               const Triangles& triangles,
               const Mat4& mv,
-              uint32_t flags);
+              uint32_t flags,
+              const SceneViewData& view);
     /**Get the material id of command.*/
     uint32_t getMaterialID() const { return _materialID; }
     /**Get a const reference of triangles.*/

--- a/axmol/scene/Camera.cpp
+++ b/axmol/scene/Camera.cpp
@@ -30,6 +30,7 @@
 #include "axmol/scene/CameraBackgroundBrush.h"
 #include "axmol/platform/RenderView.h"
 #include "axmol/scene/Scene.h"
+#include "axmol/base/Director.h"
 #include "axmol/renderer/Renderer.h"
 #include "axmol/renderer/QuadCommand.h"
 #include "axmol/renderer/RenderTexture.h"
@@ -37,7 +38,6 @@
 namespace ax
 {
 
-Camera* Camera::_visitingCamera = nullptr;
 Viewport Camera::_defaultViewport;
 
 // start static methods
@@ -94,12 +94,6 @@ Camera* Camera::getDefaultCamera()
 const Viewport& Camera::getDefaultViewport()
 {
     return _defaultViewport;
-}
-
-const Mat4& Camera::getVisitingViewProjectionMatrix()
-{
-    AXASSERT(_visitingCamera, "Camera::getVisitingViewProjectionMatrix() requires a visiting camera");
-    return _visitingCamera ? _visitingCamera->getViewProjectionMatrix() : Mat4::identity;
 }
 
 void Camera::setDefaultViewport(const Viewport& vp)
@@ -190,12 +184,6 @@ const Mat4& Camera::getViewProjectionMatrix() const
     }
 
     return _viewProjection;
-}
-
-void Camera::setAdditionalProjection(const Mat4& mat)
-{
-    _projection = mat * _projection;
-    getViewProjectionMatrix();
 }
 
 void Camera::updateProjection()
@@ -511,7 +499,16 @@ void Camera::clearBackground()
 {
     if (_clearBrush)
     {
-        _clearBrush->drawBackground(this);
+        SceneRenderState state(Director::getInstance()->getRenderer(), this);
+        _clearBrush->drawBackground(state);
+    }
+}
+
+void Camera::clearBackground(const SceneRenderState& state)
+{
+    if (_clearBrush)
+    {
+        _clearBrush->drawBackground(state);
     }
 }
 
@@ -553,10 +550,10 @@ void Camera::setNearPlane(float nearPlane)
     updateProjection();
 }
 
-void Camera::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void Camera::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     _viewProjectionUpdated = _transformUpdated;
-    return Node::visit(renderer, parentTransform, parentFlags);
+    return Node::visit(state, parentTransform, parentFlags);
 }
 
 void Camera::setBackgroundBrush(CameraBackgroundBrush* clearBrush)

--- a/axmol/scene/Camera.h
+++ b/axmol/scene/Camera.h
@@ -42,6 +42,7 @@ class Scene;
 class RenderView;
 class RenderTexture;
 class CameraBackgroundBrush;
+struct SceneRenderState;
 
 /**
  * Note:
@@ -96,22 +97,6 @@ public:
      */
     static Camera* create(CameraMode mode);
 
-    /**
-     * Get the visiting camera , the visiting camera shall be set on Scene::render
-     */
-    static const Camera* getVisitingCamera() { return _visitingCamera; }
-
-    /**
-     * Set the visiting camera for draw context. Used by engine internals
-     * for offscreen capture (Transition, Utils, etc.)
-     */
-    static void setVisitingCamera(Camera* camera) { _visitingCamera = camera; }
-
-    /**
-     * Get the view-projection matrix of the current draw context.
-     */
-    static const Mat4& getVisitingViewProjectionMatrix();
-
     static const Viewport& getDefaultViewport();
     static void setDefaultViewport(const Viewport& vp);
 
@@ -135,6 +120,7 @@ public:
     /**get & set Camera flag*/
     CameraFlag getCameraFlag() const { return _cameraFlag; }
     void setCameraFlag(CameraFlag flag) { _cameraFlag = flag; }
+    CameraMode getCameraMode() const { return _cameraMode; }
 
     /**
      * Set a render texture as the camera's offscreen render target.
@@ -342,6 +328,7 @@ public:
      Use setBackgroundBrush to modify this default behavior.
      */
     void clearBackground();
+    void clearBackground(const SceneRenderState& state);
     /**
      Apply the FBO, RenderTargets and viewport.
      */
@@ -364,7 +351,7 @@ public:
      */
     CameraBackgroundBrush* getBackgroundBrush() const { return _clearBrush; }
 
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     bool isBrushValid();
 
@@ -372,10 +359,6 @@ public:
      * Set the owner scene of the camera, this method shall not be invoked manually
      */
     void setScene(Scene* scene);
-
-    /**set additional matrix for the projection matrix, it multiplies mat to projection matrix when called, used by
-     * WP8*/
-    void setAdditionalProjection(const Mat4& mat);
 
     /**
      * Configure a perspective projection for this Camera.
@@ -446,7 +429,6 @@ public:
     }
 
 protected:
-    static Camera* _visitingCamera;
     static Viewport _defaultViewport;
 
     /**

--- a/axmol/scene/CameraBackgroundBrush.cpp
+++ b/axmol/scene/CameraBackgroundBrush.cpp
@@ -27,6 +27,7 @@
 #include <stddef.h>  // offsetof
 #include "axmol/base/Types.h"
 #include "axmol/scene/Camera.h"
+#include "axmol/scene/Node.h"
 #include "axmol/base/Macros.h"
 #include "axmol/base/Utils.h"
 #include "axmol/base/Environment.h"
@@ -52,6 +53,15 @@ CameraBackgroundBrush::~CameraBackgroundBrush()
 {
     AX_SAFE_RELEASE_NULL(_programState);
     AX_SAFE_RELEASE_NULL(_vertexLayout);
+}
+
+void CameraBackgroundBrush::drawBackground(Camera* camera)
+{
+    if (!camera)
+        return;
+
+    SceneRenderState state(Director::getInstance()->getRenderer(), camera);
+    drawBackground(state);
 }
 
 CameraBackgroundBrush* CameraBackgroundBrush::createNoneBrush()
@@ -164,9 +174,12 @@ void CameraBackgroundDepthBrush::initBuffer()
     _customCommand.updateIndexBuffer(indices, sizeof(indices));
 }
 
-void CameraBackgroundDepthBrush::drawBackground(Camera* /*camera*/)
+void CameraBackgroundDepthBrush::drawBackground(const SceneRenderState& state)
 {
-    auto* renderer = Director::getInstance()->getRenderer();
+    auto* renderer = state.getRenderer();
+    if (!renderer)
+        return;
+
     // `clear screen` should be executed before other commands
     auto* groupCommand = renderer->getNextGroupCommand();
     groupCommand->init(-1.0f);
@@ -219,7 +232,7 @@ bool CameraBackgroundColorBrush::init()
     return true;
 }
 
-void CameraBackgroundColorBrush::drawBackground(Camera* camera)
+void CameraBackgroundColorBrush::drawBackground(const SceneRenderState& state)
 {
     BlendFunc op = {BlendFunc::ALPHA_NON_PREMULTIPLIED.src, BlendFunc::ALPHA_NON_PREMULTIPLIED.dst};
 
@@ -228,7 +241,7 @@ void CameraBackgroundColorBrush::drawBackground(Camera* camera)
     blend.destinationRGBBlendFactor = blend.destinationAlphaBlendFactor = op.dst;
     blend.blendEnabled                                                  = true;
 
-    CameraBackgroundDepthBrush::drawBackground(camera);
+    CameraBackgroundDepthBrush::drawBackground(state);
 }
 
 void CameraBackgroundColorBrush::setColor(const Color& color)
@@ -333,28 +346,28 @@ CameraBackgroundSkyBoxBrush* CameraBackgroundSkyBoxBrush::create()
     return ret;
 }
 
-void CameraBackgroundSkyBoxBrush::drawBackground(Camera* camera)
+void CameraBackgroundSkyBoxBrush::drawBackground(const SceneRenderState& state)
 {
-    auto* renderer = Director::getInstance()->getRenderer();
+    auto* renderer = state.getRenderer();
+    if (!renderer || !_actived)
+        return;
+
     // `clear screen` should be executed before other commands
     auto* groupCommand = renderer->getNextGroupCommand();
     groupCommand->init(-1.0f);
     _customCommand.init(0.0f);
 
-    if (!_actived)
-        return;
-
-    Mat4 cameraModelMat = camera->getNodeToWorldTransform();
-    Mat4 projectionMat  = camera->getProjectionMatrix();
+    Mat4 viewToWorld         = state.getViewMatrix().getInversed();
+    const Mat4& projectionMat = state.getProjectionMatrix();
 
     _customCommand.blendDesc().blendEnabled = false;
 
     Vec4 color(1.f, 1.f, 1.f, 1.f);
-    cameraModelMat.m[12] = cameraModelMat.m[13] = cameraModelMat.m[14] = 0;
-    cameraModelMat.scale(1 / projectionMat.m[0], 1 / projectionMat.m[5], 1.0);
+    viewToWorld.m[12] = viewToWorld.m[13] = viewToWorld.m[14] = 0;
+    viewToWorld.scale(1 / projectionMat.m[0], 1 / projectionMat.m[5], 1.0);
 
     _programState->setUniform(_uniformColorLoc, &color, sizeof(color));
-    _programState->setUniform(_uniformCameraRotLoc, cameraModelMat.m, sizeof(cameraModelMat.m));
+    _programState->setUniform(_uniformCameraRotLoc, viewToWorld.m, sizeof(viewToWorld.m));
 
     renderer->addCommand(groupCommand);
     renderer->pushGroup(groupCommand->getRenderQueueID());

--- a/axmol/scene/CameraBackgroundBrush.cpp
+++ b/axmol/scene/CameraBackgroundBrush.cpp
@@ -357,7 +357,7 @@ void CameraBackgroundSkyBoxBrush::drawBackground(const SceneRenderState& state)
     groupCommand->init(-1.0f);
     _customCommand.init(0.0f);
 
-    Mat4 viewToWorld         = state.getViewMatrix().getInversed();
+    Mat4 viewToWorld          = state.getViewMatrix().getInversed();
     const Mat4& projectionMat = state.getProjectionMatrix();
 
     _customCommand.blendDesc().blendEnabled = false;

--- a/axmol/scene/CameraBackgroundBrush.h
+++ b/axmol/scene/CameraBackgroundBrush.h
@@ -42,6 +42,7 @@ class CameraBackgroundColorBrush;
 class CameraBackgroundDepthBrush;
 class CameraBackgroundSkyBoxBrush;
 class Camera;
+struct SceneRenderState;
 
 namespace rhi
 {
@@ -115,7 +116,8 @@ public:
     /**
      * draw the background
      */
-    virtual void drawBackground(Camera* /*camera*/) {}
+    void drawBackground(Camera* camera);
+    virtual void drawBackground(const SceneRenderState& /*state*/) {}
 
     virtual bool isValid() { return true; }
 
@@ -151,7 +153,7 @@ public:
     /**
      * Draw background
      */
-    void drawBackground(Camera* camera) override;
+    void drawBackground(const SceneRenderState& state) override;
 
     /**
      * Set depth
@@ -212,7 +214,7 @@ public:
     /**
      * Draw background
      */
-    void drawBackground(Camera* camera) override;
+    void drawBackground(const SceneRenderState& state) override;
 
     /**
      * Set clear color
@@ -274,7 +276,7 @@ public:
     /**
      * Draw background
      */
-    void drawBackground(Camera* camera) override;
+    void drawBackground(const SceneRenderState& state) override;
 
     bool isActived() const;
     void setActived(bool actived);

--- a/axmol/scene/Node.cpp
+++ b/axmol/scene/Node.cpp
@@ -67,6 +67,86 @@ AX_DLL uint64_t hashNodeName(std::string_view name)
 uint32_t Node::s_globalOrderOfArrival = 0;
 int Node::__attachedNodeCount         = 0;
 
+SceneViewData SceneViewData::fromCamera(const Camera& camera)
+{
+    SceneViewData data;
+    data.view           = camera.getViewMatrix();
+    data.projection     = camera.getProjectionMatrix();
+    data.viewProjection = camera.getViewProjectionMatrix();
+    camera.getNodeToWorldTransform().getTranslation(&data.position);
+    return data;
+}
+
+SceneViewData SceneViewData::fromMatrices(const Mat4& view, const Mat4& projection, const Vec3& position)
+{
+    SceneViewData data;
+    data.view       = view;
+    data.projection = projection;
+    data.position   = position;
+    Mat4::multiply(projection, view, &data.viewProjection);
+    return data;
+}
+
+float SceneViewData::getDepthInView(const Mat4& transform) const
+{
+    float camWorldZ = -(view.m[2] * transform.m[12] + view.m[6] * transform.m[13] + view.m[10] * transform.m[14] +
+                        view.m[14]);
+    return camWorldZ;
+}
+
+SceneRenderState::SceneRenderState(Renderer* renderer, const Camera* camera)
+    : renderer(renderer)
+    , camera(camera)
+    , view(camera ? SceneViewData::fromCamera(*camera) : SceneViewData{})
+    , cameraFlag(camera ? static_cast<unsigned short>(camera->getCameraFlag()) : 0)
+{}
+
+SceneRenderState::SceneRenderState(Renderer* renderer, const Camera* camera, const SceneViewData& view)
+    : renderer(renderer)
+    , camera(camera)
+    , view(view)
+    , cameraFlag(camera ? static_cast<unsigned short>(camera->getCameraFlag()) : 0)
+    , viewOverridden(true)
+{}
+
+bool SceneRenderState::requiresVisibilityUpdate(uint32_t flags) const
+{
+    return viewOverridden || (flags & Node::FLAGS_TRANSFORM_DIRTY) ||
+           (camera && camera->isViewProjectionUpdated());
+}
+
+bool SceneRenderState::checkVisibility(const Mat4& transform, const Vec2& size) const
+{
+    if (viewOverridden)
+        return true;
+
+    if (!renderer || !camera || camera->getCameraMode() != CameraMode::Classic)
+        return true;
+
+    auto director = Director::getInstance();
+    if (!director)
+        return true;
+
+    Rect visibleRect(director->getVisibleOrigin(), director->getVisibleSize());
+
+    float hSizeX = size.width / 2;
+    float hSizeY = size.height / 2;
+    Vec3 v3p(hSizeX, hSizeY, 0);
+    transform.transformPoint(&v3p);
+    Vec2 v2p = camera->projectWorldToCanvas(v3p);
+
+    float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]),
+                          fabsf(hSizeX * transform.m[0] - hSizeY * transform.m[4]));
+    float wshh = std::max(fabsf(hSizeX * transform.m[1] + hSizeY * transform.m[5]),
+                          fabsf(hSizeX * transform.m[1] - hSizeY * transform.m[5]));
+
+    visibleRect.origin.x -= wshw;
+    visibleRect.origin.y -= wshh;
+    visibleRect.size.width += wshw * 2;
+    visibleRect.size.height += wshh * 2;
+    return visibleRect.containsPoint(v2p);
+}
+
 // MARK: Constructor, Destructor, Init
 
 Node::Node()
@@ -1218,18 +1298,24 @@ void Node::sortAllChildren()
 void Node::draw()
 {
     auto renderer = _director->getRenderer();
-    draw(renderer, _modelViewTransform, FLAGS_TRANSFORM_DIRTY);
+    auto scene     = _director->getRunningScene();
+    auto camera    = scene ? scene->getDefaultCamera() : nullptr;
+    SceneRenderState state(renderer, camera);
+    draw(state, _modelViewTransform, FLAGS_TRANSFORM_DIRTY);
 }
 
-void Node::draw(Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t /*flags*/) {}
+void Node::draw(const SceneRenderState& /*state*/, const Mat4& /*transform*/, uint32_t /*flags*/) {}
 
 void Node::visit()
 {
     auto renderer = _director->getRenderer();
-    visit(renderer, Mat4::identity, FLAGS_TRANSFORM_DIRTY);
+    auto scene     = _director->getRunningScene();
+    auto camera    = scene ? scene->getDefaultCamera() : nullptr;
+    SceneRenderState state(renderer, camera);
+    visit(state, Mat4::identity, FLAGS_TRANSFORM_DIRTY);
 }
 
-uint32_t Node::processParentFlags(const Mat4& parentTransform, uint32_t parentFlags)
+uint32_t Node::processParentFlags(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (_usingNormalizedPosition)
     {
@@ -1246,7 +1332,7 @@ uint32_t Node::processParentFlags(const Mat4& parentTransform, uint32_t parentFl
 
     // Fixes Github issue #16100. Basically when having two cameras, one camera might set as dirty the
     // node that is not visited by it, and might affect certain calculations. Besides, it is faster to do this.
-    if (!isVisitableByVisitingCamera())
+    if (!isVisitableByCamera(state.cameraFlag))
         return parentFlags;
 
     uint32_t flags = parentFlags;
@@ -1262,14 +1348,12 @@ uint32_t Node::processParentFlags(const Mat4& parentTransform, uint32_t parentFl
     return flags;
 }
 
-bool Node::isVisitableByVisitingCamera() const
+bool Node::isVisitableByCamera(unsigned short cameraFlag) const
 {
-    auto camera          = Camera::getVisitingCamera();
-    bool visibleByCamera = camera ? ((unsigned short)camera->getCameraFlag() & _cameraMask) != 0 : true;
-    return visibleByCamera;
+    return cameraFlag == 0 ? true : ((cameraFlag & _cameraMask) != 0);
 }
 
-void Node::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void Node::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -1277,9 +1361,9 @@ void Node::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t paren
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
 
     int i = 0;
 
@@ -1292,20 +1376,20 @@ void Node::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t paren
             auto node = _children.at(i);
 
             if (node && node->_localZOrder < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
         // self draw
         if (visibleByCamera)
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
 
         for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
+            (*it)->visit(state, _modelViewTransform, flags);
     }
     else if (visibleByCamera)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
     }
 
     // FIX ME: Why need to set _orderOfArrival to 0??
@@ -1907,8 +1991,18 @@ Vec2 Node::convertToWorldSpaceAR(const Vec2& nodePoint) const
 
 Vec2 Node::convertToScreenSpace(const Vec2& nodePoint) const
 {
+    auto scene  = _director->getRunningScene();
+    auto camera = scene ? scene->getDefaultCamera() : nullptr;
+    return convertToScreenSpace(nodePoint, camera);
+}
+
+Vec2 Node::convertToScreenSpace(const Vec2& nodePoint, const Camera* camera) const
+{
+    if (!camera)
+        return Vec2::zero;
+
     Vec2 worldPoint(this->convertToWorldSpace(nodePoint));
-    return Camera::getDefaultCamera()->projectWorldToScreen(Vec3(worldPoint.x, worldPoint.y, 0.0f));
+    return camera->projectWorldToScreen(Vec3(worldPoint.x, worldPoint.y, 0.0f));
 }
 
 // convenience methods which take a PointerEvent instead of Vec2

--- a/axmol/scene/Node.cpp
+++ b/axmol/scene/Node.cpp
@@ -89,8 +89,8 @@ SceneViewData SceneViewData::fromMatrices(const Mat4& view, const Mat4& projecti
 
 float SceneViewData::getDepthInView(const Mat4& transform) const
 {
-    float camWorldZ = -(view.m[2] * transform.m[12] + view.m[6] * transform.m[13] + view.m[10] * transform.m[14] +
-                        view.m[14]);
+    float camWorldZ =
+        -(view.m[2] * transform.m[12] + view.m[6] * transform.m[13] + view.m[10] * transform.m[14] + view.m[14]);
     return camWorldZ;
 }
 
@@ -111,8 +111,7 @@ SceneRenderState::SceneRenderState(Renderer* renderer, const Camera* camera, con
 
 bool SceneRenderState::requiresVisibilityUpdate(uint32_t flags) const
 {
-    return viewOverridden || (flags & Node::FLAGS_TRANSFORM_DIRTY) ||
-           (camera && camera->isViewProjectionUpdated());
+    return viewOverridden || (flags & Node::FLAGS_TRANSFORM_DIRTY) || (camera && camera->isViewProjectionUpdated());
 }
 
 bool SceneRenderState::checkVisibility(const Mat4& transform, const Vec2& size) const
@@ -1298,8 +1297,8 @@ void Node::sortAllChildren()
 void Node::draw()
 {
     auto renderer = _director->getRenderer();
-    auto scene     = _director->getRunningScene();
-    auto camera    = scene ? scene->getDefaultCamera() : nullptr;
+    auto scene    = _director->getRunningScene();
+    auto camera   = scene ? scene->getDefaultCamera() : nullptr;
     SceneRenderState state(renderer, camera);
     draw(state, _modelViewTransform, FLAGS_TRANSFORM_DIRTY);
 }
@@ -1309,8 +1308,8 @@ void Node::draw(const SceneRenderState& /*state*/, const Mat4& /*transform*/, ui
 void Node::visit()
 {
     auto renderer = _director->getRenderer();
-    auto scene     = _director->getRunningScene();
-    auto camera    = scene ? scene->getDefaultCamera() : nullptr;
+    auto scene    = _director->getRunningScene();
+    auto camera   = scene ? scene->getDefaultCamera() : nullptr;
     SceneRenderState state(renderer, camera);
     visit(state, Mat4::identity, FLAGS_TRANSFORM_DIRTY);
 }

--- a/axmol/scene/Node.h
+++ b/axmol/scene/Node.h
@@ -108,11 +108,11 @@ struct AX_DLL SceneViewData
 
 struct AX_DLL SceneRenderState
 {
-    Renderer* renderer         = nullptr;
-    const Camera* camera       = nullptr;
+    Renderer* renderer   = nullptr;
+    const Camera* camera = nullptr;
     SceneViewData view;
-    unsigned short cameraFlag  = 0;
-    bool viewOverridden        = false;
+    unsigned short cameraFlag = 0;
+    bool viewOverridden       = false;
 
     SceneRenderState() = default;
     SceneRenderState(Renderer* renderer, const Camera* camera);

--- a/axmol/scene/Node.h
+++ b/axmol/scene/Node.h
@@ -87,6 +87,48 @@ typedef std::map<uint64_t, Node*> NodeIndexerMap_t;
 
 AX_DLL uint64_t hashNodeName(std::string_view);
 
+/**
+ * Scene graph render traversal state for a single camera/view pass.
+ *
+ * This is intentionally separate from ax::rhi::RenderContext. It carries
+ * scene-level view information needed by Node::visit()/draw(), while RHI
+ * RenderContext owns GPU command encoding.
+ */
+struct AX_DLL SceneViewData
+{
+    Mat4 view{Mat4::identity};
+    Mat4 projection{Mat4::identity};
+    Mat4 viewProjection{Mat4::identity};
+    Vec3 position{Vec3::zero};
+
+    static SceneViewData fromCamera(const Camera& camera);
+    static SceneViewData fromMatrices(const Mat4& view, const Mat4& projection, const Vec3& position);
+    float getDepthInView(const Mat4& transform) const;
+};
+
+struct AX_DLL SceneRenderState
+{
+    Renderer* renderer         = nullptr;
+    const Camera* camera       = nullptr;
+    SceneViewData view;
+    unsigned short cameraFlag  = 0;
+    bool viewOverridden        = false;
+
+    SceneRenderState() = default;
+    SceneRenderState(Renderer* renderer, const Camera* camera);
+    SceneRenderState(Renderer* renderer, const Camera* camera, const SceneViewData& view);
+
+    Renderer* getRenderer() const { return renderer; }
+    const Camera* getCamera() const { return camera; }
+    const SceneViewData& getView() const { return view; }
+    const Mat4& getViewMatrix() const { return view.view; }
+    const Mat4& getProjectionMatrix() const { return view.projection; }
+    const Mat4& getViewProjectionMatrix() const { return view.viewProjection; }
+    float getDepthInView(const Mat4& transform) const { return view.getDepthInView(transform); }
+    bool requiresVisibilityUpdate(uint32_t flags) const;
+    bool checkVisibility(const Mat4& transform, const Vec2& size) const;
+};
+
 /** @class Node
 * @brief Node is the base element of the Scene Graph. Elements of the Scene Graph must be Node objects or subclasses of
 it. The most common Node objects are: Scene, Layer, Sprite, Menu, Label.
@@ -1109,21 +1151,21 @@ public:
      * AND YOU SHOULD NOT DISABLE THEM AFTER DRAWING YOUR NODE
      * But if you enable any other GL state, you should disable it after drawing your node.
      *
-     * @param renderer A given renderer.
+     * @param state A scene render traversal state.
      * @param transform A transform matrix.
      * @param flags Renderer flag.
      */
-    virtual void draw(Renderer* renderer, const Mat4& transform, uint32_t flags);
+    virtual void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags);
     virtual void draw() final;
 
     /**
      * Visits this node's children and draw them recursively.
      *
-     * @param renderer A given renderer.
+     * @param state A scene render traversal state.
      * @param parentTransform A transform matrix.
      * @param parentFlags Renderer flag.
      */
-    virtual void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags);
+    virtual void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags);
     virtual void visit() final;
 
     /** Returns the Scene that contains the Node.
@@ -1818,6 +1860,7 @@ public:
      * get & set camera mask, the node is visible by the camera whose camera flag & node's camera mask is true
      */
     unsigned short getCameraMask() const { return _cameraMask; }
+    bool isVisitableByCamera(unsigned short cameraFlag) const;
 
     /**
      * Modify the camera mask for current node.
@@ -1914,6 +1957,7 @@ protected:
 
     /// Convert axmol coordinates to UI windows coordinate.
     Vec2 convertToScreenSpace(const Vec2& nodePoint) const;
+    Vec2 convertToScreenSpace(const Vec2& nodePoint, const Camera* camera) const;
 
     AX_DEPRECATED("3.0") Vec2 convertToWindowSpace(const Vec2& nodePoint) const
     {
@@ -1921,7 +1965,7 @@ protected:
     }
 
     Mat4 transform(const Mat4& parentTransform);
-    uint32_t processParentFlags(const Mat4& parentTransform, uint32_t parentFlags);
+    uint32_t processParentFlags(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags);
 
     virtual void updateCascadeOpacity();
     virtual void disableCascadeOpacity();
@@ -1931,9 +1975,6 @@ protected:
 
     bool doEnumerate(std::string name, std::function<bool(Node*)> callback) const;
     bool doEnumerateRecursive(const Node* node, std::string_view name, std::function<bool(Node*)> callback) const;
-
-    // check whether this camera mask is visible by the current visiting camera
-    bool isVisitableByVisitingCamera() const;
 
     // update quaternion from Rotation3D
     void updateRotationQuat();

--- a/axmol/scene/Scene.cpp
+++ b/axmol/scene/Scene.cpp
@@ -71,7 +71,6 @@ Scene::Scene()
     // avoiding a stall after changing step size.
     _fixedAccumulator = _fixedDeltaTime;
 
-    Camera::_visitingCamera = nullptr;
 }
 
 Scene::~Scene()
@@ -210,10 +209,10 @@ void Scene::setDebugCamera(Camera* camera)
     Object::assign(_debugCamera, camera);
 }
 
-void Scene::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void Scene::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     AX_PROFILER_ZONE_SCOPED;
-    Node::visit(renderer, parentTransform, parentFlags);
+    Node::visit(state, parentTransform, parentFlags);
 }
 
 void Scene::removeAllChildren()

--- a/axmol/scene/Scene.cpp
+++ b/axmol/scene/Scene.cpp
@@ -70,7 +70,6 @@ Scene::Scene()
     // Set accumulator to fixedDeltaTime so the next tick will immediately run at least one fixedUpdate,
     // avoiding a stall after changing step size.
     _fixedAccumulator = _fixedDeltaTime;
-
 }
 
 Scene::~Scene()

--- a/axmol/scene/Scene.h
+++ b/axmol/scene/Scene.h
@@ -97,7 +97,7 @@ public:
      */
     const std::vector<BaseLight*>& getLights() const { return _lights; }
 
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     /** override function */
     void removeAllChildren() override;

--- a/axmol/scene/SceneCompositor.cpp
+++ b/axmol/scene/SceneCompositor.cpp
@@ -69,8 +69,6 @@ void SceneCompositor::renderScene(Renderer* renderer, Scene* scene)
         if (!camera->isVisible())
             continue;
 
-        Camera::setVisitingCamera(camera);
-
         camera->setAdditionalTransform(Mat4::identity);
 
         auto targetTexture = camera->getTargetTexture();
@@ -83,15 +81,16 @@ void SceneCompositor::renderScene(Renderer* renderer, Scene* scene)
             _renderTexturePass->begin(camera);
 
             camera->apply();
+            SceneRenderState renderState(renderer, camera);
 
             // Override viewport to render texture dimensions (camera->apply sets it to screen)
             // renderer->setViewport(vp.x, vp.y, vp.width, vp.height);
 
-            camera->clearBackground();
-            scene->visit(renderer, transform, 0);
+            camera->clearBackground(renderState);
+            scene->visit(renderState, transform, 0);
 #if defined(AX_ENABLE_NAVMESH)
             if (scene->_navMesh)
-                scene->_navMesh->debugDraw(renderer);
+                scene->_navMesh->debugDraw(renderState);
 #endif
 
             _renderTexturePass->end();
@@ -101,11 +100,12 @@ void SceneCompositor::renderScene(Renderer* renderer, Scene* scene)
         else
         {
             camera->apply();
-            camera->clearBackground();
-            scene->visit(renderer, transform, 0);
+            SceneRenderState renderState(renderer, camera);
+            camera->clearBackground(renderState);
+            scene->visit(renderState, transform, 0);
 #if defined(AX_ENABLE_NAVMESH)
             if (scene->_navMesh)
-                scene->_navMesh->debugDraw(renderer);
+                scene->_navMesh->debugDraw(renderState);
 #endif
 
             renderer->render();
@@ -115,28 +115,25 @@ void SceneCompositor::renderScene(Renderer* renderer, Scene* scene)
 #if defined(AX_ENABLE_PHYSICS_3D) || defined(AX_ENABLE_NAVMESH)
     if (scene->_debugCamera) [[unlikely]]
     {
-        Camera::setVisitingCamera(scene->_debugCamera);
-
         scene->_debugCamera->setAdditionalTransform(Mat4::identity);
+        SceneRenderState debugRenderState(renderer, scene->_debugCamera);
 
         scene->_debugCamera->apply();
-        scene->_debugCamera->clearBackground();
+        scene->_debugCamera->clearBackground(debugRenderState);
 
 #    if defined(AX_ENABLE_NAVMESH)
         if (scene->_navMesh)
-            scene->_navMesh->debugDraw(renderer);
+            scene->_navMesh->debugDraw(debugRenderState);
 #    endif
 
 #    if defined(AX_ENABLE_PHYSICS_3D)
         if (scene->_physicsWorld3D)
-            scene->_physicsWorld3D->debugDraw(renderer);
+            scene->_physicsWorld3D->debugDraw(debugRenderState);
 #    endif
 
         renderer->render();
     }
 #endif
-
-    Camera::setVisitingCamera(nullptr);
 }
 
 void SceneCompositor::setScissorRect(float x, float y, float w, float h)

--- a/axmol/ui/EditBox/EditBox.cpp
+++ b/axmol/ui/EditBox/EditBox.cpp
@@ -779,12 +779,12 @@ std::string EditBox::getDescription() const
     return "EditBox";
 }
 
-void EditBox::draw(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void EditBox::draw(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
-    Widget::draw(renderer, parentTransform, parentFlags);
+    Widget::draw(state, parentTransform, parentFlags);
     if (_editBoxImpl)
     {
-        _editBoxImpl->draw(renderer, parentTransform, parentFlags & FLAGS_TRANSFORM_DIRTY);
+        _editBoxImpl->draw(state, parentTransform, parentFlags & FLAGS_TRANSFORM_DIRTY);
     }
 }
 

--- a/axmol/ui/EditBox/EditBox.h
+++ b/axmol/ui/EditBox/EditBox.h
@@ -602,7 +602,7 @@ public:
     /**
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void draw(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
     /**
      * @lua NA
      */

--- a/axmol/ui/EditBox/EditBoxImpl-common.cpp
+++ b/axmol/ui/EditBox/EditBoxImpl-common.cpp
@@ -325,7 +325,7 @@ void EditBoxImplCommon::setGlobalZOrder(float globalZOrder)
     }
 }
 
-void EditBoxImplCommon::draw(Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t flags)
+void EditBoxImplCommon::draw(const SceneRenderState& /*state*/, const Mat4& /*transform*/, uint32_t flags)
 {
     if (flags)
     {

--- a/axmol/ui/EditBox/EditBoxImpl-common.h
+++ b/axmol/ui/EditBox/EditBoxImpl-common.h
@@ -96,7 +96,7 @@ public:
     /**
      * @lua NA
      */
-    void draw(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void draw(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
     /**
      * @lua NA
      */

--- a/axmol/ui/EditBox/EditBoxImpl.h
+++ b/axmol/ui/EditBox/EditBoxImpl.h
@@ -96,7 +96,7 @@ public:
     /**
      * @lua NA
      */
-    virtual void draw(ax::Renderer* renderer, ax::Mat4 const& transform, uint32_t flags) = 0;
+    virtual void draw(const ax::SceneRenderState& state, ax::Mat4 const& transform, uint32_t flags) = 0;
     /**
      * @lua NA
      */

--- a/axmol/ui/InputField.cpp
+++ b/axmol/ui/InputField.cpp
@@ -446,7 +446,8 @@ bool InputField::detachWithIME()
 
 bool InputField::hitTestWithIME(const Vec2& location)
 {
-    const Camera* camera = _hittedByCamera ? _hittedByCamera : Camera::getDefaultCamera();
+    auto scene           = _director->getRunningScene();
+    const Camera* camera = _hittedByCamera ? _hittedByCamera : (scene ? scene->getDefaultCamera() : nullptr);
     return hitTestSelf(location, camera, nullptr);
 }
 

--- a/axmol/ui/LayoutGroup.cpp
+++ b/axmol/ui/LayoutGroup.cpp
@@ -199,7 +199,7 @@ bool LayoutGroup::isClippingEnabled() const
     return _clippingEnabled;
 }
 
-void LayoutGroup::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void LayoutGroup::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (!_visible)
     {
@@ -217,10 +217,10 @@ void LayoutGroup::visit(Renderer* renderer, const Mat4& parentTransform, uint32_
         switch (_clippingType)
         {
         case ClippingType::STENCIL:
-            stencilClippingVisit(renderer, parentTransform, parentFlags);
+            stencilClippingVisit(state, parentTransform, parentFlags);
             break;
         case ClippingType::SCISSOR:
-            scissorClippingVisit(renderer, parentTransform, parentFlags);
+            scissorClippingVisit(state, parentTransform, parentFlags);
             break;
         default:
             break;
@@ -229,35 +229,35 @@ void LayoutGroup::visit(Renderer* renderer, const Mat4& parentTransform, uint32_
     else
     {
         // no need to adapt render again
-        ProtectedNode::visit(renderer, parentTransform, parentFlags);
+        ProtectedNode::visit(state, parentTransform, parentFlags);
     }
 }
 
-void LayoutGroup::stencilClippingVisit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void LayoutGroup::stencilClippingVisit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (!_visible)
         return;
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     // Add group command
 
-    auto* groupCommand = renderer->getNextGroupCommand();
+    auto* groupCommand = state.getRenderer()->getNextGroupCommand();
     groupCommand->init(_globalZOrder);
-    renderer->addCommand(groupCommand);
-    renderer->pushGroup(groupCommand->getRenderQueueID());
+    state.getRenderer()->addCommand(groupCommand);
+    state.getRenderer()->pushGroup(groupCommand->getRenderQueueID());
 
     //    _beforeVisitCmdStencil.init(_globalZOrder);
     //    _beforeVisitCmdStencil.func = AX_CALLBACK_0(StencilStateManager::onBeforeVisit, _stencilStateManager);
-    //    renderer->addCommand(&_beforeVisitCmdStencil);
+    //    state.getRenderer()->addCommand(&_beforeVisitCmdStencil);
     _stencilStateManager->onBeforeVisit(_globalZOrder);
 
-    _clippingStencil->visit(renderer, _modelViewTransform, flags);
+    _clippingStencil->visit(state, _modelViewTransform, flags);
 
-    auto afterDrawStencilCmd = renderer->nextCallbackCommand();
+    auto afterDrawStencilCmd = state.getRenderer()->nextCallbackCommand();
     afterDrawStencilCmd->init(_globalZOrder);
     afterDrawStencilCmd->func = AX_CALLBACK_0(StencilStateManager::onAfterDrawStencil, _stencilStateManager);
-    renderer->addCommand(afterDrawStencilCmd);
+    state.getRenderer()->addCommand(afterDrawStencilCmd);
 
     int i = 0;  // used by _children
     int j = 0;  // used by _protectedChildren
@@ -273,7 +273,7 @@ void LayoutGroup::stencilClippingVisit(Renderer* renderer, const Mat4& parentTra
         auto node = _children.at(i);
 
         if (node && node->getLocalZOrder() < 0)
-            node->visit(renderer, _modelViewTransform, flags);
+            node->visit(state, _modelViewTransform, flags);
         else
             break;
     }
@@ -283,7 +283,7 @@ void LayoutGroup::stencilClippingVisit(Renderer* renderer, const Mat4& parentTra
         auto node = _protectedChildren.at(j);
 
         if (node && node->getLocalZOrder() < 0)
-            node->visit(renderer, _modelViewTransform, flags);
+            node->visit(state, _modelViewTransform, flags);
         else
             break;
     }
@@ -291,23 +291,23 @@ void LayoutGroup::stencilClippingVisit(Renderer* renderer, const Mat4& parentTra
     //
     // draw self
     //
-    this->draw(renderer, _modelViewTransform, flags);
+    this->draw(state, _modelViewTransform, flags);
 
     //
     // draw children and protectedChildren zOrder >= 0
     //
     for (auto it = _protectedChildren.cbegin() + j, itCend = _protectedChildren.cend(); it != itCend; ++it)
-        (*it)->visit(renderer, _modelViewTransform, flags);
+        (*it)->visit(state, _modelViewTransform, flags);
 
     for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-        (*it)->visit(renderer, _modelViewTransform, flags);
+        (*it)->visit(state, _modelViewTransform, flags);
 
-    auto afterVisitCmdStencil = renderer->nextCallbackCommand();
+    auto afterVisitCmdStencil = state.getRenderer()->nextCallbackCommand();
     afterVisitCmdStencil->init(_globalZOrder);
     afterVisitCmdStencil->func = AX_CALLBACK_0(StencilStateManager::onAfterVisit, _stencilStateManager);
-    renderer->addCommand(afterVisitCmdStencil);
+    state.getRenderer()->addCommand(afterVisitCmdStencil);
 
-    renderer->popGroup();
+    state.getRenderer()->popGroup();
 }
 
 void LayoutGroup::onBeforeVisitScissor()
@@ -351,31 +351,31 @@ void LayoutGroup::onAfterVisitScissor()
     }
 }
 
-void LayoutGroup::scissorClippingVisit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void LayoutGroup::scissorClippingVisit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (parentFlags & FLAGS_DIRTY_MASK)
     {
         _clippingRectDirty = true;
     }
 
-    auto* groupCommand = renderer->getNextGroupCommand();
+    auto* groupCommand = state.getRenderer()->getNextGroupCommand();
     groupCommand->init(_globalZOrder);
-    renderer->addCommand(groupCommand);
-    renderer->pushGroup(groupCommand->getRenderQueueID());
+    state.getRenderer()->addCommand(groupCommand);
+    state.getRenderer()->pushGroup(groupCommand->getRenderQueueID());
 
-    auto beforeVisitCmdScissor = renderer->nextCallbackCommand();
+    auto beforeVisitCmdScissor = state.getRenderer()->nextCallbackCommand();
     beforeVisitCmdScissor->init(_globalZOrder);
     beforeVisitCmdScissor->func = AX_CALLBACK_0(LayoutGroup::onBeforeVisitScissor, this);
-    renderer->addCommand(beforeVisitCmdScissor);
+    state.getRenderer()->addCommand(beforeVisitCmdScissor);
 
-    ProtectedNode::visit(renderer, parentTransform, parentFlags);
+    ProtectedNode::visit(state, parentTransform, parentFlags);
 
-    auto afterVisitCmdScissor = renderer->nextCallbackCommand();
+    auto afterVisitCmdScissor = state.getRenderer()->nextCallbackCommand();
     afterVisitCmdScissor->init(_globalZOrder);
     afterVisitCmdScissor->func = AX_CALLBACK_0(LayoutGroup::onAfterVisitScissor, this);
-    renderer->addCommand(afterVisitCmdScissor);
+    state.getRenderer()->addCommand(afterVisitCmdScissor);
 
-    renderer->popGroup();
+    state.getRenderer()->popGroup();
 }
 
 void LayoutGroup::setClippingEnabled(bool able)

--- a/axmol/ui/LayoutGroup.h
+++ b/axmol/ui/LayoutGroup.h
@@ -371,7 +371,7 @@ public:
     void addChild(Node* child, int localZOrder, int tag) override;
     void addChild(Node* child, int localZOrder, std::string_view name) override;
 
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     void removeChild(Node* child, bool cleanup = true) override;
 
@@ -476,8 +476,8 @@ protected:
     void copySpecialProperties(Widget* model) override;
     void copyClonedWidgetChildren(Widget* model) override;
 
-    void stencilClippingVisit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags);
-    void scissorClippingVisit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags);
+    void stencilClippingVisit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags);
+    void scissorClippingVisit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags);
 
     void setStencilClippingSize(const Vec2& size);
     const Rect& getClippingRect();

--- a/axmol/ui/VideoPlayer.cpp
+++ b/axmol/ui/VideoPlayer.cpp
@@ -527,10 +527,12 @@ static void createVideoControlTexture()
         ++i;
     }
 
-    node->visit();
+    auto* renderer = Director::getInstance()->getRenderer();
+    SceneRenderState renderState(renderer, camera);
+    node->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
     pass->end();
 
-    Director::getInstance()->getRenderer()->render();
+    renderer->render();
 
     g_mediaControlsTexture = rt;
 }
@@ -1201,9 +1203,9 @@ Node* VideoPlayer::getRenderNode()
     return pvd->_vrender;
 }
 
-void VideoPlayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void VideoPlayer::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    ax::ui::Widget::draw(renderer, transform, flags);
+    ax::ui::Widget::draw(state, transform, flags);
 
     auto pvd     = reinterpret_cast<PrivateVideoContext*>(_videoContext);
     auto vrender = pvd->_vrender;

--- a/axmol/ui/VideoPlayer.h
+++ b/axmol/ui/VideoPlayer.h
@@ -362,7 +362,7 @@ public:
     virtual void addEventListener(const VideoPlayerCallback& callback);
 
     void setVisible(bool visible) override;
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void onEnter() override;
     void onExit() override;
 

--- a/axmol/ui/WebView/WebView-inl.h
+++ b/axmol/ui/WebView/WebView-inl.h
@@ -132,10 +132,10 @@ void WebView::setScalesPageToFit(bool const scalesPageToFit)
     _impl->setScalesPageToFit(scalesPageToFit);
 }
 
-void WebView::draw(ax::Renderer* renderer, ax::Mat4 const& transform, uint32_t flags)
+void WebView::draw(const ax::SceneRenderState& state, ax::Mat4 const& transform, uint32_t flags)
 {
-    ax::ui::Widget::draw(renderer, transform, flags);
-    _impl->draw(renderer, transform, flags);
+    ax::ui::Widget::draw(state, transform, flags);
+    _impl->draw(state.getRenderer(), transform, flags);
 }
 
 void WebView::setVisible(bool visible)

--- a/axmol/ui/WebView/WebView.h
+++ b/axmol/ui/WebView/WebView.h
@@ -205,7 +205,7 @@ public:
      */
     void setBounces(bool bounce);
 
-    void draw(ax::Renderer* renderer, ax::Mat4 const& transform, uint32_t flags) override;
+    void draw(const ax::SceneRenderState& state, ax::Mat4 const& transform, uint32_t flags) override;
 
     /**
      * Toggle visibility of WebView.

--- a/axmol/ui/Widget.cpp
+++ b/axmol/ui/Widget.cpp
@@ -240,12 +240,12 @@ void Widget::onExit()
     ProtectedNode::onExit();
 }
 
-void Widget::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void Widget::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     if (_visible)
     {
         updateLayout();
-        ProtectedNode::visit(renderer, parentTransform, parentFlags);
+        ProtectedNode::visit(state, parentTransform, parentFlags);
     }
 }
 

--- a/axmol/ui/Widget.h
+++ b/axmol/ui/Widget.h
@@ -277,7 +277,7 @@ public:
 
     /**
      */
-    void visit(ax::Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const ax::SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     /**
      * Set a callback to pointer event listener.

--- a/axmol/vr/OpenXRDriver.cpp
+++ b/axmol/vr/OpenXRDriver.cpp
@@ -265,16 +265,123 @@ Vec2 OpenXRDriver::xrToVec2(const XrVector2f& v)
     return Vec2(v.x, v.y);
 }
 
-void OpenXRDriver::setPointerRayTransform(const Mat4& transform)
+static Vec3 slerpDirection(const Vec3& from, const Vec3& to, float t)
 {
-    _pointerRayTransform      = transform;
-    _pointerRayTransformValid = true;
+    float cosTheta = std::clamp(from.dot(to), -1.0f, 1.0f);
+    const float theta = std::acos(cosTheta);
+    if (theta < 1e-5f)
+        return from;
+
+    const float sinTheta = std::sin(theta);
+    if (std::abs(sinTheta) < 1e-5f)
+    {
+        Vec3 direction = from + (to - from) * t;
+        direction.normalize();
+        return direction;
+    }
+
+    Vec3 direction = from * (std::sin((1.0f - t) * theta) / sinTheta) + to * (std::sin(t * theta) / sinTheta);
+    direction.normalize();
+    return direction;
 }
 
-void OpenXRDriver::clearPointerRayTransform()
+static Ray makeRayFromXrPose(const XrPosef& pose)
 {
-    _pointerRayTransform      = Mat4::identity;
-    _pointerRayTransformValid = false;
+    const Mat4 poseTransform = OpenXRDriver::xrPoseToMat4(pose);
+
+    Vec3 origin(Vec3::zero);
+    poseTransform.transformPoint(&origin);
+
+    Vec3 direction(0.0f, 0.0f, -1.0f);
+    poseTransform.transformVector(&direction);
+    direction.normalize();
+
+    return Ray(origin, direction);
+}
+
+static float calculateStabilizedLerp(float distance, float deltaTime)
+{
+    constexpr float frameTime90Hz = 1.0f / 90.0f;
+
+    if (distance >= 1.0f)
+        return 1.0f;
+    if (distance <= 0.0f)
+        return 0.0f;
+
+    const float doubleFrameLerp = distance - distance * distance;
+    const float tripleFrameLerp = doubleFrameLerp * doubleFrameLerp;
+    const float timeSlice       = deltaTime / frameTime90Hz;
+
+    return distance * std::clamp(timeSlice, 0.0f, 1.0f) +
+           doubleFrameLerp * std::clamp(timeSlice - 1.0f, 0.0f, 1.0f) +
+           tripleFrameLerp * std::clamp(timeSlice - 2.0f, 0.0f, 1.0f);
+}
+
+static float directionAngle(const Vec3& from, const Vec3& to)
+{
+    return std::acos(std::clamp(from.dot(to), -1.0f, 1.0f));
+}
+
+static Ray stabilizeControllerRay(OpenXRDriver::ControllerState& ctrl, const Ray& rawRay, float deltaTime)
+{
+    constexpr float pi                          = 3.14159265358979323846f;
+    constexpr float positionStabilizationMeters = 0.25f;
+    constexpr float angleStabilizationRadians   = 20.0f * pi / 180.0f;
+
+    if (!ctrl.stabilizedRayValid)
+    {
+        ctrl.stabilizedTrackingRay = rawRay;
+        ctrl.stabilizedRayValid    = true;
+        return ctrl.stabilizedTrackingRay;
+    }
+
+    const Ray previousRay = ctrl.stabilizedTrackingRay;
+
+    const Vec3 positionOffset             = rawRay.origin - previousRay.origin;
+    const float positionDistance          = positionOffset.length();
+    const float directionDistance         = directionAngle(previousRay.direction, rawRay.direction);
+    constexpr float directionResetRadians = 30.0f * pi / 180.0f;
+    if (positionDistance >= positionStabilizationMeters || directionDistance >= directionResetRadians)
+    {
+        ctrl.stabilizedTrackingRay = rawRay;
+        return ctrl.stabilizedTrackingRay;
+    }
+
+    const float positionLerp =
+        calculateStabilizedLerp(positionDistance / positionStabilizationMeters, deltaTime);
+    const Vec3 stabilizedOrigin = previousRay.origin + positionOffset * positionLerp;
+
+    const float referenceDistance = std::max(ctrl.stabilizationReferenceDistance, 0.001f);
+    const Vec3 previousEndpoint   = previousRay.origin + previousRay.direction * referenceDistance;
+
+    Vec3 endpointPreservingDirection = previousEndpoint - stabilizedOrigin;
+    if (endpointPreservingDirection.lengthSquared() < 1e-8f)
+        endpointPreservingDirection = previousRay.direction;
+    else
+        endpointPreservingDirection.normalize();
+
+    const float distanceScale     = 1.0f + std::log(std::max(referenceDistance, 1.0f));
+    const float endpointAngleSpan = angleStabilizationRadians * std::clamp(distanceScale, 1.0f, 3.0f);
+    const float directError       = directionAngle(previousRay.direction, rawRay.direction);
+    const float endpointError     = directionAngle(endpointPreservingDirection, rawRay.direction);
+    const float directRatio       = directError / angleStabilizationRadians;
+    const float endpointRatio     = endpointError / endpointAngleSpan;
+
+    Vec3 stabilizedDirection;
+    if (endpointRatio < directRatio)
+    {
+        const float directionLerp = calculateStabilizedLerp(endpointRatio, deltaTime * distanceScale);
+        stabilizedDirection = slerpDirection(endpointPreservingDirection, rawRay.direction, directionLerp);
+    }
+    else
+    {
+        const float directionLerp = calculateStabilizedLerp(directRatio, deltaTime * distanceScale);
+        stabilizedDirection = slerpDirection(previousRay.direction, rawRay.direction, directionLerp);
+    }
+
+    ctrl.stabilizedTrackingRay = Ray(stabilizedOrigin, stabilizedDirection);
+
+    return ctrl.stabilizedTrackingRay;
 }
 
 // ---------------------------------------------------------------------------
@@ -409,8 +516,8 @@ void OpenXRDriver::pollEvents()
     _viewsLocated           = false;
     _locatedViewCount       = 0;
     _locatedViewsPoseValid  = false;
-    _headViewTransformValid = false;
-    _headViewTransform      = Mat4::identity;
+    _headPoseTransformValid = false;
+    _headPoseTransform      = Mat4::identity;
 
     if (_initialized && _xrInstance != XR_NULL_HANDLE)
         xrPollEvents();
@@ -446,7 +553,7 @@ void OpenXRDriver::pollEvents()
 
             _viewsLocated = true;
             if (_locatedViewsPoseValid)
-                updatePointerViewTransform(_locatedViewCount);
+                updateHeadPoseTransform(_locatedViewCount);
         }
     }
 
@@ -493,10 +600,10 @@ bool OpenXRDriver::locateViews(uint32_t& viewCountOutput)
     return true;
 }
 
-void OpenXRDriver::updatePointerViewTransform(uint32_t viewCount)
+void OpenXRDriver::updateHeadPoseTransform(uint32_t viewCount)
 {
-    _headViewTransformValid = false;
-    _headViewTransform      = Mat4::identity;
+    _headPoseTransformValid = false;
+    _headPoseTransform      = Mat4::identity;
 
     if (viewCount == 0 || _views.empty())
         return;
@@ -509,8 +616,10 @@ void OpenXRDriver::updatePointerViewTransform(uint32_t viewCount)
         centerPose.position.z = (_views[0].pose.position.z + _views[1].pose.position.z) * 0.5f;
     }
 
-    _headViewTransform      = xrPoseToMat4(centerPose);
-    _headViewTransformValid = true;
+    centerPose = scaleXrPosePosition(centerPose, _xrToSceneScale);
+
+    _headPoseTransform      = xrPoseToMat4(centerPose);
+    _headPoseTransformValid = true;
 }
 
 bool OpenXRDriver::acquireSwapchains(std::vector<AcquiredSwapchain>& acquired)
@@ -1410,9 +1519,23 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
         {
             ctrl.poseValid                = false;
             ctrl.rayHitValid              = false;
-            ctrl.visualRayOriginValid     = false;
-            ctrl.visualRayStartValid      = false;
-            ctrl.lastPointerEventRayValid = false;
+            ctrl.stabilizedRayValid       = false;
+            ctrl.rawWorldRayValid         = false;
+            ctrl.rawAimPoseUpdated        = false;
+            ctrl.aimTracked               = false;
+            ctrl.rawAimSampleTime         = 0;
+            ctrl.lastStabilizedSampleTime = 0;
+            ctrl.rawGripPoseValid         = false;
+            ctrl.triggerPrevious          = false;
+            ctrl.gripPrevious             = false;
+            ctrl.thumbstickClickPrevious  = false;
+            ctrl.menuPrevious             = false;
+            ctrl.aPrevious                = false;
+            ctrl.bPrevious                = false;
+            ctrl.xPrevious                = false;
+            ctrl.yPrevious                = false;
+            ctrl.thumbstickActivePrevious = false;
+            ctrl.posePrevious             = false;
         }
         return;
     }
@@ -1432,17 +1555,11 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
         return;
     }
 
-    // Controller poses are located in the same OpenXR local space as the eye poses.
-    // VRSceneCompositor owns the stable pointer-ray camera and pushes its world
-    // transform here before polling actions. Do not use the inverse HMD pose here;
-    // that converts the ray to head-relative space and makes scene hit testing miss.
-    const Mat4& controllerToWorld = _pointerRayTransformValid ? _pointerRayTransform : Mat4::identity;
-
+    // Poll buttons and raw tracking-space poses only. Scene-world pointer rays
+    // are resolved after the scene update, once the frame view snapshot is known.
     for (uint32_t hand = 0; hand < 2; ++hand)
     {
-        auto& ctrl                = _controllers[hand];
-        ctrl.visualRayOriginValid = false;
-        ctrl.visualRayStartValid  = false;
+        auto& ctrl = _controllers[hand];
 
         // Poll trigger
         XrActionStateGetInfo getInfo{XR_TYPE_ACTION_STATE_GET_INFO};
@@ -1546,184 +1663,227 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
             }
         }
 
-        // Poll aim pose
+        // Poll aim pose. VALID can contain an inferred or last-known pose, so
+        // only TRACKED samples are allowed to advance the pointer ray.
         getInfo.action = _aimPoseAction;
         XrActionStatePose poseState{XR_TYPE_ACTION_STATE_POSE};
-        XrResult poseResult = xrGetActionStatePose(_xrSession, &getInfo, &poseState);
-        ctrl.poseValid      = XR_SUCCEEDED(poseResult) && poseState.isActive == XR_TRUE;
+        const XrResult poseResult = xrGetActionStatePose(_xrSession, &getInfo, &poseState);
+        const bool poseActive     = XR_SUCCEEDED(poseResult) && poseState.isActive == XR_TRUE;
 
-        if (ctrl.poseValid && ctrl.aimSpace != XR_NULL_HANDLE)
+        ctrl.rawAimPoseUpdated   = false;
+        ctrl.aimTracked          = false;
+        ctrl.rawGripPoseValid    = false;
+
+        if (poseActive && ctrl.aimSpace != XR_NULL_HANDLE)
         {
             XrSpaceLocation location{XR_TYPE_SPACE_LOCATION};
-            XrResult locateResult = xrLocateSpace(ctrl.aimSpace, _localSpace, predictedDisplayTime, &location);
+            const XrResult locateResult =
+                xrLocateSpace(ctrl.aimSpace, _localSpace, predictedDisplayTime, &location);
 
-            if (XR_SUCCEEDED(locateResult) && (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) &&
-                (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT))
+            constexpr XrSpaceLocationFlags requiredValidFlags =
+                XR_SPACE_LOCATION_ORIENTATION_VALID_BIT | XR_SPACE_LOCATION_POSITION_VALID_BIT;
+            constexpr XrSpaceLocationFlags requiredTrackedFlags =
+                XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT | XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
+
+            const bool locationValid =
+                XR_SUCCEEDED(locateResult) &&
+                (location.locationFlags & requiredValidFlags) == requiredValidFlags;
+            const bool locationTracked =
+                locationValid && (location.locationFlags & requiredTrackedFlags) == requiredTrackedFlags;
+
+            if (locationTracked)
             {
-                const float xrToSceneScale = _xrToSceneScale;
-                Ray visualRay              = xrPoseToRay(location.pose);
+                ctrl.rawAimPose             = location.pose;
+                ctrl.rawAimPoseUpdated      = true;
+                ctrl.aimTracked             = true;
+                ctrl.poseValid              = true;
+                ctrl.rawAimSampleTime       = predictedDisplayTime;
+                ctrl.invalidPoseFrameCount  = 0;
 
-                visualRay.origin *= xrToSceneScale;
-                visualRay.transform(controllerToWorld);
-                Ray eventRay = visualRay;
-
-                ctrl.currentRay          = visualRay;
-                ctrl.visualRayStart      = visualRay.origin;
-                ctrl.visualRayStartValid = true;
-                bool gripPoseValid       = false;
-                Mat4 gripPose            = Mat4::identity;
                 if (ctrl.gripSpace != XR_NULL_HANDLE)
                 {
                     XrSpaceLocation gripLocation{XR_TYPE_SPACE_LOCATION};
-                    XrResult gripLocateResult =
+                    const XrResult gripLocateResult =
                         xrLocateSpace(ctrl.gripSpace, _localSpace, predictedDisplayTime, &gripLocation);
-                    if (XR_SUCCEEDED(gripLocateResult))
+                    if (XR_SUCCEEDED(gripLocateResult) &&
+                        (gripLocation.locationFlags & requiredValidFlags) == requiredValidFlags &&
+                        (gripLocation.locationFlags & requiredTrackedFlags) == requiredTrackedFlags)
                     {
-                        if ((gripLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT))
-                        {
-                            ctrl.visualRayOrigin.set(gripLocation.pose.position.x * xrToSceneScale,
-                                                     gripLocation.pose.position.y * xrToSceneScale,
-                                                     gripLocation.pose.position.z * xrToSceneScale);
-                            controllerToWorld.transformPoint(&ctrl.visualRayOrigin);
-                            ctrl.visualRayOriginValid = true;
-                            ctrl.visualRayStart       = ctrl.visualRayOrigin;
-                            ctrl.visualRayStartValid  = true;
-                        }
-
-                        if ((gripLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) &&
-                            (gripLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT))
-                        {
-                            gripPose = controllerToWorld *
-                                       xrPoseToMat4(scaleXrPosePosition(gripLocation.pose, xrToSceneScale));
-                            gripPoseValid = true;
-                        }
+                        ctrl.rawGripPose      = gripLocation.pose;
+                        ctrl.rawGripPoseValid = true;
                     }
                 }
+            }
+        }
 
-                XRInputEvent::State poseState;
-                poseState.eventType          = XRInputEvent::EventType::Pose;
-                poseState.hand               = hand == 0 ? XRInputEvent::Hand::Left : XRInputEvent::Hand::Right;
-                poseState.input              = XRInputEvent::Input::AimPose;
-                poseState.phase              = XRInputEvent::Phase::Active;
-                poseState.poseValid          = true;
-                poseState.aimRay             = eventRay;
-                poseState.gripPoseValid      = gripPoseValid;
-                poseState.gripPose           = gripPose;
-                poseState.interactionProfile = ctrl.interactionProfile;
-                InputSystem::getInstance()->handleXRInput(poseState);
-
-                InputPhase phase = InputPhase::PointerMove;
-                if (ctrl.triggerPressed && !ctrl.triggerPrevious)
-                    phase = InputPhase::PointerDown;
-                else if (!ctrl.triggerPressed && ctrl.triggerPrevious)
-                    phase = InputPhase::PointerUp;
-
-                constexpr float pointerRayOriginEpsilon    = 0.005f;
-                constexpr float pointerRayDirectionEpsilon = 0.015f;
-                const bool pointerRayChanged               = !ctrl.lastPointerEventRayValid ||
-                                               eventRay.origin.distanceSquared(ctrl.lastPointerEventRay.origin) >
-                                                   pointerRayOriginEpsilon * pointerRayOriginEpsilon ||
-                                               eventRay.direction.distanceSquared(ctrl.lastPointerEventRay.direction) >
-                                                   pointerRayDirectionEpsilon * pointerRayDirectionEpsilon;
-                const bool pointerButtonChanged = phase == InputPhase::PointerDown || phase == InputPhase::PointerUp;
-                const bool shouldDispatchPointerEvent = pointerButtonChanged || pointerRayChanged;
-
-                // Build pointer input state. PointerUp must keep the triggering button as Primary so the
-                // dispatcher can find the capture created by PointerDown.
-                PointerInputState inputState;
-                inputState.id             = ctrl.pointerId;
-                inputState.pressure       = ctrl.triggerPressed ? 1.0f : 0.0f;
-                inputState.button         = (phase == InputPhase::PointerDown || phase == InputPhase::PointerUp)
-                                                ? InputButton::Primary
-                                                : InputButton::None;
-                inputState.pressedButtons = ctrl.triggerPressed ? (1u << InputButton::Primary) : 0;
-                inputState.type           = PointerType::Controller;
-
-                // Use screen center as the 2D position placeholder
-                Vec2 centerPoint(_director->getCanvasSize().width * 0.5f, _director->getCanvasSize().height * 0.5f);
-
-                PointerHitResult hitResult;
-                bool hasHitResult = false;
-                if (shouldDispatchPointerEvent)
-                {
-                    hitResult =
-                        InputSystem::getInstance()->handleVRPointerEvent(phase, centerPoint, eventRay, inputState);
-                    hasHitResult                  = true;
-                    ctrl.lastPointerEventRay      = eventRay;
-                    ctrl.lastPointerEventRayValid = true;
-                }
-                else
-                {
-                    hitResult    = InputSystem::getInstance()->hitTestVRPointer(centerPoint, eventRay, inputState);
-                    hasHitResult = true;
-                }
-
-                constexpr float thumbstickScrollDeadzone = 0.0001f;
-                if (std::abs(ctrl.thumbstick.y) > thumbstickScrollDeadzone)
-                {
-                    PointerInputState scrollState;
-                    scrollState.id             = ctrl.pointerId;
-                    scrollState.pressure       = 0.0f;
-                    scrollState.button         = InputButton::None;
-                    scrollState.pressedButtons = inputState.pressedButtons;
-                    scrollState.type           = PointerType::Controller;
-                    auto scrollHitResult       = InputSystem::getInstance()->handleVRPointerScroll(
-                        centerPoint, Vec2{0.0f, -ctrl.thumbstick.y}, eventRay, scrollState);
-                    if (!hasHitResult)
-                    {
-                        hitResult    = scrollHitResult;
-                        hasHitResult = true;
-                    }
-                }
-
-                if (hasHitResult)
-                    ctrl.rayHitValid = hitResult.hit;
-                if (hasHitResult && hitResult.hit)
-                {
-                    Vec3 visualHitPoint = hitResult.worldPoint;
-
-                    if (_pointerRayTransformValid && hitResult.camera)
-                    {
-                        hitResult.camera->getWorldToNodeTransform().transformPoint(&visualHitPoint);
-                        _pointerRayTransform.transformPoint(&visualHitPoint);
-                    }
-
-                    const float hitDistance =
-                        std::max(0.0f, (visualHitPoint - ctrl.currentRay.origin).dot(ctrl.currentRay.direction));
-                    const Vec3 closestPoint = ctrl.currentRay.origin + ctrl.currentRay.direction * hitDistance;
-                    constexpr float maxVisualHitError = 1.0f;
-                    if (visualHitPoint.distanceSquared(closestPoint) > maxVisualHitError * maxVisualHitError)
-                        visualHitPoint = closestPoint;
-
-                    ctrl.rayHitPoint = visualHitPoint;
-                }
+        if (!ctrl.aimTracked)
+        {
+            constexpr uint8_t trackingLossGraceFrames = 6;
+            if (ctrl.stabilizedRayValid && ctrl.invalidPoseFrameCount < trackingLossGraceFrames)
+            {
+                ++ctrl.invalidPoseFrameCount;
+                ctrl.poseValid = true;
             }
             else
             {
                 ctrl.poseValid                = false;
                 ctrl.rayHitValid              = false;
-                ctrl.visualRayOriginValid     = false;
-                ctrl.visualRayStartValid      = false;
-                ctrl.lastPointerEventRayValid = false;
+                ctrl.stabilizedRayValid       = false;
+                ctrl.rawWorldRayValid         = false;
+                ctrl.lastStabilizedSampleTime = 0;
             }
         }
-        else if (ctrl.posePrevious)
+    }
+}
+
+void OpenXRDriver::resolveControllerPointers(const Mat4& trackingToWorld, float sceneRayMaxDistance)
+{
+    const float xrToSceneScale = _xrToSceneScale;
+    const float fallbackTrackingDistance =
+        std::max(sceneRayMaxDistance / std::max(xrToSceneScale, 0.0001f), 0.25f);
+
+    for (uint32_t hand = 0; hand < 2; ++hand)
+    {
+        auto& ctrl = _controllers[hand];
+
+        if (ctrl.poseValid)
         {
+            if (!ctrl.rayHitValid)
+                ctrl.stabilizationReferenceDistance = fallbackTrackingDistance;
+
+            if (ctrl.rawAimPoseUpdated)
+            {
+                Ray rawRay = makeRayFromXrPose(ctrl.rawAimPose);
+                rawRay.direction.normalize();
+
+                float deltaTime = 1.0f / 90.0f;
+                if (ctrl.lastStabilizedSampleTime > 0 &&
+                    ctrl.rawAimSampleTime > ctrl.lastStabilizedSampleTime)
+                {
+                    constexpr double xrTimeToSeconds = 1.0e-9;
+                    deltaTime = static_cast<float>(
+                        static_cast<double>(ctrl.rawAimSampleTime - ctrl.lastStabilizedSampleTime) * xrTimeToSeconds);
+                    deltaTime = std::clamp(deltaTime, 1.0f / 240.0f, 1.0f / 30.0f);
+                }
+
+                ctrl.rawTrackingRay          = rawRay;
+                stabilizeControllerRay(ctrl, rawRay, deltaTime);
+                ctrl.lastStabilizedSampleTime = ctrl.rawAimSampleTime;
+            }
+
+            const Ray& trackingRay = ctrl.stabilizedTrackingRay;
+
+            PointerRayContext rayContext;
+            rayContext.trackingRay            = trackingRay;
+            rayContext.primaryTrackingToWorld = trackingToWorld;
+            rayContext.trackingScale          = xrToSceneScale;
+
+            Ray eventRay = trackingRay;
+            eventRay.origin *= xrToSceneScale;
+            eventRay.transform(trackingToWorld);
+            eventRay.direction.normalize();
+
+            ctrl.currentRay = eventRay;
+
+            Ray rawWorldRay = ctrl.rawTrackingRay;
+            rawWorldRay.origin *= xrToSceneScale;
+            rawWorldRay.transform(trackingToWorld);
+            rawWorldRay.direction.normalize();
+            ctrl.rawWorldRay      = rawWorldRay;
+            ctrl.rawWorldRayValid = true;
+
+            bool gripPoseValid = false;
+            Mat4 gripPose      = Mat4::identity;
+            if (ctrl.rawGripPoseValid)
+            {
+                gripPose      = xrPoseToMat4(scaleXrPosePosition(ctrl.rawGripPose, xrToSceneScale));
+                gripPose      = trackingToWorld * gripPose;
+                gripPoseValid = true;
+            }
+
             XRInputEvent::State poseState;
             poseState.eventType          = XRInputEvent::EventType::Pose;
             poseState.hand               = hand == 0 ? XRInputEvent::Hand::Left : XRInputEvent::Hand::Right;
             poseState.input              = XRInputEvent::Input::AimPose;
-            poseState.phase              = XRInputEvent::Phase::Inactive;
-            poseState.poseValid          = false;
+            poseState.phase              = XRInputEvent::Phase::Active;
+            poseState.poseValid          = true;
+            poseState.aimRay             = eventRay;
+            poseState.gripPoseValid      = gripPoseValid;
+            poseState.gripPose           = gripPose;
             poseState.interactionProfile = ctrl.interactionProfile;
             InputSystem::getInstance()->handleXRInput(poseState);
-            ctrl.rayHitValid              = false;
-            ctrl.visualRayOriginValid     = false;
-            ctrl.visualRayStartValid      = false;
-            ctrl.lastPointerEventRayValid = false;
+
+            InputPhase phase = InputPhase::PointerMove;
+            if (ctrl.triggerPressed && !ctrl.triggerPrevious)
+                phase = InputPhase::PointerDown;
+            else if (!ctrl.triggerPressed && ctrl.triggerPrevious)
+                phase = InputPhase::PointerUp;
+
+            PointerInputState inputState;
+            inputState.id             = ctrl.pointerId;
+            inputState.pressure       = ctrl.triggerPressed ? 1.0f : 0.0f;
+            inputState.button         = (phase == InputPhase::PointerDown || phase == InputPhase::PointerUp)
+                                            ? InputButton::Primary
+                                            : InputButton::None;
+            inputState.pressedButtons = ctrl.triggerPressed ? (1u << InputButton::Primary) : 0;
+            inputState.type           = PointerType::Controller;
+
+            Vec2 centerPoint(_director->getCanvasSize().width * 0.5f, _director->getCanvasSize().height * 0.5f);
+
+            PointerHitResult hitResult;
+            bool hasHitResult = false;
+            InputSystem::getInstance()->handleVRPointerEvent(phase, centerPoint, eventRay, inputState, &rayContext);
+
+            hitResult    = InputSystem::getInstance()->hitTestVRPointer(centerPoint, eventRay, inputState, &rayContext);
+            hasHitResult = true;
+
+            constexpr float thumbstickScrollDeadzone = 0.0001f;
+            if (std::abs(ctrl.thumbstick.y) > thumbstickScrollDeadzone)
+            {
+                PointerInputState scrollState;
+                scrollState.id             = ctrl.pointerId;
+                scrollState.pressure       = 0.0f;
+                scrollState.button         = InputButton::None;
+                scrollState.pressedButtons = inputState.pressedButtons;
+                scrollState.type           = PointerType::Controller;
+                InputSystem::getInstance()->handleVRPointerScroll(centerPoint, Vec2{0.0f, -ctrl.thumbstick.y}, eventRay,
+                                                                  scrollState, &rayContext);
+            }
+
+            ctrl.rayHitValid = hasHitResult && hitResult.hit;
+            if (ctrl.rayHitValid)
+            {
+                ctrl.rayHitPoint = hitResult.visualPointValid ? hitResult.visualPoint : hitResult.worldPoint;
+
+                const float sceneHitDistance = ctrl.rayHitPoint.distance(eventRay.origin);
+                ctrl.stabilizationReferenceDistance =
+                    std::max(sceneHitDistance / std::max(xrToSceneScale, 0.0001f), 0.25f);
+            }
+            else
+            {
+                ctrl.stabilizationReferenceDistance = fallbackTrackingDistance;
+            }
+        }
+        else
+        {
+            if (ctrl.posePrevious)
+            {
+                XRInputEvent::State poseState;
+                poseState.eventType          = XRInputEvent::EventType::Pose;
+                poseState.hand               = hand == 0 ? XRInputEvent::Hand::Left : XRInputEvent::Hand::Right;
+                poseState.input              = XRInputEvent::Input::AimPose;
+                poseState.phase              = XRInputEvent::Phase::Inactive;
+                poseState.poseValid          = false;
+                poseState.interactionProfile = ctrl.interactionProfile;
+                InputSystem::getInstance()->handleXRInput(poseState);
+            }
+            ctrl.rayHitValid                     = false;
+            ctrl.stabilizedRayValid              = false;
+            ctrl.rawWorldRayValid                = false;
+            ctrl.lastStabilizedSampleTime        = 0;
+            ctrl.stabilizationReferenceDistance = fallbackTrackingDistance;
         }
 
-        // Save previous button states for edge detection
         ctrl.triggerPrevious          = ctrl.triggerPressed;
         ctrl.gripPrevious             = ctrl.gripPressed;
         ctrl.thumbstickClickPrevious  = ctrl.thumbstickClickPressed;

--- a/axmol/vr/OpenXRDriver.cpp
+++ b/axmol/vr/OpenXRDriver.cpp
@@ -267,7 +267,7 @@ Vec2 OpenXRDriver::xrToVec2(const XrVector2f& v)
 
 static Vec3 slerpDirection(const Vec3& from, const Vec3& to, float t)
 {
-    float cosTheta = std::clamp(from.dot(to), -1.0f, 1.0f);
+    float cosTheta    = std::clamp(from.dot(to), -1.0f, 1.0f);
     const float theta = std::acos(cosTheta);
     if (theta < 1e-5f)
         return from;
@@ -312,8 +312,7 @@ static float calculateStabilizedLerp(float distance, float deltaTime)
     const float tripleFrameLerp = doubleFrameLerp * doubleFrameLerp;
     const float timeSlice       = deltaTime / frameTime90Hz;
 
-    return distance * std::clamp(timeSlice, 0.0f, 1.0f) +
-           doubleFrameLerp * std::clamp(timeSlice - 1.0f, 0.0f, 1.0f) +
+    return distance * std::clamp(timeSlice, 0.0f, 1.0f) + doubleFrameLerp * std::clamp(timeSlice - 1.0f, 0.0f, 1.0f) +
            tripleFrameLerp * std::clamp(timeSlice - 2.0f, 0.0f, 1.0f);
 }
 
@@ -347,8 +346,7 @@ static Ray stabilizeControllerRay(OpenXRDriver::ControllerState& ctrl, const Ray
         return ctrl.stabilizedTrackingRay;
     }
 
-    const float positionLerp =
-        calculateStabilizedLerp(positionDistance / positionStabilizationMeters, deltaTime);
+    const float positionLerp    = calculateStabilizedLerp(positionDistance / positionStabilizationMeters, deltaTime);
     const Vec3 stabilizedOrigin = previousRay.origin + positionOffset * positionLerp;
 
     const float referenceDistance = std::max(ctrl.stabilizationReferenceDistance, 0.001f);
@@ -371,12 +369,12 @@ static Ray stabilizeControllerRay(OpenXRDriver::ControllerState& ctrl, const Ray
     if (endpointRatio < directRatio)
     {
         const float directionLerp = calculateStabilizedLerp(endpointRatio, deltaTime * distanceScale);
-        stabilizedDirection = slerpDirection(endpointPreservingDirection, rawRay.direction, directionLerp);
+        stabilizedDirection       = slerpDirection(endpointPreservingDirection, rawRay.direction, directionLerp);
     }
     else
     {
         const float directionLerp = calculateStabilizedLerp(directRatio, deltaTime * distanceScale);
-        stabilizedDirection = slerpDirection(previousRay.direction, rawRay.direction, directionLerp);
+        stabilizedDirection       = slerpDirection(previousRay.direction, rawRay.direction, directionLerp);
     }
 
     ctrl.stabilizedTrackingRay = Ray(stabilizedOrigin, stabilizedDirection);
@@ -1670,15 +1668,14 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
         const XrResult poseResult = xrGetActionStatePose(_xrSession, &getInfo, &poseState);
         const bool poseActive     = XR_SUCCEEDED(poseResult) && poseState.isActive == XR_TRUE;
 
-        ctrl.rawAimPoseUpdated   = false;
-        ctrl.aimTracked          = false;
-        ctrl.rawGripPoseValid    = false;
+        ctrl.rawAimPoseUpdated = false;
+        ctrl.aimTracked        = false;
+        ctrl.rawGripPoseValid  = false;
 
         if (poseActive && ctrl.aimSpace != XR_NULL_HANDLE)
         {
             XrSpaceLocation location{XR_TYPE_SPACE_LOCATION};
-            const XrResult locateResult =
-                xrLocateSpace(ctrl.aimSpace, _localSpace, predictedDisplayTime, &location);
+            const XrResult locateResult = xrLocateSpace(ctrl.aimSpace, _localSpace, predictedDisplayTime, &location);
 
             constexpr XrSpaceLocationFlags requiredValidFlags =
                 XR_SPACE_LOCATION_ORIENTATION_VALID_BIT | XR_SPACE_LOCATION_POSITION_VALID_BIT;
@@ -1686,19 +1683,18 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
                 XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT | XR_SPACE_LOCATION_POSITION_TRACKED_BIT;
 
             const bool locationValid =
-                XR_SUCCEEDED(locateResult) &&
-                (location.locationFlags & requiredValidFlags) == requiredValidFlags;
+                XR_SUCCEEDED(locateResult) && (location.locationFlags & requiredValidFlags) == requiredValidFlags;
             const bool locationTracked =
                 locationValid && (location.locationFlags & requiredTrackedFlags) == requiredTrackedFlags;
 
             if (locationTracked)
             {
-                ctrl.rawAimPose             = location.pose;
-                ctrl.rawAimPoseUpdated      = true;
-                ctrl.aimTracked             = true;
-                ctrl.poseValid              = true;
-                ctrl.rawAimSampleTime       = predictedDisplayTime;
-                ctrl.invalidPoseFrameCount  = 0;
+                ctrl.rawAimPose            = location.pose;
+                ctrl.rawAimPoseUpdated     = true;
+                ctrl.aimTracked            = true;
+                ctrl.poseValid             = true;
+                ctrl.rawAimSampleTime      = predictedDisplayTime;
+                ctrl.invalidPoseFrameCount = 0;
 
                 if (ctrl.gripSpace != XR_NULL_HANDLE)
                 {
@@ -1738,9 +1734,8 @@ void OpenXRDriver::pollXrActions(XrTime predictedDisplayTime)
 
 void OpenXRDriver::resolveControllerPointers(const Mat4& trackingToWorld, float sceneRayMaxDistance)
 {
-    const float xrToSceneScale = _xrToSceneScale;
-    const float fallbackTrackingDistance =
-        std::max(sceneRayMaxDistance / std::max(xrToSceneScale, 0.0001f), 0.25f);
+    const float xrToSceneScale           = _xrToSceneScale;
+    const float fallbackTrackingDistance = std::max(sceneRayMaxDistance / std::max(xrToSceneScale, 0.0001f), 0.25f);
 
     for (uint32_t hand = 0; hand < 2; ++hand)
     {
@@ -1757,16 +1752,15 @@ void OpenXRDriver::resolveControllerPointers(const Mat4& trackingToWorld, float 
                 rawRay.direction.normalize();
 
                 float deltaTime = 1.0f / 90.0f;
-                if (ctrl.lastStabilizedSampleTime > 0 &&
-                    ctrl.rawAimSampleTime > ctrl.lastStabilizedSampleTime)
+                if (ctrl.lastStabilizedSampleTime > 0 && ctrl.rawAimSampleTime > ctrl.lastStabilizedSampleTime)
                 {
                     constexpr double xrTimeToSeconds = 1.0e-9;
-                    deltaTime = static_cast<float>(
+                    deltaTime                        = static_cast<float>(
                         static_cast<double>(ctrl.rawAimSampleTime - ctrl.lastStabilizedSampleTime) * xrTimeToSeconds);
                     deltaTime = std::clamp(deltaTime, 1.0f / 240.0f, 1.0f / 30.0f);
                 }
 
-                ctrl.rawTrackingRay          = rawRay;
+                ctrl.rawTrackingRay = rawRay;
                 stabilizeControllerRay(ctrl, rawRay, deltaTime);
                 ctrl.lastStabilizedSampleTime = ctrl.rawAimSampleTime;
             }
@@ -1877,10 +1871,10 @@ void OpenXRDriver::resolveControllerPointers(const Mat4& trackingToWorld, float 
                 poseState.interactionProfile = ctrl.interactionProfile;
                 InputSystem::getInstance()->handleXRInput(poseState);
             }
-            ctrl.rayHitValid                     = false;
-            ctrl.stabilizedRayValid              = false;
-            ctrl.rawWorldRayValid                = false;
-            ctrl.lastStabilizedSampleTime        = 0;
+            ctrl.rayHitValid                    = false;
+            ctrl.stabilizedRayValid             = false;
+            ctrl.rawWorldRayValid               = false;
+            ctrl.lastStabilizedSampleTime       = 0;
             ctrl.stabilizationReferenceDistance = fallbackTrackingDistance;
         }
 

--- a/axmol/vr/OpenXRDriver.h
+++ b/axmol/vr/OpenXRDriver.h
@@ -31,6 +31,7 @@
 #include "axmol/math/Ray.h"
 #include "axmol/base/RefPtr.h"
 #include "axmol/math/Mat4.h"
+#include "axmol/math/Quat.h"
 #include "axmol/math/Vec2.h"
 #include "axmol/platform/PlatformMacros.h"
 
@@ -97,16 +98,26 @@ public:
         bool thumbstickActivePrevious{false};
         bool posePrevious{false};
 
+        XrPosef rawAimPose{};
+        XrPosef rawGripPose{};
+        XrTime rawAimSampleTime{0};
+        XrTime lastStabilizedSampleTime{0};
+        bool rawAimPoseUpdated{false};
+        bool aimTracked{false};
+        bool rawGripPoseValid{false};
+        Ray rawTrackingRay;
+        Ray stabilizedTrackingRay;
+        bool stabilizedRayValid{false};
+        float stabilizationReferenceDistance{50.0f};
+        uint8_t invalidPoseFrameCount{0};
+
+        // rawWorldRay, currentRay, and rayHitPoint are expressed in scene world space.
+        Ray rawWorldRay;
+        bool rawWorldRayValid{false};
         Ray currentRay;
-        Ray lastPointerEventRay;
-        Vec3 visualRayOrigin{Vec3::zero};
-        Vec3 visualRayStart{Vec3::zero};
         Vec3 rayHitPoint{Vec3::zero};
-        bool visualRayOriginValid{false};
-        bool visualRayStartValid{false};
         bool rayHitValid{false};
         bool poseValid{false};
-        bool lastPointerEventRayValid{false};
         intptr_t pointerId{-1};
         std::string interactionProfile;
     };
@@ -154,15 +165,14 @@ public:
     const XrFrameState& getFrameState() const { return _frameState; }
     const std::vector<XrView>& getViews() const { return _views; }
     const ControllerState* getControllers() const { return _controllers; }
-    Mat4 getPointerViewTransform() const { return _headViewTransform; }
-    bool isPointerViewTransformValid() const { return _headViewTransformValid; }
-    void setPointerRayTransform(const Mat4& transform);
-    void clearPointerRayTransform();
+    const Mat4& getHeadPoseTransform() const { return _headPoseTransform; }
+    bool isHeadPoseTransformValid() const { return _headPoseTransformValid; }
     void setCompositorAlive(bool alive) { _compositorAlive = alive; }
     bool isCompositorAlive() const { return _compositorAlive; }
 
     void setXrToSceneScale(float scale) { _xrToSceneScale = scale > 0.0f ? scale : 1.0f; }
     float getXrToSceneScale() const { return _xrToSceneScale; }
+    void resolveControllerPointers(const Mat4& trackingToWorld, float sceneRayMaxDistance);
 
     static Mat4 xrPoseToMat4(const XrPosef& pose);
     static Mat4 xrFovToProjection(const XrFovf& fov, float nearZ, float farZ);
@@ -190,7 +200,7 @@ private:
 
     bool initXrActions();
     void pollXrActions(XrTime predictedDisplayTime);
-    void updatePointerViewTransform(uint32_t viewCount);
+    void updateHeadPoseTransform(uint32_t viewCount);
     void shutdownXrActions();
     bool xrPollEvents();
     void logXrInteractionProfiles();
@@ -249,10 +259,8 @@ private:
     bool _compositorAlive{false};
     float _xrToSceneScale{1.0f};
 
-    Mat4 _headViewTransform{Mat4::identity};
-    bool _headViewTransformValid{false};
-    Mat4 _pointerRayTransform{Mat4::identity};
-    bool _pointerRayTransformValid{false};
+    Mat4 _headPoseTransform{Mat4::identity};
+    bool _headPoseTransformValid{false};
 
     void* _graphicsBindingStorage{nullptr};
 

--- a/axmol/vr/VRPreviewSceneCompositor.cpp
+++ b/axmol/vr/VRPreviewSceneCompositor.cpp
@@ -215,7 +215,6 @@ void VRPreviewSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
     renderSceneToEye(renderer, scene, RightEyeIndex, rightEyeTransform);
     renderDistortionPass(renderer);
 
-    Camera::setVisitingCamera(nullptr);
 }
 
 void VRPreviewSceneCompositor::renderSceneToEye(Renderer* renderer,
@@ -246,8 +245,6 @@ void VRPreviewSceneCompositor::renderSceneToEye(Renderer* renderer,
         else
             _rtPass->clear(ClearFlag::DEPTH_AND_STENCIL, {});
 
-        Camera::setVisitingCamera(camera);
-
         // VR rendering reuses the original scene cameras for both eyes.
         // Each eye applies a temporary view override through Camera::setAdditionalTransform(),
         // avoiding duplicated camera objects and keeping camera ownership in the scene.
@@ -262,9 +259,10 @@ void VRPreviewSceneCompositor::renderSceneToEye(Renderer* renderer,
         // Scissor changes are executed by renderer commands, not immediately
         // during scene traversal. Queue push/pop callbacks around the scene
         // commands so clipped UI is transformed at execution time.
+        SceneRenderState renderState(renderer, camera);
         renderer->addCallbackCommand(
             [this, eyeIndex]() { _scissorTransformStack.push(_eyes[eyeIndex].scissorTransform); });
-        scene->visit(renderer, transform, 0);
+        scene->visit(renderState, transform, 0);
         renderer->addCallbackCommand([this]() { _scissorTransformStack.pop(); });
 
         _rtPass->end();

--- a/axmol/vr/VRPreviewSceneCompositor.cpp
+++ b/axmol/vr/VRPreviewSceneCompositor.cpp
@@ -214,7 +214,6 @@ void VRPreviewSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
     renderSceneToEye(renderer, scene, LeftEyeIndex, leftEyeTransform);
     renderSceneToEye(renderer, scene, RightEyeIndex, rightEyeTransform);
     renderDistortionPass(renderer);
-
 }
 
 void VRPreviewSceneCompositor::renderSceneToEye(Renderer* renderer,

--- a/axmol/vr/VRSceneCompositor.cpp
+++ b/axmol/vr/VRSceneCompositor.cpp
@@ -69,8 +69,7 @@ static Vec3 sampleCubicBezier(const Vec3& p0, const Vec3& p1, const Vec3& p2, co
     const float oneMinusT  = 1.0f - t;
     const float oneMinusT2 = oneMinusT * oneMinusT;
     const float t2         = t * t;
-    return p0 * (oneMinusT2 * oneMinusT) + p1 * (3.0f * oneMinusT2 * t) +
-           p2 * (3.0f * oneMinusT * t2) + p3 * (t2 * t);
+    return p0 * (oneMinusT2 * oneMinusT) + p1 * (3.0f * oneMinusT2 * t) + p2 * (3.0f * oneMinusT * t2) + p3 * (t2 * t);
 }
 
 VRSceneCompositor::VRSceneCompositor()
@@ -276,13 +275,11 @@ void VRSceneCompositor::drawControllerRays(Renderer* renderer, const SceneViewDa
         std::array<V3F_C4F, curveVertexCount + reticleVertexCount> vertices;
         size_t vertexCount = 0;
 
-        const bool useSubtleCurve = _controllerRayVisualStyle == ControllerRayVisualStyle::SubtleCurve;
-        const Ray& visualSourceRay =
-            useSubtleCurve && ctrl.rawWorldRayValid ? ctrl.rawWorldRay : ctrl.currentRay;
-        const Vec3 rayOrigin = visualSourceRay.origin;
-        const Vec3 rayEnd    = ctrl.rayHitValid
-                                   ? ctrl.rayHitPoint
-                                   : ctrl.currentRay.origin + ctrl.currentRay.direction * visualMaxDistance;
+        const bool useSubtleCurve  = _controllerRayVisualStyle == ControllerRayVisualStyle::SubtleCurve;
+        const Ray& visualSourceRay = useSubtleCurve && ctrl.rawWorldRayValid ? ctrl.rawWorldRay : ctrl.currentRay;
+        const Vec3 rayOrigin       = visualSourceRay.origin;
+        const Vec3 rayEnd          = ctrl.rayHitValid ? ctrl.rayHitPoint
+                                                      : ctrl.currentRay.origin + ctrl.currentRay.direction * visualMaxDistance;
 
         const Color rayColor = ctrl.triggerPressed ? _controllerRayPressedColor : _controllerRayIdleColor;
 
@@ -291,14 +288,14 @@ void VRSceneCompositor::drawControllerRays(Renderer* renderer, const SceneViewDa
         {
             if (useSubtleCurve)
             {
-                constexpr float hitCurveRatio       = 0.35f;
-                constexpr float freeCurveRatio      = 0.18f;
-                constexpr float curveBlend          = 0.45f;
-                const float curveRatio              = ctrl.rayHitValid ? hitCurveRatio : freeCurveRatio;
-                const float maxControlDistance      = std::max(1.0f, visualMaxDistance * 0.2f);
-                const float controlDistance         = std::min(lineLength * curveRatio, maxControlDistance);
-                const Vec3 quadraticControl         = rayOrigin + visualSourceRay.direction * controlDistance;
-                const Vec3 endpointVector           = rayEnd - rayOrigin;
+                constexpr float hitCurveRatio  = 0.35f;
+                constexpr float freeCurveRatio = 0.18f;
+                constexpr float curveBlend     = 0.45f;
+                const float curveRatio         = ctrl.rayHitValid ? hitCurveRatio : freeCurveRatio;
+                const float maxControlDistance = std::max(1.0f, visualMaxDistance * 0.2f);
+                const float controlDistance    = std::min(lineLength * curveRatio, maxControlDistance);
+                const Vec3 quadraticControl    = rayOrigin + visualSourceRay.direction * controlDistance;
+                const Vec3 endpointVector      = rayEnd - rayOrigin;
 
                 // Keep the Unity-like controller curve subtle; hit-test still uses ctrl.currentRay.
                 const Vec3 control1 = (rayOrigin + quadraticControl * 2.0f) / 3.0f;
@@ -307,14 +304,13 @@ void VRSceneCompositor::drawControllerRays(Renderer* renderer, const SceneViewDa
                 Vec3 previousPoint = rayOrigin;
                 for (size_t pointIndex = 1; pointIndex < curvePointCount; ++pointIndex)
                 {
-                    const float t =
-                        static_cast<float>(pointIndex) / static_cast<float>(curvePointCount - 1);
+                    const float t            = static_cast<float>(pointIndex) / static_cast<float>(curvePointCount - 1);
                     const Vec3 straightPoint = rayOrigin + endpointVector * t;
-                    const Vec3 curvePoint = sampleCubicBezier(rayOrigin, control1, control2, rayEnd, t);
-                    const Vec3 point = straightPoint + (curvePoint - straightPoint) * curveBlend;
-                    vertices[vertexCount++] = {previousPoint, rayColor};
-                    vertices[vertexCount++] = {point, rayColor};
-                    previousPoint           = point;
+                    const Vec3 curvePoint    = sampleCubicBezier(rayOrigin, control1, control2, rayEnd, t);
+                    const Vec3 point         = straightPoint + (curvePoint - straightPoint) * curveBlend;
+                    vertices[vertexCount++]  = {previousPoint, rayColor};
+                    vertices[vertexCount++]  = {point, rayColor};
+                    previousPoint            = point;
                 }
             }
             else
@@ -333,8 +329,7 @@ void VRSceneCompositor::drawControllerRays(Renderer* renderer, const SceneViewDa
                 facing = -ctrl.currentRay.direction;
             facing.normalize();
 
-            const Vec3 upReference =
-                std::abs(facing.dot(Vec3::yAxis)) > 0.95f ? Vec3::xAxis : Vec3::yAxis;
+            const Vec3 upReference = std::abs(facing.dot(Vec3::yAxis)) > 0.95f ? Vec3::xAxis : Vec3::yAxis;
 
             Vec3 reticleRight;
             Vec3::cross(upReference, facing, &reticleRight);
@@ -424,7 +419,7 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
     const auto sourceScissorSize  = _director->getRenderView()->getViewportRect().size;
     const auto& views             = _xrDriver->getViews();
     const uint32_t eyeRenderCount = std::min<uint32_t>(viewCountOutput, static_cast<uint32_t>(acquired.size()));
-    const Mat4 trackingToWorld = _frameTrackingToWorld;
+    const Mat4 trackingToWorld    = _frameTrackingToWorld;
 
     for (uint32_t eyeIdx = 0; eyeIdx < eyeRenderCount; ++eyeIdx)
     {
@@ -437,9 +432,8 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
         _rtPass->setTarget(swapchain.renderTarget);
         _rtPass->setViewport(Viewport(0, 0, static_cast<int>(eyeW), static_cast<int>(eyeH)));
 
-        const Mat4 eyeToTracking =
-            OpenXRDriver::xrPoseToMat4(scaleXrPosePosition(view.pose, _xrToSceneScale));
-        const Mat4 projection = OpenXRDriver::xrFovToProjection(view.fov, _nearZ, _farZ);
+        const Mat4 eyeToTracking     = OpenXRDriver::xrPoseToMat4(scaleXrPosePosition(view.pose, _xrToSceneScale));
+        const Mat4 projection        = OpenXRDriver::xrFovToProjection(view.fov, _nearZ, _farZ);
         const Mat4 primaryEyeToWorld = trackingToWorld * eyeToTracking;
         const Mat4 primaryEyeView    = primaryEyeToWorld.getInversed();
 
@@ -459,8 +453,7 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
 
             Vec3 cameraEyePosition = Vec3::zero;
             cameraEyeToWorld.getTranslation(&cameraEyePosition);
-            const auto cameraEyeViewData =
-                SceneViewData::fromMatrices(cameraEyeView, projection, cameraEyePosition);
+            const auto cameraEyeViewData = SceneViewData::fromMatrices(cameraEyeView, projection, cameraEyePosition);
 
             SceneRenderState renderState(renderer, camera, cameraEyeViewData);
 

--- a/axmol/vr/VRSceneCompositor.cpp
+++ b/axmol/vr/VRSceneCompositor.cpp
@@ -25,18 +25,17 @@
 #include "axmol/vr/VRSceneCompositor.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <vector>
 
 #include "axmol/base/Director.h"
-#include "axmol/base/Logging.h"
-#include "axmol/math/Vec4.h"
 #include "axmol/renderer/ProgramManager.h"
 #include "axmol/renderer/Renderer.h"
 #include "axmol/renderer/RenderTexturePass.h"
 #include "axmol/rhi/ProgramState.h"
-#include "axmol/rhi/RenderTarget.h"
 #include "axmol/scene/Camera.h"
+#include "axmol/scene/Node.h"
 #include "axmol/scene/Scene.h"
 #include "axmol/platform/RenderView.h"
 
@@ -65,25 +64,13 @@ static XrPosef scaleXrPosePosition(const XrPosef& pose, float scale)
     return scaledPose;
 }
 
-struct VRProjectedPoint
+static Vec3 sampleCubicBezier(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3, float t)
 {
-    Vec4 clip;
-    Vec3 ndc;
-};
-
-static VRProjectedPoint projectControllerRayPoint(const Mat4& mvp, const Vec3& point)
-{
-    VRProjectedPoint projected;
-    projected.clip.set(point.x, point.y, point.z, 1.0f);
-    mvp.transformVector(&projected.clip);
-
-    if (std::abs(projected.clip.w) > 0.000001f)
-    {
-        projected.ndc.set(projected.clip.x / projected.clip.w, projected.clip.y / projected.clip.w,
-                          projected.clip.z / projected.clip.w);
-    }
-
-    return projected;
+    const float oneMinusT  = 1.0f - t;
+    const float oneMinusT2 = oneMinusT * oneMinusT;
+    const float t2         = t * t;
+    return p0 * (oneMinusT2 * oneMinusT) + p1 * (3.0f * oneMinusT2 * t) +
+           p2 * (3.0f * oneMinusT * t2) + p3 * (t2 * t);
 }
 
 VRSceneCompositor::VRSceneCompositor()
@@ -132,8 +119,21 @@ void VRSceneCompositor::pollEvents()
         return;
 
     xrDriver->setXrToSceneScale(_xrToSceneScale);
-    syncPointerRayCamera(_director->getRunningScene());
     xrDriver->pollEvents();
+}
+
+void VRSceneCompositor::resolveXrFrameInput(Scene* scene)
+{
+    if (!_xrDriver || !_xrDriver->isCompositorAlive())
+        return;
+
+    Camera* xrViewCamera       = scene ? resolveXrViewCamera(scene) : nullptr;
+    _frameTrackingToWorld      = xrViewCamera ? xrViewCamera->getNodeToWorldTransform() : Mat4::identity;
+    _frameTrackingToWorldValid = xrViewCamera != nullptr;
+
+    _xrDriver->setXrToSceneScale(_xrToSceneScale);
+    const float sceneRayMaxDistance = _controllerRayLength > 0.0f ? _controllerRayLength : _farZ;
+    _xrDriver->resolveControllerPointers(_frameTrackingToWorld, sceneRayMaxDistance);
 }
 
 bool VRSceneCompositor::isVRActive() const
@@ -160,59 +160,6 @@ void VRSceneCompositor::setXrToSceneScale(float scale)
     _xrToSceneScale = scale > 0.0f ? scale : 1.0f;
     if (_xrDriver)
         _xrDriver->setXrToSceneScale(_xrToSceneScale);
-}
-
-Camera* VRSceneCompositor::selectPointerRaySourceCamera(Scene* scene) const
-{
-    if (!scene)
-        return nullptr;
-
-    auto defaultCamera = scene->getDefaultCamera();
-    if (defaultCamera && defaultCamera->isVisible())
-        return defaultCamera;
-
-    for (auto camera : scene->getCameras())
-    {
-        if (camera && camera->isVisible())
-            return camera;
-    }
-
-    return defaultCamera;
-}
-
-Camera* VRSceneCompositor::ensurePointerRayCamera(Scene* scene)
-{
-    auto sourceCamera = selectPointerRaySourceCamera(scene);
-    if (!sourceCamera)
-        return nullptr;
-
-    if (!_pointerRayCamera)
-        _pointerRayCamera = RefPtr<Camera>(Camera::create());
-    _pointerRayCamera->configurePerspective(60.0f, 1.0f, _nearZ, _farZ);
-
-    const auto canvasSize = _director->getCanvasSize();
-    const float aspect    = canvasSize.height > 0.0f ? canvasSize.width / canvasSize.height : 1.0f;
-    _pointerRayCamera->configurePerspective(60.0f, aspect, _nearZ, _farZ);
-    _pointerRayCamera->setNodeToParentTransform(sourceCamera->getNodeToWorldTransform());
-    _pointerRayCamera->setAdditionalTransform(Mat4::identity);
-    _pointerRayCamera->setCameraFlag(sourceCamera->getCameraFlag());
-
-    return _pointerRayCamera.get();
-}
-
-void VRSceneCompositor::syncPointerRayCamera(Scene* scene)
-{
-    if (!_xrDriver)
-        return;
-
-    auto camera = ensurePointerRayCamera(scene);
-    if (!camera)
-    {
-        _xrDriver->clearPointerRayTransform();
-        return;
-    }
-
-    _xrDriver->setPointerRayTransform(camera->getNodeToWorldTransform());
 }
 
 void VRSceneCompositor::ensureControllerRayResources()
@@ -277,21 +224,43 @@ void VRSceneCompositor::onAfterControllerRayDraw()
     renderer->setDepthWrite(_controllerRayOldDepthWrite);
 }
 
-void VRSceneCompositor::drawControllerRays(Renderer* renderer, uint32_t eyeIdx, const XrView& view)
+Camera* VRSceneCompositor::resolveXrViewCamera(Scene* scene) const
 {
-    if (!_controllerRayVisible || !renderer)
+    if (!scene)
+        return nullptr;
+
+    Camera* fallback = nullptr;
+    for (auto* camera : scene->getCameras())
+    {
+        if (!camera || !camera->isVisible())
+            continue;
+
+        if (!fallback)
+            fallback = camera;
+
+        if (camera->getCameraMode() != CameraMode::Classic)
+            return camera;
+    }
+
+    return fallback ? fallback : scene->getDefaultCamera();
+}
+
+void VRSceneCompositor::drawControllerRays(Renderer* renderer, const SceneViewData& view)
+{
+    if (!_controllerRayVisible || !renderer || !_xrDriver)
         return;
 
     ensureControllerRayResources();
     if (!_controllerRayResourcesInitialized)
         return;
 
-    auto camera = Camera::getVisitingCamera();
-    if (!camera)
+    const auto* controllers = _xrDriver->getControllers();
+    if (!controllers)
         return;
 
-    const auto* controllers = _xrDriver->getControllers();
-    const Mat4& mvp         = camera->getViewProjectionMatrix();
+    // _controllerRayLength is a scene-world visual cap. Input rays themselves
+    // are already scene-world rays.
+    const float visualMaxDistance = _controllerRayLength > 0.0f ? _controllerRayLength : _farZ;
 
     for (uint32_t hand = 0; hand < 2; ++hand)
     {
@@ -300,36 +269,123 @@ void VRSceneCompositor::drawControllerRays(Renderer* renderer, uint32_t eyeIdx, 
             continue;
 
         auto& command = _controllerRayCommands[hand];
-        V3F_C4F vertices[6];
+
+        constexpr size_t curvePointCount    = 16;
+        constexpr size_t curveVertexCount   = (curvePointCount - 1) * 2;
+        constexpr size_t reticleVertexCount = 4;
+        std::array<V3F_C4F, curveVertexCount + reticleVertexCount> vertices;
         size_t vertexCount = 0;
 
-        const float sceneScale     = std::max(1.0f, _director->getZEye());
-        const float sceneRayLength = _controllerRayLength * sceneScale;
-        const Vec3 start           = ctrl.visualRayStartValid ? ctrl.visualRayStart : ctrl.currentRay.origin;
-        const Vec3 maxEnd          = start + ctrl.currentRay.direction * sceneRayLength;
-        const Vec3 reticlePoint    = ctrl.rayHitValid ? ctrl.rayHitPoint : maxEnd;
-        const Vec3 end             = reticlePoint;
-        const Color rayColor       = ctrl.triggerPressed ? _controllerRayPressedColor : _controllerRayIdleColor;
+        const bool useSubtleCurve = _controllerRayVisualStyle == ControllerRayVisualStyle::SubtleCurve;
+        const Ray& visualSourceRay =
+            useSubtleCurve && ctrl.rawWorldRayValid ? ctrl.rawWorldRay : ctrl.currentRay;
+        const Vec3 rayOrigin = visualSourceRay.origin;
+        const Vec3 rayEnd    = ctrl.rayHitValid
+                                   ? ctrl.rayHitPoint
+                                   : ctrl.currentRay.origin + ctrl.currentRay.direction * visualMaxDistance;
 
-        vertices[vertexCount++] = {start, rayColor};
-        vertices[vertexCount++] = {end, rayColor};
+        const Color rayColor = ctrl.triggerPressed ? _controllerRayPressedColor : _controllerRayIdleColor;
+
+        const float lineLength = rayOrigin.distance(rayEnd);
+        if (lineLength > 1e-5f)
+        {
+            if (useSubtleCurve)
+            {
+                constexpr float hitCurveRatio       = 0.35f;
+                constexpr float freeCurveRatio      = 0.18f;
+                constexpr float curveBlend          = 0.45f;
+                const float curveRatio              = ctrl.rayHitValid ? hitCurveRatio : freeCurveRatio;
+                const float maxControlDistance      = std::max(1.0f, visualMaxDistance * 0.2f);
+                const float controlDistance         = std::min(lineLength * curveRatio, maxControlDistance);
+                const Vec3 quadraticControl         = rayOrigin + visualSourceRay.direction * controlDistance;
+                const Vec3 endpointVector           = rayEnd - rayOrigin;
+
+                // Keep the Unity-like controller curve subtle; hit-test still uses ctrl.currentRay.
+                const Vec3 control1 = (rayOrigin + quadraticControl * 2.0f) / 3.0f;
+                const Vec3 control2 = (quadraticControl * 2.0f + rayEnd) / 3.0f;
+
+                Vec3 previousPoint = rayOrigin;
+                for (size_t pointIndex = 1; pointIndex < curvePointCount; ++pointIndex)
+                {
+                    const float t =
+                        static_cast<float>(pointIndex) / static_cast<float>(curvePointCount - 1);
+                    const Vec3 straightPoint = rayOrigin + endpointVector * t;
+                    const Vec3 curvePoint = sampleCubicBezier(rayOrigin, control1, control2, rayEnd, t);
+                    const Vec3 point = straightPoint + (curvePoint - straightPoint) * curveBlend;
+                    vertices[vertexCount++] = {previousPoint, rayColor};
+                    vertices[vertexCount++] = {point, rayColor};
+                    previousPoint           = point;
+                }
+            }
+            else
+            {
+                vertices[vertexCount++] = {rayOrigin, rayColor};
+                vertices[vertexCount++] = {rayEnd, rayColor};
+            }
+        }
 
         if (ctrl.rayHitValid)
         {
-            const float reticleRadius = std::max(0.025f * sceneScale, 3.0f);
-            vertices[vertexCount++]   = {reticlePoint + Vec3(-reticleRadius, 0.0f, 0.0f), _controllerRayHitColor};
-            vertices[vertexCount++]   = {reticlePoint + Vec3(reticleRadius, 0.0f, 0.0f), _controllerRayHitColor};
-            vertices[vertexCount++]   = {reticlePoint + Vec3(0.0f, -reticleRadius, 0.0f), _controllerRayHitColor};
-            vertices[vertexCount++]   = {reticlePoint + Vec3(0.0f, reticleRadius, 0.0f), _controllerRayHitColor};
+            const Vec3& center = rayEnd;
+
+            Vec3 facing = view.position - center;
+            if (facing.lengthSquared() < 1e-8f)
+                facing = -ctrl.currentRay.direction;
+            facing.normalize();
+
+            const Vec3 upReference =
+                std::abs(facing.dot(Vec3::yAxis)) > 0.95f ? Vec3::xAxis : Vec3::yAxis;
+
+            Vec3 reticleRight;
+            Vec3::cross(upReference, facing, &reticleRight);
+            if (reticleRight.lengthSquared() < 1e-8f)
+                reticleRight = Vec3::xAxis;
+            reticleRight.normalize();
+
+            Vec3 reticleUp;
+            Vec3::cross(facing, reticleRight, &reticleUp);
+            reticleUp.normalize();
+
+            constexpr float reticleAngularRadius = 0.008f;
+            const float viewDistance             = std::max(view.position.distance(center), 0.001f);
+            const float reticleRadius            = viewDistance * std::tan(reticleAngularRadius);
+
+            const Vec3 rightOffset = reticleRight * reticleRadius;
+            const Vec3 upOffset    = reticleUp * reticleRadius;
+
+            vertices[vertexCount++] = {
+                center - rightOffset,
+                _controllerRayHitColor,
+            };
+            vertices[vertexCount++] = {
+                center + rightOffset,
+                _controllerRayHitColor,
+            };
+            vertices[vertexCount++] = {
+                center - upOffset,
+                _controllerRayHitColor,
+            };
+            vertices[vertexCount++] = {
+                center + upOffset,
+                _controllerRayHitColor,
+            };
         }
 
-        if (command.getVertexCapacity() < vertexCount)
-            command.createVertexBuffer(sizeof(V3F_C4F), vertexCount, CustomCommand::BufferUsage::DYNAMIC);
+        if (vertexCount == 0)
+            continue;
 
-        command.unsafePS()->setUniform(_controllerRayMVPLocation, mvp.m, sizeof(mvp.m));
-        command.updateVertexBuffer(vertices, vertexCount * sizeof(V3F_C4F));
+        if (command.getVertexCapacity() < vertexCount)
+        {
+            command.createVertexBuffer(sizeof(V3F_C4F), vertexCount, CustomCommand::BufferUsage::DYNAMIC);
+        }
+
+        command.unsafePS()->setUniform(_controllerRayMVPLocation, view.viewProjection.m, sizeof(view.viewProjection.m));
+
+        command.updateVertexBuffer(vertices.data(), vertexCount * sizeof(V3F_C4F));
+
         command.setVertexDrawInfo(0, vertexCount);
         command.init(0.0f);
+
         renderer->addCommand(&command);
     }
 }
@@ -341,6 +397,8 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
         SceneCompositor::renderScene(renderer, scene);
         return;
     }
+
+    resolveXrFrameInput(scene);
 
     // For debugging, don't remove
 #ifndef NDEBUG
@@ -366,6 +424,7 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
     const auto sourceScissorSize  = _director->getRenderView()->getViewportRect().size;
     const auto& views             = _xrDriver->getViews();
     const uint32_t eyeRenderCount = std::min<uint32_t>(viewCountOutput, static_cast<uint32_t>(acquired.size()));
+    const Mat4 trackingToWorld = _frameTrackingToWorld;
 
     for (uint32_t eyeIdx = 0; eyeIdx < eyeRenderCount; ++eyeIdx)
     {
@@ -378,72 +437,67 @@ void VRSceneCompositor::renderScene(Renderer* renderer, Scene* scene)
         _rtPass->setTarget(swapchain.renderTarget);
         _rtPass->setViewport(Viewport(0, 0, static_cast<int>(eyeW), static_cast<int>(eyeH)));
 
-        Mat4 eyeTransform = OpenXRDriver::xrPoseToMat4(scaleXrPosePosition(view.pose, _xrToSceneScale));
+        const Mat4 eyeToTracking =
+            OpenXRDriver::xrPoseToMat4(scaleXrPosePosition(view.pose, _xrToSceneScale));
+        const Mat4 projection = OpenXRDriver::xrFovToProjection(view.fov, _nearZ, _farZ);
+        const Mat4 primaryEyeToWorld = trackingToWorld * eyeToTracking;
+        const Mat4 primaryEyeView    = primaryEyeToWorld.getInversed();
 
-        int passCount          = 0;
-        bool renderedScenePass = false;
-        Camera* eyeCamera      = nullptr;
+        Vec3 primaryEyePosition = Vec3::zero;
+        primaryEyeToWorld.getTranslation(&primaryEyePosition);
+        const auto primaryEyeViewData = SceneViewData::fromMatrices(primaryEyeView, projection, primaryEyePosition);
+
+        int passCount = 0;
+
         for (const auto& camera : scene->getCameras())
         {
-            if (!camera->isVisible())
+            if (!camera || !camera->isVisible())
                 continue;
 
-            if (!eyeCamera)
-                eyeCamera = camera;
+            const Mat4 cameraEyeToWorld = camera->getNodeToWorldTransform() * eyeToTracking;
+            const Mat4 cameraEyeView    = cameraEyeToWorld.getInversed();
 
-            Camera::setVisitingCamera(camera);
+            Vec3 cameraEyePosition = Vec3::zero;
+            cameraEyeToWorld.getTranslation(&cameraEyePosition);
+            const auto cameraEyeViewData =
+                SceneViewData::fromMatrices(cameraEyeView, projection, cameraEyePosition);
 
-            const Mat4 originalProjection = camera->getProjectionMatrix();
-            camera->setAdditionalTransform(eyeTransform);
-            camera->setProjectionMatrix(OpenXRDriver::xrFovToProjection(view.fov, _nearZ, _farZ));
-            camera->updateViewProjectionState();
+            SceneRenderState renderState(renderer, camera, cameraEyeViewData);
 
             _rtPass->begin();
+
             if (passCount++ == 0)
             {
                 _rtPass->clear(ClearFlag::COLOR | ClearFlag::DEPTH_AND_STENCIL,
                                {.color = clearColor, .depth = 1.0f, .stencil = 0});
-                camera->clearBackground();
+                camera->clearBackground(renderState);
             }
             else
+            {
                 _rtPass->clear(ClearFlag::DEPTH_AND_STENCIL, {.depth = 1.0f, .stencil = 0});
+            }
+
             renderer->addCallbackCommand([this, scissorTransform]() { _scissorTransformStack.push(scissorTransform); });
-            scene->visit(renderer, transform, 0);
+
+            scene->visit(renderState, transform, 0);
+
             renderer->addCallbackCommand([this]() {
                 if (!_scissorTransformStack.empty())
                     _scissorTransformStack.pop();
             });
+
             _rtPass->end();
-
             renderer->render();
-            renderedScenePass = true;
-
-            camera->setProjectionMatrix(originalProjection);
-            camera->setAdditionalTransform(Mat4::identity);
         }
 
-        auto rayCamera = _pointerRayCamera ? _pointerRayCamera.get() : eyeCamera;
-        if (rayCamera)
+        if (_controllerRayVisible)
         {
-            Camera::setVisitingCamera(rayCamera);
-
-            const Mat4 originalProjection = rayCamera->getProjectionMatrix();
-            rayCamera->setAdditionalTransform(eyeTransform);
-            rayCamera->setProjectionMatrix(OpenXRDriver::xrFovToProjection(view.fov, _nearZ, _farZ));
-            rayCamera->updateViewProjectionState();
-
             _rtPass->begin();
-            drawControllerRays(renderer, eyeIdx, view);
+            drawControllerRays(renderer, primaryEyeViewData);
             _rtPass->end();
             renderer->render();
-
-            rayCamera->setProjectionMatrix(originalProjection);
-            rayCamera->setAdditionalTransform(Mat4::identity);
-            Camera::setVisitingCamera(nullptr);
         }
     }
-
-    Camera::setVisitingCamera(nullptr);
 
     renderer->submitCurrentFrameCommands(true);
     _xrDriver->releaseSwapchains(acquired);

--- a/axmol/vr/VRSceneCompositor.h
+++ b/axmol/vr/VRSceneCompositor.h
@@ -32,6 +32,7 @@ namespace ax
 {
 
 class Camera;
+struct SceneViewData;
 
 inline namespace experimental
 {
@@ -42,6 +43,12 @@ struct VRScissorTransform
     float sy{1.0f};
     float ox{0.0f};
     float oy{0.0f};
+};
+
+enum class ControllerRayVisualStyle
+{
+    Straight,
+    SubtleCurve,
 };
 
 /**
@@ -68,6 +75,8 @@ public:
 
     void setControllerRayVisible(bool visible) { _controllerRayVisible = visible; }
     void setControllerRayLength(float length) { _controllerRayLength = length; }
+    void setControllerRayVisualStyle(ControllerRayVisualStyle style) { _controllerRayVisualStyle = style; }
+    ControllerRayVisualStyle getControllerRayVisualStyle() const { return _controllerRayVisualStyle; }
     void setControllerRayColors(const Color& idle, const Color& pressed, const Color& hit);
     void setXrToSceneScale(float scale);
     float getXrToSceneScale() const { return _xrToSceneScale; }
@@ -86,12 +95,11 @@ protected:
     const ScissorRect& getScissorRect() const override;
 
 private:
+    void resolveXrFrameInput(Scene* scene);
     void ensureControllerRayResources();
     void shutdownControllerRayResources();
-    Camera* ensurePointerRayCamera(Scene* scene);
-    Camera* selectPointerRaySourceCamera(Scene* scene) const;
-    void syncPointerRayCamera(Scene* scene);
-    void drawControllerRays(Renderer* renderer, uint32_t eyeIdx, const XrView& view);
+    Camera* resolveXrViewCamera(Scene* scene) const;
+    void drawControllerRays(Renderer* renderer, const SceneViewData& view);
     void onBeforeControllerRayDraw();
     void onAfterControllerRayDraw();
 
@@ -101,20 +109,21 @@ private:
     rhi::UniformLocation _controllerRayMVPLocation;
     bool _controllerRayResourcesInitialized{false};
     bool _controllerRayVisible{true};
-    float _controllerRayLength{10.0f};
+    ControllerRayVisualStyle _controllerRayVisualStyle{ControllerRayVisualStyle::SubtleCurve};
+    float _controllerRayLength{50.0f};
     Color _controllerRayIdleColor{0.25f, 0.75f, 1.0f, 0.9f};
     Color _controllerRayPressedColor{1.0f, 1.0f, 1.0f, 1.0f};
     Color _controllerRayHitColor{0.2f, 1.0f, 0.6f, 1.0f};
     bool _controllerRayOldDepthTest{false};
     bool _controllerRayOldDepthWrite{false};
-    uint32_t _controllerRayDebugFrameCounter{0};
 
     float _nearZ{0.1f};
     float _farZ{1000.0f};
     float _xrToSceneScale{1.0f};
+    Mat4 _frameTrackingToWorld{Mat4::identity};
+    bool _frameTrackingToWorldValid{false};
 
     RefPtr<RenderTexturePass> _rtPass;
-    RefPtr<Camera> _pointerRayCamera;
 
     ScissorRect _sourceScissorRect;
     LinearStack<VRScissorTransform> _scissorTransformStack;

--- a/extensions/DragonBones/src/DragonBones/CCArmatureDisplay.cpp
+++ b/extensions/DragonBones/src/DragonBones/CCArmatureDisplay.cpp
@@ -159,7 +159,8 @@ void DBCCSprite::draw(const ax::SceneRenderState& state, const ax::Mat4& transfo
     if (_insideBounds)
 #endif
     {
-        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags, state.getView());
+        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags,
+                               state.getView());
         state.getRenderer()->addCommand(&_trianglesCommand);
 
 #if AX_SPRITE_DEBUG_DRAW

--- a/extensions/DragonBones/src/DragonBones/CCArmatureDisplay.cpp
+++ b/extensions/DragonBones/src/DragonBones/CCArmatureDisplay.cpp
@@ -131,66 +131,36 @@ DBCCSprite* DBCCSprite::create()
     return sprite;
 }
 
-bool DBCCSprite::_checkVisibility(const ax::Mat4& transform, const ax::Size& size, const ax::Rect& rect)
+bool DBCCSprite::_checkVisibility(const ax::SceneRenderState& state,
+                                  const ax::Mat4& transform,
+                                  const ax::Size& size,
+                                  const ax::Rect& rect)
 {
-    auto scene = ax::Director::getInstance()->getRunningScene();
-
-    // If draw to Rendertexture, return true directly.
-    //  only cull the default camera. The culling algorithm is valid for default camera.
-    if (!scene || (scene && scene->getDefaultCamera() != ax::Camera::getVisitingCamera()))
-        return true;
-
-    auto director = ax::Director::getInstance();
-    ax::Rect visiableRect(director->getVisibleOrigin(), director->getVisibleSize());
-
-    // transform center point to screen space
-    float hSizeX = size.width / 2;
-    float hSizeY = size.height / 2;
-
-    ax::Vec3 v3p(hSizeX, hSizeY, 0);
-
-    transform.transformPoint(&v3p);
-    ax::Vec2 v2p = ax::Camera::getVisitingCamera()->projectWorldToCanvas(v3p);
-
-    // convert content size to world coordinates
-    float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]),
-                          fabsf(hSizeX * transform.m[0] - hSizeY * transform.m[4]));
-    float wshh = std::max(fabsf(hSizeX * transform.m[1] + hSizeY * transform.m[5]),
-                          fabsf(hSizeX * transform.m[1] - hSizeY * transform.m[5]));
-
-    // enlarge visible rect half size in screen coord
-    visiableRect.origin.x -= wshw;
-    visiableRect.origin.y -= wshh;
-    visiableRect.size.width += wshw * 2;
-    visiableRect.size.height += wshh * 2;
-    bool ret = visiableRect.containsPoint(v2p);
-    return ret;
+    return state.checkVisibility(transform, size);
 }
 
-void DBCCSprite::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void DBCCSprite::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
 #if AX_USE_CULLING
     const auto& rect = _polyInfo.getRect();
 
     // Don't do calculate the culling if the transform was not updated
-    auto visitingCamera = ax::Camera::getVisitingCamera();
-    auto defaultCamera  = ax::Camera::getDefaultCamera();
-    if (visitingCamera == defaultCamera)
+    auto visitingCamera = state.getCamera();
+    if (visitingCamera)
     {
-        _insideBounds = ((flags & FLAGS_TRANSFORM_DIRTY) || visitingCamera->isViewProjectionUpdated())
-                            ? _checkVisibility(transform, _contentSize, rect)
-                            : _insideBounds;
+        _insideBounds = state.requiresVisibilityUpdate(flags) ? _checkVisibility(state, transform, _contentSize, rect)
+                                                              : _insideBounds;
     }
     else
     {
-        _insideBounds = _checkVisibility(transform, _contentSize, rect);
+        _insideBounds = _checkVisibility(state, transform, _contentSize, rect);
     }
 
     if (_insideBounds)
 #endif
     {
-        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags);
-        renderer->addCommand(&_trianglesCommand);
+        _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags, state.getView());
+        state.getRenderer()->addCommand(&_trianglesCommand);
 
 #if AX_SPRITE_DEBUG_DRAW
         _debugDrawNode->clear();

--- a/extensions/DragonBones/src/DragonBones/CCArmatureDisplay.h
+++ b/extensions/DragonBones/src/DragonBones/CCArmatureDisplay.h
@@ -126,13 +126,16 @@ protected:
     /**
      * Modify for polyInfo rect
      */
-    bool _checkVisibility(const ax::Mat4& transform, const ax::Size& size, const ax::Rect& rect);
+    bool _checkVisibility(const ax::SceneRenderState& state,
+                          const ax::Mat4& transform,
+                          const ax::Size& size,
+                          const ax::Rect& rect);
 
 public:
     /**
      * Modify for polyInfo rect
      */
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
     /**
      * Modify for cocos2dx 3.7, 3.8, 3.9
      */

--- a/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
@@ -669,7 +669,7 @@ void EffectEmitter::update(float delta)
 	}
 }
 
-void EffectEmitter::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& parentTransform, uint32_t parentFlags)
+void EffectEmitter::draw(const cocos2d::SceneRenderState& state, const cocos2d::Mat4& parentTransform, uint32_t parentFlags)
 {
     if (!manager->getInternalManager()->GetShown(handle) ||
         manager->getInternalManager()->GetTotalInstanceCount() < 1)
@@ -681,7 +681,7 @@ void EffectEmitter::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& paren
         ax::Director::getInstance()->getRenderer()->setFrameBufferOnly(false);
     }
 
-    auto renderCommand = renderer->nextCallbackCommand();
+    auto renderCommand = state.getRenderer()->nextCallbackCommand();
 
 	renderCommand->init(_globalZOrder);
 
@@ -704,8 +704,8 @@ void EffectEmitter::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& paren
 		renderer2d->EndRendering();
 
 		// Count drawcall and vertex
-		renderer->addDrawnBatches(renderer2d->GetDrawCallCount());
-		renderer->addDrawnVertices(renderer2d->GetDrawVertexCount());
+		state.getRenderer()->addDrawnBatches(renderer2d->GetDrawCallCount());
+		state.getRenderer()->addDrawnVertices(renderer2d->GetDrawVertexCount());
 		renderer2d->ResetDrawCallCount();
 		renderer2d->ResetDrawVertexCount();
 
@@ -714,9 +714,9 @@ void EffectEmitter::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& paren
         }
 	};
 
-	renderer->addCommand(renderCommand);
+	state.getRenderer()->addCommand(renderCommand);
 
-	cocos2d::Node::draw(renderer, parentTransform, parentFlags);
+	cocos2d::Node::draw(state, parentTransform, parentFlags);
 }
 
 ::Effekseer::Handle EffectManager::play(Effect* effect, float x, float y, float z)

--- a/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.cpp
@@ -688,7 +688,9 @@ void EffectEmitter::draw(const cocos2d::SceneRenderState& state, const cocos2d::
 	auto renderer2d = manager->getInternalRenderer();
 	Effekseer::Matrix44 mCamera = renderer2d->GetCameraMatrix();
 	Effekseer::Matrix44 mProj = renderer2d->GetProjectionMatrix();
+    Effekseer::Manager::LayerParameter layerParameter = manager->getInternalManager()->GetLayerParameter(0);
 	renderCommand->func = [=]() -> void {
+        manager->getInternalManager()->SetLayerParameter(0, layerParameter);
 		renderer2d->SetCameraMatrix(mCamera);
 		renderer2d->SetProjectionMatrix(mProj);
 
@@ -841,8 +843,11 @@ void EffectManager::setIsDistortionEnabled(bool value)
     }
 }
 
-void EffectManager::begin(cocos2d::Renderer* renderer, float globalZOrder)
+void EffectManager::begin(const cocos2d::SceneRenderState& state, float globalZOrder)
 {
+    setCameraMatrix(state.getViewMatrix());
+    setProjectionMatrix(state.getProjectionMatrix());
+
 	if (isDistortionEnabled)
 	{
 		isDistorted = false;
@@ -854,6 +859,8 @@ void EffectManager::begin(cocos2d::Renderer* renderer, float globalZOrder)
 	}
 
     newFrame();
+
+    AX_UNUSED_PARAM(globalZOrder);
 
 	// TODO Batch render
 	/*
@@ -869,12 +876,15 @@ void EffectManager::begin(cocos2d::Renderer* renderer, float globalZOrder)
 
 
 
-	renderer->addCommand(&beginCommand);
+	state.getRenderer()->addCommand(&beginCommand);
 	*/
 }
 
-void EffectManager::end(cocos2d::Renderer* renderer, float globalZOrder)
+void EffectManager::end(const cocos2d::SceneRenderState& state, float globalZOrder)
 {
+    AX_UNUSED_PARAM(state);
+    AX_UNUSED_PARAM(globalZOrder);
+
 	// TODO Batch render
 	/*
 	endCommand.init(globalZOrder);
@@ -884,7 +894,7 @@ void EffectManager::end(cocos2d::Renderer* renderer, float globalZOrder)
 		renderer2d->EndRendering();
 	};
 
-	renderer->addCommand(&endCommand);
+	state.getRenderer()->addCommand(&endCommand);
 	*/
 }
 

--- a/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.h
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.h
@@ -377,14 +377,14 @@ public:
 		\~English	Inherit visit and add a process before drawing the layer.
 		\~Japanese	visitを継承してレイヤーの描画を行う前に実行する。
 	*/
-	void begin(cocos2d::Renderer* renderer, float globalZOrder);
+	void begin(const cocos2d::SceneRenderState& state, float globalZOrder);
 
 	/**
 		@brief
 		\~English	Inherit visit and add a process after drawing the layer.
 		\~Japanese	visitを継承してレイヤーの描画を行った後に実行する。
 	*/
-	void end(cocos2d::Renderer* renderer, float globalZOrder);
+	void end(const cocos2d::SceneRenderState& state, float globalZOrder);
 
     /**
         @brief

--- a/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.h
+++ b/extensions/Effekseer/EffekseerForCocos2d-x/EffekseerForCocos2d-x.h
@@ -298,7 +298,7 @@ public:
 
 	void update(float delta) override;
 
-	void draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& parentTransform, uint32_t parentFlags) override;
+	void draw(const cocos2d::SceneRenderState& state, const cocos2d::Mat4& parentTransform, uint32_t parentFlags) override;
 };
 
 class EffectManager : public cocos2d::Object

--- a/extensions/GUI/src/GUI/ScrollView/ScrollView.cpp
+++ b/extensions/GUI/src/GUI/ScrollView/ScrollView.cpp
@@ -655,7 +655,7 @@ void ScrollView::onAfterDraw()
     }
 }
 
-void ScrollView::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void ScrollView::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible
     if (!isVisible())
@@ -663,10 +663,10 @@ void ScrollView::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     this->beforeDraw();
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
 
     if (!_children.empty())
     {
@@ -678,7 +678,7 @@ void ScrollView::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t
             Node* child = _children.at(i);
             if (child->getLocalZOrder() < 0)
             {
-                child->visit(renderer, _modelViewTransform, flags);
+                child->visit(state, _modelViewTransform, flags);
             }
             else
             {
@@ -688,18 +688,18 @@ void ScrollView::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t
 
         // this draw
         if (visibleByCamera)
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
 
         // draw children zOrder >= 0
         for (; i < _children.size(); i++)
         {
             Node* child = _children.at(i);
-            child->visit(renderer, _modelViewTransform, flags);
+            child->visit(state, _modelViewTransform, flags);
         }
     }
     else if (visibleByCamera)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
     }
 
     this->afterDraw();

--- a/extensions/GUI/src/GUI/ScrollView/ScrollView.h
+++ b/extensions/GUI/src/GUI/ScrollView/ScrollView.h
@@ -241,7 +241,7 @@ public:
     /**
      * @lua NA
      */
-    void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags) override;
 
     using Node::addChild;
     void addChild(Node* child, int zOrder, int tag) override;

--- a/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
+++ b/extensions/ImGui/src/ImGui/backends/imgui_impl_axmol.cpp
@@ -450,8 +450,12 @@ IMGUI_IMPL_API void ImGui_ImplAxmol_RenderDrawData(ImDrawData* draw_data)
                         const auto tr = node->getNodeToParentTransform();
                         node->setVisible(true);
                         node->setNodeToParentTransform(tr);
-                        const auto& proj = Camera::getDefaultCamera()->getViewProjectionMatrix();
-                        node->visit(Director::getInstance()->getRenderer(), proj.getInversed() * bd->Projection, 0);
+                        auto director = Director::getInstance();
+                        auto scene    = director->getRunningScene();
+                        auto camera   = scene ? scene->getDefaultCamera() : nullptr;
+                        const auto& proj = camera ? camera->getViewProjectionMatrix() : Mat4::identity;
+                        SceneRenderState renderState(director->getRenderer(), camera);
+                        node->visit(renderState, proj.getInversed() * bd->Projection, 0);
                         node->setVisible(false);
                     }
                 }

--- a/extensions/Particle3D/src/Particle3D/PU/PUBeamRender.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PUBeamRender.cpp
@@ -58,7 +58,7 @@ PUBeamRender* PUBeamRender::create(std::string_view texFile)
     return br;
 }
 
-void PUBeamRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUBeamRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     const ParticlePool& particlePool = particleSystem->getParticlePool();
     if (!_isVisible || particlePool.empty() || !_billboardChain)
@@ -106,7 +106,7 @@ void PUBeamRender::render(Renderer* renderer, const Mat4& transform, ParticleSys
         }
     }
 
-    _billboardChain->render(renderer, transform, particleSystem);
+    _billboardChain->render(state, transform, particleSystem);
 }
 
 PUBeamRender::PUBeamRender()

--- a/extensions/Particle3D/src/Particle3D/PU/PUBeamRender.h
+++ b/extensions/Particle3D/src/Particle3D/PU/PUBeamRender.h
@@ -93,7 +93,7 @@ public:
     void unPrepare() override;
     void updateRender(PUParticle3D* particle, float deltaTime, bool firstParticle) override;
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
     void particleEmitted(PUParticleSystem3D* particleSystem, PUParticle3D* particle) override;
     void particleExpired(PUParticleSystem3D* particleSystem, PUParticle3D* particle) override;
 

--- a/extensions/Particle3D/src/Particle3D/PU/PUBillboardChain.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PUBillboardChain.cpp
@@ -91,7 +91,7 @@ PUBillboardChain::PUBillboardChain(std::string_view /*name*/,
 //-----------------------------------------------------------------------
 PUBillboardChain::~PUBillboardChain()
 {
-    // AX_SAFE_RELEASE(_texture);
+    AX_SAFE_RELEASE(_texture);
     AX_SAFE_RELEASE(_programState);
     AX_SAFE_RELEASE(_vertexBuffer);
     AX_SAFE_RELEASE(_indexBuffer);
@@ -393,7 +393,7 @@ size_t PUBillboardChain::getNumChainElements(size_t chainIndex) const
     }
 }
 //-----------------------------------------------------------------------
-void PUBillboardChain::updateVertexBuffer(const Mat4& camMat)
+void PUBillboardChain::updateVertexBuffer(const Vec3& eyePos)
 {
     setupBuffers();
 
@@ -412,8 +412,6 @@ void PUBillboardChain::updateVertexBuffer(const Mat4& camMat)
     // const Vector3& camPos = cam->getDerivedPosition();
     // Vector3 eyePos = mParentNode->_getDerivedOrientation().Inverse() *
     //	(camPos - mParentNode->_getDerivedPosition()) / mParentNode->_getDerivedScale();
-
-    Vec3 eyePos(camMat.m[12], camMat.m[13], camMat.m[14]);
 
     Vec3 chainTangent;
     for (ChainSegmentList::iterator segi = _chainSegmentList.begin(); segi != _chainSegmentList.end(); ++segi)
@@ -630,13 +628,14 @@ void PUBillboardChain::updateIndexBuffer()
 void PUBillboardChain::init(std::string_view texFile)
 {
     AX_SAFE_RELEASE_NULL(_programState);
+    AX_SAFE_RELEASE_NULL(_texture);
 
     if (!texFile.empty())
     {
         auto tex = Director::getInstance()->getTextureCache()->addImage(texFile);
         if (tex)
         {
-            _texture      = tex;
+            Object::assign(_texture, tex);
             auto* program = axpm->getBuiltinProgram(rhi::ProgramType::PARTICLE_TEXTURE_3D);
             _programState = new rhi::ProgramState(program);
         }
@@ -668,14 +667,11 @@ void PUBillboardChain::init(std::string_view texFile)
     _meshCommand.setAfterCallback(AX_CALLBACK_0(PUBillboardChain::onAfterDraw, this));
 }
 
-void PUBillboardChain::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUBillboardChain::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
-    auto camera    = Camera::getVisitingCamera();
-    auto cameraMat = camera->getNodeToWorldTransform();
-
     if (!_chainSegmentList.empty())
     {
-        updateVertexBuffer(cameraMat);
+        updateVertexBuffer(state.getView().position);
         updateIndexBuffer();
 
         _meshCommand.setVertexBuffer(_vertexBuffer);
@@ -687,7 +683,7 @@ void PUBillboardChain::render(Renderer* renderer, const Mat4& transform, Particl
             _meshCommand.init(0.0);
             _stateBlock.setBlendFunc(particleSystem->getBlendFunc());
 
-            const auto& projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+            const auto& projectionMatrix = state.getViewProjectionMatrix();
             _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
             if (_texture)
@@ -698,7 +694,7 @@ void PUBillboardChain::render(Renderer* renderer, const Mat4& transform, Particl
             auto uColor = Vec4(1, 1, 1, 1);
             _programState->setUniform(_locColor, &uColor, sizeof(uColor));
 
-            renderer->addCommand(&_meshCommand);
+            state.getRenderer()->addCommand(&_meshCommand);
         }
     }
 }

--- a/extensions/Particle3D/src/Particle3D/PU/PUBillboardChain.h
+++ b/extensions/Particle3D/src/Particle3D/PU/PUBillboardChain.h
@@ -43,6 +43,7 @@ class VertexBuffer;
 class Texture2D;
 class ParticleSystem3D;
 class Renderer;
+struct SceneRenderState;
 
 class PUBillboardChain
 {
@@ -224,7 +225,7 @@ public:
     void setDepthWrite(bool isDepthWrite);
     void setBlendFunc(const BlendFunc& blendFunc);
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem);
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem);
 
     // Overridden members follow
     // void _updateRenderQueue(RenderQueue*);
@@ -241,7 +242,7 @@ protected:
     // Setup buffers
     virtual void setupBuffers();
     /// Update the contents of the vertex buffer
-    virtual void updateVertexBuffer(const Mat4& camMat);
+    virtual void updateVertexBuffer(const Vec3& eyePos);
     /// Update the contents of the index buffer
     virtual void updateIndexBuffer();
 

--- a/extensions/Particle3D/src/Particle3D/PU/PUParticleSystem3D.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PUParticleSystem3D.cpp
@@ -1291,14 +1291,14 @@ void PUParticleSystem3D::removeAllListener()
     _listeners.clear();
 }
 
-void PUParticleSystem3D::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void PUParticleSystem3D::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (!_isEnabled)
         return;
     if (getAliveParticleCount() <= 0)
         return;
     if (_render)
-        _render->render(renderer, transform, this);
+        _render->render(state, transform, this);
 
     if (!_emittedSystemParticlePool.empty())
     {
@@ -1307,7 +1307,7 @@ void PUParticleSystem3D::draw(Renderer* renderer, const Mat4& transform, uint32_
             PUParticle3D* particle = static_cast<PUParticle3D*>(const_cast<ParticlePool&>(iter.second).getFirst());
             while (particle)
             {
-                static_cast<PUParticleSystem3D*>(particle->particleEntityPtr)->draw(renderer, transform, flags);
+                static_cast<PUParticleSystem3D*>(particle->particleEntityPtr)->draw(state, transform, flags);
                 particle = static_cast<PUParticle3D*>(const_cast<ParticlePool&>(iter.second).getNext());
             }
         }

--- a/extensions/Particle3D/src/Particle3D/PU/PUParticleSystem3D.h
+++ b/extensions/Particle3D/src/Particle3D/PU/PUParticleSystem3D.h
@@ -221,7 +221,7 @@ public:
     static PUParticleSystem3D* create(std::string_view filePath);
     static PUParticleSystem3D* create(std::string_view filePath, std::string_view materialPath);
 
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     void update(float delta) override;
     void forceUpdate(float delta);

--- a/extensions/Particle3D/src/Particle3D/PU/PURender.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PURender.cpp
@@ -72,7 +72,7 @@ PUParticle3DQuadRender* PUParticle3DQuadRender::create(std::string_view texFile)
     return ret;
 }
 
-void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUParticle3DQuadRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();
@@ -108,8 +108,7 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4& transform, P
         _indices.resize(activeParticleList.size() * 6);
     }
 
-    auto camera    = Camera::getVisitingCamera();
-    auto cameraMat = camera->getNodeToWorldTransform();
+    const Mat4 viewToWorld = state.getViewMatrix().getInversed();
 
     // for (auto&& iter : activeParticleList){
     //     iter->depthInView = -(viewMat.m[2] * iter->positionInWorld.x + viewMat.m[6] * iter->positionInWorld.y +
@@ -117,9 +116,9 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4& transform, P
     // }
 
     // std::sort(activeParticleList.begin(), activeParticleList.end(), compareParticle3D);
-    Vec3 right(cameraMat.m[0], cameraMat.m[1], cameraMat.m[2]);
-    Vec3 up(cameraMat.m[4], cameraMat.m[5], cameraMat.m[6]);
-    Vec3 backward(cameraMat.m[8], cameraMat.m[9], cameraMat.m[10]);
+    Vec3 right(viewToWorld.m[0], viewToWorld.m[1], viewToWorld.m[2]);
+    Vec3 up(viewToWorld.m[4], viewToWorld.m[5], viewToWorld.m[6]);
+    Vec3 backward(viewToWorld.m[8], viewToWorld.m[9], viewToWorld.m[10]);
 
     Mat4 pRotMat;
     Vec3 position;  // particle position
@@ -284,10 +283,10 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4& transform, P
         auto uColor = Vec4(1, 1, 1, 1);
         _programState->setUniform(_locColor, &uColor, sizeof(uColor));
 
-        const auto& projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+        const auto& projectionMatrix = state.getViewProjectionMatrix();
         _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
-        renderer->addCommand(&_meshCommand);
+        state.getRenderer()->addCommand(&_meshCommand);
     }
 }
 
@@ -494,7 +493,7 @@ PUParticle3DModelRender* PUParticle3DModelRender::create(std::string_view modelF
     return ret;
 }
 
-void PUParticle3DModelRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUParticle3DModelRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     if (!_isVisible)
         return;
@@ -551,7 +550,7 @@ void PUParticle3DModelRender::render(Renderer* renderer, const Mat4& transform, 
         if (_meshList[index]->getCameraMask() != particleSystem->getCameraMask())
             _meshList[index]->setCameraMask(particleSystem->getCameraMask());
         _meshList[index]->setColor(Color32(particle->color));
-        _meshList[index]->visit(renderer, mat, Node::FLAGS_DIRTY_MASK);
+        _meshList[index]->visit(state, mat, Node::FLAGS_DIRTY_MASK);
         ++index;
     }
 }
@@ -602,7 +601,7 @@ PUParticle3DEntityRender::PUParticle3DEntityRender()
 
 PUParticle3DEntityRender::~PUParticle3DEntityRender()
 {
-    // AX_SAFE_RELEASE(_texture);
+    AX_SAFE_RELEASE(_texture);
     AX_SAFE_RELEASE(_programState);
     AX_SAFE_RELEASE(_vertexBuffer);
     AX_SAFE_RELEASE(_indexBuffer);
@@ -612,12 +611,13 @@ PUParticle3DEntityRender::~PUParticle3DEntityRender()
 bool PUParticle3DEntityRender::initRender(std::string_view texFile)
 {
     AX_SAFE_RELEASE_NULL(_programState);
+    AX_SAFE_RELEASE_NULL(_texture);
     if (!texFile.empty())
     {
         auto tex = Director::getInstance()->getTextureCache()->addImage(texFile);
         if (tex)
         {
-            _texture      = tex;
+            Object::assign(_texture, tex);
             auto* program = axpm->getBuiltinProgram(rhi::ProgramType::PARTICLE_TEXTURE_3D);
             _programState = new rhi::ProgramState(program);
         }
@@ -681,16 +681,15 @@ PUParticle3DBoxRender* PUParticle3DBoxRender::create(std::string_view texFile)
     return ret;
 }
 
-void PUParticle3DBoxRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUParticle3DBoxRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();
     if (!_isVisible || particlePool.empty())
         return;
 
-    auto camera    = Camera::getVisitingCamera();
-    auto cameraMat = camera->getNodeToWorldTransform();
-    Vec3 backward(cameraMat.m[8], cameraMat.m[9], cameraMat.m[10]);
+    const Mat4 viewToWorld = state.getViewMatrix().getInversed();
+    Vec3 backward(viewToWorld.m[8], viewToWorld.m[9], viewToWorld.m[10]);
 
     if (_vertexBuffer == nullptr && _indexBuffer == nullptr)
     {
@@ -785,12 +784,12 @@ void PUParticle3DBoxRender::render(Renderer* renderer, const Mat4& transform, Pa
             _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
         }
 
-        const auto& projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+        const auto& projectionMatrix = state.getViewProjectionMatrix();
         _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
         _meshCommand.setIndexDrawInfo(0, _indices.size());
 
-        renderer->addCommand(&_meshCommand);
+        state.getRenderer()->addCommand(&_meshCommand);
     }
 }
 
@@ -867,16 +866,15 @@ PUSphereRender* PUSphereRender::create(std::string_view texFile)
     return ret;
 }
 
-void PUSphereRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUSphereRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();
     if (!_isVisible || particlePool.empty())
         return;
 
-    auto camera    = Camera::getVisitingCamera();
-    auto cameraMat = camera->getNodeToWorldTransform();
-    Vec3 backward(cameraMat.m[8], cameraMat.m[9], cameraMat.m[10]);
+    const Mat4 viewToWorld = state.getViewMatrix().getInversed();
+    Vec3 backward(viewToWorld.m[8], viewToWorld.m[9], viewToWorld.m[10]);
 
     unsigned int vertexCount = (_numberOfRings + 1) * (_numberOfSegments + 1);
     unsigned int indexCount  = 6 * _numberOfRings * (_numberOfSegments + 1);
@@ -956,10 +954,10 @@ void PUSphereRender::render(Renderer* renderer, const Mat4& transform, ParticleS
             _programState->setTexture(_locTexture, 0, _texture->getRHITexture());
         }
 
-        const auto& projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+        const auto& projectionMatrix = state.getViewProjectionMatrix();
         _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
-        renderer->addCommand(&_meshCommand);
+        state.getRenderer()->addCommand(&_meshCommand);
     }
 }
 

--- a/extensions/Particle3D/src/Particle3D/PU/PURender.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PURender.cpp
@@ -72,7 +72,9 @@ PUParticle3DQuadRender* PUParticle3DQuadRender::create(std::string_view texFile)
     return ret;
 }
 
-void PUParticle3DQuadRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUParticle3DQuadRender::render(const SceneRenderState& state,
+                                    const Mat4& transform,
+                                    ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();
@@ -493,7 +495,9 @@ PUParticle3DModelRender* PUParticle3DModelRender::create(std::string_view modelF
     return ret;
 }
 
-void PUParticle3DModelRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUParticle3DModelRender::render(const SceneRenderState& state,
+                                     const Mat4& transform,
+                                     ParticleSystem3D* particleSystem)
 {
     if (!_isVisible)
         return;
@@ -681,7 +685,9 @@ PUParticle3DBoxRender* PUParticle3DBoxRender::create(std::string_view texFile)
     return ret;
 }
 
-void PUParticle3DBoxRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PUParticle3DBoxRender::render(const SceneRenderState& state,
+                                   const Mat4& transform,
+                                   ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();

--- a/extensions/Particle3D/src/Particle3D/PU/PURender.h
+++ b/extensions/Particle3D/src/Particle3D/PU/PURender.h
@@ -154,7 +154,7 @@ public:
     void setTextureCoordsColumns(unsigned short textureCoordsColumns);
     unsigned int getNumTextureCoords();
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
 
     PUParticle3DQuadRender* clone() override;
     void copyAttributesTo(PUParticle3DQuadRender* render);
@@ -187,7 +187,7 @@ class AX_EXT_API PUParticle3DModelRender : public PURender
 public:
     static PUParticle3DModelRender* create(std::string_view modelFile, std::string_view texFile = "");
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
 
     PUParticle3DModelRender* clone() override;
     void copyAttributesTo(PUParticle3DModelRender* render);
@@ -208,7 +208,7 @@ class AX_EXT_API PUParticle3DBoxRender : public PUParticle3DEntityRender
 public:
     static PUParticle3DBoxRender* create(std::string_view texFile = "");
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
 
     PUParticle3DBoxRender* clone() override;
 
@@ -224,7 +224,7 @@ class AX_EXT_API PUSphereRender : public PUParticle3DEntityRender
 public:
     static PUSphereRender* create(std::string_view texFile = "");
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
 
     PUSphereRender* clone() override;
     void copyAttributesTo(PUSphereRender* render);

--- a/extensions/Particle3D/src/Particle3D/PU/PURibbonTrailRender.cpp
+++ b/extensions/Particle3D/src/Particle3D/PU/PURibbonTrailRender.cpp
@@ -57,7 +57,7 @@ PURibbonTrailRender* PURibbonTrailRender::create(std::string_view texFile)
     return br;
 }
 
-void PURibbonTrailRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void PURibbonTrailRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     if (!_isVisible || !_trail)
         return;
@@ -93,7 +93,7 @@ void PURibbonTrailRender::render(Renderer* renderer, const Mat4& transform, Part
     }
 
     if (needDraw)
-        _trail->render(renderer, transform, particleSystem);
+        _trail->render(state, transform, particleSystem);
 }
 
 PURibbonTrailRender::PURibbonTrailRender()

--- a/extensions/Particle3D/src/Particle3D/PU/PURibbonTrailRender.h
+++ b/extensions/Particle3D/src/Particle3D/PU/PURibbonTrailRender.h
@@ -90,7 +90,7 @@ public:
     void unPrepare() override;
     void updateRender(PUParticle3D* particle, float deltaTime, bool firstParticle) override;
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
     void particleEmitted(PUParticleSystem3D* particleSystem, PUParticle3D* particle) override;
     void particleExpired(PUParticleSystem3D* particleSystem, PUParticle3D* particle) override;
 

--- a/extensions/Particle3D/src/Particle3D/Particle3DRender.cpp
+++ b/extensions/Particle3D/src/Particle3D/Particle3DRender.cpp
@@ -70,7 +70,9 @@ Particle3DQuadRender* Particle3DQuadRender::create(std::string_view texFile)
     return ret;
 }
 
-void Particle3DQuadRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
+void Particle3DQuadRender::render(const SceneRenderState& state,
+                                  const Mat4& transform,
+                                  ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();
@@ -106,7 +108,7 @@ void Particle3DQuadRender::render(const SceneRenderState& state, const Mat4& tra
         _indexData.resize(activeParticleList.size() * 6);
     }
 
-    const Mat4& viewMat = state.getViewMatrix();
+    const Mat4& viewMat    = state.getViewMatrix();
     const Mat4 viewToWorld = viewMat.getInversed();
 
     Mat4 pRotMat;
@@ -275,7 +277,9 @@ Particle3DModelRender* Particle3DModelRender::create(std::string_view modelFile,
     return ret;
 }
 
-void Particle3DModelRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
+void Particle3DModelRender::render(const SceneRenderState& state,
+                                   const Mat4& transform,
+                                   ParticleSystem3D* particleSystem)
 {
     if (!_isVisible)
         return;

--- a/extensions/Particle3D/src/Particle3D/Particle3DRender.cpp
+++ b/extensions/Particle3D/src/Particle3D/Particle3DRender.cpp
@@ -46,7 +46,7 @@ Particle3DQuadRender::Particle3DQuadRender()
 
 Particle3DQuadRender::~Particle3DQuadRender()
 {
-    // AX_SAFE_RELEASE(_texture);
+    AX_SAFE_RELEASE(_texture);
     AX_SAFE_RELEASE(_programState);
     AX_SAFE_RELEASE(_vertexBuffer);
     AX_SAFE_RELEASE(_indexBuffer);
@@ -70,7 +70,7 @@ Particle3DQuadRender* Particle3DQuadRender::create(std::string_view texFile)
     return ret;
 }
 
-void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void Particle3DQuadRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     // batch and generate draw
     const ParticlePool& particlePool = particleSystem->getParticlePool();
@@ -106,14 +106,13 @@ void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, Par
         _indexData.resize(activeParticleList.size() * 6);
     }
 
-    auto camera         = Camera::getVisitingCamera();
-    auto cameraMat      = camera->getNodeToWorldTransform();
-    const Mat4& viewMat = cameraMat.getInversed();
+    const Mat4& viewMat = state.getViewMatrix();
+    const Mat4 viewToWorld = viewMat.getInversed();
 
     Mat4 pRotMat;
-    Vec3 right(cameraMat.m[0], cameraMat.m[1], cameraMat.m[2]);
-    Vec3 up(cameraMat.m[4], cameraMat.m[5], cameraMat.m[6]);
-    Vec3 backward(cameraMat.m[8], cameraMat.m[9], cameraMat.m[10]);
+    Vec3 right(viewToWorld.m[0], viewToWorld.m[1], viewToWorld.m[2]);
+    Vec3 up(viewToWorld.m[4], viewToWorld.m[5], viewToWorld.m[6]);
+    Vec3 backward(viewToWorld.m[8], viewToWorld.m[9], viewToWorld.m[10]);
 
     Vec3 position;  // particle position
     int vertexindex = 0;
@@ -158,14 +157,13 @@ void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, Par
     _vertexBuffer->updateData(&_posuvcolors[0], vertexindex * sizeof(_posuvcolors[0]));
     _indexBuffer->updateData(&_indexData[0], index * sizeof(_indexData[0]));
 
-    float depthZ = -(viewMat.m[2] * transform.m[12] + viewMat.m[6] * transform.m[13] + viewMat.m[10] * transform.m[14] +
-                     viewMat.m[14]);
+    float depthZ = state.getDepthInView(transform);
 
-    auto beforeCommand = renderer->nextCallbackCommand();
+    auto beforeCommand = state.getRenderer()->nextCallbackCommand();
     beforeCommand->init(depthZ);
     _meshCommand.init(depthZ);
 
-    auto afterCommand = renderer->nextCallbackCommand();
+    auto afterCommand = state.getRenderer()->nextCallbackCommand();
     afterCommand->init(depthZ);
 
     beforeCommand->func = [this] { onBeforeDraw(); };  // AX_CALLBACK_0(Particle3DQuadRender::onBeforeDraw, this);
@@ -174,7 +172,7 @@ void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, Par
     _meshCommand.setVertexBuffer(_vertexBuffer);
     _meshCommand.setIndexBuffer(_indexBuffer, MeshCommand::IndexFormat::U_SHORT);
 
-    const auto& projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMatrix = state.getViewProjectionMatrix();
     _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
     if (_texture)
@@ -187,21 +185,22 @@ void Particle3DQuadRender::render(Renderer* renderer, const Mat4& transform, Par
 
     _meshCommand.setIndexDrawInfo(0, index);
 
-    renderer->addCommand(beforeCommand);
-    renderer->addCommand(&_meshCommand);
-    renderer->addCommand(afterCommand);
+    state.getRenderer()->addCommand(beforeCommand);
+    state.getRenderer()->addCommand(&_meshCommand);
+    state.getRenderer()->addCommand(afterCommand);
 }
 
 bool Particle3DQuadRender::initQuadRender(std::string_view texFile)
 {
     AX_SAFE_RELEASE_NULL(_programState);
+    AX_SAFE_RELEASE_NULL(_texture);
 
     if (!texFile.empty())
     {
         auto tex = Director::getInstance()->getTextureCache()->addImage(texFile);
         if (tex)
         {
-            _texture      = tex;
+            Object::assign(_texture, tex);
             auto* program = axpm->getBuiltinProgram(rhi::ProgramType::PARTICLE_TEXTURE_3D);
             _programState = new rhi::ProgramState(program);
         }
@@ -276,7 +275,7 @@ Particle3DModelRender* Particle3DModelRender::create(std::string_view modelFile,
     return ret;
 }
 
-void Particle3DModelRender::render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem)
+void Particle3DModelRender::render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem)
 {
     if (!_isVisible)
         return;
@@ -323,7 +322,7 @@ void Particle3DModelRender::render(Renderer* renderer, const Mat4& transform, Pa
         mat.m[12]    = particle->position.x;
         mat.m[13]    = particle->position.y;
         mat.m[14]    = particle->position.z;
-        _meshList[index++]->draw(renderer, mat, 0);
+        _meshList[index++]->draw(state, mat, 0);
     }
 }
 

--- a/extensions/Particle3D/src/Particle3D/Particle3DRender.h
+++ b/extensions/Particle3D/src/Particle3D/Particle3DRender.h
@@ -40,6 +40,7 @@ namespace ax
 
 class ParticleSystem3D;
 class Renderer;
+struct SceneRenderState;
 class MeshCommand;
 class MeshRenderer;
 class IndexBuffer;
@@ -54,7 +55,7 @@ class AX_EXT_API Particle3DRender : public Object
     friend class ParticleSystem3D;
 
 public:
-    virtual void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) = 0;
+    virtual void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) = 0;
 
     /** Perform activities when a Renderer is started.
      */
@@ -96,7 +97,7 @@ class AX_EXT_API Particle3DQuadRender : public Particle3DRender
 public:
     static Particle3DQuadRender* create(std::string_view texFile = "");
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
 
     void reset() override;
     Particle3DQuadRender();
@@ -140,7 +141,7 @@ class AX_EXT_API Particle3DModelRender : public Particle3DRender
 public:
     static Particle3DModelRender* create(std::string_view modelFile, std::string_view texFile = "");
 
-    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem) override;
+    void render(const SceneRenderState& state, const Mat4& transform, ParticleSystem3D* particleSystem) override;
 
     void reset() override;
     Particle3DModelRender();

--- a/extensions/Particle3D/src/Particle3D/ParticleSystem3D.cpp
+++ b/extensions/Particle3D/src/Particle3D/ParticleSystem3D.cpp
@@ -169,11 +169,11 @@ void ParticleSystem3D::update(float delta)
     }
 }
 
-void ParticleSystem3D::draw(Renderer* renderer, const Mat4& transform, uint32_t /*flags*/)
+void ParticleSystem3D::draw(const SceneRenderState& state, const Mat4& transform, uint32_t /*flags*/)
 {
     if (getAliveParticleCount() && _render)
     {
-        _render->render(renderer, transform, this);
+        _render->render(state, transform, this);
     }
 }
 

--- a/extensions/Particle3D/src/Particle3D/ParticleSystem3D.h
+++ b/extensions/Particle3D/src/Particle3D/ParticleSystem3D.h
@@ -175,7 +175,7 @@ public:
     /**
      * override function
      */
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     /**
      * override function

--- a/extensions/fairygui/src/fairygui/display/FUIContainer.cpp
+++ b/extensions/fairygui/src/fairygui/display/FUIContainer.cpp
@@ -292,20 +292,20 @@ const Rect& FUIContainer::getClippingRect()
     return _rectClippingSupport->_clippingRect;
 }
 
-void FUIContainer::visit(ax::Renderer * renderer, const ax::Mat4 & parentTransform, uint32_t parentFlags)
+void FUIContainer::visit(const ax::SceneRenderState& state, const ax::Mat4 & parentTransform, uint32_t parentFlags)
 {
     if (_stencilClippingSupport != nullptr)
     {
         if (!_visible || _children.empty())
             return;
 
-        uint32_t flags = processParentFlags(parentTransform, parentFlags);
+        uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
         //Add group command
-        auto* stencilGroupCommand = renderer->getNextGroupCommand();
+        auto* stencilGroupCommand = state.getRenderer()->getNextGroupCommand();
         stencilGroupCommand->init(_globalZOrder);
-        renderer->addCommand(stencilGroupCommand);
-        renderer->pushGroup(stencilGroupCommand->getRenderQueueID());
+        state.getRenderer()->addCommand(stencilGroupCommand);
+        state.getRenderer()->pushGroup(stencilGroupCommand->getRenderQueueID());
 
         _stencilClippingSupport->_stencilStateManager->onBeforeVisit(_globalZOrder);
 
@@ -320,15 +320,15 @@ void FUIContainer::visit(ax::Renderer * renderer, const ax::Mat4 & parentTransfo
             AX_SAFE_RELEASE_NULL(programState);
 
         }
-        _stencilClippingSupport->_stencil->visit(renderer, _modelViewTransform, flags);
+        _stencilClippingSupport->_stencil->visit(state, _modelViewTransform, flags);
 
-        auto afterDrawStencilCmd = renderer->nextCallbackCommand();
+        auto afterDrawStencilCmd = state.getRenderer()->nextCallbackCommand();
         afterDrawStencilCmd->init(_globalZOrder);
         afterDrawStencilCmd->func = AX_CALLBACK_0(StencilStateManager::onAfterDrawStencil, _stencilClippingSupport->_stencilStateManager);
-        renderer->addCommand(afterDrawStencilCmd);
+        state.getRenderer()->addCommand(afterDrawStencilCmd);
 
         int i = 0;
-        bool visibleByCamera = isVisitableByVisitingCamera();
+        bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
 
         if (!_children.empty())
         {
@@ -339,28 +339,28 @@ void FUIContainer::visit(ax::Renderer * renderer, const ax::Mat4 & parentTransfo
                 auto node = _children.at(i);
 
                 if (node && node->getLocalZOrder() < 0)
-                    node->visit(renderer, _modelViewTransform, flags);
+                    node->visit(state, _modelViewTransform, flags);
                 else
                     break;
             }
             // self draw
             if (visibleByCamera)
-                this->draw(renderer, _modelViewTransform, flags);
+                this->draw(state, _modelViewTransform, flags);
 
             for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
-                (*it)->visit(renderer, _modelViewTransform, flags);
+                (*it)->visit(state, _modelViewTransform, flags);
         }
         else if (visibleByCamera)
         {
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
         }
 
-        auto afterVisitCmd = renderer->nextCallbackCommand();
+        auto afterVisitCmd = state.getRenderer()->nextCallbackCommand();
         afterVisitCmd->init(_globalZOrder);
         afterVisitCmd->func = AX_CALLBACK_0(StencilStateManager::onAfterVisit, _stencilClippingSupport->_stencilStateManager);
-        renderer->addCommand(afterVisitCmd);
+        state.getRenderer()->addCommand(afterVisitCmd);
 
-        renderer->popGroup();
+        state.getRenderer()->popGroup();
     }
     else if (_rectClippingSupport != nullptr && _rectClippingSupport->_clippingEnabled)
     {
@@ -368,26 +368,26 @@ void FUIContainer::visit(ax::Renderer * renderer, const ax::Mat4 & parentTransfo
         {
             _rectClippingSupport->_clippingRectDirty = true;
         }
-        auto* rectClippingGroupCommand = renderer->getNextGroupCommand();
+        auto* rectClippingGroupCommand = state.getRenderer()->getNextGroupCommand();
         rectClippingGroupCommand->init(_globalZOrder);
-        renderer->addCommand(rectClippingGroupCommand);
-        renderer->pushGroup(rectClippingGroupCommand->getRenderQueueID());
+        state.getRenderer()->addCommand(rectClippingGroupCommand);
+        state.getRenderer()->pushGroup(rectClippingGroupCommand->getRenderQueueID());
 
-        auto beforeVisitCmdScissor = renderer->nextCallbackCommand();
+        auto beforeVisitCmdScissor = state.getRenderer()->nextCallbackCommand();
         beforeVisitCmdScissor->init(_globalZOrder);
         beforeVisitCmdScissor->func = AX_CALLBACK_0(FUIContainer::onBeforeVisitScissor, this);
-        renderer->addCommand(beforeVisitCmdScissor);
+        state.getRenderer()->addCommand(beforeVisitCmdScissor);
 
-        Node::visit(renderer, parentTransform, parentFlags);
+        Node::visit(state, parentTransform, parentFlags);
 
-        auto afterVisitCmdScissor = renderer->nextCallbackCommand();
+        auto afterVisitCmdScissor = state.getRenderer()->nextCallbackCommand();
         afterVisitCmdScissor->init(_globalZOrder);
         afterVisitCmdScissor->func = AX_CALLBACK_0(FUIContainer::onAfterVisitScissor, this);
-        renderer->addCommand(afterVisitCmdScissor);
-        renderer->popGroup();
+        state.getRenderer()->addCommand(afterVisitCmdScissor);
+        state.getRenderer()->popGroup();
     }
     else
-        Node::visit(renderer, parentTransform, parentFlags);
+        Node::visit(state, parentTransform, parentFlags);
 }
 
 void FUIContainer::setGlobalZOrder(float globalZOrder)

--- a/extensions/fairygui/src/fairygui/display/FUIContainer.h
+++ b/extensions/fairygui/src/fairygui/display/FUIContainer.h
@@ -55,7 +55,7 @@ public:
     void onEnterTransitionDidFinish() override;
     void onExitTransitionDidStart() override;
     void onExit() override;
-    void visit(ax::Renderer *renderer, const ax::Mat4 &parentTransform, uint32_t parentFlags) override;
+    void visit(const ax::SceneRenderState& state, const ax::Mat4 &parentTransform, uint32_t parentFlags) override;
     void setCameraMask(unsigned short mask, bool applyChildren = true) override;
     void setGlobalZOrder(float globalZOrder) override;
 

--- a/extensions/fairygui/src/fairygui/display/FUIRichText.cpp
+++ b/extensions/fairygui/src/fairygui/display/FUIRichText.cpp
@@ -237,12 +237,12 @@ const char* FUIRichText::hitTestLink(const ax::Vec2 & worldPoint)
     return nullptr;
 }
 
-void FUIRichText::visit(ax::Renderer * renderer, const ax::Mat4 & parentTransform, uint32_t parentFlags)
+void FUIRichText::visit(const ax::SceneRenderState& state, const ax::Mat4 & parentTransform, uint32_t parentFlags)
 {
     if (_visible)
         formatText();
 
-    Node::visit(renderer, parentTransform, parentFlags);
+    Node::visit(state, parentTransform, parentFlags);
 }
 
 void FUIRichText::formatText()

--- a/extensions/fairygui/src/fairygui/display/FUIRichText.h
+++ b/extensions/fairygui/src/fairygui/display/FUIRichText.h
@@ -42,7 +42,7 @@ public:
     HtmlObject* getControl(const std::string& name) const;
 
     const char* hitTestLink(const ax::Vec2& worldPoint);
-    virtual void visit(ax::Renderer *renderer, const ax::Mat4 &parentTransform, uint32_t parentFlags) override;
+    virtual void visit(const ax::SceneRenderState& state, const ax::Mat4 &parentTransform, uint32_t parentFlags) override;
 
     virtual const ax::Size& getContentSize() const override;
 

--- a/extensions/fairygui/src/fairygui/display/FUISprite.cpp
+++ b/extensions/fairygui/src/fairygui/display/FUISprite.cpp
@@ -467,30 +467,24 @@ Vec2 FUISprite::boundaryTexCoord(char index)
     return Vec2::zero;
 }
 
-void FUISprite::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void FUISprite::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
     if (_texture == _empty)
         return;
 
     if (_fillMethod == FillMethod::None)
-        Sprite::draw(renderer, transform, flags);
+        Sprite::draw(state, transform, flags);
     else
     {
-        setMVPMatrixUniform();
+        setMVPMatrixUniform(state);
 #if AX_USE_CULLING
         // Don't calculate the culling if the transform was not updated
-        auto visitingCamera = Camera::getVisitingCamera();
-        auto defaultCamera = Camera::getDefaultCamera();
+        auto visitingCamera = state.getCamera();
         if (visitingCamera == nullptr) {
             _insideBounds = true;
         }
-        else if (visitingCamera == defaultCamera) {
-            _insideBounds = ((flags & FLAGS_TRANSFORM_DIRTY) || visitingCamera->isViewProjectionUpdated()) ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
-        }
-        else
-        {
-            // XXX: this always return true since
-            _insideBounds = renderer->checkVisibility(transform, _contentSize);
+        else {
+            _insideBounds = state.requiresVisibilityUpdate(flags) ? state.checkVisibility(transform, _contentSize) : _insideBounds;
         }
 
         if(_insideBounds)
@@ -501,9 +495,10 @@ void FUISprite::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t
                                    _blendFunc,
                                    _fillTriangles,
                                    transform,
-                                   flags);
+                                   flags,
+                                   state.getView());
 
-            renderer->addCommand(&_trianglesCommand);
+            state.getRenderer()->addCommand(&_trianglesCommand);
         }
     }
 }

--- a/extensions/fairygui/src/fairygui/display/FUISprite.h
+++ b/extensions/fairygui/src/fairygui/display/FUISprite.h
@@ -36,7 +36,7 @@ public:
     virtual void setContentSize(const ax::Size& size) override;
 
 protected:
-    virtual void draw(ax::Renderer *renderer, const ax::Mat4 &transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4 &transform, uint32_t flags) override;
 
     ax::Tex2F textureCoordFromAlphaPoint(ax::Vec2 alpha);
     ax::Vec3 vertexFromAlphaPoint(ax::Vec2 alpha);

--- a/extensions/fairygui/src/fairygui/event/InputProcessor.cpp
+++ b/extensions/fairygui/src/fairygui/event/InputProcessor.cpp
@@ -325,7 +325,7 @@ bool InputProcessor::onPointerDown(ax::PointerEvent* event)
         return false;
     }
     
-    auto camera = Camera::getVisitingCamera();
+    auto camera     = event->getCamera();
     Vec2 pt         = event->getWorldPoint();
     GObject* target = _owner->hitTest(pt, camera);
     if (!target)
@@ -356,7 +356,7 @@ bool InputProcessor::onPointerDown(ax::PointerEvent* event)
 
 void InputProcessor::onPointerMove(ax::PointerEvent* event)
 {
-    auto camera = Camera::getVisitingCamera();
+    auto camera     = event->getCamera();
     Vec2 pt         = event->getWorldPoint();
     GObject* target = _owner->hitTest(pt, camera);
     if (!target)
@@ -401,7 +401,7 @@ void InputProcessor::onPointerMove(ax::PointerEvent* event)
 
 void InputProcessor::onPointerUp(ax::PointerEvent* event)
 {
-    auto camera = Camera::getVisitingCamera();
+    auto camera     = event->getCamera();
     Vec2 pt         = event->getWorldPoint();
     GObject* target = _owner->hitTest(pt, camera);
     if (!target)
@@ -513,7 +513,7 @@ void InputProcessor::onPointerCancel(ax::PointerEvent* event)
 
 bool InputProcessor::onPointerScroll(ax::PointerEvent* event)
 {
-    auto camera = Camera::getVisitingCamera();
+    auto camera = event->getCamera();
     Vec2 pt = event->getWorldPoint();
     GObject* target = _owner->hitTest(pt, camera);
     if (!target)

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.cpp
@@ -132,7 +132,7 @@ bool PhysicsDebugNode::initWithWorld(b2WorldId worldId)
     return ret;
 }
 
-void PhysicsDebugNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void PhysicsDebugNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (!b2World_IsValid(_world))
     {
@@ -146,7 +146,7 @@ void PhysicsDebugNode::draw(Renderer* renderer, const Mat4& transform, uint32_t 
         b2World_Draw(_world, _debugDraw);
     }
 
-    DrawNode::draw(renderer, transform, flags);
+    DrawNode::draw(state, transform, flags);
 }
 
 PhysicsDebugNode::PhysicsDebugNode() : _ownDebugDraw(true)

--- a/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.h
+++ b/extensions/physics-nodes/src/physics-nodes/PhysicsDebugNode.h
@@ -51,7 +51,7 @@ public:
     float getPTMRatio() const { return _ratio; }
 
     // Overrides
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     b2DebugDraw& getB2DebugDraw() { return *_debugDraw; }
 

--- a/extensions/sceneext/src/sceneext/ActionTimeline/BoneNode.cpp
+++ b/extensions/sceneext/src/sceneext/ActionTimeline/BoneNode.cpp
@@ -338,7 +338,7 @@ void BoneNode::setDebugDrawColor(const ax::Color& color)
     updateColor();
 }
 
-void BoneNode::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags)
+void BoneNode::visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -346,9 +346,9 @@ void BoneNode::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, ui
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
-    bool visibleByCamera = isVisitableByVisitingCamera();
+    bool visibleByCamera = isVisitableByCamera(state.cameraFlag);
     bool isdebugdraw     = visibleByCamera && _isRackShow && nullptr == _rootSkeleton;
     int i                = 0;
 
@@ -362,32 +362,32 @@ void BoneNode::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, ui
             if (_rootSkeleton != nullptr && _boneSkins.contains(node))  // skip skin when bone is in a skeleton
                 continue;
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
         // self draw
         if (isdebugdraw)
-            this->draw(renderer, _modelViewTransform, flags);
+            this->draw(state, _modelViewTransform, flags);
 
         for (auto it = _children.cbegin() + i; it != _children.cend(); ++it)
         {
             auto node = (*it);
             if (_rootSkeleton != nullptr && _boneSkins.contains(node))  // skip skin when bone is in a skeleton
                 continue;
-            node->visit(renderer, _modelViewTransform, flags);
+            node->visit(state, _modelViewTransform, flags);
         }
     }
     else if (isdebugdraw)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
     }
 }
 
-void BoneNode::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void BoneNode::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder, _blendFunc);
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
 
 #ifdef AX_STUDIO_ENABLED_VIEW
 // TODO
@@ -555,9 +555,9 @@ bool BoneNode::isPointOnRack(const ax::Vec2& bonePoint)
 }
 #endif  // AX_STUDIO_ENABLED_VIEW
 
-void BoneNode::batchBoneDrawToSkeleton(BoneNode* bone) const
+void BoneNode::batchBoneDrawToSkeleton(const ax::SceneRenderState& state, BoneNode* bone) const
 {
-    bool visibleByCamera = bone->isVisitableByVisitingCamera();
+    bool visibleByCamera = bone->isVisitableByCamera(state.cameraFlag);
     if (!visibleByCamera)
     {
         return;
@@ -589,7 +589,7 @@ void BoneNode::batchBoneDrawToSkeleton(BoneNode* bone) const
 }
 
 // call after self visit
-void BoneNode::visitSkins(ax::Renderer* renderer, BoneNode* bone) const
+void BoneNode::visitSkins(const ax::SceneRenderState& state, BoneNode* bone) const
 {
     // quick return if not visible. children won't be drawn.
     if (!bone->_visible)
@@ -601,7 +601,7 @@ void BoneNode::visitSkins(ax::Renderer* renderer, BoneNode* bone) const
     {
         bone->sortAllChildren();
         for (auto it = bone->_boneSkins.cbegin(); it != bone->_boneSkins.cend(); ++it)
-            (*it)->visit(renderer, bone->_modelViewTransform, true);
+            (*it)->visit(state, bone->_modelViewTransform, true);
     }
 
     // FIX ME: Why need to set _orderOfArrival to 0??

--- a/extensions/sceneext/src/sceneext/ActionTimeline/BoneNode.h
+++ b/extensions/sceneext/src/sceneext/ActionTimeline/BoneNode.h
@@ -139,7 +139,7 @@ public:
     virtual ax::Rect getVisibleSkinsRect() const;
 
     // transform & draw
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
     // set local zorder, and dirty the debugdraw to make debugdraw's render layer right
     void setLocalZOrder(int localZOrder) override;
@@ -194,15 +194,15 @@ protected:
     void disableCascadeColor() override;
 
     // override Node::visit, just visit bones in children
-    void visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
 
     // a help function for SkeletonNode
     // for batch bone's draw to _rootSkeleton
-    virtual void batchBoneDrawToSkeleton(BoneNode* bone) const;
+    virtual void batchBoneDrawToSkeleton(const ax::SceneRenderState& state, BoneNode* bone) const;
 
     // a help function for SkeletonNode
     // @param bone, visit bone's skins
-    virtual void visitSkins(ax::Renderer* renderer, BoneNode* bone) const;
+    virtual void visitSkins(const ax::SceneRenderState& state, BoneNode* bone) const;
 
     // a help function for SkeletonNode
     // set bone's rootSkeleton = skeleton

--- a/extensions/sceneext/src/sceneext/ActionTimeline/SkeletonNode.cpp
+++ b/extensions/sceneext/src/sceneext/ActionTimeline/SkeletonNode.cpp
@@ -161,7 +161,7 @@ void SkeletonNode::updateColor()
     _transformUpdated = _transformDirty = _inverseDirty = _contentSizeDirty = true;
 }
 
-void SkeletonNode::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags)
+void SkeletonNode::visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -169,7 +169,7 @@ void SkeletonNode::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
     int i = 0;
     if (!_children.empty())
@@ -181,35 +181,35 @@ void SkeletonNode::visit(ax::Renderer* renderer, const ax::Mat4& parentTransform
             auto node = _children.at(i);
 
             if (node && node->getLocalZOrder() < 0)
-                node->visit(renderer, _modelViewTransform, flags);
+                node->visit(state, _modelViewTransform, flags);
             else
                 break;
         }
 
         for (auto it = _children.cbegin() + i; it != _children.cend(); ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
+            (*it)->visit(state, _modelViewTransform, flags);
     }
 
     checkSubBonesDirty();
     for (const auto& bone : _subOrderedAllBones)
     {
-        visitSkins(renderer, bone);
+        visitSkins(state, bone);
     }
 
     if (_isRackShow)
     {
-        this->draw(renderer, _modelViewTransform, flags);
+        this->draw(state, _modelViewTransform, flags);
         // batch draw all sub bones
         _batchBoneCommand.init(_globalZOrder, _blendFunc);
-        renderer->addCommand(&_batchBoneCommand);
-        batchDrawAllSubBones();
+        state.getRenderer()->addCommand(&_batchBoneCommand);
+        batchDrawAllSubBones(state);
     }
 }
 
-void SkeletonNode::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void SkeletonNode::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder, _blendFunc);
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
     for (int i = 0; i < 8; ++i)
     {
         ax::Vec4 pos;
@@ -226,14 +226,14 @@ void SkeletonNode::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint3
     _programState->setUniform(_mvpLocation, transform.m, sizeof(transform.m));
 }
 
-void SkeletonNode::batchDrawAllSubBones()
+void SkeletonNode::batchDrawAllSubBones(const ax::SceneRenderState& state)
 {
     checkSubBonesDirty();
 
     _batchedVeticesCount = 0;
     for (const auto& bone : _subOrderedAllBones)
     {
-        batchBoneDrawToSkeleton(bone);
+        batchBoneDrawToSkeleton(state, bone);
     }
 
     _batchBoneCommand.createVertexBuffer(sizeof(VertexData), _batchedVeticesCount,

--- a/extensions/sceneext/src/sceneext/ActionTimeline/SkeletonNode.h
+++ b/extensions/sceneext/src/sceneext/ActionTimeline/SkeletonNode.h
@@ -80,8 +80,8 @@ protected:
     void updateVertices() override;
     void updateColor() override;
 
-    void visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
 protected:
     ax::StringMap<BoneNode*> _subBonesMap;
@@ -112,7 +112,7 @@ private:
     int _batchedVeticesCount;
     ax::CustomCommand _batchBoneCommand;
 
-    void batchDrawAllSubBones();
+    void batchDrawAllSubBones(const ax::SceneRenderState& state);
 };
 
 NS_TIMELINE_END

--- a/extensions/sceneext/src/sceneext/Armature.cpp
+++ b/extensions/sceneext/src/sceneext/Armature.cpp
@@ -360,7 +360,7 @@ void Armature::update(float dt)
     _armatureTransformDirty = false;
 }
 
-void Armature::draw(ax::Renderer* renderer, const Mat4& transform, uint32_t flags)
+void Armature::draw(const ax::SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_parentBone == nullptr && _batchNode == nullptr)
     {
@@ -400,17 +400,17 @@ void Armature::draw(ax::Renderer* renderer, const Mat4& transform, uint32_t flag
                         skin->setBlendFunc(_blendFunc);
                     }
                 }
-                skin->draw(renderer, transform, flags);
+                skin->draw(state, transform, flags);
             }
             break;
             case CS_DISPLAY_ARMATURE:
             {
-                node->draw(renderer, transform, flags);
+                node->draw(state, transform, flags);
             }
             break;
             default:
             {
-                node->visit(renderer, transform, flags);
+                node->visit(state, transform, flags);
                 //                AX_NODE_DRAW_SETUP();
             }
             break;
@@ -418,7 +418,7 @@ void Armature::draw(ax::Renderer* renderer, const Mat4& transform, uint32_t flag
         }
         else if (Node* node = dynamic_cast<Node*>(object))
         {
-            node->visit(renderer, transform, flags);
+            node->visit(state, transform, flags);
             //            AX_NODE_DRAW_SETUP();
         }
     }
@@ -436,7 +436,7 @@ void Armature::onExit()
     unscheduleUpdate();
 }
 
-void Armature::visit(ax::Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void Armature::visit(const ax::SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -444,12 +444,12 @@ void Armature::visit(ax::Renderer* renderer, const Mat4& parentTransform, uint32
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
-    if (isVisitableByVisitingCamera())
+    if (isVisitableByCamera(state.cameraFlag))
     {
         sortAllChildren();
-        draw(renderer, _modelViewTransform, flags);
+        draw(state, _modelViewTransform, flags);
     }
 }
 

--- a/extensions/sceneext/src/sceneext/Armature.h
+++ b/extensions/sceneext/src/sceneext/Armature.h
@@ -125,7 +125,9 @@ public:
     /**
      * @lua NA
      */
-    virtual void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    virtual void visit(const ax::SceneRenderState& state,
+                       const ax::Mat4& parentTransform,
+                       uint32_t parentFlags) override;
     void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
     void update(float dt) override;
 

--- a/extensions/sceneext/src/sceneext/Armature.h
+++ b/extensions/sceneext/src/sceneext/Armature.h
@@ -125,8 +125,8 @@ public:
     /**
      * @lua NA
      */
-    virtual void visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
     void update(float dt) override;
 
     void onEnter() override;

--- a/extensions/sceneext/src/sceneext/BatchNode.cpp
+++ b/extensions/sceneext/src/sceneext/BatchNode.cpp
@@ -86,7 +86,7 @@ void BatchNode::removeChild(Node* child, bool cleanup)
     Node::removeChild(child, cleanup);
 }
 
-void BatchNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void BatchNode::visit(const SceneRenderState& state, const Mat4& parentTransform, uint32_t parentFlags)
 {
     // quick return if not visible. children won't be drawn.
     if (!_visible)
@@ -94,16 +94,16 @@ void BatchNode::visit(Renderer* renderer, const Mat4& parentTransform, uint32_t 
         return;
     }
 
-    uint32_t flags = processParentFlags(parentTransform, parentFlags);
+    uint32_t flags = processParentFlags(state, parentTransform, parentFlags);
 
-    if (isVisitableByVisitingCamera())
+    if (isVisitableByCamera(state.cameraFlag))
     {
         sortAllChildren();
-        draw(renderer, _modelViewTransform, flags);
+        draw(state, _modelViewTransform, flags);
     }
 }
 
-void BatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void BatchNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_children.empty())
     {
@@ -124,14 +124,14 @@ void BatchNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
                 pushed = true;
             }
 
-            armature->visit(renderer, transform, flags);
+            armature->visit(state, transform, flags);
         }
         else
         {
-            renderer->popGroup();
+            state.getRenderer()->popGroup();
             pushed = false;
 
-            ((Node*)object)->visit(renderer, transform, flags);
+            ((Node*)object)->visit(state, transform, flags);
         }
     }
 }

--- a/extensions/sceneext/src/sceneext/BatchNode.h
+++ b/extensions/sceneext/src/sceneext/BatchNode.h
@@ -55,8 +55,8 @@ public:
     void addChild(ax::Node* pChild, int zOrder, int tag) override;
     void addChild(ax::Node* pChild, int zOrder, std::string_view name) override;
     void removeChild(ax::Node* child, bool cleanup) override;
-    virtual void visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
 protected:
     void generateGroupCommand();

--- a/extensions/sceneext/src/sceneext/BatchNode.h
+++ b/extensions/sceneext/src/sceneext/BatchNode.h
@@ -55,7 +55,9 @@ public:
     void addChild(ax::Node* pChild, int zOrder, int tag) override;
     void addChild(ax::Node* pChild, int zOrder, std::string_view name) override;
     void removeChild(ax::Node* child, bool cleanup) override;
-    virtual void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    virtual void visit(const ax::SceneRenderState& state,
+                       const ax::Mat4& parentTransform,
+                       uint32_t parentFlags) override;
     void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
 protected:

--- a/extensions/sceneext/src/sceneext/Skin.cpp
+++ b/extensions/sceneext/src/sceneext/Skin.cpp
@@ -224,14 +224,14 @@ Mat4 Skin::getNodeToWorldTransformAR() const
     return TransformConcat(_bone->getArmature()->getNodeToWorldTransform(), displayTransform);
 }
 
-void Skin::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void Skin::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     _quadCommand.setWeakPSVL(_programState, _vertexLayout);
 
     // TODO: implement z order
-    _quadCommand.init(_globalZOrder, _texture, _blendFunc, &_quad, 1, transform, flags);
+    _quadCommand.init(_globalZOrder, _texture, _blendFunc, &_quad, 1, transform, flags, state.getView());
 
-    renderer->addCommand(&_quadCommand);
+    state.getRenderer()->addCommand(&_quadCommand);
 }
 
 void Skin::setBone(Bone* bone)

--- a/extensions/sceneext/src/sceneext/Skin.h
+++ b/extensions/sceneext/src/sceneext/Skin.h
@@ -56,7 +56,7 @@ public:
     ax::Mat4 getNodeToWorldTransform() const override;
     ax::Mat4 getNodeToWorldTransformAR() const;
 
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
     /**
      *  @lua NA

--- a/extensions/scripting/lua-bindings/auto/axlua_3d_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_3d_auto.cpp
@@ -2494,7 +2494,7 @@ int lua_ax_3d_Mesh_draw(lua_State* tolua_S)
     argc = lua_gettop(tolua_S)-1;
     if (argc == 8)
     {
-        ax::Renderer* arg0;
+        ax::SceneRenderState arg0;
         double arg1;
         ax::Mat4 arg2;
         unsigned int arg3;
@@ -2503,7 +2503,8 @@ int lua_ax_3d_Mesh_draw(lua_State* tolua_S)
         bool arg6;
         bool arg7;
 
-        ok &= luaval_to_object<ax::Renderer>(tolua_S, 2, "ax.Renderer",&arg0, "ax.Mesh:draw");
+        #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
 
         ok &= luaval_to_number(tolua_S, 3, &arg1, "ax.Mesh:draw");
 

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -91131,56 +91131,6 @@ int lua_ax_base_Camera_setScene(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Camera_setAdditionalProjection(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Camera* obj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Camera",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    obj = (ax::Camera*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!obj)
-    {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Camera_setAdditionalProjection'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        ax::Mat4 arg0;
-
-        ok &= luaval_to_mat4(tolua_S, 2, &arg0, "ax.Camera:setAdditionalProjection");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Camera_setAdditionalProjection'", nullptr);
-            return 0;
-        }
-        obj->setAdditionalProjection(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Camera:setAdditionalProjection",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Camera_setAdditionalProjection'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_base_Camera_configurePerspective(lua_State* tolua_S)
 {
     int argc = 0;
@@ -91445,110 +91395,6 @@ int lua_ax_base_Camera_create(lua_State* tolua_S)
 #endif
     return 0;
 }
-int lua_ax_base_Camera_getVisitingCamera(lua_State* tolua_S)
-{
-    int argc = 0;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.Camera",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    argc = lua_gettop(tolua_S) - 1;
-
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Camera_getVisitingCamera'", nullptr);
-            return 0;
-        }
-        auto&& ret = ax::Camera::getVisitingCamera();
-        object_to_luaval<ax::Camera>(tolua_S, "ax.Camera",(ax::Camera*)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.Camera:getVisitingCamera",argc, 0);
-    return 0;
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Camera_getVisitingCamera'.",&tolua_err);
-#endif
-    return 0;
-}
-int lua_ax_base_Camera_setVisitingCamera(lua_State* tolua_S)
-{
-    int argc = 0;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.Camera",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    argc = lua_gettop(tolua_S) - 1;
-
-    if (argc == 1)
-    {
-        ax::Camera* arg0;
-        ok &= luaval_to_object<ax::Camera>(tolua_S, 2, "ax.Camera",&arg0, "ax.Camera:setVisitingCamera");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Camera_setVisitingCamera'", nullptr);
-            return 0;
-        }
-        ax::Camera::setVisitingCamera(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.Camera:setVisitingCamera",argc, 1);
-    return 0;
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Camera_setVisitingCamera'.",&tolua_err);
-#endif
-    return 0;
-}
-int lua_ax_base_Camera_getVisitingViewProjectionMatrix(lua_State* tolua_S)
-{
-    int argc = 0;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ax.Camera",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    argc = lua_gettop(tolua_S) - 1;
-
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Camera_getVisitingViewProjectionMatrix'", nullptr);
-            return 0;
-        }
-        auto&& ret = ax::Camera::getVisitingViewProjectionMatrix();
-        mat4_to_luaval(tolua_S, ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ax.Camera:getVisitingViewProjectionMatrix",argc, 0);
-    return 0;
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Camera_getVisitingViewProjectionMatrix'.",&tolua_err);
-#endif
-    return 0;
-}
 int lua_ax_base_Camera_getDefaultViewport(lua_State* tolua_S)
 {
     int argc = 0;
@@ -91801,15 +91647,11 @@ int lua_register_ax_base_Camera(lua_State* tolua_S)
         tolua_function(tolua_S,"getBackgroundBrush",lua_ax_base_Camera_getBackgroundBrush);
         tolua_function(tolua_S,"isBrushValid",lua_ax_base_Camera_isBrushValid);
         tolua_function(tolua_S,"setScene",lua_ax_base_Camera_setScene);
-        tolua_function(tolua_S,"setAdditionalProjection",lua_ax_base_Camera_setAdditionalProjection);
         tolua_function(tolua_S,"configurePerspective",lua_ax_base_Camera_configurePerspective);
         tolua_function(tolua_S,"configureOrthographic",lua_ax_base_Camera_configureOrthographic);
         tolua_function(tolua_S,"configureOrthographicView",lua_ax_base_Camera_configureOrthographicView);
         tolua_function(tolua_S,"applyViewport",lua_ax_base_Camera_applyViewport);
         tolua_function(tolua_S,"create", lua_ax_base_Camera_create);
-        tolua_function(tolua_S,"getVisitingCamera", lua_ax_base_Camera_getVisitingCamera);
-        tolua_function(tolua_S,"setVisitingCamera", lua_ax_base_Camera_setVisitingCamera);
-        tolua_function(tolua_S,"getVisitingViewProjectionMatrix", lua_ax_base_Camera_getVisitingViewProjectionMatrix);
         tolua_function(tolua_S,"getDefaultViewport", lua_ax_base_Camera_getDefaultViewport);
         tolua_function(tolua_S,"setDefaultViewport", lua_ax_base_Camera_setDefaultViewport);
         tolua_function(tolua_S,"getDefaultCamera", lua_ax_base_Camera_getDefaultCamera);
@@ -97910,56 +97752,6 @@ int lua_ax_base_Pass_setTechnique(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_base_Pass_updateMVPUniform(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::Pass* obj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ax.Pass",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    obj = (ax::Pass*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!obj)
-    {
-        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Pass_updateMVPUniform'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        ax::Mat4 arg0;
-
-        ok &= luaval_to_mat4(tolua_S, 2, &arg0, "ax.Pass:updateMVPUniform");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Pass_updateMVPUniform'", nullptr);
-            return 0;
-        }
-        obj->updateMVPUniform(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Pass:updateMVPUniform",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Pass_updateMVPUniform'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_base_Pass_setUniformTexture(lua_State* tolua_S)
 {
     int argc = 0;
@@ -98916,7 +98708,6 @@ int lua_register_ax_base_Pass(lua_State* tolua_S)
         tolua_function(tolua_S,"getName",lua_ax_base_Pass_getName);
         tolua_function(tolua_S,"clone",lua_ax_base_Pass_clone);
         tolua_function(tolua_S,"setTechnique",lua_ax_base_Pass_setTechnique);
-        tolua_function(tolua_S,"updateMVPUniform",lua_ax_base_Pass_updateMVPUniform);
         tolua_function(tolua_S,"setUniformTexture",lua_ax_base_Pass_setUniformTexture);
         tolua_function(tolua_S,"setUniformNormTexture",lua_ax_base_Pass_setUniformNormTexture);
         tolua_function(tolua_S,"setUniformColor",lua_ax_base_Pass_setUniformColor);
@@ -115439,4 +115230,3 @@ TOLUA_API int register_all_ax_base(lua_State* tolua_S)
     tolua_endmodule(tolua_S);
     return 1;
 }
-

--- a/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_base_auto.cpp
@@ -8859,8 +8859,9 @@ int lua_ax_base_Node_draw(lua_State* tolua_S)
     ok  = true;
     do {
         if (argc == 3) {
-            ax::Renderer* arg0;
-            ok &= luaval_to_object<ax::Renderer>(tolua_S, 2, "ax.Renderer",&arg0, "ax.Node:draw");
+            ax::SceneRenderState arg0;
+            #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
 
             if (!ok) { break; }
             ax::Mat4 arg1;
@@ -8918,8 +8919,9 @@ int lua_ax_base_Node_visit(lua_State* tolua_S)
     ok  = true;
     do {
         if (argc == 3) {
-            ax::Renderer* arg0;
-            ok &= luaval_to_object<ax::Renderer>(tolua_S, 2, "ax.Renderer",&arg0, "ax.Node:visit");
+            ax::SceneRenderState arg0;
+            #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
 
             if (!ok) { break; }
             ax::Mat4 arg1;
@@ -12132,6 +12134,56 @@ int lua_ax_base_Node_getCameraMask(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_base_Node_isVisitableByCamera(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Node* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Node",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Node*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Node_isVisitableByCamera'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1)
+    {
+        unsigned short arg0;
+
+        ok &= luaval_to_int(tolua_S, 2, &arg0, "ax.Node:isVisitableByCamera");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Node_isVisitableByCamera'", nullptr);
+            return 0;
+        }
+        auto&& ret = obj->isVisitableByCamera(arg0);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Node:isVisitableByCamera",argc, 1);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Node_isVisitableByCamera'.",&tolua_err);
+#endif
+
+    return 0;
+}
 int lua_ax_base_Node_setCameraMask(lua_State* tolua_S)
 {
     int argc = 0;
@@ -13020,6 +13072,7 @@ int lua_register_ax_base_Node(lua_State* tolua_S)
         tolua_function(tolua_S,"setOnExitTransitionDidStartCallback",lua_ax_base_Node_setOnExitTransitionDidStartCallback);
         tolua_function(tolua_S,"getOnExitTransitionDidStartCallback",lua_ax_base_Node_getOnExitTransitionDidStartCallback);
         tolua_function(tolua_S,"getCameraMask",lua_ax_base_Node_getCameraMask);
+        tolua_function(tolua_S,"isVisitableByCamera",lua_ax_base_Node_isVisitableByCamera);
         tolua_function(tolua_S,"setCameraMask",lua_ax_base_Node_setCameraMask);
         tolua_function(tolua_S,"applyMaskOnEnter",lua_ax_base_Node_applyMaskOnEnter);
         tolua_function(tolua_S,"setProgramState",lua_ax_base_Node_setProgramState);
@@ -89515,6 +89568,53 @@ int lua_ax_base_Camera_setCameraFlag(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_base_Camera_getCameraMode(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Camera* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Camera",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Camera*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Camera_getCameraMode'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Camera_getCameraMode'", nullptr);
+            return 0;
+        }
+        int ret = (int)obj->getCameraMode();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Camera:getCameraMode",argc, 0);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Camera_getCameraMode'.",&tolua_err);
+#endif
+
+    return 0;
+}
 int lua_ax_base_Camera_setTargetTexture(lua_State* tolua_S)
 {
     int argc = 0;
@@ -90801,18 +90901,14 @@ int lua_ax_base_Camera_clearBackground(lua_State* tolua_S)
     int argc = 0;
     ax::Camera* obj = nullptr;
     bool ok  = true;
-
 #if _AX_DEBUG >= 1
     tolua_Error tolua_err;
 #endif
 
-
 #if _AX_DEBUG >= 1
     if (!tolua_isusertype(tolua_S,1,"ax.Camera",0,&tolua_err)) goto tolua_lerror;
 #endif
-
     obj = (ax::Camera*)tolua_tousertype(tolua_S,1,0);
-
 #if _AX_DEBUG >= 1
     if (!obj)
     {
@@ -90820,20 +90916,29 @@ int lua_ax_base_Camera_clearBackground(lua_State* tolua_S)
         return 0;
     }
 #endif
-
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Camera_clearBackground'", nullptr);
-            return 0;
+    do {
+        if (argc == 1) {
+            ax::SceneRenderState arg0;
+            #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
+
+            if (!ok) { break; }
+            obj->clearBackground(arg0);
+            lua_settop(tolua_S, 1);
+            return 1;
         }
-        obj->clearBackground();
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Camera:clearBackground",argc, 0);
+    }while(0);
+    ok  = true;
+    do {
+        if (argc == 0) {
+            obj->clearBackground();
+            lua_settop(tolua_S, 1);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.Camera:clearBackground",argc, 0);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -91614,6 +91719,7 @@ int lua_register_ax_base_Camera(lua_State* tolua_S)
         tolua_function(tolua_S,"updateViewProjectionState",lua_ax_base_Camera_updateViewProjectionState);
         tolua_function(tolua_S,"getCameraFlag",lua_ax_base_Camera_getCameraFlag);
         tolua_function(tolua_S,"setCameraFlag",lua_ax_base_Camera_setCameraFlag);
+        tolua_function(tolua_S,"getCameraMode",lua_ax_base_Camera_getCameraMode);
         tolua_function(tolua_S,"setTargetTexture",lua_ax_base_Camera_setTargetTexture);
         tolua_function(tolua_S,"getTargetTexture",lua_ax_base_Camera_getTargetTexture);
         tolua_function(tolua_S,"lookAt",lua_ax_base_Camera_lookAt);
@@ -91715,18 +91821,14 @@ int lua_ax_base_CameraBackgroundBrush_drawBackground(lua_State* tolua_S)
     int argc = 0;
     ax::CameraBackgroundBrush* obj = nullptr;
     bool ok  = true;
-
 #if _AX_DEBUG >= 1
     tolua_Error tolua_err;
 #endif
 
-
 #if _AX_DEBUG >= 1
     if (!tolua_isusertype(tolua_S,1,"ax.CameraBackgroundBrush",0,&tolua_err)) goto tolua_lerror;
 #endif
-
     obj = (ax::CameraBackgroundBrush*)tolua_tousertype(tolua_S,1,0);
-
 #if _AX_DEBUG >= 1
     if (!obj)
     {
@@ -91734,23 +91836,33 @@ int lua_ax_base_CameraBackgroundBrush_drawBackground(lua_State* tolua_S)
         return 0;
     }
 #endif
-
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
-    {
-        ax::Camera* arg0;
+    do {
+        if (argc == 1) {
+            ax::SceneRenderState arg0;
+            #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
 
-        ok &= luaval_to_object<ax::Camera>(tolua_S, 2, "ax.Camera",&arg0, "ax.CameraBackgroundBrush:drawBackground");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_CameraBackgroundBrush_drawBackground'", nullptr);
-            return 0;
+            if (!ok) { break; }
+            obj->drawBackground(arg0);
+            lua_settop(tolua_S, 1);
+            return 1;
         }
-        obj->drawBackground(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.CameraBackgroundBrush:drawBackground",argc, 1);
+    }while(0);
+    ok  = true;
+    do {
+        if (argc == 1) {
+            ax::Camera* arg0;
+            ok &= luaval_to_object<ax::Camera>(tolua_S, 2, "ax.Camera",&arg0, "ax.CameraBackgroundBrush:drawBackground");
+
+            if (!ok) { break; }
+            obj->drawBackground(arg0);
+            lua_settop(tolua_S, 1);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "ax.CameraBackgroundBrush:drawBackground",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -92861,18 +92973,22 @@ int lua_ax_base_GridBase_blit(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 0)
+    if (argc == 1)
     {
+        ax::SceneRenderState arg0;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GridBase_blit'", nullptr);
             return 0;
         }
-        obj->blit();
+        obj->blit(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GridBase:blit",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GridBase:blit",argc, 1);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -93637,21 +93753,25 @@ int lua_ax_base_GridBase_afterDraw(lua_State* tolua_S)
 #endif
 
     argc = lua_gettop(tolua_S)-1;
-    if (argc == 1)
+    if (argc == 2)
     {
         ax::Node* arg0;
+        ax::SceneRenderState arg1;
 
         ok &= luaval_to_object<ax::Node>(tolua_S, 2, "ax.Node",&arg0, "ax.GridBase:afterDraw");
+
+        #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_GridBase_afterDraw'", nullptr);
             return 0;
         }
-        obj->afterDraw(arg0);
+        obj->afterDraw(arg0, arg1);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GridBase:afterDraw",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.GridBase:afterDraw",argc, 2);
     return 0;
 
 #if _AX_DEBUG >= 1
@@ -97752,6 +97872,59 @@ int lua_ax_base_Pass_setTechnique(lua_State* tolua_S)
 
     return 0;
 }
+int lua_ax_base_Pass_updateMVPUniform(lua_State* tolua_S)
+{
+    int argc = 0;
+    ax::Pass* obj = nullptr;
+    bool ok  = true;
+
+#if _AX_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if _AX_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ax.Pass",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    obj = (ax::Pass*)tolua_tousertype(tolua_S,1,0);
+
+#if _AX_DEBUG >= 1
+    if (!obj)
+    {
+        tolua_error(tolua_S,"invalid 'obj' in function 'lua_ax_base_Pass_updateMVPUniform'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 2)
+    {
+        ax::MeshCommand* arg0;
+        ax::Mat4 arg1;
+
+        ok &= luaval_to_object<ax::MeshCommand>(tolua_S, 2, "ax.MeshCommand",&arg0, "ax.Pass:updateMVPUniform");
+
+        ok &= luaval_to_mat4(tolua_S, 3, &arg1, "ax.Pass:updateMVPUniform");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_base_Pass_updateMVPUniform'", nullptr);
+            return 0;
+        }
+        obj->updateMVPUniform(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ax.Pass:updateMVPUniform",argc, 2);
+    return 0;
+
+#if _AX_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_ax_base_Pass_updateMVPUniform'.",&tolua_err);
+#endif
+
+    return 0;
+}
 int lua_ax_base_Pass_setUniformTexture(lua_State* tolua_S)
 {
     int argc = 0;
@@ -98708,6 +98881,7 @@ int lua_register_ax_base_Pass(lua_State* tolua_S)
         tolua_function(tolua_S,"getName",lua_ax_base_Pass_getName);
         tolua_function(tolua_S,"clone",lua_ax_base_Pass_clone);
         tolua_function(tolua_S,"setTechnique",lua_ax_base_Pass_setTechnique);
+        tolua_function(tolua_S,"updateMVPUniform",lua_ax_base_Pass_updateMVPUniform);
         tolua_function(tolua_S,"setUniformTexture",lua_ax_base_Pass_setUniformTexture);
         tolua_function(tolua_S,"setUniformNormTexture",lua_ax_base_Pass_setUniformNormTexture);
         tolua_function(tolua_S,"setUniformColor",lua_ax_base_Pass_setUniformColor);
@@ -115230,3 +115404,4 @@ TOLUA_API int register_all_ax_base(lua_State* tolua_S)
     tolua_endmodule(tolua_S);
     return 1;
 }
+

--- a/extensions/scripting/lua-bindings/auto/axlua_navmesh_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_navmesh_auto.cpp
@@ -2114,9 +2114,10 @@ int lua_ax_navmesh_NavMesh_debugDraw(lua_State* tolua_S)
     argc = lua_gettop(tolua_S)-1;
     if (argc == 1)
     {
-        ax::Renderer* arg0;
+        ax::SceneRenderState arg0;
 
-        ok &= luaval_to_object<ax::Renderer>(tolua_S, 2, "ax.Renderer",&arg0, "ax.NavMesh:debugDraw");
+        #pragma warning NO CONVERSION TO NATIVE FOR SceneRenderState
+        ok = false;
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_ax_navmesh_NavMesh_debugDraw'", nullptr);

--- a/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
+++ b/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.cpp
@@ -89,7 +89,7 @@ public:
 
 #endif
 
-void LuaNode::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void LuaNode::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
     int handler =
         ScriptHandlerMgr::getInstance()->getObjectHandler((void*)this, ScriptHandlerMgr::HandlerType::LUANODE_DRAW);

--- a/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.hpp
+++ b/extensions/scripting/lua-bindings/manual/base/axlua_base_manual.hpp
@@ -87,7 +87,7 @@ class LuaNode : public ax::Node
 public:
     virtual ~LuaNode() {}
 
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    void draw(const ax::SceneRenderState& renderer, const ax::Mat4& transform, uint32_t flags) override;
 };
 
 TOLUA_API int tolua_luanode_open(lua_State* tolua_S);

--- a/extensions/spine/src/spine/SkeletonAnimation.cpp
+++ b/extensions/spine/src/spine/SkeletonAnimation.cpp
@@ -190,14 +190,14 @@ namespace spine {
 		}
 
 
-		static bool cullRectangle(Renderer *renderer, const Mat4 &transform, const axmol::Rect &rect) {
-			if (Camera::getVisitingCamera() == nullptr)
+		static bool cullRectangle(const axmol::SceneRenderState &state, const Mat4 &transform, const axmol::Rect &rect) {
+			if (state.getCamera() == nullptr)
 				return false;
 
 			auto director = Director::getInstance();
 			auto scene = director->getRunningScene();
 
-			if (!scene || (scene && Camera::getDefaultCamera() != Camera::getVisitingCamera()))
+			if (!scene || !state.getCamera() || state.getCamera()->getCameraMode() != CameraMode::Classic)
 				return false;
 
 			Rect visibleRect(director->getVisibleOrigin(), director->getVisibleSize());
@@ -207,7 +207,14 @@ namespace spine {
 			float hSizeY = rect.size.height / 2;
 			Vec3 v3p(rect.origin.x + hSizeX, rect.origin.y + hSizeY, 0);
 			transform.transformPoint(&v3p);
-			Vec2 v2p = Camera::getVisitingCamera()->projectWorldToCanvas(v3p);
+			const auto &viewProjection = state.getViewProjectionMatrix();
+			Vec4 clipPos;
+			viewProjection.transformVector(Vec4(v3p.x, v3p.y, v3p.z, 1.0f), &clipPos);
+			if (clipPos.w == 0.0f)
+				return false;
+			auto canvasSize = director->getCanvasSize();
+			Vec2 v2p((clipPos.x / clipPos.w + 1.0f) * 0.5f * canvasSize.width,
+			         (clipPos.y / clipPos.w + 1.0f) * 0.5f * canvasSize.height);
 
 			// convert content size to world coordinates
 			float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]), fabsf(hSizeX * transform.m[0] - hSizeY * transform.m[4]));
@@ -377,7 +384,7 @@ namespace spine {
 		if (_postUpdateListener) _postUpdateListener(this);
 	}
 
-	void SkeletonAnimation::draw(Renderer *renderer, const Mat4 &transform, uint32_t transformFlags) {
+	void SkeletonAnimation::draw(const axmol::SceneRenderState &state, const Mat4 &transform, uint32_t transformFlags) {
 		if (_firstDraw && _state) {
 			_firstDraw = false;
 			update(0);
@@ -400,7 +407,7 @@ namespace spine {
 #if AX_USE_CULLING
 		const axmol::Rect bb = computeBoundingRect(worldCoords, coordCount / 2);
 
-		if (cullRectangle(renderer, transform, bb)) {
+		if (cullRectangle(state, transform, bb)) {
 			VLA_FREE(worldCoords);
 			return;
 		}
@@ -588,7 +595,7 @@ namespace spine {
 						vertex->texCoord.v = uvs[vv + 1];
 						vertex->color = color_r;
 					}
-					batch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
+					batch->addCommand(state, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
 				} else {
 					// Not clipping.
 					auto vertex = triangles.verts;
@@ -596,7 +603,7 @@ namespace spine {
 						 ++v, ++vertex) {
 						vertex->color = color_r;
 					}
-					batch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
+					batch->addCommand(state, _globalZOrder, texture, _programState, blendFunc, triangles, transform, transformFlags);
 				}
 			} else {
 				// Two color tinting.
@@ -629,14 +636,14 @@ namespace spine {
 						vertex->color = color_r;
 						vertex->color2 = darkColor_r;
 					}
-					lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
+					lastTwoColorTrianglesCommand = twoColorBatch->addCommand(state, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
 				} else {
 					V3F_C4B_C4B_T2F *vertex = trianglesTwoColor.verts;
 					for (int v = 0, vn = trianglesTwoColor.vertCount; v < vn; ++v, ++vertex) {
 						vertex->color = color_r;
 						vertex->color2 = darkColor_r;
 					}
-					lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
+					lastTwoColorTrianglesCommand = twoColorBatch->addCommand(state, _globalZOrder, texture, _programState, blendFunc, trianglesTwoColor, transform, transformFlags);
 				}
 			}
 			_clipper->clipEnd(slot);
@@ -678,14 +685,14 @@ namespace spine {
 		}
 
 		if (_debugBoundingRect || _debugSlots || _debugBones || _debugMeshes) {
-			drawDebug(renderer, transform, transformFlags);
+			drawDebug(state, transform, transformFlags);
 		}
 
 		VLA_FREE(worldCoords);
 	}
 
 
-	void SkeletonAnimation::drawDebug(Renderer *renderer, const Mat4 &transform, uint32_t transformFlags) {
+	void SkeletonAnimation::drawDebug(const axmol::SceneRenderState &state, const Mat4 &transform, uint32_t transformFlags) {
 		DrawNode *drawNode = DrawNode::create();
 		drawNode->setGlobalZOrder(getGlobalZOrder());
 
@@ -773,7 +780,7 @@ namespace spine {
 			}
 		}
 
-		drawNode->draw(renderer, transform, transformFlags);
+		drawNode->draw(state, transform, transformFlags);
 	}
 
 	axmol::Rect SkeletonAnimation::getBoundingBox() const {

--- a/extensions/spine/src/spine/SkeletonAnimation.h
+++ b/extensions/spine/src/spine/SkeletonAnimation.h
@@ -196,12 +196,12 @@ namespace spine {
 		virtual void onTrackEntryEvent(spine::TrackEntry *entry, spine::EventType type, spine::Event *event);
 
 		void update(float deltaTime) override;
-		void draw(ax::Renderer *renderer, const ax::Mat4 &transform, uint32_t transformFlags) override;
+		void draw(const ax::SceneRenderState &state, const ax::Mat4 &transform, uint32_t transformFlags) override;
 		void onEnter() override;
 		void onExit() override;
 
 		void setAnimationStateEnabled(bool enabled);
-		virtual void drawDebug(ax::Renderer *renderer, const ax::Mat4 &transform, uint32_t transformFlags);
+		virtual void drawDebug(const ax::SceneRenderState &state, const ax::Mat4 &transform, uint32_t transformFlags);
 
 		spine::StartListener _startListener;
 		spine::InterruptListener _interruptListener;

--- a/extensions/spine/src/spine/SkeletonBatch.cpp
+++ b/extensions/spine/src/spine/SkeletonBatch.cpp
@@ -153,9 +153,9 @@ namespace spine {
 	}
 
 
-	axmol::TrianglesCommand *SkeletonBatch::addCommand(axmol::Renderer *renderer, float globalOrder, axmol::Texture2D *texture, rhi::ProgramState *programState, axmol::BlendFunc blendType, const axmol::TrianglesCommand::Triangles &triangles, const axmol::Mat4 &mv, uint32_t flags) {
+	axmol::TrianglesCommand *SkeletonBatch::addCommand(const axmol::SceneRenderState &state, float globalOrder, axmol::Texture2D *texture, rhi::ProgramState *programState, axmol::BlendFunc blendType, const axmol::TrianglesCommand::Triangles &triangles, const axmol::Mat4 &mv, uint32_t flags) {
 		SkeletonCommand *command = nextFreeCommand();
-		const axmol::Mat4 &projectionMat = axmol::Camera::getVisitingViewProjectionMatrix();
+		const axmol::Mat4 &projectionMat = state.getViewProjectionMatrix();
 
 		if (programState == nullptr)
 			programState = _programState;
@@ -167,8 +167,8 @@ namespace spine {
 		pipelinePS->setUniform(command->_locMVP, projectionMat.m, sizeof(projectionMat.m));
 		pipelinePS->setTexture(command->_locTexture, 0, texture->getRHITexture());
 
-		command->init(globalOrder, texture, blendType, triangles, mv, flags);
-		renderer->addCommand(command);
+		command->init(globalOrder, texture, blendType, triangles, mv, flags, state.getView());
+		state.getRenderer()->addCommand(command);
 		return command;
 	}
 

--- a/extensions/spine/src/spine/SkeletonBatch.h
+++ b/extensions/spine/src/spine/SkeletonBatch.h
@@ -41,6 +41,10 @@
 
 #include <vector>
 
+namespace ax {
+	struct SceneRenderState;
+}
+
 namespace spine {
 	struct SkeletonCommand : public ax::TrianglesCommand {
 		ax::rhi::UniformLocation _locMVP;
@@ -58,7 +62,7 @@ namespace spine {
 		void deallocateVertices(uint32_t numVertices);
 		unsigned short *allocateIndices(uint32_t numIndices);
 		void deallocateIndices(uint32_t numVertices);
-		ax::TrianglesCommand *addCommand(ax::Renderer *renderer, float globalOrder, ax::Texture2D *texture, ax::rhi::ProgramState *programState, ax::BlendFunc blendType, const ax::TrianglesCommand::Triangles &triangles, const ax::Mat4 &mv, uint32_t flags);
+		ax::TrianglesCommand *addCommand(const ax::SceneRenderState &state, float globalOrder, ax::Texture2D *texture, ax::rhi::ProgramState *programState, ax::BlendFunc blendType, const ax::TrianglesCommand::Triangles &triangles, const ax::Mat4 &mv, uint32_t flags);
 
 		ax::rhi::ProgramState* updateCommandPipelinePS(SkeletonCommand* command, ax::rhi::ProgramState* programState);
 

--- a/extensions/spine/src/spine/SkeletonTwoColorBatch.cpp
+++ b/extensions/spine/src/spine/SkeletonTwoColorBatch.cpp
@@ -62,9 +62,10 @@ namespace spine {
 										BlendFunc blendType,
 										const TwoColorTriangles &triangles,
 										const Mat4 &mv,
-										uint32_t flags) {
+										uint32_t flags,
+										const axmol::SceneViewData &view) {
 
-		ax::RenderCommand::init(globalOrder, mv, flags);
+		ax::RenderCommand::init(globalOrder, mv, flags, view);
 
 		_triangles = triangles;
 		if (_triangles.indexCount % 3 != 0) {
@@ -260,7 +261,7 @@ namespace spine {
 		_indices.setSize(_indices.size() - numIndices, 0);
 	}
 
-	TwoColorTrianglesCommand *SkeletonTwoColorBatch::addCommand(axmol::Renderer *renderer, float globalOrder, axmol::Texture2D *texture, rhi::ProgramState *programState, axmol::BlendFunc blendType, const TwoColorTriangles &triangles, const axmol::Mat4 &mv, uint32_t flags) {
+	TwoColorTrianglesCommand *SkeletonTwoColorBatch::addCommand(const axmol::SceneRenderState &state, float globalOrder, axmol::Texture2D *texture, rhi::ProgramState *programState, axmol::BlendFunc blendType, const TwoColorTriangles &triangles, const axmol::Mat4 &mv, uint32_t flags) {
 		TwoColorTrianglesCommand *command = nextFreeCommand();
 
 		auto pipelinePS = command->unsafePS();
@@ -274,20 +275,19 @@ namespace spine {
 
 		AXASSERT(pipelinePS, "programState should not be null");
 
-		const axmol::Mat4 &projectionMat =
-				axmol::Camera::getVisitingViewProjectionMatrix();
+		const axmol::Mat4 &projectionMat = state.getViewProjectionMatrix();
 
 		auto finalMatrix = projectionMat * mv;
 
 		pipelinePS->setUniform(_locPMatrix, finalMatrix.m, sizeof(finalMatrix.m));
 		pipelinePS->setTexture(_locTexture, 0, texture->getRHITexture());
 
-		command->init(globalOrder, texture, pipelinePS, blendType, triangles, mv, flags);
+		command->init(globalOrder, texture, pipelinePS, blendType, triangles, mv, flags, state.getView());
 
 		command->setOwnPSVL(pipelinePS, _twoColorVertexLayout, ax::RenderCommand::ADOPT_FLAG_PS);
 
-		command->updateVertexAndIndexBuffer(renderer, triangles.verts, triangles.vertCount, triangles.indices, triangles.indexCount);
-		renderer->addCommand(command);
+		command->updateVertexAndIndexBuffer(state.getRenderer(), triangles.verts, triangles.vertCount, triangles.indices, triangles.indexCount);
+		state.getRenderer()->addCommand(command);
 		return command;
 	}
 

--- a/extensions/spine/src/spine/SkeletonTwoColorBatch.h
+++ b/extensions/spine/src/spine/SkeletonTwoColorBatch.h
@@ -41,6 +41,10 @@
 #include <spine/spine.h>
 #include <vector>
 
+namespace ax {
+	struct SceneRenderState;
+}
+
 namespace spine {
 	struct V3F_C4B_C4B_T2F {
 		axmol::Vec3 position;
@@ -62,7 +66,7 @@ namespace spine {
 
 		~TwoColorTrianglesCommand();
 
-		void init(float globalOrder, axmol::Texture2D *texture, axmol::rhi::ProgramState *programState, axmol::BlendFunc blendType, const TwoColorTriangles &triangles, const axmol::Mat4 &mv, uint32_t flags);
+		void init(float globalOrder, axmol::Texture2D *texture, axmol::rhi::ProgramState *programState, axmol::BlendFunc blendType, const TwoColorTriangles &triangles, const axmol::Mat4 &mv, uint32_t flags, const axmol::SceneViewData &view);
 
 		void updateCommandPipelineDescriptor(axmol::rhi::ProgramState *programState);
 
@@ -118,7 +122,7 @@ namespace spine {
 		unsigned short *allocateIndices(uint32_t numIndices);
 		void deallocateIndices(uint32_t numIndices);
 
-		TwoColorTrianglesCommand *addCommand(axmol::Renderer *renderer, float globalOrder, axmol::Texture2D *texture, axmol::rhi::ProgramState *programState, axmol::BlendFunc blendType, const TwoColorTriangles &triangles, const axmol::Mat4 &mv, uint32_t flags);
+		TwoColorTrianglesCommand *addCommand(const axmol::SceneRenderState &state, float globalOrder, axmol::Texture2D *texture, axmol::rhi::ProgramState *programState, axmol::BlendFunc blendType, const TwoColorTriangles &triangles, const axmol::Mat4 &mv, uint32_t flags);
 
 		void batch(axmol::Renderer *renderer, TwoColorTrianglesCommand *command);
 

--- a/tests/cpp-tests/Source/AppDelegate.cpp
+++ b/tests/cpp-tests/Source/AppDelegate.cpp
@@ -65,7 +65,7 @@ void AppDelegate::applicationWillLaunch()
 
     // set app context attributes: red,green,blue,alpha,depth,stencil,multisamplesCount
     // powerPreference only affect when RHI backend is D3D11, D3D12, Vulkan
-    ContextAttrs contextAttrs = {.debugLayerEnabled = true, .powerPreference = PowerPreference::HighPerformance};
+    ContextAttrs contextAttrs = {.debugLayerEnabled = false, .powerPreference = PowerPreference::HighPerformance};
 
     // V-Sync is enabled by default since axmol 2.2.
     // Uncomment to disable V-Sync and unlock FPS.

--- a/tests/cpp-tests/Source/Box2DTestBed/samples/draw.cpp
+++ b/tests/cpp-tests/Source/Box2DTestBed/samples/draw.cpp
@@ -422,9 +422,9 @@ void SampleDrawNode::AddCircle(const SolidCircleData& circle)
     _solidCirclesDirty = true;
 }
 
-void SampleDrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void SampleDrawNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    PhysicsDebugNode::draw(renderer, transform, flags);
+    PhysicsDebugNode::draw(state, transform, flags);
 
     /// circle
 
@@ -446,7 +446,7 @@ void SampleDrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t fl
 
     // submit draw command
     if (_customCommandCircle.getInstanceCount() > 0)
-        submitDrawCommand(renderer, _customCommandCircle, transform);
+        submitDrawCommand(state, _customCommandCircle, transform);
 
     /// solid circle
 
@@ -469,7 +469,7 @@ void SampleDrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t fl
 
     // submit draw command
     if (_customCommandSolidCircle.getInstanceCount() > 0)
-        submitDrawCommand(renderer, _customCommandSolidCircle, transform);
+        submitDrawCommand(state, _customCommandSolidCircle, transform);
 
     /// capsule
 
@@ -491,10 +491,10 @@ void SampleDrawNode::draw(Renderer* renderer, const Mat4& transform, uint32_t fl
 
     // submit draw command
     if (_customCommandCapsule.getInstanceCount() > 0)
-        submitDrawCommand(renderer, _customCommandCapsule, transform);
+        submitDrawCommand(state, _customCommandCapsule, transform);
 }
 
-void SampleDrawNode::submitDrawCommand(Renderer* renderer, CustomCommand& cmd, const Mat4& transform)
+void SampleDrawNode::submitDrawCommand(const SceneRenderState& state, CustomCommand& cmd, const Mat4& transform)
 {
     rhi::BlendDesc& blendDescriptor             = cmd.blendDesc();
     blendDescriptor.blendEnabled                = true;
@@ -504,7 +504,7 @@ void SampleDrawNode::submitDrawCommand(Renderer* renderer, CustomCommand& cmd, c
     blendDescriptor.destinationAlphaBlendFactor = rhi::BlendFactor::ONE_MINUS_SRC_ALPHA;
 
     auto pipelinePS     = cmd.unsafePS();
-    const auto& matrixP = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixP = state.getViewProjectionMatrix();
     Mat4 matrixMVP      = matrixP * transform;
     auto mvpLocation    = pipelinePS->getUniformLocation("u_MVPMatrix");
     pipelinePS->setUniform(mvpLocation, matrixMVP.m, sizeof(matrixMVP.m));
@@ -516,7 +516,7 @@ void SampleDrawNode::submitDrawCommand(Renderer* renderer, CustomCommand& cmd, c
     pipelinePS->setUniform(uniformLocation, &pixelScale, sizeof(pixelScale));
 
     cmd.init(_globalZOrder);
-    renderer->addCommand(&cmd);
+    state.getRenderer()->addCommand(&cmd);
 }
 
 void SampleDrawNode::clear()

--- a/tests/cpp-tests/Source/Box2DTestBed/samples/draw.h
+++ b/tests/cpp-tests/Source/Box2DTestBed/samples/draw.h
@@ -90,9 +90,9 @@ public:
     void AddCircle(const SolidCircleData& circle);
     void AddCapsule(const CapsuleData& capsule);
 
-    void submitDrawCommand(Renderer* renderer, CustomCommand& cmd, const Mat4& transform);
+    void submitDrawCommand(const SceneRenderState& state, CustomCommand& cmd, const Mat4& transform);
 
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void clear() override;
 
     CustomCommand _customCommandCircle;

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
@@ -565,10 +565,10 @@ void RawStencilBufferTest::initCommands()
     //    _disableStencilCallback.func = [=]() { renderer->setStencilTest(false); };
     //    _disableStencilCallback.init(_globalZOrder);
 
-    auto program              = axpm->getBuiltinProgram(rhi::ProgramType::POSITION_UCOLOR);
-    _programState             = new rhi::ProgramState(program);
-    _locColor                 = _programState->getProgram()->getUniformLocation("u_color");
-    _locMVPMatrix             = _programState->getProgram()->getUniformLocation("u_MVPMatrix");
+    auto program  = axpm->getBuiltinProgram(rhi::ProgramType::POSITION_UCOLOR);
+    _programState = new rhi::ProgramState(program);
+    _locColor     = _programState->getProgram()->getUniformLocation("u_color");
+    _locMVPMatrix = _programState->getProgram()->getUniformLocation("u_MVPMatrix");
 
     Object::assign(_vertexLayout, _programState->getVertexLayout());
 

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.cpp
@@ -569,8 +569,6 @@ void RawStencilBufferTest::initCommands()
     _programState             = new rhi::ProgramState(program);
     _locColor                 = _programState->getProgram()->getUniformLocation("u_color");
     _locMVPMatrix             = _programState->getProgram()->getUniformLocation("u_MVPMatrix");
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
-    _programState->setUniform(_locMVPMatrix, projectionMat.m, sizeof(projectionMat.m));
 
     Object::assign(_vertexLayout, _programState->getVertexLayout());
 
@@ -611,12 +609,15 @@ void RawStencilBufferTest::initCommands()
     }
 }
 
-void RawStencilBufferTest::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void RawStencilBufferTest::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
+    const auto& projectionMat = state.getViewProjectionMatrix();
+    _programState->setUniform(_locMVPMatrix, projectionMat.m, sizeof(projectionMat.m));
+
     auto winPoint  = Vec2(Director::getInstance()->getCanvasSize());
     auto planeSize = winPoint * (1.0 / _planeCount);
 
-    renderer->addCallbackCommand([=]() { renderer->setStencilTest(true); }, _globalZOrder);
+    state.getRenderer()->addCallbackCommand([=]() { state.getRenderer()->setStencilTest(true); }, _globalZOrder);
 
     for (int i = 0, cmdIndex = 0; i < _planeCount; i++)
     {
@@ -626,22 +627,22 @@ void RawStencilBufferTest::draw(Renderer* renderer, const Mat4& transform, uint3
         _sprites.at(i)->setPosition(spritePoint);
         _spritesStencil.at(i)->setPosition(spritePoint);
 
-        renderer->clear(ClearFlag::STENCIL, Color::black, 0.f, 0x0, _globalZOrder);
+        state.getRenderer()->clear(ClearFlag::STENCIL, Color::black, 0.f, 0x0, _globalZOrder);
 
-        renderer->addCommand(&_renderCmds[cmdIndex]);
+        state.getRenderer()->addCommand(&_renderCmds[cmdIndex]);
         cmdIndex++;
 
         _modelViewTransform = this->transform(transform);
-        _spritesStencil.at(i)->visit(renderer, _modelViewTransform, flags);
+        _spritesStencil.at(i)->visit(state, _modelViewTransform, flags);
 
-        renderer->addCommand(&_renderCmds[cmdIndex]);
+        state.getRenderer()->addCommand(&_renderCmds[cmdIndex]);
         cmdIndex++;
 
         _modelViewTransform = this->transform(transform);
-        _sprites.at(i)->visit(renderer, _modelViewTransform, flags);
+        _sprites.at(i)->visit(state, _modelViewTransform, flags);
     }
 
-    renderer->addCallbackCommand([=]() { renderer->setStencilTest(false); }, _globalZOrder);
+    state.getRenderer()->addCallbackCommand([=]() { state.getRenderer()->setStencilTest(false); }, _globalZOrder);
 }
 
 void RawStencilBufferTest::onBeforeDrawClip(int planeIndex)
@@ -936,7 +937,8 @@ void ClippingToRenderTextureTest::reproduceBug()
     {
         auto scope = RefPtr<RenderTexturePass>(RenderTexturePass::obtain(rt), tlx::adopt_object);
         scope->begin();
-        container->visit();
+        SceneRenderState renderState(_director->getRenderer(), getDefaultCamera());
+        container->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
         scope->end();
     }
 }

--- a/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.h
+++ b/tests/cpp-tests/Source/ClippingNodeTest/ClippingNodeTest.h
@@ -182,7 +182,7 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
     virtual void setup() override;
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
     virtual void setupStencilForClippingOnPlane(int plane);
     virtual void setupStencilForDrawingOnPlane(int plane);

--- a/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.cpp
+++ b/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.cpp
@@ -199,7 +199,9 @@ void EffekseerTest::update(float delta)
     count++;
 }
 
-void EffekseerTest::visit(const cocos2d::SceneRenderState& state, const cocos2d::Mat4& parentTransform, uint32_t parentFlags)
+void EffekseerTest::visit(const cocos2d::SceneRenderState& state,
+                          const cocos2d::Mat4& parentTransform,
+                          uint32_t parentFlags)
 {
     /**
             visitを継承して、エフェクトを実際に描画する処理を追加します。

--- a/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.cpp
+++ b/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.cpp
@@ -199,7 +199,7 @@ void EffekseerTest::update(float delta)
     count++;
 }
 
-void EffekseerTest::visit(cocos2d::Renderer* renderer, const cocos2d::Mat4& parentTransform, uint32_t parentFlags)
+void EffekseerTest::visit(const cocos2d::SceneRenderState& state, const cocos2d::Mat4& parentTransform, uint32_t parentFlags)
 {
     /**
             visitを継承して、エフェクトを実際に描画する処理を追加します。
@@ -210,7 +210,7 @@ void EffekseerTest::visit(cocos2d::Renderer* renderer, const cocos2d::Mat4& pare
 
             你继承的visit，然后添加的实际绘制效果的过程。
     */
-    manager->begin(renderer, _globalZOrder);
-    cocos2d::Scene::visit(renderer, parentTransform, parentFlags);
-    manager->end(renderer, _globalZOrder);
+    manager->begin(state, _globalZOrder);
+    cocos2d::Scene::visit(state, parentTransform, parentFlags);
+    manager->end(state, _globalZOrder);
 }

--- a/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.h
+++ b/tests/cpp-tests/Source/EffekseerTest/EffekseerTest.h
@@ -52,7 +52,7 @@ public:
     virtual std::string title() const override;
 
     void update(float delta) override;
-    void visit(ax::Renderer* renderer, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
+    void visit(const ax::SceneRenderState& state, const ax::Mat4& parentTransform, uint32_t parentFlags) override;
 
 protected:
     std::string _title;

--- a/tests/cpp-tests/Source/ExtensionsTest/TableViewTest/CustomTableViewCell.cpp
+++ b/tests/cpp-tests/Source/ExtensionsTest/TableViewTest/CustomTableViewCell.cpp
@@ -26,9 +26,9 @@
 
 using namespace ax;
 
-void CustomTableViewCell::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void CustomTableViewCell::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    TableViewCell::draw(renderer, transform, flags);
+    TableViewCell::draw(state, transform, flags);
     // draw bounding box
     // 	auto pos = getPosition();
     // 	auto size = Size(178, 200);

--- a/tests/cpp-tests/Source/ExtensionsTest/TableViewTest/CustomTableViewCell.h
+++ b/tests/cpp-tests/Source/ExtensionsTest/TableViewTest/CustomTableViewCell.h
@@ -34,7 +34,7 @@
 class CustomTableViewCell : public ax::extension::TableViewCell
 {
 public:
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 };
 
 #endif /* __CUSTOMTABELVIEWCELL_H__ */

--- a/tests/cpp-tests/Source/MeshRendererTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Source/MeshRendererTest/DrawNode3D.cpp
@@ -107,11 +107,11 @@ bool DrawNode3D::init()
     return true;
 }
 
-void DrawNode3D::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void DrawNode3D::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    _customCommand.init(_globalZOrder, transform, flags);
+    _customCommand.init(_globalZOrder, transform, flags, state.getView());
 
-    updateCommand(renderer, transform, flags);
+    updateCommand(state, transform, flags);
 
     if (_isDirty && !_bufferLines.empty())
     {
@@ -123,13 +123,13 @@ void DrawNode3D::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
 
     if (!_bufferLines.empty())
     {
-        renderer->addCommand(&_customCommand);
+        state.getRenderer()->addCommand(&_customCommand);
     }
 }
 
-void DrawNode3D::updateCommand(ax::Renderer* renderer, const Mat4& transform, uint32_t flags)
+void DrawNode3D::updateCommand(const ax::SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    const auto& matrixP = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixP = state.getViewProjectionMatrix();
     auto mvp            = matrixP * transform;
 
     _customCommand.unsafePS()->setUniform(_locMVPMatrix, mvp.m, sizeof(mvp.m));

--- a/tests/cpp-tests/Source/MeshRendererTest/DrawNode3D.h
+++ b/tests/cpp-tests/Source/MeshRendererTest/DrawNode3D.h
@@ -78,10 +78,10 @@ public:
      */
     void setBlendFunc(const BlendFunc& blendFunc);
 
-    void updateCommand(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags);
+    void updateCommand(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags);
 
     // Overrides
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
     DrawNode3D();
     virtual ~DrawNode3D();

--- a/tests/cpp-tests/Source/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Source/NodeTest/NodeTest.cpp
@@ -933,7 +933,7 @@ public:
         return sprite;
     }
     bool setProgramState(rhi::ProgramState* programState, bool ownPS = false) override;
-    virtual void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    virtual void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
 protected:
     CustomCommand _customCommand;
@@ -954,13 +954,13 @@ bool MySprite::setProgramState(rhi::ProgramState* programState, bool ownPS /* = 
     return false;
 }
 
-void MySprite::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void MySprite::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    const auto& projectionMat = Camera::getVisitingViewProjectionMatrix();
+    const auto& projectionMat = state.getViewProjectionMatrix();
     auto mvpMatrix            = projectionMat * transform;
     _customCommand.unsafePS()->setUniform(_mvpMatrixLocation, mvpMatrix.m, sizeof(mvpMatrix.m));
-    _customCommand.init(_globalZOrder, transform, flags);
-    renderer->addCommand(&_customCommand);
+    _customCommand.init(_globalZOrder, transform, flags, state.getView());
+    state.getRenderer()->addCommand(&_customCommand);
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
@@ -164,8 +164,15 @@ void Physics3DTestDemo::onPointerUp(ax::PointerEvent* event)
     if (!_needShootBox)
         return;
 
-    auto ray = _camera->screenToRay(event->getPoint());
-    shootBox(_camera->getPosition3D() + ray.direction * 10.0f);
+    if (event->resolveRayForCamera(_camera))
+    {
+        shootBox(event->getRay());
+    }
+    else
+    {
+        auto ray = _camera->screenToRay(event->getPoint());
+        shootBox(Ray(_camera->getPosition3D(), ray.direction));
+    }
     event->stopPropagation();
 }
 
@@ -177,14 +184,19 @@ Physics3DTestDemo::~Physics3DTestDemo() {}
 
 void Physics3DTestDemo::shootBox(const ax::Vec3& des)
 {
-    Vec3 linearVel = des - _camera->getPosition3D();
+    shootBox(Ray(_camera->getPosition3D(), des - _camera->getPosition3D()));
+}
+
+void Physics3DTestDemo::shootBox(const ax::Ray& ray)
+{
+    Vec3 linearVel = ray.direction;
     linearVel.normalize();
     linearVel *= 100.0f;
     auto mesh = MeshRenderer::create("MeshRendererTest/box.c3t");
     mesh->setTexture("Images/Icon.png");
 
     this->addChild(mesh);
-    mesh->setPosition3D(_camera->getPosition3D());
+    mesh->setPosition3D(ray.origin);
     mesh->setScale(0.5f);
 
     // In Bullet, shootBox used a BoxCollider3D with CCD swept sphere radius.

--- a/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.h
+++ b/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.h
@@ -34,6 +34,7 @@ namespace ax
 {
 
 class Joint3D;
+class Ray;
 class Rigidbody3D;
 
 }  // namespace ax
@@ -59,6 +60,7 @@ public:
 
 protected:
     void shootBox(const ax::Vec3& des);
+    void shootBox(const ax::Ray& ray);
 
 protected:
     std::string _title;

--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
@@ -564,24 +564,27 @@ void RenderTextureTestDepthStencil::draw(const SceneRenderState& state, const Ma
 
         //    _renderCmds[0].init(_globalZOrder);
         //    _renderCmds[0].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeClear, this);
-        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeClear, this), _globalZOrder);
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeClear, this),
+                                                _globalZOrder);
 
         //    _renderCmds[1].init(_globalZOrder);
         //    _renderCmds[1].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeStencil, this);
         state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeStencil, this),
-                                     _globalZOrder);
+                                                _globalZOrder);
 
         _spriteDS->visit(state, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
 
         //    _renderCmds[2].init(_globalZOrder);
         //    _renderCmds[2].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeDraw, this);
-        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeDraw, this), _globalZOrder);
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeDraw, this),
+                                                _globalZOrder);
 
         _spriteDraw->visit(state, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
 
         //    _renderCmds[3].init(_globalZOrder);
         //    _renderCmds[3].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onAfterDraw, this);
-        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onAfterDraw, this), _globalZOrder);
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onAfterDraw, this),
+                                                _globalZOrder);
 
         /// !!!end will set current render target to default renderTarget
         /// !!!all render target share one depthStencilDesc, TODO: optimize me?

--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.cpp
@@ -165,12 +165,13 @@ void RenderTextureSave::addImage(ax::Object* sender)
 
     {
         _rtxPass->begin(getDefaultCamera());
+        SceneRenderState renderState(_director->getRenderer(), getDefaultCamera());
 
         Sprite* sprite = Sprite::create("Images/test-rgba1.png");
         sprite->setPosition(
             sprite->getContentSize().width + AXRANDOM_0_1() * (s.width - sprite->getContentSize().width),
             sprite->getContentSize().height + AXRANDOM_0_1() * (s.height - sprite->getContentSize().height));
-        sprite->visit();
+        sprite->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
 
         _rtxPass->end();
     }
@@ -192,6 +193,7 @@ void RenderTextureSave::onPointerMove(PointerEvent* event)
 
     {
         _rtxPass->begin(getDefaultCamera());
+        SceneRenderState renderState(_director->getRenderer(), getDefaultCamera());
 
         // for extra points, we'll draw this smoothly from the last position and vary the sprite's
         // scale/rotation/offset
@@ -220,7 +222,7 @@ void RenderTextureSave::onPointerMove(PointerEvent* event)
                 // Use AXRANDOM_0_1() will cause error when loading libtests.so on android, I don't know why.
                 brush->setColor(Color32(rand() % 127 + 128, 255, 255, brush->getOpacity()));
                 // Call visit to draw the brush, don't call draw..
-                brush->visit();
+                brush->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
             }
         }
 
@@ -275,8 +277,9 @@ RenderTextureIssue937::RenderTextureIssue937()
                                                       Rect(0, 0, s.width, s.height),
                                                       Rect(0, 0, pixelSize.width, pixelSize.height)));
         scope->begin(getDefaultCamera());
-        spr_premulti->visit();
-        spr_nonpremulti->visit();
+        SceneRenderState renderState(_director->getRenderer(), getDefaultCamera());
+        spr_premulti->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
+        spr_nonpremulti->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
         scope->end();
     }
 
@@ -425,9 +428,11 @@ void RenderTextureZbuffer::renderScreenShot()
 
     {
         auto renderer = _director->getRenderer();
+        auto camera   = getDefaultCamera();
         auto scope    = RefPtr<RenderTexturePass>(RenderTexturePass::obtain(texture), tlx::adopt_object);
-        scope->begin(getDefaultCamera());
-        this->visit(renderer, getNodeToParentTransform(), 0);
+        scope->begin(camera);
+        SceneRenderState renderState(renderer, camera);
+        this->visit(renderState, getNodeToParentTransform(), 0);
         scope->end();
     }
 
@@ -473,11 +478,12 @@ RenderTexturePartTest::RenderTexturePartTest()
                                                       Rect(0, 0, size.width, size.height),
                                                       Rect(0, 0, pixelSize.width, pixelSize.height)));
         scope->begin(getDefaultCamera());
+        SceneRenderState renderState(_director->getRenderer(), getDefaultCamera());
         scope->clear(ClearFlag::COLOR, {.color = Color(1, 0, 0, 1)});
-        sprite1->visit();
-        sprite11->visit();
-        sprite2->visit();
-        sprite22->visit();
+        sprite1->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
+        sprite11->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
+        sprite2->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
+        sprite22->visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
         scope->end();
     }
 
@@ -549,7 +555,7 @@ RenderTextureTestDepthStencil::~RenderTextureTestDepthStencil()
     _renderer->setStencilTest(bitmask::any(_dsDesc.flags, DepthStencilFlags::STENCIL_TEST));
 }
 
-void RenderTextureTestDepthStencil::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void RenderTextureTestDepthStencil::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     {
         _rtxPass->begin();
@@ -558,24 +564,24 @@ void RenderTextureTestDepthStencil::draw(Renderer* renderer, const Mat4& transfo
 
         //    _renderCmds[0].init(_globalZOrder);
         //    _renderCmds[0].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeClear, this);
-        renderer->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeClear, this), _globalZOrder);
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeClear, this), _globalZOrder);
 
         //    _renderCmds[1].init(_globalZOrder);
         //    _renderCmds[1].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeStencil, this);
-        renderer->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeStencil, this),
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeStencil, this),
                                      _globalZOrder);
 
-        _spriteDS->visit();
+        _spriteDS->visit(state, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
 
         //    _renderCmds[2].init(_globalZOrder);
         //    _renderCmds[2].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeDraw, this);
-        renderer->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeDraw, this), _globalZOrder);
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onBeforeDraw, this), _globalZOrder);
 
-        _spriteDraw->visit();
+        _spriteDraw->visit(state, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
 
         //    _renderCmds[3].init(_globalZOrder);
         //    _renderCmds[3].func = AX_CALLBACK_0(RenderTextureTestDepthStencil::onAfterDraw, this);
-        renderer->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onAfterDraw, this), _globalZOrder);
+        state.getRenderer()->addCallbackCommand(AX_CALLBACK_0(RenderTextureTestDepthStencil::onAfterDraw, this), _globalZOrder);
 
         /// !!!end will set current render target to default renderTarget
         /// !!!all render target share one depthStencilDesc, TODO: optimize me?
@@ -690,17 +696,17 @@ void RenderTextureTargetNode::update(float dt)
     time += dt;
 }
 
-void RenderTextureTargetNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void RenderTextureTargetNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     {
         _rtxPass->begin();
         if (_shouldClear)
             _rtxPass->clear(ClearFlag::COLOR, {.color = Color(0, 0, 0, 0)});
-        _container->visit();
+        _container->visit(state, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
         _rtxPass->end();
     }
 
-    RenderTextureTest::draw(renderer, transform, flags);
+    RenderTextureTest::draw(state, transform, flags);
 }
 
 std::string RenderTextureTargetNode::title() const
@@ -737,7 +743,7 @@ SpriteRenderTextureBug::SimpleSprite* SpriteRenderTextureBug::SimpleSprite::crea
     return sprite;
 }
 
-void SpriteRenderTextureBug::SimpleSprite::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void SpriteRenderTextureBug::SimpleSprite::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     if (_rt == nullptr)
     {
@@ -752,7 +758,7 @@ void SpriteRenderTextureBug::SimpleSprite::draw(Renderer* renderer, const Mat4& 
         _rtxPass->end();
     }
 
-    Sprite::draw(renderer, transform, flags);
+    Sprite::draw(state, transform, flags);
 }
 
 SpriteRenderTextureBug::SpriteRenderTextureBug()
@@ -836,7 +842,8 @@ Issue16113Test::Issue16113Test()
             scope->begin();
             scope->clear(ClearFlag::COLOR, {.color = Color(0, 0, 0, 0)});
             text->setPosition(canvasSize.width / 2, canvasSize.height / 2);
-            text->Node::visit();
+            SceneRenderState renderState(_director->getRenderer(), getDefaultCamera());
+            text->Node::visit(renderState, Mat4::identity, Node::FLAGS_TRANSFORM_DIRTY);
             scope->end();
         }
         auto callback = [this](RenderTexture* rt, std::string_view path) { rt->release(); };

--- a/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.h
+++ b/tests/cpp-tests/Source/RenderTextureTest/RenderTextureTest.h
@@ -101,7 +101,7 @@ public:
     virtual ~RenderTextureTestDepthStencil();
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
 private:
     //    ax::CallbackCommand _renderCmds[4];
@@ -136,7 +136,7 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
 
-    void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
     void touched(ax::Object* sender);
 
@@ -166,7 +166,7 @@ public:
         static SimpleSprite* create(const char* filename, const ax::Rect& rect);
         SimpleSprite();
         ~SimpleSprite();
-        virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags);
+        virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags);
 
     public:
         ax::RenderTexture* _rt;

--- a/tests/cpp-tests/Source/RendererTest/RendererTest.cpp
+++ b/tests/cpp-tests/Source/RendererTest/RendererTest.cpp
@@ -195,7 +195,7 @@ class SpriteInGroupCommand : public Sprite
 public:
     static SpriteInGroupCommand* create(std::string_view filename);
 
-    virtual void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    virtual void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 };
 
 SpriteInGroupCommand* SpriteInGroupCommand::create(std::string_view filename)
@@ -206,15 +206,15 @@ SpriteInGroupCommand* SpriteInGroupCommand::create(std::string_view filename)
     return sprite;
 }
 
-void SpriteInGroupCommand::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void SpriteInGroupCommand::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    AXASSERT(renderer, "Render is null");
-    auto* spriteWrapperCommand = renderer->getNextGroupCommand();
+    AXASSERT(state.getRenderer(), "Renderer is null");
+    auto* spriteWrapperCommand = state.getRenderer()->getNextGroupCommand();
     spriteWrapperCommand->init(_globalZOrder);
-    renderer->addCommand(spriteWrapperCommand);
-    renderer->pushGroup(spriteWrapperCommand->getRenderQueueID());
-    Sprite::draw(renderer, transform, flags);
-    renderer->popGroup();
+    state.getRenderer()->addCommand(spriteWrapperCommand);
+    state.getRenderer()->pushGroup(spriteWrapperCommand->getRenderQueueID());
+    Sprite::draw(state, transform, flags);
+    state.getRenderer()->popGroup();
 }
 
 GroupCommandTest::GroupCommandTest()

--- a/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Source/Scene3DTest/Scene3DTest.cpp
@@ -42,10 +42,10 @@ class SkeletonAnimationCullingFix : public SkeletonAnimation
 public:
     SkeletonAnimationCullingFix() : SkeletonAnimation() {}
 
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t transformFlags) override
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t transformFlags) override
     {
-        renderer->setCullMode(CullMode::NONE);
-        SkeletonAnimation::draw(renderer, transform, transformFlags);
+        state.getRenderer()->setCullMode(CullMode::NONE);
+        SkeletonAnimation::draw(state, transform, transformFlags);
         // RenderState::StateBlock::invalidate(ax::RenderState::StateBlock::RS_ALL_ONES);
     }
 
@@ -213,10 +213,10 @@ static int8_t cameraDepth(GAME_CAMERAS_ORDER camera)
     return static_cast<int8_t>(camera - CAMERA_UI_2D);
 }
 
-/** The scenes, located in different position, won't see each other. */
+/** The overlay scenes stay separated because they intentionally reuse some layer masks. */
 static Vec3 s_scenePositons[SCENE_COUNT] = {
     Vec3(0, 0, 0),       //  center  :   UI scene
-    Vec3(0, 10000, 0),   //  top     :   World sub scene
+    Vec3(0, 0, 0),       //  center  :   World sub scene, isolated by USER1 camera mask
     Vec3(10000, 0, 0),   //  right   :   Dialog sub scene
     Vec3(0, -10000, 0),  //  bottom  :   OSD sub scene
 };
@@ -268,6 +268,7 @@ bool Scene3DTestScene::init()
         ca->configurePerspective(60, visibleSize.width / visibleSize.height, 0.1f, 200);
         ca->setDepth(cameraDepth(CAMERA_WORLD_3D_SCENE));
         ca->setName(s_CameraNames[CAMERA_WORLD_3D_SCENE]);
+        ca->setCameraFlag(s_CF[LAYER_BACKGROUND]);
         _worldScene->addChild(ca);
         // create 3D objects and add to world scene
         createWorld3D();
@@ -279,6 +280,8 @@ bool Scene3DTestScene::init()
         ca->setPosition3D(_player->getPosition3D() + Vec3(0, 45, 60));
         ca->setRotation3D(Vec3(-45, 0, 0));
         _worldScene->setPosition3D(s_scenePositons[SCENE_WORLD]);
+        _worldScene->setCameraMask(s_CM[LAYER_BACKGROUND], true);
+
         this->addChild(_worldScene);
 
         ////////////////////////////////////////////////////////////////////////

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest.cpp
@@ -151,14 +151,14 @@ void ShaderNode::setPosition(const Vec2& newPosition)
                             position.y * frameSize.height / visibleSize.height * renderScale);
 }
 
-void ShaderNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void ShaderNode::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    _customCommand.init(_globalZOrder, transform, flags);
+    _customCommand.init(_globalZOrder, transform, flags, state.getView());
 
     _programState->setUniform(_locResolution, &_resolution, sizeof(_resolution));
     _programState->setUniform(_locCenter, &_center, sizeof(_center));
 
-    auto projectionMatrix = Camera::getVisitingViewProjectionMatrix();
+    auto projectionMatrix = state.getViewProjectionMatrix();
     auto finalMatrix      = projectionMatrix * transform;
 
     _programState->setUniform(_locMVP, finalMatrix.m, sizeof(finalMatrix.m));
@@ -172,7 +172,7 @@ void ShaderNode::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
     _programState->setUniform(_locSinTime, &sinTime, sizeof(sinTime));
     _programState->setUniform(_locCosTime, &cosTime, sizeof(cosTime));
 
-    renderer->addCommand(&_customCommand);
+    state.getRenderer()->addCommand(&_customCommand);
     AX_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, 6);
 }
 
@@ -384,7 +384,7 @@ public:
     void initProgram();
 
     static SpriteBlur* create(const char* pszFileName);
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
     void setBlurRadius(float radius);
     void setBlurSampleNum(float num);
 
@@ -448,10 +448,10 @@ void SpriteBlur::initProgram()
     SET_UNIFORM(_programState, "sampleNum", 7.0f);
 }
 
-void SpriteBlur::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void SpriteBlur::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
-    SET_UNIFORM(_programState, "u_PMatrix", Camera::getVisitingViewProjectionMatrix());
-    Sprite::draw(renderer, transform, flags);
+    SET_UNIFORM(_programState, "u_PMatrix", state.getViewProjectionMatrix());
+    Sprite::draw(state, transform, flags);
 }
 
 void SpriteBlur::setBlurRadius(float radius)

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest.h
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest.h
@@ -144,7 +144,7 @@ public:
 
     virtual void update(float dt) override;
     virtual void setPosition(const ax::Vec2& newPosition) override;
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags) override;
+    virtual void draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags) override;
 
 protected:
     ShaderNode();

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest2.cpp
@@ -144,7 +144,8 @@ public:
             }
 
             // normal effect: order == 0
-            _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags, state.getView());
+            _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags,
+                                   state.getView());
 
             updateUniforms(_trianglesCommand.unsafePS());
             state.getRenderer()->addCommand(&_trianglesCommand);

--- a/tests/cpp-tests/Source/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Source/ShaderTest/ShaderTest2.cpp
@@ -114,13 +114,13 @@ public:
         std::sort(std::begin(_effects), std::end(_effects), tuple_sort);
     }
 
-    void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override
+    void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override
     {
-        setMVPMatrixUniform();
+        setMVPMatrixUniform(state);
 #if AX_USE_CULLING
         // Don't do calculate the culling if the transform was not updated
         _insideBounds =
-            (flags & FLAGS_TRANSFORM_DIRTY) ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
+            (flags & FLAGS_TRANSFORM_DIRTY) ? state.checkVisibility(transform, _contentSize) : _insideBounds;
 
         if (_insideBounds)
 #endif
@@ -136,18 +136,18 @@ public:
                 if (programState)
                 {
                     QuadCommand& q = std::get<2>(effect);
-                    q.init(_globalZOrder, _texture, _blendFunc, &_quad, 1, transform, flags);
+                    q.init(_globalZOrder, _texture, _blendFunc, &_quad, 1, transform, flags, state.getView());
                     updateUniforms(programState);
-                    renderer->addCommand(&q);
+                    state.getRenderer()->addCommand(&q);
                 }
                 idx++;
             }
 
             // normal effect: order == 0
-            _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags);
+            _trianglesCommand.init(_globalZOrder, _texture, _blendFunc, _polyInfo.triangles, transform, flags, state.getView());
 
             updateUniforms(_trianglesCommand.unsafePS());
-            renderer->addCommand(&_trianglesCommand);
+            state.getRenderer()->addCommand(&_trianglesCommand);
 
             // positive effects: order >= 0
             for (auto&& it = std::begin(_effects) + idx; it != std::end(_effects); ++it)
@@ -155,9 +155,9 @@ public:
                 QuadCommand& q     = std::get<2>(*it);
                 auto* programState = std::get<1>(*it)->getProgramState();
                 updateUniforms(programState);
-                q.init(_globalZOrder, _texture, _blendFunc, &_quad, 1, transform, flags);
+                q.init(_globalZOrder, _texture, _blendFunc, &_quad, 1, transform, flags, state.getView());
                 q.setWeakPSVL(programState, std::get<1>(*it)->getVertexLayout());
-                renderer->addCommand(&q);
+                state.getRenderer()->addCommand(&q);
                 idx++;
             }
         }

--- a/tests/live2d-tests/Source/LAppView.cpp
+++ b/tests/live2d-tests/Source/LAppView.cpp
@@ -95,9 +95,9 @@ void LAppView::onExit()
     delete viewMatrix;
 }
 
-void LAppView::draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags)
+void LAppView::draw(const ax::SceneRenderState& state, const ax::Mat4& transform, uint32_t flags)
 {
-    DrawNode::draw(renderer, transform, flags);
+    DrawNode::draw(state, transform, flags);
     onDraw(transform, flags);
 }
 

--- a/tests/live2d-tests/Source/LAppView.hpp
+++ b/tests/live2d-tests/Source/LAppView.hpp
@@ -25,7 +25,7 @@ public:
     virtual void onEnter();
     virtual void onExit();
 
-    virtual void draw(ax::Renderer* renderer, const ax::Mat4& transform, uint32_t flags);
+    virtual void draw(const ax::SceneRenderState& renderer, const ax::Mat4& transform, uint32_t flags);
     void onDraw(const ax::Mat4& transform, uint32_t flags);
 
     bool onPointerDown(ax::PointerEvent* event);

--- a/tests/lua-tests/Source/lua_test_bindings.cpp
+++ b/tests/lua-tests/Source/lua_test_bindings.cpp
@@ -78,7 +78,7 @@ public:
     void setBlendFunc(const BlendFunc& blendFunc);
 
     // Overrides
-    virtual void draw(Renderer* renderer, const Mat4& transform, uint32_t flags) override;
+    virtual void draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags) override;
 
     DrawNode3D();
     virtual ~DrawNode3D();
@@ -189,11 +189,11 @@ bool DrawNode3D::init()
     return true;
 }
 
-void DrawNode3D::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
+void DrawNode3D::draw(const SceneRenderState& state, const Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder);
     // update mvp matrix
-    const auto& matrixP = Camera::getVisitingViewProjectionMatrix();
+    const auto& matrixP = state.getViewProjectionMatrix();
     auto mvp            = matrixP * transform;
     _programState->setUniform(_locMVPMatrix, mvp.m, sizeof(mvp.m));
 
@@ -214,7 +214,7 @@ void DrawNode3D::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
 
     if (!_buffer.empty())
     {
-        renderer->addCommand(&_customCommand);
+        state.getRenderer()->addCommand(&_customCommand);
     }
 }
 

--- a/tests/unit-tests/Source/axmol/2d/NodeTests.cpp
+++ b/tests/unit-tests/Source/axmol/2d/NodeTests.cpp
@@ -42,8 +42,10 @@ TEST_SUITE("2d/Node")
         CHECK_EQ(0.0f, node.getNormalizedPosition().x);
         CHECK_EQ(0.0f, node.getNormalizedPosition().y);
 
+        SceneRenderState renderState;
+
         node.setPositionNormalized({0.5f, 0.5f});
-        node.visit(nullptr, Mat4::identity, Node::FLAGS_CONTENT_SIZE_DIRTY);
+        node.visit(renderState, Mat4::identity, Node::FLAGS_CONTENT_SIZE_DIRTY);
         CHECK_EQ(100.0f, node.getPosition().x);
         CHECK_EQ(50.0f, node.getPosition().y);
         CHECK_EQ(0.5f, node.getNormalizedPosition().x);
@@ -51,13 +53,13 @@ TEST_SUITE("2d/Node")
 
         parent.setContentSize(Vec2(400.0f, 200.0f));
         node.setPosition(100.0f, 50.0f);
-        node.visit(nullptr, Mat4::identity, Node::FLAGS_CONTENT_SIZE_DIRTY);
+        node.visit(renderState, Mat4::identity, Node::FLAGS_CONTENT_SIZE_DIRTY);
         CHECK_EQ(100.0f, node.getPosition().x);
         CHECK_EQ(50.0f, node.getPosition().y);
 
         node.setPosition(0.0f, 0.0f);
         node.setPositionNormalized({0.5f, 0.5f});
-        node.visit(nullptr, Mat4::identity, Node::FLAGS_CONTENT_SIZE_DIRTY);
+        node.visit(renderState, Mat4::identity, Node::FLAGS_CONTENT_SIZE_DIRTY);
         CHECK_EQ(200.0f, node.getPosition().x);
         CHECK_EQ(100.0f, node.getPosition().y);
     }


### PR DESCRIPTION
- Introduce `SceneViewData` and `SceneRenderState` to carry immutable per-pass view, projection, renderer, and camera-mask data through scene traversal.
- Remove the global visiting-Camera state and migrate render commands, background brushes, offscreen rendering, extensions, tests, and Lua bindings to explicit view data.
- Rework OpenXR rendering to build independent per-eye views without mutating persistent Camera objects.
- Unify VR pointer-ray hit testing across 2D, UI, terrain, and multi-camera scenes, with consistent world-space hit results and reticle rendering.
- Fix view-dependent regressions in skyboxes, VideoPlayer controls, RenderTexture paths, and grid-based transition effects.

## Describe your changes


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
