### PR TITLE
[v3] Support key modifiers in keyboard input event

### DIFF
--- a/axmol/base/InputSystem.cpp
+++ b/axmol/base/InputSystem.cpp
@@ -374,9 +374,9 @@ void InputSystem::dispatchEvent(Event* event, bool immediate)
 
 // Platform-facing unified input handlers ---------------------------------
 
-void InputSystem::handleKeyEvent(KeyboardEvent::KeyCode keyCode, InputPhase phase)
+void InputSystem::handleKeyEvent(KeyboardEvent::KeyCode keyCode, InputPhase phase, uint32_t modifiers)
 {
-    KeyboardEvent event(keyCode, phase);
+    KeyboardEvent event(keyCode, phase, modifiers);
     dispatchEvent(&event);
     bool stopped = event.isStopped();
 

--- a/axmol/base/InputSystem.h
+++ b/axmol/base/InputSystem.h
@@ -84,7 +84,7 @@ public:
     /////////////////////////////////////////////////////////////////////////////
 
     // handle key event
-    void handleKeyEvent(KeyboardEvent::KeyCode keyCode, InputPhase phase);
+    void handleKeyEvent(KeyboardEvent::KeyCode keyCode, InputPhase phase, uint32_t modifiers);
 
     // pointer input handling helpers migrated from RenderView
     void handlePointerDown(Vec2 point, const PointerInputState& state);

--- a/axmol/base/InputSystem.h
+++ b/axmol/base/InputSystem.h
@@ -84,7 +84,7 @@ public:
     /////////////////////////////////////////////////////////////////////////////
 
     // handle key event
-    void handleKeyEvent(KeyboardEvent::KeyCode keyCode, InputPhase phase, uint32_t modifiers);
+    void handleKeyEvent(KeyboardEvent::KeyCode keyCode, InputPhase phase, uint32_t modifiers = 0);
 
     // pointer input handling helpers migrated from RenderView
     void handlePointerDown(Vec2 point, const PointerInputState& state);

--- a/axmol/base/KeyboardEvent.cpp
+++ b/axmol/base/KeyboardEvent.cpp
@@ -34,7 +34,7 @@ KeyboardEvent::KeyboardEvent(KeyCode keyCode, InputPhase phase)
     : Event(Type::KEYBOARD), _keyCode(keyCode), _phase(phase), _modifiers(0)
 {}
 
-KeyboardEvent::KeyboardEvent(KeyCode keyCode, InputPhase phase, uint32_t modifiers) 
+KeyboardEvent::KeyboardEvent(KeyCode keyCode, InputPhase phase, uint32_t modifiers)
     : Event(Type::KEYBOARD), _keyCode(keyCode), _phase(phase), _modifiers(modifiers)
 {}
 

--- a/axmol/base/KeyboardEvent.cpp
+++ b/axmol/base/KeyboardEvent.cpp
@@ -31,7 +31,11 @@ namespace ax
 {
 
 KeyboardEvent::KeyboardEvent(KeyCode keyCode, InputPhase phase)
-    : Event(Type::KEYBOARD), _keyCode(keyCode), _phase(phase)
+    : Event(Type::KEYBOARD), _keyCode(keyCode), _phase(phase), _modifiers(0)
+{}
+
+KeyboardEvent::KeyboardEvent(KeyCode keyCode, InputPhase phase, uint32_t modifiers) 
+    : Event(Type::KEYBOARD), _keyCode(keyCode), _phase(phase), _modifiers(modifiers)
 {}
 
 }  // namespace ax

--- a/axmol/base/KeyboardEvent.h
+++ b/axmol/base/KeyboardEvent.h
@@ -220,13 +220,30 @@ public:
         KEY_PLAY
     };
 
+    enum KeyModifier : uint16_t
+    {
+        SHIFT     = 1,
+        CONTROL   = 2,
+        ALT       = 4,
+        SUPER     = 8,
+        CAPS_LOCK = 16,
+        NUM_LOCK  = 32
+    };
+
     /** Constructor.
      *
      * @param keyCode A given keycode.
-     * @param isKeyDown whether is key down event
-     * @param isRepeat whether key down repeat
+     * @param phase Input phase
      */
     KeyboardEvent(KeyCode keyCode, InputPhase phase);
+
+    /** Constructor.
+     *
+     * @param keyCode A given keycode.
+     * @param phase Input phase
+     * @param modifiers identifies any modifier keys that are active
+     */
+    KeyboardEvent(KeyCode keyCode, InputPhase phase, uint32_t modifiers);
 
     /**
      * @brief Get the key code.
@@ -252,9 +269,20 @@ public:
      */
     InputPhase getPhase() const { return _phase; }
 
+    /**
+     * @brief Retrieve the modifiers of this keyboard event.
+     *
+     * Returns the modifier keys
+     *
+     * @return uint32_t bitmasked value of modifier keys as
+     * declared in KeyModifier
+     */
+    uint32_t getModifiers() const { return _modifiers; }
+
 private:
     KeyCode _keyCode;
     InputPhase _phase{InputPhase::KeyDown};
+    uint32_t _modifiers;
 
     friend class KeyboardEventListener;
 };

--- a/axmol/platform/pc/RenderView-pc.cpp
+++ b/axmol/platform/pc/RenderView-pc.cpp
@@ -399,7 +399,50 @@ static constexpr KeyCodeItem s_keyCodeItems[] = {
     {GLFW_KEY_RIGHT_ALT, KeyboardEvent::KeyCode::KEY_RIGHT_ALT},
     {GLFW_KEY_RIGHT_SUPER, KeyboardEvent::KeyCode::KEY_HYPER},
     {GLFW_KEY_MENU, KeyboardEvent::KeyCode::KEY_MENU},
-    {GLFW_KEY_LAST, KeyboardEvent::KeyCode::KEY_NONE}};
+    {GLFW_KEY_LAST, KeyboardEvent::KeyCode::KEY_NONE}
+};
+
+static uint32_t mapModifiers(int glfwMods)
+{
+    if (glfwMods == 0)
+        return 0;
+
+    uint32_t result = 0;
+
+    if ((glfwMods & GLFW_MOD_CONTROL) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::CONTROL;
+    }
+
+    if ((glfwMods & GLFW_MOD_ALT) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::ALT;
+    }
+
+    if ((glfwMods & GLFW_MOD_SHIFT) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::SHIFT;
+    }
+
+    if ((glfwMods & GLFW_MOD_SUPER) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::SUPER;
+    }
+
+    // GLFW_MOD_CAPS_LOCK and GLFW_MOD_NUM_LOCK require
+    // GLFW_LOCK_KEY_MODS input mode to be set
+    if ((glfwMods & GLFW_MOD_CAPS_LOCK) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::CAPS_LOCK;
+    }
+
+    if ((glfwMods & GLFW_MOD_NUM_LOCK) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::NUM_LOCK;
+    }
+
+    return result;
+}
 
 // wasm input bridge
 #if defined(__EMSCRIPTEN__)
@@ -1716,9 +1759,11 @@ void RenderView::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double 
 }
 #endif
 
-void RenderView::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/)
+void RenderView::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int mods)
 {
     auto keyCode = _keyCodeMap[key];
+    auto mappedModifiers = mapModifiers(mods);
+
 #if defined(__EMSCRIPTEN__)
     if (isWebInputFieldProxyFocused() && keyCode == KeyboardEvent::KeyCode::KEY_BACKSPACE)
         return;
@@ -1738,7 +1783,7 @@ void RenderView::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scanco
         break;
     }
 
-    InputSystem::getInstance()->handleKeyEvent(keyCode, phase);
+    InputSystem::getInstance()->handleKeyEvent(keyCode, phase, mappedModifiers);
 }
 
 void RenderView::onGLFWCharCallback(GLFWwindow* /*window*/, unsigned int charCode)

--- a/axmol/platform/pc/RenderView-pc.cpp
+++ b/axmol/platform/pc/RenderView-pc.cpp
@@ -399,8 +399,7 @@ static constexpr KeyCodeItem s_keyCodeItems[] = {
     {GLFW_KEY_RIGHT_ALT, KeyboardEvent::KeyCode::KEY_RIGHT_ALT},
     {GLFW_KEY_RIGHT_SUPER, KeyboardEvent::KeyCode::KEY_HYPER},
     {GLFW_KEY_MENU, KeyboardEvent::KeyCode::KEY_MENU},
-    {GLFW_KEY_LAST, KeyboardEvent::KeyCode::KEY_NONE}
-};
+    {GLFW_KEY_LAST, KeyboardEvent::KeyCode::KEY_NONE}};
 
 static uint32_t mapModifiers(int glfwMods)
 {
@@ -1761,7 +1760,7 @@ void RenderView::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double 
 
 void RenderView::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int mods)
 {
-    auto keyCode = _keyCodeMap[key];
+    auto keyCode         = _keyCodeMap[key];
     auto mappedModifiers = mapModifiers(mods);
 
 #if defined(__EMSCRIPTEN__)

--- a/axmol/platform/winrt/RenderView-winrt.cpp
+++ b/axmol/platform/winrt/RenderView-winrt.cpp
@@ -276,6 +276,51 @@ uint32_t toAxPressedButtons(PointerPointProperties const& properties)
         buttons |= 1u << 4;
     return buttons;
 }
+
+uint32_t getKeyModifiers(CoreWindow const& sender)
+{
+    uint32_t modifiers = 0;
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::Control) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::CONTROL;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::Shift) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::SHIFT;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::Menu) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::ALT;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::NumberKeyLock) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::NUM_LOCK;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::CapitalLock) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::CAPS_LOCK;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::LeftWindows) & CoreVirtualKeyStates::Down) ==
+            CoreVirtualKeyStates::Down ||
+        (sender.GetKeyState(Windows::System::VirtualKey::RightWindows) & CoreVirtualKeyStates::Down) ==
+            CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::SUPER;
+    }
+
+    return modifiers;
+}
 }  // namespace
 
 RenderView* RenderView::create(std::string_view viewName)
@@ -744,14 +789,14 @@ void RenderView::onPointerWheelChanged(Windows::Foundation::IInspectable const& 
     handlePointerEvent(InputPhase::PointerScroll, args);
 }
 
-void RenderView::onKeyPressed(CoreWindow const& /*sender*/, KeyEventArgs const& args)
+void RenderView::onKeyPressed(CoreWindow const& sender, KeyEventArgs const& args)
 {
-    handleKeyboardEvent(ax::InputPhase::KeyDown, args);
+    handleKeyboardEvent(ax::InputPhase::KeyDown, getKeyModifiers(sender), args);
 }
 
-void RenderView::onKeyReleased(CoreWindow const& /*sender*/, KeyEventArgs const& args)
+void RenderView::onKeyReleased(CoreWindow const& sender, KeyEventArgs const& args)
 {
-    handleKeyboardEvent(ax::InputPhase::KeyUp, args);
+    handleKeyboardEvent(ax::InputPhase::KeyUp, getKeyModifiers(sender), args);
 }
 
 void RenderView::onCharacterReceived(CoreWindow const& /*sender*/, CharacterReceivedEventArgs const& args)
@@ -800,7 +845,7 @@ void RenderView::onBackButtonPressed(Windows::Foundation::IInspectable const& /*
                                      BackRequestedEventArgs const& args)
 {
     Director::getInstance()->postTask([]() {
-        InputSystem::getInstance()->handleKeyEvent(KeyboardEvent::KeyCode::KEY_ESCAPE, InputPhase::KeyUp);
+        InputSystem::getInstance()->handleKeyEvent(KeyboardEvent::KeyCode::KEY_ESCAPE, InputPhase::KeyUp, 0);
     }, Director::TaskTiming::FrameBoundary);
     args.Handled(true);
 }
@@ -907,7 +952,7 @@ void RenderView::handlePointerEvent(ax::InputPhase phase, PointerEventArgs const
     }, Director::TaskTiming::FrameBoundary);
 }
 
-void RenderView::handleKeyboardEvent(ax::InputPhase phase, KeyEventArgs const& args)
+void RenderView::handleKeyboardEvent(ax::InputPhase phase, uint32_t modifiers, KeyEventArgs const& args)
 {
     int key = static_cast<int>(args.VirtualKey());
     auto it = _keyCodeMap.find(key);
@@ -918,8 +963,8 @@ void RenderView::handleKeyboardEvent(ax::InputPhase phase, KeyEventArgs const& a
         const auto isKeyDown = phase == ax::InputPhase::KeyDown;
         if (isKeyDown && args.KeyStatus().WasKeyDown)
             phase = ax::InputPhase::KeyRepeat;
-        Director::getInstance()->postTask([keyCode, phase]() {
-            InputSystem::getInstance()->handleKeyEvent(keyCode, phase);
+        Director::getInstance()->postTask([keyCode, phase, modifiers]() {
+            InputSystem::getInstance()->handleKeyEvent(keyCode, phase, modifiers);
         }, Director::TaskTiming::FrameBoundary);
     }
     else

--- a/axmol/platform/winrt/RenderView-winrt.h
+++ b/axmol/platform/winrt/RenderView-winrt.h
@@ -100,7 +100,7 @@ public:
                         Windows::UI::Core::CoreWindowEventArgs const& args);
 
     void handlePointerEvent(ax::InputPhase phase, Windows::UI::Core::PointerEventArgs const& args);
-    void handleKeyboardEvent(ax::InputPhase phase, Windows::UI::Core::KeyEventArgs const& args);
+    void handleKeyboardEvent(ax::InputPhase phase, uint32_t modifiers, Windows::UI::Core::KeyEventArgs const& args);
 
     AlertResult showAlertDialog(const winrt::hstring& title, const winrt::hstring& message, AlertStyle style);
 


### PR DESCRIPTION
## Describe your changes

Added support for reading the modifier keys from the keyboard input event.  This works for both GLFW and UWP apps.

## Issue ticket number and link
#3267 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
