### PR TITLE
[v2] Support key modifiers in keyboard input event

### DIFF
--- a/core/base/EventKeyboard.cpp
+++ b/core/base/EventKeyboard.cpp
@@ -31,7 +31,11 @@ namespace ax
 {
 
 EventKeyboard::EventKeyboard(KeyCode keyCode, bool isKeyDown, bool isRepeat)
-    : Event(Type::KEYBOARD), _keyCode(keyCode), _isKeyDown(isKeyDown), _isRepeat(isRepeat)
+    : Event(Type::KEYBOARD), _keyCode(keyCode), _isKeyDown(isKeyDown), _isRepeat(isRepeat), _modifiers(0)
 {}
 
-}
+EventKeyboard::EventKeyboard(KeyCode keyCode, bool isKeyDown, uint32_t modifiers, bool isRepeat)
+    : Event(Type::KEYBOARD), _keyCode(keyCode), _isKeyDown(isKeyDown), _isRepeat(isRepeat), _modifiers(modifiers)
+{}
+
+}  // namespace ax

--- a/core/base/EventKeyboard.h
+++ b/core/base/EventKeyboard.h
@@ -220,6 +220,16 @@ public:
         KEY_PLAY
     };
 
+    enum KeyModifier : uint16_t
+    {
+        SHIFT = 1,
+        CONTROL = 2,
+        ALT = 4,
+        SUPER = 8,
+        CAPS_LOCK = 16,
+        NUM_LOCK = 32
+    };
+
     /** Constructor.
      *
      * @param keyCode A given keycode.
@@ -228,12 +238,22 @@ public:
      */
     EventKeyboard(KeyCode keyCode, bool isKeyDown, bool isRepeat = false);
 
+    /** Constructor.
+     *
+     * @param keyCode A given keycode.
+     * @param isKeyDown whether is key down event
+     * @param isRepeat whether key down repeat
+     * @param modifiers identifies any modifier keys that are active
+     */
+    EventKeyboard(KeyCode keyCode, bool isKeyDown, uint32_t modifiers, bool isRepeat = false);
+
     bool isRepeat() const { return _isRepeat; }
 
 private:
     KeyCode _keyCode;
     bool _isKeyDown;
     bool _isRepeat;
+    uint32_t _modifiers;
 
     friend class EventListenerKeyboard;
 };

--- a/core/platform/RenderViewImpl.cpp
+++ b/core/platform/RenderViewImpl.cpp
@@ -365,6 +365,48 @@ static EventMouse::MouseButton checkMouseButton(GLFWwindow* window)
     return mouseButton;
 }
 
+static uint32_t mapModifiers(int glfwMods)
+{
+    if (glfwMods == 0)
+        return 0;
+
+    uint32_t result = 0;
+
+    if ((glfwMods & GLFW_MOD_CONTROL) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::CONTROL;
+    }
+
+    if ((glfwMods & GLFW_MOD_ALT) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::ALT;
+    }
+
+    if ((glfwMods & GLFW_MOD_SHIFT) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::SHIFT;
+    }
+
+    if ((glfwMods & GLFW_MOD_SUPER) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::SUPER;
+    }
+
+    // GLFW_MOD_CAPS_LOCK and GLFW_MOD_NUM_LOCK require 
+    // GLFW_LOCK_KEY_MODS input mode to be set
+    if ((glfwMods & GLFW_MOD_CAPS_LOCK) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::CAPS_LOCK;
+    }
+
+    if ((glfwMods & GLFW_MOD_NUM_LOCK) != 0)
+    {
+        result |= EventKeyboard::KeyModifier::NUM_LOCK;
+    }
+
+    return result;
+}
+
 RenderViewImpl::RenderViewImpl(bool initglfw)
     : _captured(false)
     , _isInRetinaMonitor(false)
@@ -1243,10 +1285,11 @@ void RenderViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, dou
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void RenderViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/)
+void RenderViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int mods)
 {
     const auto isKeyDown = action != GLFW_RELEASE;
-    EventKeyboard event(g_keyCodeMap[key], isKeyDown, action == GLFW_REPEAT);
+    auto mappedModifiers = mapModifiers(mods);
+    EventKeyboard event(g_keyCodeMap[key], isKeyDown, mappedModifiers, action == GLFW_REPEAT);
     auto dispatcher = Director::getInstance()->getEventDispatcher();
     dispatcher->dispatchEvent(&event);
 

--- a/core/platform/winrt/InputEvent.cpp
+++ b/core/platform/winrt/InputEvent.cpp
@@ -125,13 +125,18 @@ void KeyboardEvent::execute()
 }
 
 WinRTKeyboardEvent::WinRTKeyboardEvent(WinRTKeyboardEventType type, const Windows::UI::Core::KeyEventArgs& args)
-	: m_type(type), m_key(args)
+    : m_type(type), m_key(args), m_modifiers(0)
+{
+}
+
+WinRTKeyboardEvent::WinRTKeyboardEvent(WinRTKeyboardEventType type, uint32_t modifiers, const Windows::UI::Core::KeyEventArgs& args)
+    : m_type(type), m_key(args), m_modifiers(modifiers)
 {
 }
 
 void WinRTKeyboardEvent::execute()
 {
-	RenderViewImpl::sharedRenderView()->OnWinRTKeyboardEvent(m_type, m_key);
+	RenderViewImpl::sharedRenderView()->OnWinRTKeyboardEvent(m_type, m_modifiers, m_key);
 }
 
 BackButtonEvent::BackButtonEvent()

--- a/core/platform/winrt/InputEvent.h
+++ b/core/platform/winrt/InputEvent.h
@@ -109,12 +109,14 @@ enum class WinRTKeyboardEventType
 class AX_DLL WinRTKeyboardEvent : public InputEvent
 {
 public:
-	WinRTKeyboardEvent(WinRTKeyboardEventType type, const Windows::UI::Core::KeyEventArgs& args);
-	virtual void execute();
+    WinRTKeyboardEvent(WinRTKeyboardEventType type, const Windows::UI::Core::KeyEventArgs& args);
+    WinRTKeyboardEvent(WinRTKeyboardEventType type, uint32_t modifiers, const Windows::UI::Core::KeyEventArgs& args);
+    virtual void execute();
 
 private:
 	WinRTKeyboardEventType m_type;
     Windows::UI::Core::KeyEventArgs m_key;
+    uint32_t m_modifiers;
 };
 
 

--- a/core/platform/winrt/Keyboard-winrt.cpp
+++ b/core/platform/winrt/Keyboard-winrt.cpp
@@ -274,7 +274,7 @@ void KeyBoardWinRT::HideKeyboard(winrt::hstring const& text)
     }
 }
 
-void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, KeyEventArgs const& args)
+void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, uint32_t modifiers, KeyEventArgs const& args)
 {
     const auto isKeyDown = type == WinRTKeyboardEventType::Down;
     const auto isRepeat = (isKeyDown && args.KeyStatus().WasKeyDown);
@@ -285,7 +285,7 @@ void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, KeyEventAr
     {
         EventKeyboard::KeyCode keyCode = it->second;
 
-        EventKeyboard event(keyCode, isKeyDown, isRepeat);
+        EventKeyboard event(keyCode, isKeyDown, modifiers, isRepeat);
         auto dispatcher = Director::getInstance()->getEventDispatcher();
         dispatcher->dispatchEvent(&event);
         if (keyCode == EventKeyboard::KeyCode::KEY_ENTER)

--- a/core/platform/winrt/Keyboard-winrt.h
+++ b/core/platform/winrt/Keyboard-winrt.h
@@ -45,7 +45,9 @@ public:
     void HideKeyboard(const winrt::hstring& text);
 
 public:
-    void OnWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
+    void OnWinRTKeyboardEvent(WinRTKeyboardEventType type,
+                              uint32_t modifiers,
+                              Windows::UI::Core::KeyEventArgs const& args);
 
 private:
     void OnTextChanged(const Windows::Foundation::IInspectable& sender,

--- a/core/platform/winrt/RenderViewImpl-winrt.cpp
+++ b/core/platform/winrt/RenderViewImpl-winrt.cpp
@@ -615,15 +615,19 @@ void RenderViewImpl::QueuePointerEvent(PointerEventType type, Windows::UI::Core:
     mInputEvents.push(e);
 }
 
-void RenderViewImpl::QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
+void RenderViewImpl::QueueWinRTKeyboardEvent(WinRTKeyboardEventType type,
+                                             uint32_t modifiers,
+                                             Windows::UI::Core::KeyEventArgs const& args)
 {
-    std::shared_ptr<WinRTKeyboardEvent> e(new WinRTKeyboardEvent(type, args));
+    std::shared_ptr<WinRTKeyboardEvent> e(new WinRTKeyboardEvent(type, modifiers, args));
     mInputEvents.push(e);
 }
 
-void RenderViewImpl::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
+void RenderViewImpl::OnWinRTKeyboardEvent(WinRTKeyboardEventType type,
+                                          uint32_t modifiers,
+                                          Windows::UI::Core::KeyEventArgs const& args)
 {
-    m_keyboard.OnWinRTKeyboardEvent(type, args);
+    m_keyboard.OnWinRTKeyboardEvent(type, modifiers, args);
 }
 
 void RenderViewImpl::QueueEvent(std::shared_ptr<InputEvent>& event)

--- a/core/platform/winrt/RenderViewImpl-winrt.h
+++ b/core/platform/winrt/RenderViewImpl-winrt.h
@@ -90,7 +90,9 @@ public:
     void OnMouseReleased(Windows::UI::Core::PointerEventArgs const& args);
     void OnMouseWheelChanged(Windows::UI::Core::PointerEventArgs const& args);
 
-    void OnWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
+    void OnWinRTKeyboardEvent(WinRTKeyboardEventType type,
+                              uint32_t modifiers,
+                              Windows::UI::Core::KeyEventArgs const& args);
 
     void OnPointerPressed(Windows::UI::Core::CoreWindow const& sender, Windows::UI::Core::PointerEventArgs const& args);
     void OnPointerWheelChanged(Windows::UI::Core::CoreWindow const&, Windows::UI::Core::PointerEventArgs const& args);
@@ -110,7 +112,9 @@ public:
 
     void QueueBackKeyPress();
     void QueuePointerEvent(PointerEventType type, Windows::UI::Core::PointerEventArgs const& args);
-    void QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
+    void QueueWinRTKeyboardEvent(WinRTKeyboardEventType type,
+                                 uint32_t modifiers,
+                                 Windows::UI::Core::KeyEventArgs const& args);
     void QueueEvent(std::shared_ptr<InputEvent>& event);
 
     AlertResult ShowAlertDialog(const winrt::hstring& title, const winrt::hstring& message, AlertStyle style);

--- a/core/platform/winrt/xaml/AxmolRenderer.cpp
+++ b/core/platform/winrt/xaml/AxmolRenderer.cpp
@@ -154,7 +154,7 @@ void AxmolRenderer::QueueBackButtonEvent()
     RenderViewImpl::sharedRenderView()->QueueBackKeyPress();
 }
 
-void AxmolRenderer::QueueKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args)
+void AxmolRenderer::QueueKeyboardEvent(WinRTKeyboardEventType type, uint32_t modifiers, Windows::UI::Core::KeyEventArgs const& args)
 {
-    RenderViewImpl::sharedRenderView()->QueueWinRTKeyboardEvent(type, args);
+    RenderViewImpl::sharedRenderView()->QueueWinRTKeyboardEvent(type, modifiers, args);
 }

--- a/core/platform/winrt/xaml/AxmolRenderer.h
+++ b/core/platform/winrt/xaml/AxmolRenderer.h
@@ -42,7 +42,9 @@ public:
     void SetQueueOperationCb(std::function<void(ax::AsyncOperation, void*)> op);
     void Draw(size_t width, size_t height, float dpi, Windows::Graphics::Display::DisplayOrientations orientation);
 	void QueuePointerEvent(ax::PointerEventType type, Windows::UI::Core::PointerEventArgs const& args);
-    void QueueKeyboardEvent(ax::WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs const& args);
+    void QueueKeyboardEvent(ax::WinRTKeyboardEventType type,
+                            uint32_t modifiers,
+                            Windows::UI::Core::KeyEventArgs const& args);
 	void QueueBackButtonEvent();
     void Pause();
     void Resume();

--- a/core/platform/winrt/xaml/OpenGLESPage.cpp
+++ b/core/platform/winrt/xaml/OpenGLESPage.cpp
@@ -27,6 +27,7 @@
 
 #include <winrt/Windows.Graphics.h>
 #include <winrt/Windows.Graphics.Display.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.System.Threading.h>
 #include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.UI.Input.Core.h>
@@ -55,6 +56,54 @@ using namespace Windows::UI::Input;
 
 namespace winrt::AxmolAppWinRT::implementation
 {
+namespace
+{
+uint32_t GetKeyModifiers(CoreWindow const& sender)
+{
+    uint32_t modifiers = 0;
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::Control) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::CONTROL;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::Shift) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::SHIFT;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::Menu) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::ALT;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::NumberKeyLock) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::NUM_LOCK;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::CapitalLock) & CoreVirtualKeyStates::Down) ==
+        CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::CAPS_LOCK;
+    }
+
+    if ((sender.GetKeyState(Windows::System::VirtualKey::LeftWindows) & CoreVirtualKeyStates::Down) ==
+            CoreVirtualKeyStates::Down ||
+        (sender.GetKeyState(Windows::System::VirtualKey::RightWindows) & CoreVirtualKeyStates::Down) ==
+            CoreVirtualKeyStates::Down)
+    {
+        modifiers |= EventKeyboard::KeyModifier::SUPER;
+    }
+
+    return modifiers;
+}
+}  // namespace
+
 OpenGLESPage::OpenGLESPage() : OpenGLESPage(nullptr) {}
 OpenGLESPage::OpenGLESPage(OpenGLES* openGLES)
     : mOpenGLES(openGLES)
@@ -411,7 +460,8 @@ void OpenGLESPage::OnKeyPressed(CoreWindow const& sender, KeyEventArgs const& ar
 {
     if (mRenderer)
     {
-        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::Down, args);
+        const auto modifiers = GetKeyModifiers(sender);
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::Down, modifiers, args);
     }
 }
 
@@ -419,11 +469,12 @@ void OpenGLESPage::_OnCharacterReceived(CoreWindow const& /*sender*/, CharacterR
 {
 }
 
-void OpenGLESPage::OnKeyReleased(CoreWindow const& /*sender*/, KeyEventArgs const& args)
+void OpenGLESPage::OnKeyReleased(CoreWindow const& sender, KeyEventArgs const& args)
 {
     if (mRenderer)
     {
-        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::Up, args);
+        const auto modifiers = GetKeyModifiers(sender);
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::Up, modifiers, args);
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Added support for reading the modifier keys from the keyboard input event. This works for both GLFW and UWP apps.

## Issue ticket number and link
#3267 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
