### PR TITLE
Set correct path to Microsoft.Windows.CppWinRT.props

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -33,7 +33,7 @@ function(ax_setup_ext_config target_name)
   )
 
   if(WINRT)
-    set_property(TARGET ${target_name} PROPERTY VS_PROJECT_IMPORT ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.props)
+    set_property(TARGET ${target_name} PROPERTY VS_PROJECT_IMPORT ${_NUGET_PACKAGE_DIR}/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.props)
   endif()
 
   if(NOT opt_DNTLINK)


### PR DESCRIPTION
## Describe your changes

This corrects the path to `Microsoft.Windows.CppWinRT.props` for the extensions to fix the UWP build issues.


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
