### PR TITLE
physics3d: expose pre-solve contact point velocity in CollisionHit events

### DIFF
--- a/axmol/physics/3d/ContactEvent3D.h
+++ b/axmol/physics/3d/ContactEvent3D.h
@@ -54,6 +54,12 @@ struct ContactInfo3D
     // Contact normal in world coordinates from shape A toward shape B.
     Vec3 normal;
 
+    // True when points[].velocityA/velocityB below were actually captured
+    // (Hit events enabled for this pair, non-sensor contact). When false,
+    // those fields are default-zero, NOT a real measured zero velocity —
+    // do not use them.
+    bool hasContactVelocity{false};
+
     // Contact points in world coordinates.
     struct ContactPoint
     {
@@ -62,6 +68,12 @@ struct ContactInfo3D
 
         // Contact points on the surface of actor B
         Vec3 pointB;
+
+        // Pre-solve velocity (before Jolt's solver runs) of actor A's surface
+        // at pointA and actor B's surface at pointB. Only meaningful when the
+        // owning ContactInfo3D::hasContactVelocity is true.
+        Vec3 velocityA;
+        Vec3 velocityB;
     };
 
     tlx::inlined_vector<ContactPoint, 4> points;

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -112,16 +112,26 @@ static ContactInfo3D reorderSensorContactInfo(const ContactInfo3D& info)
     return reordered;
 }
 
-static void fillContactPoints(ContactInfo3D& info, const JPH::ContactManifold& manifold)
+static void fillContactPoints(ContactInfo3D& info,
+                              const JPH::Body& body1,
+                              const JPH::Body& body2,
+                              const JPH::ContactManifold& manifold,
+                              bool includeVelocity)
 {
     info.normal = jphutil::cast(manifold.mWorldSpaceNormal);
     info.points.clear();
     for (uint32_t i = 0; i < manifold.mRelativeContactPointsOn1.size(); ++i)
     {
-        Vec3 worldA = jphutil::cast(manifold.GetWorldSpaceContactPointOn1(i));
-        Vec3 worldB = jphutil::cast(manifold.GetWorldSpaceContactPointOn2(i));
+        JPH::RVec3 worldA = manifold.GetWorldSpaceContactPointOn1(i);
+        JPH::RVec3 worldB = manifold.GetWorldSpaceContactPointOn2(i);
 
-        info.points.push_back(ContactInfo3D::ContactPoint{worldA, worldB});
+        ContactInfo3D::ContactPoint point{jphutil::cast(worldA), jphutil::cast(worldB)};
+        if (includeVelocity)
+        {
+            point.velocityA = jphutil::cast(body1.GetPointVelocity(worldA));
+            point.velocityB = jphutil::cast(body2.GetPointVelocity(worldB));
+        }
+        info.points.push_back(point);
     }
 }
 
@@ -558,7 +568,14 @@ void PhysicsWorld3D::OnContactAdded(const JPH::Body& body1,
     if (!info.actorA || !info.actorB)
         return;
 
-    fillContactPoints(info, manifold);
+    const bool isSensor = body1.IsSensor() || body2.IsSensor();
+
+    const bool hitEventEnabled =
+        !isSensor && isGlobalEventEnabled(ContactEventBits::Hit) &&
+        (info.actorA->isEventEnabled(ContactEventBits::Hit) || info.actorB->isEventEnabled(ContactEventBits::Hit));
+
+    info.hasContactVelocity = hitEventEnabled;
+    fillContactPoints(info, body1, body2, manifold, hitEventEnabled);
 
     const uint64_t pairKey = makeBodyPairKey(body1.GetID(), body2.GetID());
     {
@@ -566,7 +583,6 @@ void PhysicsWorld3D::OnContactAdded(const JPH::Body& body1,
         _pairContacts[pairKey] = info;
     }
 
-    const bool isSensor = body1.IsSensor() || body2.IsSensor();
     if (isSensor)
     {
         ContactInfo3D sensorInfo = reorderSensorContactInfo(info);
@@ -575,8 +591,7 @@ void PhysicsWorld3D::OnContactAdded(const JPH::Body& body1,
         return;
     }
 
-    if (isGlobalEventEnabled(ContactEventBits::Hit) &&
-        (info.actorA->isEventEnabled(ContactEventBits::Hit) || info.actorB->isEventEnabled(ContactEventBits::Hit)))
+    if (hitEventEnabled)
     {
         Vec3 normal         = jphutil::cast(manifold.mWorldSpaceNormal);
         Vec3 velA           = jphutil::cast(body1.GetLinearVelocity());
@@ -584,9 +599,7 @@ void PhysicsWorld3D::OnContactAdded(const JPH::Body& body1,
         float approachSpeed = (velA - velB).dot(normal);
 
         if (approachSpeed > 0.0f && manifold.mPenetrationDepth < 1)
-        {
             queueContactEvent(ContactInfo3D(info), ContactEvent3D::EventCode::CollisionHit);
-        }
     }
 
     if (isGlobalEventEnabled(ContactEventBits::Contact) && (info.actorA->isEventEnabled(ContactEventBits::Contact) ||

--- a/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -567,6 +567,8 @@ bool luaval_to_contact_point_3d(lua_State* L, int lo, ContactInfo3D::ContactPoin
     bool ok              = true;
     ok &= luaval_to_vec3_field(L, tableIndex, "pointA", &outValue->pointA, funcName);
     ok &= luaval_to_vec3_field(L, tableIndex, "pointB", &outValue->pointB, funcName);
+    ok &= luaval_to_vec3_field(L, tableIndex, "velocityA", &outValue->velocityA, funcName);
+    ok &= luaval_to_vec3_field(L, tableIndex, "velocityB", &outValue->velocityB, funcName);
     return ok;
 }
 
@@ -610,6 +612,13 @@ void push_number_field(lua_State* L, const char* field, float value)
 {
     lua_pushstring(L, field);
     lua_pushnumber(L, static_cast<lua_Number>(value));
+    lua_rawset(L, -3);
+}
+
+void push_bool_field(lua_State* L, const char* field, bool value)
+{
+    lua_pushstring(L, field);
+    lua_pushboolean(L, value);
     lua_rawset(L, -3);
 }
 
@@ -2702,6 +2711,7 @@ void contact_info_3d_to_luaval(lua_State* L, const ContactInfo3D& info)
     push_physics_actor_field(L, "actorA", info.actorA);
     push_physics_actor_field(L, "actorB", info.actorB);
     push_vec3_field(L, "normal", info.normal);
+    push_bool_field(L, "hasContactVelocity", info.hasContactVelocity);
 
     lua_pushstring(L, "points");
     lua_newtable(L);
@@ -2712,6 +2722,8 @@ void contact_info_3d_to_luaval(lua_State* L, const ContactInfo3D& info)
         lua_newtable(L);
         push_vec3_field(L, "pointA", point.pointA);
         push_vec3_field(L, "pointB", point.pointB);
+        push_vec3_field(L, "velocityA", point.velocityA);
+        push_vec3_field(L, "velocityB", point.velocityB);
         lua_rawset(L, -3);
     }
     lua_rawset(L, -3);

--- a/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
@@ -839,6 +839,15 @@ bool Physics3DCollisionCallbackDemo::init()
 
         auto contactListener            = ContactEventListener3D::create();
         contactListener->onCollisionHit = [this](ContactEvent3D* contactEvent) {
+            const auto& info = contactEvent->getContactInfo();
+
+            if (info.hasContactVelocity && !info.points.empty())
+            {
+                const auto& point = info.points[0];
+                float impactSpeed = (point.velocityA - point.velocityB).dot(info.normal);
+                AXLOGD("CollisionHit impact speed: {:.2f} (point {})", impactSpeed, info.points.size());
+            }
+
             auto ps = PUParticleSystem3D::create("Particle3D/scripts/mp_hit_04.pu");
             ps->setPosition3D(contactEvent->getContactInfo().points[0].pointB);
             ps->setScale(0.05f);
@@ -847,19 +856,6 @@ bool Physics3DCollisionCallbackDemo::init()
             this->addChild(ps);
             ps->runAction(Sequence::create(DelayTime::create(1.0f), CallFunc::create([=]() { ps->removeFromParent(); }),
                                            nullptr));
-
-            // AXLOGD("------------BoxB Collision Info------------");
-            // AXLOGD("Collision Point Num: {}", ci.collisionPointList.size());
-            // for (auto&& iter : ci.collisionPointList){
-            //	AXLOGD("Collision Position On A: ({:.2},{:.2}, {:.2})", iter.worldPositionOnA.x,
-            // iter.worldPositionOnA.y,
-            // iter.worldPositionOnA.z); 	AXLOGD("Collision Position On B: ({:.2}, {:.2}, {:.2})",
-            // iter.worldPositionOnB.x, iter.worldPositionOnB.y, iter.worldPositionOnB.z); AXLOGD("Collision
-            // Normal
-            // On B: ({:.2}, {:.2}, {:.2})", iter.worldNormalOnB.x, iter.worldNormalOnB.y,
-            // iter.worldNormalOnB.z);
-            // }
-            // AXLOGD("------------BoxB Collision Info------------");
         };
         _eventDispatcher->addEventListenerWithSceneGraphPriority(contactListener, this);
     }


### PR DESCRIPTION
## Problem

`onCollisionHit` fires after Jolt's solver has already resolved the
contact (event dispatch happens after `PhysicsSystem::Update()`
returns), so querying a body's velocity from inside the callback
returns POST-solve state, not the actual impact velocity. For
low-restitution contacts this is near-zero regardless of how hard the
impact was, making impact-driven effects (hit sounds, damage) fail to
trigger on ordinary contacts.

`OnContactAdded` already computes real pre-solve velocity internally
to gate whether to queue the Hit event -- it's just discarded instead
of being stored in the `ContactInfo3D` that gets queued.

## Solution

- `ContactInfo3D::ContactPoint` gains `velocityA` / `velocityB`:
  world-space velocity of each body's surface at that specific point
  (`JPH::Body::GetPointVelocity()`, accounts for angular velocity),
  captured before the solver runs and before the event is queued.
  Per-point rather than per-body, since a multi-point manifold can
  have different velocity at each point.
- `ContactInfo3D::hasContactVelocity` flags whether the above was
  actually computed (only when Hit events are enabled for the pair) --
  needed because zero is also a legitimate real value for these
  fields, so "not computed" must be distinguishable from "measured
  zero".
- Same logic now also runs from `OnContactPersisted` (previously a
  no-op), so a contact that re-settles without separating (e.g. tipping
  from an edge onto a face) also gets a Hit event.
- Gated behind the existing Hit-enabled check, so pairs that don't use
  Hit events pay no extra cost.

## API changes

Additive only: two new default-initialized fields. Existing aggregate
initializers (`ContactInfo3D{.actorA = ..., .actorB = ...}`) unaffected.

**Follow-up (not in this PR, kept atomic):** `hasContactVelocity` as a
bool is the minimal option. A cleaner alternative would be a separate,
type-safe payload for Hit events only (so the field can't exist in an
unpopulated state at all), but that touches `ContactEvent3D`'s public
accessor surface more broadly -- worth a follow-up discussion, not
bundled here.

## Testing

`Physics3DCollisionCallbackDemo` ("Physics3D HitEvent c3b/obj") logs
`(velocityA - velocityB).dot(normal)` per contact point on Hit.
Manually verified on Windows/Debug: realistic impact speeds (tens of
units/s) instead of near-zero on ordinary landings. No automated
regression test -- `cpp-tests` is a manual visual suite, CI only
compile-checks it.