### PR TITLE
[v2] Provide access to get current editing state of EditBox

### DIFF
--- a/core/ui/UIEditBox/UIEditBox.cpp
+++ b/core/ui/UIEditBox/UIEditBox.cpp
@@ -881,12 +881,7 @@ void EditBox::setGlobalZOrder(float globalZOrder)
 
 bool EditBox::isEditing() const
 {
-    if (_editBoxImpl)
-    {
-        return _editBoxImpl->isEditing();
-    }
-
-    return false;
+    return _editBoxImpl && _editBoxImpl->isEditing();
 }
 
 #if AX_ENABLE_SCRIPT_BINDING

--- a/core/ui/UIEditBox/UIEditBox.cpp
+++ b/core/ui/UIEditBox/UIEditBox.cpp
@@ -879,6 +879,16 @@ void EditBox::setGlobalZOrder(float globalZOrder)
     }
 }
 
+bool EditBox::isEditing() const
+{
+    if (_editBoxImpl)
+    {
+        return _editBoxImpl->isEditing();
+    }
+
+    return false;
+}
+
 #if AX_ENABLE_SCRIPT_BINDING
 void EditBox::registerScriptEditBoxHandler(int handler)
 {

--- a/core/ui/UIEditBox/UIEditBox.h
+++ b/core/ui/UIEditBox/UIEditBox.h
@@ -639,6 +639,12 @@ public:
     void openKeyboard() const;
     void closeKeyboard() const;
 
+    /**
+     * Get the editing state of the EditBox
+     * @return true if editing
+     */
+    bool isEditing() const;
+
 protected:
     virtual void releaseUpEvent() override;
 

--- a/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -180,7 +180,7 @@ void EditBoxImplAndroid::setNativeTextHorizontalAlignment(ax::TextHAlignment ali
 
 bool EditBoxImplAndroid::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplAndroid::setNativeText(const char* pText)

--- a/core/ui/UIEditBox/UIEditBoxImpl-linux.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-linux.cpp
@@ -310,7 +310,7 @@ EditBoxImplLinux::~EditBoxImplLinux() {}
 
 bool EditBoxImplLinux::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplLinux::nativeOpenKeyboard()

--- a/core/ui/UIEditBox/UIEditBoxImpl-wasm.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-wasm.cpp
@@ -90,7 +90,7 @@ EditBoxImplWasm::~EditBoxImplWasm()
 
 bool EditBoxImplWasm::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplWasm::createNativeControl(const Rect& frame)

--- a/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/core/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -93,7 +93,7 @@ EditBoxImplWin::~EditBoxImplWin()
 
 bool EditBoxImplWin::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplWin::cleanupEditCtrl()


### PR DESCRIPTION
## Describe your changes

Remove hard-coded editing state for platforms that had it set, and instead return current editing state that was already available via the `_editingMode` flag.

Add `EditBox::isEditing()` method to expose the current editing state of the EditBox.

Tested Wasm, Win32, and Android, and they're working correctly.  The only one I can't test at the moment is Linux, but it shouldn't be any different, since it is returning the existing `_editingMode` value as well.  The other platforms were not changed, since they already returned the correct value.

## Issue ticket number and link
#3276 

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
