### PR TITLE
[v3] Provide access to current editing state of EditBox

### DIFF
--- a/axmol/ui/EditBox/EditBox.cpp
+++ b/axmol/ui/EditBox/EditBox.cpp
@@ -878,6 +878,11 @@ void EditBox::setGlobalZOrder(float globalZOrder)
     }
 }
 
+bool EditBox::isEditing() const
+{
+    return _editBoxImpl && _editBoxImpl->isEditing();
+}
+
 #if AX_ENABLE_SCRIPT_BINDING
 void EditBox::registerScriptEditBoxHandler(int handler)
 {

--- a/axmol/ui/EditBox/EditBox.h
+++ b/axmol/ui/EditBox/EditBox.h
@@ -633,6 +633,12 @@ public:
     void openKeyboard() const;
     void closeKeyboard() const;
 
+    /**
+     * Get the editing state of the EditBox
+     * @return true if editing
+     */
+    bool isEditing() const;
+
 protected:
     void releaseUpEvent() override;
 

--- a/axmol/ui/EditBox/EditBoxImpl-android.cpp
+++ b/axmol/ui/EditBox/EditBoxImpl-android.cpp
@@ -145,7 +145,7 @@ void EditBoxImplAndroid::setNativeTextHorizontalAlignment(ax::TextHAlignment ali
 
 bool EditBoxImplAndroid::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplAndroid::setNativeText(std::string_view text)

--- a/axmol/ui/EditBox/EditBoxImpl-linux.cpp
+++ b/axmol/ui/EditBox/EditBoxImpl-linux.cpp
@@ -456,7 +456,7 @@ EditBoxImplLinux::~EditBoxImplLinux()
 
 bool EditBoxImplLinux::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplLinux::nativeOpenKeyboard()

--- a/axmol/ui/EditBox/EditBoxImpl-wasm.cpp
+++ b/axmol/ui/EditBox/EditBoxImpl-wasm.cpp
@@ -86,7 +86,7 @@ EditBoxImplWasm::~EditBoxImplWasm()
 
 bool EditBoxImplWasm::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplWasm::createNativeControl()

--- a/axmol/ui/EditBox/EditBoxImpl-win32.cpp
+++ b/axmol/ui/EditBox/EditBoxImpl-win32.cpp
@@ -90,7 +90,7 @@ EditBoxImplWin::~EditBoxImplWin()
 
 bool EditBoxImplWin::isEditing()
 {
-    return false;
+    return _editingMode;
 }
 
 void EditBoxImplWin::cleanupEditCtrl()


### PR DESCRIPTION
## Describe your changes

Same as the v2 changes from PR #3277 

Remove hard-coded editing state for platforms that had it set, and instead return current editing state that was already available via the _editingMode flag.

Add EditBox::isEditing() method to expose the current editing state of the EditBox.

## Issue ticket number and link
#3276

## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
