### PR TITLE
Fix: swap ContactPoint sideA/sideB on sensor actor reorder

### DIFF
--- a/axmol/physics/3d/ContactEvent3D.h
+++ b/axmol/physics/3d/ContactEvent3D.h
@@ -54,26 +54,21 @@ struct ContactInfo3D
     // Contact normal in world coordinates from shape A toward shape B.
     Vec3 normal;
 
-    // True when points[].velocityA/velocityB below were actually captured
-    // (Hit events enabled for this pair, non-sensor contact). When false,
-    // those fields are default-zero, NOT a real measured zero velocity —
-    // do not use them.
+    // True when points[].sideA/sideB.velocity were actually captured; false
+    // means "not computed", not a real zero.
     bool hasContactVelocity{false};
 
     // Contact points in world coordinates.
     struct ContactPoint
     {
-        // Contact points on the surface of actor A
-        Vec3 pointA;
+        struct Side
+        {
+            Vec3 point;
+            Vec3 velocity;  // pre-solve; valid only if hasContactVelocity
+        };
 
-        // Contact points on the surface of actor B
-        Vec3 pointB;
-
-        // Pre-solve velocity (before Jolt's solver runs) of actor A's surface
-        // at pointA and actor B's surface at pointB. Only meaningful when the
-        // owning ContactInfo3D::hasContactVelocity is true.
-        Vec3 velocityA;
-        Vec3 velocityB;
+        Side sideA;
+        Side sideB;
     };
 
     tlx::inlined_vector<ContactPoint, 4> points;

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -592,9 +592,8 @@ void PhysicsWorld3D::OnContactAdded(const JPH::Body& body1,
 
     if (isSensor)
     {
-        ContactInfo3D sensorInfo = reorderSensorContactInfo(info);
-        if (checkSensorEvent(sensorInfo))
-            queueContactEvent(std::move(sensorInfo), ContactEvent3D::EventCode::SensorBegin);
+        if (checkSensorEvent(info))
+            queueContactEvent(reorderSensorContactInfo(info), ContactEvent3D::EventCode::SensorBegin);
         return;
     }
 
@@ -646,9 +645,8 @@ void PhysicsWorld3D::OnContactRemoved(const JPH::SubShapeIDPair& subShapePair)
 
     if (isSensor)
     {
-        ContactInfo3D sensorInfo = reorderSensorContactInfo(info);
-        if (checkSensorEvent(sensorInfo))
-            queueContactEvent(std::move(sensorInfo), ContactEvent3D::EventCode::SensorEnd);
+        if (checkSensorEvent(info))
+            queueContactEvent(reorderSensorContactInfo(info), ContactEvent3D::EventCode::SensorEnd);
         return;
     }
 

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -557,7 +557,7 @@ JPH::ValidateResult PhysicsWorld3D::OnContactValidate(const JPH::Body& body1,
     const Vec3 normal = jphutil::cast(-collisionResult.mPenetrationAxis.Normalized());
 
     ContactInfo3D info{.actorA = actorA, .actorB = actorB, .normal = normal};
-    info.points.push_back({worldA, worldB});
+    info.points.push_back({.sideA = {.point = worldA}, .sideB = {.point = worldB}});
 
     if (!_preSolveCallback || _preSolveCallback(info))
         return JPH::ValidateResult::AcceptAllContactsForThisBodyPair;

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -101,6 +101,9 @@ static Collider3D* asSensorCollider(PhysicsActor* actor)
     return collider && collider->isSensor() ? collider : nullptr;
 }
 
+// If both actors are sensors, actorA ends up being whichever one Jolt
+// reports first -- not guaranteed consistent across contacts of the same
+// pair. Compare against a known actor pointer, don't assume actorA == self.
 static ContactInfo3D reorderSensorContactInfo(const ContactInfo3D& info)
 {
     if (asSensorCollider(info.actorA) || !asSensorCollider(info.actorB))
@@ -109,6 +112,8 @@ static ContactInfo3D reorderSensorContactInfo(const ContactInfo3D& info)
     ContactInfo3D reordered = info;
     std::swap(reordered.actorA, reordered.actorB);
     reordered.normal = -reordered.normal;
+    for (auto& point : reordered.points)
+        std::swap(point.sideA, point.sideB);
     return reordered;
 }
 
@@ -125,11 +130,13 @@ static void fillContactPoints(ContactInfo3D& info,
         JPH::RVec3 worldA = manifold.GetWorldSpaceContactPointOn1(i);
         JPH::RVec3 worldB = manifold.GetWorldSpaceContactPointOn2(i);
 
-        ContactInfo3D::ContactPoint point{jphutil::cast(worldA), jphutil::cast(worldB)};
+        ContactInfo3D::ContactPoint point;
+        point.sideA.point = jphutil::cast(worldA);
+        point.sideB.point = jphutil::cast(worldB);
         if (includeVelocity)
         {
-            point.velocityA = jphutil::cast(body1.GetPointVelocity(worldA));
-            point.velocityB = jphutil::cast(body2.GetPointVelocity(worldB));
+            point.sideA.velocity = jphutil::cast(body1.GetPointVelocity(worldA));
+            point.sideB.velocity = jphutil::cast(body2.GetPointVelocity(worldB));
         }
         info.points.push_back(point);
     }

--- a/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -565,10 +565,10 @@ bool luaval_to_contact_point_3d(lua_State* L, int lo, ContactInfo3D::ContactPoin
 
     const int tableIndex = lua_table_abs_index(L, lo);
     bool ok              = true;
-    ok &= luaval_to_vec3_field(L, tableIndex, "pointA", &outValue->pointA, funcName);
-    ok &= luaval_to_vec3_field(L, tableIndex, "pointB", &outValue->pointB, funcName);
-    ok &= luaval_to_vec3_field(L, tableIndex, "velocityA", &outValue->velocityA, funcName);
-    ok &= luaval_to_vec3_field(L, tableIndex, "velocityB", &outValue->velocityB, funcName);
+    ok &= luaval_to_vec3_field(L, tableIndex, "pointA", &outValue->sideA.point, funcName);
+    ok &= luaval_to_vec3_field(L, tableIndex, "pointB", &outValue->sideB.point, funcName);
+    ok &= luaval_to_vec3_field(L, tableIndex, "velocityA", &outValue->sideA.velocity, funcName);
+    ok &= luaval_to_vec3_field(L, tableIndex, "velocityB", &outValue->sideB.velocity, funcName);
     return ok;
 }
 
@@ -2720,10 +2720,10 @@ void contact_info_3d_to_luaval(lua_State* L, const ContactInfo3D& info)
     {
         lua_pushnumber(L, index++);
         lua_newtable(L);
-        push_vec3_field(L, "pointA", point.pointA);
-        push_vec3_field(L, "pointB", point.pointB);
-        push_vec3_field(L, "velocityA", point.velocityA);
-        push_vec3_field(L, "velocityB", point.velocityB);
+        push_vec3_field(L, "pointA", point.sideA.point);
+        push_vec3_field(L, "pointB", point.sideB.point);
+        push_vec3_field(L, "velocityA", point.sideA.velocity);
+        push_vec3_field(L, "velocityB", point.sideB.velocity);
         lua_rawset(L, -3);
     }
     lua_rawset(L, -3);

--- a/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
@@ -844,12 +844,12 @@ bool Physics3DCollisionCallbackDemo::init()
             if (info.hasContactVelocity && !info.points.empty())
             {
                 const auto& point = info.points[0];
-                float impactSpeed = (point.velocityA - point.velocityB).dot(info.normal);
+                float impactSpeed = (point.sideA.velocity - point.sideB.velocity).dot(info.normal);
                 AXLOGD("CollisionHit impact speed: {:.2f} (point {})", impactSpeed, info.points.size());
             }
 
             auto ps = PUParticleSystem3D::create("Particle3D/scripts/mp_hit_04.pu");
-            ps->setPosition3D(contactEvent->getContactInfo().points[0].pointB);
+            ps->setPosition3D(contactEvent->getContactInfo().points[0].sideB.point);
             ps->setScale(0.05f);
             ps->startParticleSystem();
             ps->setCameraMask(2);


### PR DESCRIPTION
## Problem
`reorderSensorContactInfo()` swaps `actorA`/`actorB` and `normal` when the
sensor is reported as `actorB`, but never touched per-point data — leaving
`points[]` misassociated with the swapped actors on every `SensorBegin`/
`SensorEnd`.

## Fix
- Restructured `ContactPoint`'s per-actor fields into a symmetric `Side`
  (`point`, `velocity`), swapped as a unit: `std::swap(point.sideA,
  point.sideB)`. Any per-point field added later goes into `Side` and is
  swapped automatically — no code change needed in
  `reorderSensorContactInfo()` when the struct grows again.
- `checkSensorEvent()` is symmetric in `actorA`/`actorB`, so it's now
  checked *before* the reorder, skipping the copy when nobody's listening.
- Documented the sensor-vs-sensor edge case: when both actors are sensors,
  which one lands in `actorA` is Jolt's arbitrary order and isn't
  guaranteed consistent across contacts of the same pair.

## Lua bindings
Updated for the new C++ layout (`sideA.point` etc.), but the Lua-facing
table keys (`pointA`/`pointB`/`velocityA`/`velocityB`) are intentionally
left unchanged — this is a C++-internal refactor, not a scripting API
change, so existing Lua code isn't affected.

## Testing
Manual, via the updated `Physics3DTest.cpp` collision/sensor demos (no
automated physics regression tests in the repo).