### PR TITLE
Fix ContactInfo3D contact velocity representation

### DIFF
--- a/axmol/physics/3d/ContactEvent3D.h
+++ b/axmol/physics/3d/ContactEvent3D.h
@@ -39,6 +39,7 @@
 #    include "axmol/tlx/inlined_vector.hpp"
 #    include <functional>
 #    include <vector>
+#    include <optional>
 
 namespace ax
 {
@@ -54,17 +55,13 @@ struct ContactInfo3D
     // Contact normal in world coordinates from shape A toward shape B.
     Vec3 normal;
 
-    // True when points[].sideA/sideB.velocity were actually captured; false
-    // means "not computed", not a real zero.
-    bool hasContactVelocity{false};
-
     // Contact points in world coordinates.
     struct ContactPoint
     {
         struct Side
         {
             Vec3 point;
-            Vec3 velocity;  // pre-solve; valid only if hasContactVelocity
+            std::optional<Vec3> velocity;
         };
 
         Side sideA;

--- a/axmol/physics/3d/PhysicsWorld3D.cpp
+++ b/axmol/physics/3d/PhysicsWorld3D.cpp
@@ -581,7 +581,6 @@ void PhysicsWorld3D::OnContactAdded(const JPH::Body& body1,
         !isSensor && isGlobalEventEnabled(ContactEventBits::Hit) &&
         (info.actorA->isEventEnabled(ContactEventBits::Hit) || info.actorB->isEventEnabled(ContactEventBits::Hit));
 
-    info.hasContactVelocity = hitEventEnabled;
     fillContactPoints(info, body1, body2, manifold, hitEventEnabled);
 
     const uint64_t pairKey = makeBodyPairKey(body1.GetID(), body2.GetID());

--- a/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/extensions/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -538,6 +538,31 @@ bool luaval_to_vec3_field(lua_State* L, int tableIndex, const char* field, Vec3*
     return true;
 }
 
+bool luaval_to_optional_vec3_field(lua_State* L,
+                                   int tableIndex,
+                                   const char* field,
+                                   std::optional<Vec3>* outValue,
+                                   const char* funcName)
+{
+    lua_pushstring(L, field);
+    lua_gettable(L, tableIndex);
+
+    if (!lua_isnil(L, -1))
+    {
+        Vec3 value;
+        if (!luaval_to_vec3(L, lua_gettop(L), &value, funcName))
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+
+        *outValue = value;
+    }
+
+    lua_pop(L, 1);
+    return true;
+}
+
 bool luaval_to_physics_actor_field(lua_State* L,
                                    int tableIndex,
                                    const char* field,
@@ -567,8 +592,8 @@ bool luaval_to_contact_point_3d(lua_State* L, int lo, ContactInfo3D::ContactPoin
     bool ok              = true;
     ok &= luaval_to_vec3_field(L, tableIndex, "pointA", &outValue->sideA.point, funcName);
     ok &= luaval_to_vec3_field(L, tableIndex, "pointB", &outValue->sideB.point, funcName);
-    ok &= luaval_to_vec3_field(L, tableIndex, "velocityA", &outValue->sideA.velocity, funcName);
-    ok &= luaval_to_vec3_field(L, tableIndex, "velocityB", &outValue->sideB.velocity, funcName);
+    ok &= luaval_to_optional_vec3_field(L, tableIndex, "velocityA", &outValue->sideA.velocity, funcName);
+    ok &= luaval_to_optional_vec3_field(L, tableIndex, "velocityB", &outValue->sideB.velocity, funcName);
     return ok;
 }
 
@@ -2711,7 +2736,6 @@ void contact_info_3d_to_luaval(lua_State* L, const ContactInfo3D& info)
     push_physics_actor_field(L, "actorA", info.actorA);
     push_physics_actor_field(L, "actorB", info.actorB);
     push_vec3_field(L, "normal", info.normal);
-    push_bool_field(L, "hasContactVelocity", info.hasContactVelocity);
 
     lua_pushstring(L, "points");
     lua_newtable(L);
@@ -2722,8 +2746,10 @@ void contact_info_3d_to_luaval(lua_State* L, const ContactInfo3D& info)
         lua_newtable(L);
         push_vec3_field(L, "pointA", point.sideA.point);
         push_vec3_field(L, "pointB", point.sideB.point);
-        push_vec3_field(L, "velocityA", point.sideA.velocity);
-        push_vec3_field(L, "velocityB", point.sideB.velocity);
+        if (point.sideA.velocity)
+            push_vec3_field(L, "velocityA", *point.sideA.velocity);
+        if (point.sideB.velocity)
+            push_vec3_field(L, "velocityB", *point.sideB.velocity);
         lua_rawset(L, -3);
     }
     lua_rawset(L, -3);

--- a/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Source/Physics3DTest/Physics3DTest.cpp
@@ -841,11 +841,15 @@ bool Physics3DCollisionCallbackDemo::init()
         contactListener->onCollisionHit = [this](ContactEvent3D* contactEvent) {
             const auto& info = contactEvent->getContactInfo();
 
-            if (info.hasContactVelocity && !info.points.empty())
+            if (!info.points.empty())
             {
                 const auto& point = info.points[0];
-                float impactSpeed = (point.sideA.velocity - point.sideB.velocity).dot(info.normal);
-                AXLOGD("CollisionHit impact speed: {:.2f} (point {})", impactSpeed, info.points.size());
+
+                if (point.sideA.velocity && point.sideB.velocity)
+                {
+                    float impactSpeed = (*point.sideA.velocity - *point.sideB.velocity).dot(info.normal);
+                    AXLOGD("CollisionHit impact speed: {:.2f} (point {})", impactSpeed, info.points.size());
+                }
             }
 
             auto ps = PUParticleSystem3D::create("Particle3D/scripts/mp_hit_04.pu");


### PR DESCRIPTION
### Description

Refactor `ContactInfo3D` contact velocity state to use `std::optional<Vec3>` instead of a separate `hasContactVelocity` flag and an always-present velocity field.

This makes velocity validity explicit at the point where the data is stored, prevents accidental reads of invalid values, and keeps the existing `ContactPoint::Side` model without duplicating contact geometry or introducing parallel arrays.

That is a follow-up PR for this one: https://github.com/axmolengine/axmol/pull/3275

**Considered alternatives:**

* Separate `ContactHitInfo3D` with dedicated hit points — rejected due to duplicated contact geometry / additional data handling.
* Always capture contact velocities — rejected due to a measured **10–15% performance regression** in Release builds on Windows in the test scenarios.
* `std::optional<Vec3>` — selected as the minimal and type-safe solution.

Lua bindings preserve the existing `velocityA` / `velocityB` API; unavailable velocities are now represented as `nil`. The obsolete `hasContactVelocity` flag is removed.
