### PR TITLE
[v2] Ensure all Slider renderers are set to the correct global Z value

### DIFF
--- a/core/ui/UISlider.cpp
+++ b/core/ui/UISlider.cpp
@@ -128,6 +128,20 @@ bool Slider::init()
     return false;
 }
 
+void Slider::setGlobalZOrder(float globalZOrder)
+{
+    Widget::setGlobalZOrder(globalZOrder);
+
+    if (_slidBallNormalRenderer)
+        _slidBallNormalRenderer->setGlobalZOrder(globalZOrder);
+
+    if (_slidBallPressedRenderer)
+        _slidBallPressedRenderer->setGlobalZOrder(globalZOrder);
+
+    if (_slidBallDisabledRenderer)
+        _slidBallDisabledRenderer->setGlobalZOrder(globalZOrder);
+}
+
 void Slider::initRenderer()
 {
     _barRenderer         = Scale9Sprite::create();
@@ -139,12 +153,19 @@ void Slider::initRenderer()
 
     addProtectedChild(_barRenderer, BASEBAR_RENDERER_Z, -1);
     addProtectedChild(_progressBarRenderer, PROGRESSBAR_RENDERER_Z, -1);
+    
+    const auto globalZOrder = getGlobalZOrder();
 
     _slidBallNormalRenderer  = Sprite::create();
+    _slidBallNormalRenderer->setGlobalZOrder(globalZOrder);
+
     _slidBallPressedRenderer = Sprite::create();
     _slidBallPressedRenderer->setVisible(false);
+    _slidBallPressedRenderer->setGlobalZOrder(globalZOrder);
+
     _slidBallDisabledRenderer = Sprite::create();
     _slidBallDisabledRenderer->setVisible(false);
+    _slidBallDisabledRenderer->setGlobalZOrder(globalZOrder);
 
     _slidBallRenderer = Node::create();
 

--- a/core/ui/UISlider.h
+++ b/core/ui/UISlider.h
@@ -280,6 +280,8 @@ public:
 
     virtual bool init() override;
 
+    void setGlobalZOrder(float globalZOrder) override;
+
 protected:
     virtual void initRenderer() override;
     float getPercentWithBallPos(const Vec2& pt) const;


### PR DESCRIPTION
## Describe your changes

This is a fix to ensure that sprites used for displaying textures in the `ui::Slider` are updated to the correct global Z value when it is changed.

When the global Z is set to a value other than 0, this is what currently happens:
<img width="599" height="107" alt="image" src="https://github.com/user-attachments/assets/35134d99-b508-437b-b3fd-ca47912ac7c8" />

This PR ensures the render node global Z is set correctly, resulting in this:
<img width="636" height="129" alt="image" src="https://github.com/user-attachments/assets/865e03f9-50ac-423e-a9df-3cf85189716d" />

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
