### PR TITLE
[v3] Change default UISceneConfiguration name

### DIFF
--- a/axmol/platform/ios/AxmolAppController.mm
+++ b/axmol/platform/ios/AxmolAppController.mm
@@ -33,7 +33,6 @@
     configurationForConnectingSceneSession:(UISceneSession*)connectingSceneSession
                                    options:(UISceneConnectionOptions*)options API_AVAILABLE(ios(13.0))
 {
-
     // Attempt to read the configuration from the project Info.plist
     if ([connectingSceneSession.configuration.name isEqualToString:@"Default Configuration"])
     {
@@ -41,7 +40,7 @@
     }
 
     // Fallback is to create the configuration programmatically
-    UISceneConfiguration* config = [[UISceneConfiguration alloc] initWithName:@"AxmolDefaultConfiguration"
+    UISceneConfiguration* config = [[UISceneConfiguration alloc] initWithName:@"Default Configuration"
                                                                   sessionRole:connectingSceneSession.role];
 
     config.delegateClass = [AxmolSceneDelegate class];


### PR DESCRIPTION
## Describe your changes

Changed the fall-back `UISceneConfiguration` name, because if it doesn't exist, iOS will display a message, such as;
`Info.plist contained no UIScene configuration dictionary (looking for configuration named "AxmolDefaultConfiguration")`

That may cause confusion, since the name that should be used in the `Info.plist` is "Default Configuration".

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
