### PR TITLE
[v3] Ensure all slider renderers are set to the correct global Z value

### DIFF
--- a/axmol/ui/Slider.cpp
+++ b/axmol/ui/Slider.cpp
@@ -151,7 +151,7 @@ void Slider::initRenderNode()
 
     const auto globalZOrder = getGlobalZOrder();
 
-    _slidBallNormalRenderer  = Sprite::create();
+    _slidBallNormalRenderer = Sprite::create();
     _slidBallNormalRenderer->setGlobalZOrder(globalZOrder);
 
     _slidBallPressedRenderer = Sprite::create();

--- a/axmol/ui/Slider.cpp
+++ b/axmol/ui/Slider.cpp
@@ -123,6 +123,20 @@ bool Slider::init()
     return false;
 }
 
+void Slider::setGlobalZOrder(float globalZOrder)
+{
+    Widget::setGlobalZOrder(globalZOrder);
+
+    if (_slidBallNormalRenderer)
+        _slidBallNormalRenderer->setGlobalZOrder(globalZOrder);
+
+    if (_slidBallPressedRenderer)
+        _slidBallPressedRenderer->setGlobalZOrder(globalZOrder);
+
+    if (_slidBallDisabledRenderer)
+        _slidBallDisabledRenderer->setGlobalZOrder(globalZOrder);
+}
+
 void Slider::initRenderNode()
 {
     _barRenderer         = Scale9Sprite::create();
@@ -135,11 +149,18 @@ void Slider::initRenderNode()
     addProtectedChild(_barRenderer, BASEBAR_RENDERER_Z, -1);
     addProtectedChild(_progressBarRenderer, PROGRESSBAR_RENDERER_Z, -1);
 
+    const auto globalZOrder = getGlobalZOrder();
+
     _slidBallNormalRenderer  = Sprite::create();
+    _slidBallNormalRenderer->setGlobalZOrder(globalZOrder);
+
     _slidBallPressedRenderer = Sprite::create();
     _slidBallPressedRenderer->setVisible(false);
+    _slidBallPressedRenderer->setGlobalZOrder(globalZOrder);
+
     _slidBallDisabledRenderer = Sprite::create();
     _slidBallDisabledRenderer->setVisible(false);
+    _slidBallDisabledRenderer->setGlobalZOrder(globalZOrder);
 
     _slidBallRenderer = Node::create();
 

--- a/axmol/ui/Slider.h
+++ b/axmol/ui/Slider.h
@@ -278,6 +278,8 @@ public:
     ResourceData getBallDisabledFile();
 
     bool init() override;
+    
+    void setGlobalZOrder(float globalZOrder) override;
 
 protected:
     void initRenderNode() override;

--- a/axmol/ui/Slider.h
+++ b/axmol/ui/Slider.h
@@ -278,7 +278,7 @@ public:
     ResourceData getBallDisabledFile();
 
     bool init() override;
-    
+
     void setGlobalZOrder(float globalZOrder) override;
 
 protected:


### PR DESCRIPTION
## Describe your changes

Same as the v2 PR #3294

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
