### PR TITLE
Fix UIWindow property on iOS app delegate

### DIFF
--- a/core/platform/ios/AxmolAppController.h
+++ b/core/platform/ios/AxmolAppController.h
@@ -28,6 +28,8 @@
 @interface AxmolAppController : NSObject <UIApplicationDelegate> {
 }
 
+@property(nullable, nonatomic, strong) UIWindow* window;
+
 @property(nonatomic, readonly) UIViewController* viewController;
 
 @end

--- a/core/platform/ios/AxmolAppController.mm
+++ b/core/platform/ios/AxmolAppController.mm
@@ -79,6 +79,7 @@ configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession
     {
         _viewController = [self createRootViewController];
         AxmolLauncher::launchApp(_viewController, nil);
+        self.window = (__bridge UIWindow*)Director::getInstance()->getRenderView()->getEAWindow();
     }
     return YES;
 }
@@ -162,6 +163,7 @@ configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession
 #if !__has_feature(objc_arc)
 - (void)dealloc
 {
+    [_window release];
     [_viewController release];
     [super dealloc];
 }


### PR DESCRIPTION
Hi!
Since the change to have the new `AxmolAppController` the `window` property is no more exposed, whereas even if optional in the `UIApplicationDelegate` few SDKs still needs it, so this PR adds back the property.