### PR TITLE
[V2] Add missing getter for the key modifiers

### DIFF
--- a/core/base/EventKeyboard.h
+++ b/core/base/EventKeyboard.h
@@ -249,6 +249,8 @@ public:
 
     bool isRepeat() const { return _isRepeat; }
 
+    uint32_t getKeyModifiers() const { return _modifiers; }
+
 private:
     KeyCode _keyCode;
     bool _isKeyDown;

--- a/core/base/EventKeyboard.h
+++ b/core/base/EventKeyboard.h
@@ -249,7 +249,7 @@ public:
 
     bool isRepeat() const { return _isRepeat; }
 
-    uint32_t getKeyModifiers() const { return _modifiers; }
+    uint32_t getModifiers() const { return _modifiers; }
 
 private:
     KeyCode _keyCode;


### PR DESCRIPTION
## Describe your changes

This change adds the missing method to allow access to the key modifiers in `EventKeyboard`, by simply adding a `getKeyModifiers()` method.

V3 already has this method.

## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Simdsoft Limited and other Axmol contributors (see AUTHORS.md)."`
- [ ] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
